### PR TITLE
Fix UMU count in Entity

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4935,16 +4935,11 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
 
     /**
-     * This method checks to see if a unit has Underwater Maneuvering Units Only
-     * Battle Mechs may have UMU's
+     * This method checks to see if a unit has Underwater Maneuvering Units
      *
      * @return <code>boolean</code> if the entity has usable UMU crits.
      */
     public boolean hasUMU() {
-        if (!(this instanceof Mech) && !(this instanceof Infantry)) {
-            return false;
-        }
-
         int umuCount = getActiveUMUCount();
 
         return umuCount > 0;
@@ -4993,10 +4988,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             && (getMovementMode() == EntityMovementMode.INF_UMU)) {
             // UMU MP for Infantry is stored in jumpMP
             return jumpMP;
-        }
-
-        if (!(this instanceof Mech)) {
-            return 0;
         }
 
         if (hasShield() && (getNumberOfShields(MiscType.S_SHIELD_LARGE) > 0)) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4940,9 +4940,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * @return <code>boolean</code> if the entity has usable UMU crits.
      */
     public boolean hasUMU() {
-        int umuCount = getActiveUMUCount();
-
-        return umuCount > 0;
+        return getActiveUMUCount() > 0;
     }
 
     /**
@@ -4951,20 +4949,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * @return number <code>int</code>of useable UMU's
      */
     public int getActiveUMUCount() {
-        int count = 0;
-
-        if (this instanceof Infantry) {
-            if ((getMovementMode() == EntityMovementMode.INF_UMU)
-            		|| (getMovementMode() == EntityMovementMode.SUBMARINE)) {
-	            // UMU MP for Infantry is stored in jumpMP
-	            return jumpMP;
-            }
-        }
-
         if (hasShield() && (getNumberOfShields(MiscType.S_SHIELD_LARGE) > 0)) {
             return 0;
         }
-
+        int count = 0;
         for (Mounted m : getMisc()) {
             EquipmentType type = m.getType();
             if ((type instanceof MiscType) && type.hasFlag(MiscType.F_UMU)
@@ -4972,7 +4960,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 count++;
             }
         }
-
         return count;
     }
 
@@ -4982,25 +4969,16 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * @return <code>int</code>Total number of UMUs a mech has.
      */
     public int getAllUMUCount() {
-        int count = 0;
-
-        if ((this instanceof Infantry)
-            && (getMovementMode() == EntityMovementMode.INF_UMU)) {
-            // UMU MP for Infantry is stored in jumpMP
-            return jumpMP;
-        }
-
         if (hasShield() && (getNumberOfShields(MiscType.S_SHIELD_LARGE) > 0)) {
             return 0;
         }
-
+        int count = 0;
         for (Mounted m : getMisc()) {
             EquipmentType type = m.getType();
             if ((type instanceof MiscType) && type.hasFlag(MiscType.F_UMU)) {
                 count++;
             }
         }
-
         return count;
     }
 

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -512,6 +512,26 @@ public class Infantry extends Entity {
         return mp;
     }
 
+    @Override
+    public boolean hasUMU() {
+        return getMovementMode().equals(EntityMovementMode.INF_UMU)
+                || getMovementMode().equals(EntityMovementMode.SUBMARINE);
+    }
+
+    @Override
+    public int getActiveUMUCount() {
+        return getAllUMUCount();
+    }
+
+    @Override
+    public int getAllUMUCount() {
+        if (hasUMU()) {
+            return jumpMP;
+        } else {
+            return 0;
+        }
+    }
+
     /**
      * Infantry can not enter water unless they have UMU mp or hover.
      */


### PR DESCRIPTION
I found this while working on protomech record sheets. The UMU count code restricts UMUs to mechs and infantry. The purpose is likely to bypass the iteration over the MiscType list, but this is a relatively cheap operation that's not worth making the code so inflexible. So instead of adding protomechs to the list of units that can use UMU I removed the check. Who knows? Maybe someday we'll have ground units that can convert to submarines. I also moved the infantry-specific logic to the Infantry class.