### PR TITLE
put bot turrets on top floor of building

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -520,7 +520,7 @@ public class Princess extends BotClient {
      * Gun Emplacements should deploy on the rooftop of the building for maximum visibility.
      */
     private int getDeployElevation(Entity deployEntity, IHex deployHex) {
-        if(deployEntity instanceof GunEmplacement) {
+        if (deployEntity instanceof GunEmplacement) {
            return deployEntity.elevationOccupied(deployHex) + deployHex.terrainLevel(Terrains.BLDG_ELEV);
         } else {
             return deployEntity.elevationOccupied(deployHex);

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -505,13 +505,25 @@ public class Princess extends BotClient {
             final IHex deployHex = game.getBoard().getHex(deployCoords);
 
             // Entity.elevatoinOccupied performs a null check on IHex
-            int deployElevation = deployEntity.elevationOccupied(deployHex);
+            int deployElevation = getDeployElevation(deployEntity, deployHex);
 
             // Compensate for hex elevation where != 0...
             deployElevation -= deployHex.getLevel();
             deploy(entityNum, deployCoords, decentFacing, deployElevation);
         } finally {
             methodEnd(getClass(), METHOD_NAME);
+        }
+    }
+    
+    /**
+     * Calculate the deployment elevation for the given entity.
+     * Gun Emplacements should deploy on the rooftop of the building for maximum visibility.
+     */
+    private int getDeployElevation(Entity deployEntity, IHex deployHex) {
+        if(deployEntity instanceof GunEmplacement) {
+           return deployEntity.elevationOccupied(deployHex) + deployHex.terrainLevel(Terrains.BLDG_ELEV);
+        } else {
+            return deployEntity.elevationOccupied(deployHex);
         }
     }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -504,7 +504,6 @@ public class Princess extends BotClient {
             final Entity deployEntity = game.getEntity(entityNum);
             final IHex deployHex = game.getBoard().getHex(deployCoords);
 
-            // Entity.elevatoinOccupied performs a null check on IHex
             int deployElevation = getDeployElevation(deployEntity, deployHex);
 
             // Compensate for hex elevation where != 0...
@@ -520,6 +519,7 @@ public class Princess extends BotClient {
      * Gun Emplacements should deploy on the rooftop of the building for maximum visibility.
      */
     private int getDeployElevation(Entity deployEntity, IHex deployHex) {
+        // Entity.elevationOccupied performs a null check on IHex
         if (deployEntity instanceof GunEmplacement) {
            return deployEntity.elevationOccupied(deployHex) + deployHex.terrainLevel(Terrains.BLDG_ELEV);
         } else {


### PR DESCRIPTION
Pretty straightforward, and I'm surprised I never noticed it. The bot would routinely place its turrets on the ground floor of a building rather than the roof, which would lead to the player being able to fire on the containing building but the bot being unable to fire back.