### PR TITLE
Protomech missile ammo bv calculation.

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15866,13 +15866,6 @@ public class AmmoType extends EquipmentType {
      * get bv for protomech loads
      */
     public double getProtoBV(int shots) {
-        if ((getAmmoType() == AmmoType.T_SRM)
-                || (getAmmoType() == AmmoType.T_SRM_STREAK)
-                || (getAmmoType() == AmmoType.T_LRM)
-                || (getAmmoType() == AmmoType.T_SRM_TORPEDO)
-                || (getAmmoType() == AmmoType.T_LRM_TORPEDO)) {
-            return ((kgPerShot * rackSize * shots) / 1000) * bv;
-        }
         return ((kgPerShot * shots) / 1000) * bv;
     }
 

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -1404,7 +1404,7 @@ public class Protomech extends Entity {
         bvText.append(startColumn);
         bvText.append(endColumn);
         bvText.append(startColumn);
-        bvText.append(ammoBV);
+        bvText.append(String.format("%.1f", ammoBV));
         bvText.append(endColumn);
         bvText.append(endRow);
 


### PR DESCRIPTION
The rack size is included in the kgPerShot. This was changed about a year and a half ago to simplify construction and validation. The side effect on BV went unnoticed until now.

Fixes #1958 