### PR TITLE
Simplify tracking of protomech torso crits.

### DIFF
--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -939,7 +939,7 @@ public class Protomech extends Entity {
             }
         }
 
-        if (mounted.getType().isHittable()) {
+        if (mounted.getType().isHittable() && (loc != LOC_BODY)) {
             int max = maxWeapons(loc);
             if (max == 0) {
                 throw new LocationFullException("Weapon "


### PR DESCRIPTION
Fixes a bug that causes protomech torso weapons to ignore critical hits. The equipment id (which is the index of the Mounted in the equipmentList) is assigned to a member field when the unit is loaded, but the assignment is made before the equipment is actually added to the list, so the index is always -1. Any slot that does not have a weapon in it is left as 0, which could be the index of anything and can lead to equipment being destroyed by a torso critical that shouldn't be.

For the fix I dispensed with static tracking of the torso weapon slots and instead iterate the equipment list to find the nth hittable torso-mounted equipment. This avoids any need for special handling in MML as weapons are removed and other are added.

Fixes #1934

Brief summary of protomech critical slots:
1. Game rules
They can have a maximum of one weapon in each arm (bipeds only), one (bipeds) or two (quads) in the main gun, and 2-6 in the torso (depending on weight class and configuration). The ones in the arms are not damaged by critical hits, and any in the main gun are destroyed on the first critical. The torso weapons are tricky. The weapons are identified as A-F. Any torso critical is accompanied by a 1d6 roll, which translates to one of the torso weapons. For quads this maps straight to the A-F. For bipeds, the mapping is 1-2(A), 3-4(B), 5-6(C). If a slot does not have a weapon in it, or the weapon has already been hit, there is no additional effect.
2. Implementation
The torso critical slots are treated as system criticals, with a separate index for each torso weapon slot. The corresponding weapon is found by the equipment id, which is assigned to a member field when the unit is loaded.