### PR TITLE
Lobby: Allow saving quirks override for units reduced to no quirks

### DIFF
--- a/megamek/mmconf/unitQuirksOverride.xml
+++ b/megamek/mmconf/unitQuirksOverride.xml
@@ -41,7 +41,6 @@ The proper names for quirks can be found in the
   "Anti-Aircraft Targeting" quirk to a unit, you will find the following entry in the messages.properties file:
     QuirksInfo.option.anti_air.displayableName
   The name you want to include in this file for the <quirk> entry is "anti_air".
-
 If you wish to remove all quirks for a unit, you can create an entry in this file with a <quirk> of "none".
 
 Example:  If you wish to declare that all Atlas variants do not have the Command Mech quirk:
@@ -52,7 +51,7 @@ Example:  If you wish to declare that all Atlas variants do not have the Command
     </unit>
 
 Example: If you decide only the AS7-D Atlas, but no other variant, should have the Command Mech quirk:
-    <unit>
+        <unit>
         <chassis>Atlas</chassis>
         <model>all</model>
         <quirk>none</quirk>
@@ -89,9 +88,63 @@ Example: You can define quirks that affect all units of a given chassis and then
 -->
 
 <unitQuirks xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../data/unitQuirksSchema.xsl">
-    <unit> <!-- Placeholder that is exactly the same as in canon file because we need to have at least one entry. -->
-        <chassis>Atlas</chassis>
-        <model>all</model>
-        <quirk>command_mech</quirk>
-    </unit>
+	<unit>
+		<chassis>Mad Cat III</chassis>
+		<unitType>Mech</unitType>
+		<quirk>animalistic</quirk>
+		<quirk>anti_air</quirk>
+		<quirk>battle_computer</quirk>
+		<quirk>imp_com</quirk>
+		<quirk>bad_rep_clan</quirk>
+		<quirk>difficult_maintain</quirk>
+	</unit>
+
+	<unit>
+		<chassis>Mad Cat Mk IV (Savage Wolf)</chassis>
+		<unitType>Mech</unitType>
+		<quirk>pro_actuator</quirk>
+		<quirk>stable</quirk>
+		<quirk>non_standard</quirk>
+	</unit>
+
+	<unit>
+		<chassis>Mad Cat (Timber Wolf)</chassis>
+		<unitType>Mech</unitType>
+		<quirk>none</quirk>
+	</unit>
+
+	<unit>
+		<chassis>Atlas</chassis>
+		<unitType>Mech</unitType>
+		<quirk>command_mech</quirk>
+	</unit>
+
+	<unit>
+		<chassis>Charger</chassis>
+		<unitType>Mech</unitType>
+		<quirk>none</quirk>
+	</unit>
+
+	<unit>
+		<chassis>Mad Cat Mk II</chassis>
+		<unitType>Mech</unitType>
+		<quirk>none</quirk>
+	</unit>
+
+	<unit>
+		<chassis>Mad Cat (Timber Wolf)</chassis>
+		<model>D</model>
+		<unitType>Mech</unitType>
+		<quirk>combat_computer</quirk>
+		<quirk>command_mech</quirk>
+		<quirk>distracting</quirk>
+	</unit>
+
+	<unit>
+		<chassis>Atlas</chassis>
+		<model>AS7-K</model>
+		<unitType>Mech</unitType>
+		<quirk>none</quirk>
+	</unit>
+
 </unitQuirks>

--- a/megamek/mmconf/unitQuirksOverride.xml
+++ b/megamek/mmconf/unitQuirksOverride.xml
@@ -41,6 +41,7 @@ The proper names for quirks can be found in the
   "Anti-Aircraft Targeting" quirk to a unit, you will find the following entry in the messages.properties file:
     QuirksInfo.option.anti_air.displayableName
   The name you want to include in this file for the <quirk> entry is "anti_air".
+
 If you wish to remove all quirks for a unit, you can create an entry in this file with a <quirk> of "none".
 
 Example:  If you wish to declare that all Atlas variants do not have the Command Mech quirk:
@@ -51,7 +52,7 @@ Example:  If you wish to declare that all Atlas variants do not have the Command
     </unit>
 
 Example: If you decide only the AS7-D Atlas, but no other variant, should have the Command Mech quirk:
-        <unit>
+    <unit>
         <chassis>Atlas</chassis>
         <model>all</model>
         <quirk>none</quirk>
@@ -88,63 +89,9 @@ Example: You can define quirks that affect all units of a given chassis and then
 -->
 
 <unitQuirks xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../data/unitQuirksSchema.xsl">
-	<unit>
-		<chassis>Mad Cat III</chassis>
-		<unitType>Mech</unitType>
-		<quirk>animalistic</quirk>
-		<quirk>anti_air</quirk>
-		<quirk>battle_computer</quirk>
-		<quirk>imp_com</quirk>
-		<quirk>bad_rep_clan</quirk>
-		<quirk>difficult_maintain</quirk>
-	</unit>
-
-	<unit>
-		<chassis>Mad Cat Mk IV (Savage Wolf)</chassis>
-		<unitType>Mech</unitType>
-		<quirk>pro_actuator</quirk>
-		<quirk>stable</quirk>
-		<quirk>non_standard</quirk>
-	</unit>
-
-	<unit>
-		<chassis>Mad Cat (Timber Wolf)</chassis>
-		<unitType>Mech</unitType>
-		<quirk>none</quirk>
-	</unit>
-
-	<unit>
-		<chassis>Atlas</chassis>
-		<unitType>Mech</unitType>
-		<quirk>command_mech</quirk>
-	</unit>
-
-	<unit>
-		<chassis>Charger</chassis>
-		<unitType>Mech</unitType>
-		<quirk>none</quirk>
-	</unit>
-
-	<unit>
-		<chassis>Mad Cat Mk II</chassis>
-		<unitType>Mech</unitType>
-		<quirk>none</quirk>
-	</unit>
-
-	<unit>
-		<chassis>Mad Cat (Timber Wolf)</chassis>
-		<model>D</model>
-		<unitType>Mech</unitType>
-		<quirk>combat_computer</quirk>
-		<quirk>command_mech</quirk>
-		<quirk>distracting</quirk>
-	</unit>
-
-	<unit>
-		<chassis>Atlas</chassis>
-		<model>AS7-K</model>
-		<unitType>Mech</unitType>
-		<quirk>none</quirk>
-	</unit>
-
+    <unit> <!-- Placeholder that is exactly the same as in canon file because we need to have at least one entry. -->
+        <chassis>Atlas</chassis>
+        <model>all</model>
+        <quirk>command_mech</quirk>
+    </unit>
 </unitQuirks>

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -4415,11 +4415,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener, 
                     }
                 }
 
-                boolean hasQuirks = true;
-                for (Entity ent : entities) {
-                    hasQuirks &= (ent.countQuirks() > 0) || (ent.countWeaponQuirks() > 0);
-                }
-                if (isQuirksEnabled && hasQuirks) {
+                if (isQuirksEnabled) {
                     menuItem = new JMenuItem("Save Quirks for Chassis");
                     menuItem.setActionCommand("SAVE_QUIRKS_ALL");
                     menuItem.addActionListener(this);

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -452,35 +452,36 @@ public class QuirksHandler {
                     output.write("\t\t" + getOpenTag(QUIRK));
                     output.write(NO_QUIRKS);
                     output.write(getCloseTag(QUIRK) + "\n");
-                }
-                for (QuirkEntry quirk : quirks) {
-                    // Write Weapon Quirk
-                    if (quirk.isWeaponQuirk()) {
-                        output.write("\t\t" + getOpenTag(WEAPON_QUIRK) + "\n");
-                        // Quirk Name
-                        output.write("\t\t\t" + getOpenTag(WEAPON_QUIRK_NAME));
-                        output.write(quirk.getQuirk());
-                        output.write(getCloseTag(WEAPON_QUIRK_NAME) + "\n");
-                        // Location
-                        output.write("\t\t\t" + getOpenTag(LOCATION));
-                        output.write(quirk.getLocation());
-                        output.write(getCloseTag(LOCATION) + "\n");
-                        // Slot
-                        output.write("\t\t\t" + getOpenTag(SLOT));
-                        output.write(quirk.getSlot() + "");
-                        output.write(getCloseTag(SLOT) + "\n");
-                        // Weapon Name
-                        output.write("\t\t\t" + getOpenTag(WEAPON_NAME));
-                        output.write(quirk.getWeaponName());
-                        output.write(getCloseTag(WEAPON_NAME) + "\n");
-                        // Close Tag
-                        output.write("\t\t" + getCloseTag(WEAPON_QUIRK) + "\n");
-                    } else { // Write normal quirk
-                        output.write("\t\t" + getOpenTag(QUIRK));
-                        output.write(quirk.getQuirk());
-                        output.write(getCloseTag(QUIRK) + "\n");
-                    }
-                }               
+                } else {
+                    for (QuirkEntry quirk : quirks) {
+                        // Write Weapon Quirk
+                        if (quirk.isWeaponQuirk()) {
+                            output.write("\t\t" + getOpenTag(WEAPON_QUIRK) + "\n");
+                            // Quirk Name
+                            output.write("\t\t\t" + getOpenTag(WEAPON_QUIRK_NAME));
+                            output.write(quirk.getQuirk());
+                            output.write(getCloseTag(WEAPON_QUIRK_NAME) + "\n");
+                            // Location
+                            output.write("\t\t\t" + getOpenTag(LOCATION));
+                            output.write(quirk.getLocation());
+                            output.write(getCloseTag(LOCATION) + "\n");
+                            // Slot
+                            output.write("\t\t\t" + getOpenTag(SLOT));
+                            output.write(quirk.getSlot() + "");
+                            output.write(getCloseTag(SLOT) + "\n");
+                            // Weapon Name
+                            output.write("\t\t\t" + getOpenTag(WEAPON_NAME));
+                            output.write(quirk.getWeaponName());
+                            output.write(getCloseTag(WEAPON_NAME) + "\n");
+                            // Close Tag
+                            output.write("\t\t" + getCloseTag(WEAPON_QUIRK) + "\n");
+                        } else { // Write normal quirk
+                            output.write("\t\t" + getOpenTag(QUIRK));
+                            output.write(quirk.getQuirk());
+                            output.write(getCloseTag(QUIRK) + "\n");
+                        }
+                    }   
+                }            
                 output.write("\t" + getCloseTag(UNIT) + "\n\n");
             }
             

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -150,6 +150,8 @@ public class QuirksHandler {
 
     private static final String MODEL_ALL = "all";
     
+    private static final String NO_QUIRKS = "none";
+    
     private static Map<String, List<QuirkEntry>> canonQuirkMap;
     private static Map<String, List<QuirkEntry>> customQuirkMap;
     private static AtomicBoolean customQuirksDirty = new AtomicBoolean(false);
@@ -446,6 +448,11 @@ public class QuirksHandler {
 
                 // Write out quirks
                 List<QuirkEntry> quirks = customQuirkMap.get(unitId);
+                if (quirks.isEmpty()) {
+                    output.write("\t\t" + getOpenTag(QUIRK));
+                    output.write(NO_QUIRKS);
+                    output.write(getCloseTag(QUIRK) + "\n");
+                }
                 for (QuirkEntry quirk : quirks) {
                     // Write Weapon Quirk
                     if (quirk.isWeaponQuirk()) {
@@ -506,7 +513,6 @@ public class QuirksHandler {
     @Nullable
     static List<QuirkEntry> getQuirks(Entity entity) {
         final String METHOD_NAME = "getQuirks(Entity)";
-        final String NO_QUIRKS = "none";
 
         if (!initialized.get() || (null == canonQuirkMap)) {
             return null;
@@ -604,7 +610,7 @@ public class QuirksHandler {
             Quirks entQuirks = entity.getQuirks();
             Enumeration<IOptionGroup> quirksGroup = entQuirks.getGroups();
             Enumeration<IOption> quirkOptions;
-           while (quirksGroup.hasMoreElements()) {
+            while (quirksGroup.hasMoreElements()) {
                 IOptionGroup group = quirksGroup.nextElement();
                 quirkOptions = group.getSortedOptions();
                 while (quirkOptions.hasMoreElements()) {


### PR DESCRIPTION
Resolves #1115 

The code explicitly checked if the selected unit(s) had at least one quirk and otherwise did not show the menu options to save the quirk override. The QuirksHandler could load a unit with zero quirks override (using <quirk>none</quirk> as in the examples) but it had no code to save this. It somehow feels intentional but I fail to see what it was good for. 
