### PR TITLE
Protomech max armor

### DIFF
--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -883,15 +883,15 @@ public class Protomech extends Entity {
                 break;
             case 13:
                 setInternal(3, 13, isQuad() ? IArmorState.ARMOR_NA : 3,
-                        isQuad() ? 13 : 6, mainGunIS);
+                        isQuad() ? 13 : 7, mainGunIS);
                 break;
             case 14:
                 setInternal(4, 14, isQuad() ? IArmorState.ARMOR_NA : 4,
-                        isQuad() ? 16 : 8, mainGunIS);
+                        isQuad() ? 14 : 8, mainGunIS);
                 break;
             case 15:
                 setInternal(4, 15, isQuad() ? IArmorState.ARMOR_NA : 4,
-                        isQuad() ? 16 : 8, mainGunIS);
+                        isQuad() ? 14 : 8, mainGunIS);
                 break;
         }
     }

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -838,13 +838,26 @@ public class TestProtomech extends TestEntity {
                 || (location == Protomech.LOC_RARM)) {
             if (proto.isQuad()) {
                 return 0;
+            } else if (proto.getWeight() < 3) {
+                return 2;
+            } else if (proto.getWeight() < 10) {
+                return 4;
+            } else {
+                return 6;
             }
-            return Math.min(proto.getOInternal(location) * 2, 6);
         } else if (location == Protomech.LOC_BODY) {
             return 0;
-        } else {
-            return proto.getOInternal(location) * 2;
+        } else if (proto.isQuad()) {
+            switch ((int) proto.getWeight()) {
+                case 3:
+                    return 12;
+                case 4:
+                case 5:
+                    return 14;
+                // else drop through
+            }
         }
+        return proto.getOInternal(location) * 2;
     }
     
 }


### PR DESCRIPTION
Fixes errors in maximum armor calculation (some locations do not follow the IS x 2 formula for all sizes). Also corrects an underlying error in the leg IS values for 14 and 15 ton quad protomechs, which changed between WoR and IO. I double-checked the other values and found what is probably a typo.

Fixes MegaMek/megameklab#627