### PR TITLE
Fix hex shift when changing tileset theme

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1447,7 +1447,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     }
 
     /**
-     *  @return a list of {@ink Coords} of all hexes on the board.
+     *  @return a list of {@link Coords} of all hexes on the board.
      *          Returns ONLY hexes where board.getHex != null.
      */
     private List<Coords> allBoardHexes() {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1445,25 +1445,27 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             drawHexBorder(g, p, Color.PINK, 0, 6);
         }
     }
+
     /**
-     *  Returns a list of Coords of all hexes on the board.
-     *  Returns ONLY hexes where board.getHex != null.
+     *  @return a list of {@ink Coords} of all hexes on the board.
+     *          Returns ONLY hexes where board.getHex != null.
      */
     private List<Coords> allBoardHexes() {
         IBoard board = game.getBoard();
-        if (board == null) return Collections.emptyList();
+        if (board == null) {
+            return Collections.emptyList();
+        }
 
-        ArrayList<Coords> CoordList = new ArrayList<Coords>();
+        List<Coords> coordList = new ArrayList<>();
         for (int i = 0; i < board.getWidth(); i++) {
             for (int j = 0; j < board.getHeight(); j++) {
-                IHex hex = board.getHex(i, j);
-                if (hex != null) {
-                    CoordList.add(new Coords(i, j));
+                if (board.getHex(i, j) != null) {
+                    coordList.add(new Coords(i, j));
                 }
             }
         }
 
-        return CoordList;
+        return coordList;
     }
 
     private Image createBlurredShadow(Image orig) {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -5096,16 +5096,18 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             tileManager.clearHex(hex);
             // Don't wait in the board editor because many hex changes 
             // makes this very slow 
-            if (clientgui != null) tileManager.waitForHex(hex);
+            if (clientgui != null) {
+                tileManager.waitForHex(hex);
+            }
             clearShadowMap();
             // Maybe have to set the hexes' theme.  Null clientgui implies board editor - don't mess with theme
             if ((selectedTheme != null) && !selectedTheme.equals("(Original Theme)") && (clientgui != null)) {
                 if (selectedTheme.equals("(No Theme)") && (hex.getTheme() != null) && !hex.getTheme().equals("")) {
                     hex.setTheme("");
-                    game.getBoard().setHex(b.getCoords(), hex);
+                    game.getBoard().setHex(c, hex);
                 } else if (!selectedTheme.equals(hex.getTheme())) {
                     hex.setTheme(selectedTheme);
-                    game.getBoard().setHex(b.getCoords(), hex);
+                    game.getBoard().setHex(c, hex);
                 }
             }
         }
@@ -6661,16 +6663,20 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
         if (selectedTheme == null) {
             return;
-
-        } else if (selectedTheme.equals("(Original Theme)")) {
-            for (Coords c: allBoardHexes()) {
+        }
+        final List<Coords> allCoords = allBoardHexes();
+        if (allCoords == null) {
+            return;
+        }
+        if (selectedTheme.equals("(Original Theme)")) {
+            for (Coords c: allCoords) {
                 IHex hex = board.getHex(c);
                 hex.resetTheme();
                 board.setHex(c, hex);
             }
 
         } else {
-            for (Coords c: allBoardHexes()) {
+            for (Coords c: allCoords) {
                 IHex hex = board.getHex(c);
                 hex.setTheme(selectedTheme.equals("(No Theme)")?
                         "":selectedTheme);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -58,21 +58,7 @@ import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
 import java.awt.image.Kernel;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.Set;
-import java.util.TimerTask;
-import java.util.TreeSet;
-import java.util.Vector;
+import java.util.*;
 
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
@@ -1463,9 +1449,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
      *  Returns a list of Coords of all hexes on the board.
      *  Returns ONLY hexes where board.getHex != null.
      */
-    private ArrayList<Coords> allBoardHexes() {
+    private List<Coords> allBoardHexes() {
         IBoard board = game.getBoard();
-        if (board == null) return null;
+        if (board == null) return Collections.emptyList();
 
         ArrayList<Coords> CoordList = new ArrayList<Coords>();
         for (int i = 0; i < board.getWidth(); i++) {
@@ -6664,19 +6650,15 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         if (selectedTheme == null) {
             return;
         }
-        final List<Coords> allCoords = allBoardHexes();
-        if (allCoords == null) {
-            return;
-        }
         if (selectedTheme.equals("(Original Theme)")) {
-            for (Coords c: allCoords) {
+            for (Coords c: allBoardHexes()) {
                 IHex hex = board.getHex(c);
                 hex.resetTheme();
                 board.setHex(c, hex);
             }
 
         } else {
-            for (Coords c: allCoords) {
+            for (Coords c: allBoardHexes()) {
                 IHex hex = board.getHex(c);
                 hex.setTheme(selectedTheme.equals("(No Theme)")?
                         "":selectedTheme);


### PR DESCRIPTION
When responding to a hex change event, the boardview repaints surrounding hexes as well, including making sure the theme is current. If not, it updates the hex but uses the coordinates of the original hex from the event rather than the coordinates of the surrounding hex.

Fixes #1946
Fixes #1645 (presumed)