### PR TITLE
BA Tube artillery fixes

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -287,7 +287,7 @@
 3135=, but the shot is impossible (<data>)
 3140=, the shot is an automatic miss (<data>), 
 3145=, the shot is an automatic hit (<data>), 
-3150= needs <data>, 
+3150=\ needs <data>, 
 3155=rolls <data> : 
 3160=<font color='C00000'>THE AUTOCANNON JAMS</font>; 
 3161=<font color='C00000'>THE DAMN THING JAMS</font>; 

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -1322,12 +1322,13 @@ public class MapMenu extends JPopupMenu {
                 }
 
                 if (hasAmmoType(AmmoType.T_ARROW_IV)
-                    || hasAmmoType(AmmoType.T_SNIPER)
-                    || hasAmmoType(AmmoType.T_CRUISE_MISSILE)
-                    || hasAmmoType(AmmoType.T_ALAMO)
-                    || hasAmmoType(AmmoType.T_KILLER_WHALE)
-                    || hasAmmoType(AmmoType.T_LONG_TOM)
-                    || hasAmmoType(AmmoType.T_THUMPER)) {
+                        || hasAmmoType(AmmoType.T_SNIPER)
+                        || hasAmmoType(AmmoType.T_CRUISE_MISSILE)
+                        || hasAmmoType(AmmoType.T_ALAMO)
+                        || hasAmmoType(AmmoType.T_KILLER_WHALE)
+                        || hasAmmoType(AmmoType.T_LONG_TOM)
+                        || hasAmmoType(AmmoType.T_THUMPER)
+                        || hasAmmoType(AmmoType.T_BA_TUBE)) {
                     menu.add(TargetMenuItem(new HexTarget(coords, board, Targetable.TYPE_HEX_ARTILLERY)));
                 }
                 if (canStartFires && hasFireExtinguisher()

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -1352,7 +1352,8 @@ public class MapMenu extends JPopupMenu {
                 || hasAmmoType(AmmoType.T_ALAMO)
                 || hasAmmoType(AmmoType.T_KILLER_WHALE)
                 || hasAmmoType(AmmoType.T_LONG_TOM)
-                || hasAmmoType(AmmoType.T_THUMPER))) {
+                || hasAmmoType(AmmoType.T_THUMPER)
+                || hasAmmoType(AmmoType.T_BA_TUBE))) {
             menu.add(TargetMenuItem(new HexTarget(coords, board, Targetable.TYPE_HEX_ARTILLERY)));
         }
         // Check for adding TAG targeting buildings and hexes

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -639,6 +639,7 @@ public class AreaEffectHelper {
             falloff = 25;
         }
         if (ammo.getAmmoType() == AmmoType.T_BA_TUBE) {
+            damage *= attackingBA;
             falloff = 2 * attackingBA;
         }
         if (ammo.getMunitionType() == AmmoType.M_CLUSTER) {


### PR DESCRIPTION
Fixes two bugs with BA tube artillery:
1. Tube artillery is not given the option to target a hex with an artillery attack.
2. Damage is not multiplied by the number active troopers.
I also added a missing space in a report message.

Fixes #1848 
Fixes #1849