### PR TITLE
Fix for #1936 swapping the order of checking Shift and Alt

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -451,8 +451,8 @@ public class BoardEditor extends JComponent
                     if ((b.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) && isLMB) {
                         if (!isDragging) {
                             hexLeveltoDraw = board.getHex(c).getLevel();
-                            if (isSHIFT) hexLeveltoDraw++;
-                            else if (isALT) hexLeveltoDraw--;
+                            if (isALT) hexLeveltoDraw--;
+                            else if (isSHIFT) hexLeveltoDraw++;
                             isDragging = true;
                         }
                     }


### PR DESCRIPTION
Fixes #1936, should make map editing a bit easier for Linux users without impacting Windows and Mac users.