### PR TITLE
minor performance improvement

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -143,7 +143,7 @@ public class MoveStep implements Serializable {
     // for optional vector movement
     private int[] mv;
     private int recoveryUnit = -1;
-    TreeMap<Integer, Vector<Integer>> launched = new TreeMap<Integer, Vector<Integer>>();
+    TreeMap<Integer, Vector<Integer>> launched;
     private boolean isEvading = false;
     private boolean isShuttingDown = false;
     private boolean isStartingUp = false;
@@ -171,7 +171,7 @@ public class MoveStep implements Serializable {
      * A collection of buildings that are crushed during this move step. This is
      * used for landed Aerodyne Dropships and Mobile Structures.
      */
-    private ArrayList<Coords> crushedBuildingLocs = new ArrayList<Coords>();
+    private ArrayList<Coords> crushedBuildingLocs;
 
     /**
      * Global logging instance.
@@ -436,8 +436,7 @@ public class MoveStep implements Serializable {
      */
     public void setVTOLBombing(boolean bombing) {
         if (bombing) {
-            setTarget(new HexTarget(getPosition(), getGame().getBoard(),
-                    Targetable.TYPE_HEX_AERO_BOMB));
+            setTarget(new HexTarget(getPosition(), Targetable.TYPE_HEX_AERO_BOMB));
         } else {
             setTarget(null);
         }
@@ -448,8 +447,7 @@ public class MoveStep implements Serializable {
      */
     public void setStrafing(boolean strafing) {
         if (strafing) {
-            setTarget(new HexTarget(getPosition(), getGame().getBoard(),
-                    Targetable.TYPE_HEX_CLEAR));
+            setTarget(new HexTarget(getPosition(), Targetable.TYPE_HEX_CLEAR));
         } else {
             setTarget(null);
         }
@@ -475,6 +473,10 @@ public class MoveStep implements Serializable {
     }
 
     public TreeMap<Integer, Vector<Integer>> getLaunched() {
+        if(launched == null) {
+            launched = new TreeMap<>();
+        }
+        
         return launched;
     }
 
@@ -3962,6 +3964,10 @@ public class MoveStep implements Serializable {
      * @return An {@link ArrayList} of {@link Coords} containing buildings within a dropship's landing zone.
      */
     public ArrayList<Coords> getCrushedBuildingLocs() {
+        if(crushedBuildingLocs == null) {
+            crushedBuildingLocs = new ArrayList<>();
+        }
+        
         return crushedBuildingLocs;
     }
 

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -721,7 +721,7 @@ public class MoveStep implements Serializable {
             for (Coords pos : secondaryPositions) {
                 Building bld = game.getBoard().getBuildingAt(pos);
                 if (bld != null) {
-                    crushedBuildingLocs.add(pos);
+                    getCrushedBuildingLocs().add(pos);
                     // This is dangerous!
                     danger = true;
                 }

--- a/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
@@ -59,6 +59,11 @@ public class InfantryPathFinder {
             // add an option to stand still
             infantryPaths.add(startingEdge);
             
+            // if, for some reason, the entity has already moved this turn or otherwise can't move, don't bother calculating paths for it
+            if(!startingEdge.getEntity().isSelectableThisTurn()) {
+                return;
+            }
+            
             // for an infantry unit with n MP, the total number of paths should be 6 * n*(n+1)/2 + 1 (triangular rule, plus "stand still")
             infantryPaths.addAll(generateChildren(startingEdge));
             


### PR DESCRIPTION
Very minor performance/memory usage improvement - avoid initializing infrequently-used fields in MoveStep, initializing them only on access. Also remove usage of deprecated constructor, avoiding passing around an extra int.

Normally this would be considered "squeezing blood from a stone", but MoveStep gets initialized quite a bit during bot pathfinding operations: imagine how many possible paths and steps a 12/18 aerospace fighter goes through.

Update: now with actual fix for #1942: apparently, ejected pilots were being evaluated for movement and coming up with endless paths. Implemented blanket fix that prevents path generation for units that have moved already.