### PR TITLE
Protomech main gun firing restrictions

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -3048,6 +3048,7 @@ WeaponAttackAction.CantAimAndCallShots=you can't combine aimed shots and called 
 WeaponAttackAction.CantClearMines=Weapon can't clear minefields.
 WeaponAttackAction.CantFireWhileGrappled=Can only fire head and front torso weapons when grappled.
 WeaponAttackAction.CantFireWithOtherWeapons=Already firing a weapon that can only be fired by itself! (%s)
+WeaponAttackAction.CantFireArmsAndMainGun=Can't fire arm-mounted weapons and the main gun in the same turn.
 WeaponAttackAction.CantMixAttacks=Other weapon attacks declared.
 WeaponAttackAction.CantMoveAndFieldGun=Can't fire field guns in same turn as moving.
 WeaponAttackAction.DumpingAmmo=Dumping remaining ammo.

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -2447,7 +2447,26 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     }
                 }
             }
-            
+
+            // Protomechs cannot fire arm weapons and main gun in the same turn
+            if ((ae instanceof Protomech)
+                    && ((weapon.getLocation() == Protomech.LOC_MAINGUN)
+                    || (weapon.getLocation() == Protomech.LOC_RARM)
+                    || (weapon.getLocation() == Protomech.LOC_LARM))) {
+                final boolean firingMainGun = weapon.getLocation() == Protomech.LOC_MAINGUN;
+                for (EntityAction ea : game.getActionsVector()) {
+                    if ((ea.getEntityId() == attackerId) && (ea instanceof WeaponAttackAction)) {
+                        WeaponAttackAction otherWAA = (WeaponAttackAction) ea;
+                        final Mounted otherWeapon = ae.getEquipment(otherWAA.getWeaponId());
+                        if ((firingMainGun && ((otherWeapon.getLocation() == Protomech.LOC_RARM)
+                                || (otherWeapon.getLocation() == Protomech.LOC_LARM)))
+                                || !firingMainGun && (otherWeapon.getLocation() == Protomech.LOC_MAINGUN)) {
+                            return Messages.getString("WeaponAttackAction.CantFireArmsAndMainGun");
+                        }
+                    }
+                }
+            }
+
             // TAG
             
             // The TAG system cannot target Airborne Aeros.


### PR DESCRIPTION
Protomechs may not fire arm-mounted weapons and the main gun on the same turn (TW, p. 184).

Fixes #1959 