### PR TITLE
Distinguish between ASF/SC and other aero units in PlasmaRifleHandler.

### DIFF
--- a/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
@@ -110,7 +110,7 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        if ((target instanceof Mech) || (target instanceof Aero)) {
+        if (target.tracksHeat()) {
             int toReturn = 10;
             toReturn = applyGlancingBlowModifier(toReturn, false);
             if (game.getOptions().booleanOption(


### PR DESCRIPTION
A plasma rifle does 10 points of damage and 1d6 points of heat to units that track heat (mechs, asfs, small craft). To all other units it does 10 + 2d6 points of damage in 5-point clusters. In MM the 10-point hit to mechs, etc. is a single volley of 10 points, while the 10+2d6 damage is 10+2d6 hits of one point each so they can be grouped. `calcDamagePerHit()` is returning 10 for all aerospace units instead of just aerospace fighters and small craft, which causes conventional fighters, fixed wing support vehicles, and dropships to take 10+2d6 hits of 10 points each.

Fixes #1850