### PR TITLE
Fix for issue #1930 - Changing Sandblaster SPA from boolean to list

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -766,6 +766,19 @@ public class CustomMechDialog extends ClientDialog implements ActionListener,
             }
             optionComp.setSelected(option.stringValue());
         }
+        
+        if ((OptionsConstants.GUNNERY_SANDBLASTER).equals(option.getName())) { // $NON-NLS-1$
+            optionComp.addValue(Messages.getString("CustomMechDialog.None")); //$NON-NLS-1$
+            TreeSet<String> uniqueWeapons = new TreeSet<String>();
+            for (int i = 0; i < entity.getWeaponList().size(); i++) {
+                Mounted m = entity.getWeaponList().get(i);
+                uniqueWeapons.add(m.getName());
+            }
+            for (String name : uniqueWeapons) {
+                optionComp.addValue(name);
+            }
+            optionComp.setSelected(option.stringValue());
+        }
 
         if (OptionsConstants.GUNNERY_SPECIALIST               
                 .equals(option.getName())) { //$NON-NLS-1$

--- a/megamek/src/megamek/common/options/PilotOptions.java
+++ b/megamek/src/megamek/common/options/PilotOptions.java
@@ -77,7 +77,7 @@ public class PilotOptions extends AbstractOptions {
         addOption(adv, OptionsConstants.GUNNERY_OBLIQUE_ARTILLERY, false); //$NON-NLS-1$
         addOption(adv, OptionsConstants.GUNNERY_OBLIQUE_ATTACKER, false); //$NON-NLS-1$
         addOption(adv, OptionsConstants.GUNNERY_RANGE_MASTER,  new Vector<String>()); //$NON-NLS-1$
-        addOption(adv, OptionsConstants.GUNNERY_SANDBLASTER, false); //$NON-NLS-1$
+        addOption(adv, OptionsConstants.GUNNERY_SANDBLASTER, new Vector<String>()); //$NON-NLS-1$
         // addOption(adv, OptionsConstants.GUNNERY_SHARPSHOOTER, false); //$NON-NLS-1$
         addOption(adv, OptionsConstants.GUNNERY_SNIPER, false); //$NON-NLS-1$
         addOption(adv, OptionsConstants.GUNNERY_WEAPON_SPECIALIST, new Vector<String>()); //$NON-NLS-1$

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -2104,8 +2104,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         }
 
         if (null != ae.getCrew()) {
-            if (ae.hasAbility(OptionsConstants.GUNNERY_SANDBLASTER) && 
-                    ae.hasAbility(OptionsConstants.GUNNERY_WEAPON_SPECIALIST, wtype.getName())) {
+            if (ae.hasAbility(OptionsConstants.GUNNERY_SANDBLASTER, wtype.getName())) {
                 if (nRange > ranges[RangeType.RANGE_MEDIUM]) {
                     nMissilesModifier += 2;
                 } else if (nRange > ranges[RangeType.RANGE_SHORT]) {


### PR DESCRIPTION
Fix in Megamek for Sandblaster SPA issue #1930. Issue does not look to be present in MekHQ, and should work the same as the Weapon Specialist SPA when a MegaMek game is launched from MekHQ, I didn't see any special code for that, but it may be present. I'm not exactly sure how save games are formatted, but this change would potentially mean a game saved with a pilot with a Sandblaster SPA set to True would try to load with MegaMek expecting a value from a list. 