### PR TITLE
Don't loop twice when applying area damage to BA

### DIFF
--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -554,10 +554,12 @@ public class AreaEffectHelper {
         vPhaseReport.add(r);
         if (entity instanceof BattleArmor) {
             // BA take full damage to each trooper, ouch!
-            for (int loc = 1; loc < entity.locations(); loc++) {
-                HitData hit = new HitData(loc);
-                vPhaseReport.addAll(server.damageEntity(entity, hit, hits,
-                        false, DamageType.NONE, false, false, false));
+            for (int loc = 0; loc < entity.locations(); loc++) {
+                if (entity.getInternal(loc) > 0) {
+                    HitData hit = new HitData(loc);
+                    vPhaseReport.addAll(server.damageEntity(entity, hit, hits,
+                            false, DamageType.NONE, false, false, false));
+                }
             }
         } else {
             while (hits > 0) {

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -554,12 +554,10 @@ public class AreaEffectHelper {
         vPhaseReport.add(r);
         if (entity instanceof BattleArmor) {
             // BA take full damage to each trooper, ouch!
-            for (int loc = 0; loc < entity.locations(); loc++) {
-                if (entity.getInternal(loc) > 0) {
-                    HitData hit = new HitData(loc);
-                    vPhaseReport.addAll(server.damageEntity(entity, hit, hits,
-                            false, DamageType.NONE, false, true, false));
-                }
+            for (int loc = 1; loc < entity.locations(); loc++) {
+                HitData hit = new HitData(loc);
+                vPhaseReport.addAll(server.damageEntity(entity, hit, hits,
+                        false, DamageType.NONE, false, false, false));
             }
         } else {
             while (hits > 0) {


### PR DESCRIPTION
When calling Server#damageEntity with areaSatArty == true, the method is called again for each suit location with areaSatArty false. Each suit is receiving the full damage value once per suit in the squad.

Fixes #1915