### PR TITLE
Restore check for null boards in map settings

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -31789,7 +31789,7 @@ public class Server implements Runnable {
                     mapSettings.replaceBoardWithRandom(MapSettings.BOARD_RANDOM);
                     mapSettings.removeUnavailable();
                     // if still only nulls left, use BOARD_GENERATED
-                    if (!mapSettings.getBoardsSelected().hasNext()) {
+                    if (mapSettings.getBoardsSelected().next() == null) {
                         mapSettings.setNullBoards((MapSettings.BOARD_GENERATED));
                     }
                     resetPlayersDone();


### PR DESCRIPTION
The purpose of this statement is to check whether the first selected board is null, and if so replace it with BOARD_GENERATED. 3a7702f changed this to a check for an empty list, which is always false.

Fixes #1974 