### PR TITLE
bot efficiency improvements; bug fixes

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -937,9 +937,9 @@ public abstract class BotClient extends Client {
         int noReductionZoneSize = getClusterTracker().getDestinationCoords(entity, destinationEdge, false).size();
         int reductionZoneSize = getClusterTracker().getDestinationCoords(entity, destinationEdge, true).size();
         
-        if(noReductionZoneSize > 0) {
+        if (noReductionZoneSize > 0) {
             return 0;
-        } else if(reductionZoneSize > 0) {
+        } else if (reductionZoneSize > 0) {
             return -50;
         } else {
             return -100;

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -111,6 +111,9 @@ public abstract class BotClient extends Client {
 
     public BotClient(String playerName, String host, int port) {
         super(playerName, host, port);
+        
+        boardClusterTracker = new BoardClusterTracker();
+        
         game.addGameListener(new GameListenerAdapter() {
 
             @Override

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -888,7 +888,7 @@ public abstract class BotClient extends Client {
             }
 
             // Make sure I'm not stuck in a dead-end.
-            coord.fitness += hasPathToEdge(deployed_ent, board);
+            coord.fitness += calculateEdgeAccessFitness(deployed_ent, board);
             
             if(coord.fitness > highestFitness) {
                 highestFitness = coord.fitness;
@@ -921,12 +921,12 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Determines if the given entity has a reasonable path to the "opposite" edge of the board from its
+     * Determines if the given entity has reasonable access to the "opposite" edge of the board from its
      * current position. Returns 0 if this can be accomplished without destroying any terrain, 
      * -50 if this can be accomplished but terrain must be destroyed,
      * -100 if this cannot be accomplished at all
      */
-    private int hasPathToEdge(Entity entity, IBoard board) {
+    private int calculateEdgeAccessFitness(Entity entity, IBoard board) {
         // Flying units can always get anywhere
         if (entity.isAirborne() || entity instanceof VTOL) {
             return 0;

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -22,7 +22,6 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -36,6 +35,7 @@ import javax.swing.JTextPane;
 import javax.swing.ScrollPaneConstants;
 
 import megamek.client.Client;
+import megamek.client.bot.princess.CardinalEdge;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.ReportDisplay;
 import megamek.common.AmmoType;
@@ -76,13 +76,13 @@ import megamek.common.event.GameReportEvent;
 import megamek.common.event.GameTurnChangeEvent;
 import megamek.common.net.Packet;
 import megamek.common.options.OptionsConstants;
-import megamek.common.pathfinder.BoardEdgePathFinder;
+import megamek.common.pathfinder.BoardClusterTracker;
+import megamek.common.pathfinder.BoardClusterTracker.BoardCluster;
 import megamek.common.preference.PreferenceManager;
+import megamek.common.util.BoardUtilities;
 import megamek.common.util.StringUtil;
 
 public abstract class BotClient extends Client {
-    private Map<EntityMovementMode, BoardEdgePathFinder> deploymentPathFinders = new HashMap<>();
-
     private List<Entity> currentTurnEnemyEntities;
     private List<Entity> currentTurnFriendlyEntities;
     
@@ -121,7 +121,7 @@ public abstract class BotClient extends Client {
 
             @Override
             public void gameTurnChange(GameTurnChangeEvent e) {
-                // On simultaneous phases, each player ending their turn will generalte a turn change
+                // On simultaneous phases, each player ending their turn will generate a turn change
                 // We want to ignore turns from other players and only listen to events we generated
                 boolean ignoreSimTurn = game.isPhaseSimultaneous() && (e.getPreviousPlayerId() != localPlayerNumber)
                         && calculatedTurnThisPhase;
@@ -219,6 +219,8 @@ public abstract class BotClient extends Client {
     }
 
     BotConfiguration config = new BotConfiguration();
+
+    protected BoardClusterTracker boardClusterTracker;
 
     public abstract void initialize();
 
@@ -883,9 +885,7 @@ public abstract class BotClient extends Client {
             }
 
             // Make sure I'm not stuck in a dead-end.
-            if (!hasPathToEdge(deployed_ent, board)) {
-                coord.fitness -= 100;
-            }
+            coord.fitness += hasPathToEdge(deployed_ent, board);
             
             if(coord.fitness > highestFitness) {
                 highestFitness = coord.fitness;
@@ -893,13 +893,15 @@ public abstract class BotClient extends Client {
         }
 
         // now, we double check: did we get a bunch of coordinates with a value way below 0?
-        // This indicates that we did not find any paths from the deployment zone to the opposite edge
-        // So we adjust each coordinate's fitness based on the "longest available path"
+        // This indicates that we do not have a way of getting to the opposite board edge,
+        // even when considering terrain destruction
+        // attempt to deploy in the biggest area this unit can access instead
         if(highestFitness < -10) {
             for(RankedCoords rc : validCoords) {
-                MovePath movePath = getBoardEdgePathFinder(deployed_ent).getLongestNonEdgePath(rc.getCoords());
-                if (movePath != null) {
-                    rc.fitness += movePath.getHexesMoved();
+                BoardCluster boardCluster = getClusterTracker().getCurrentBoardCluster(deployed_ent, rc.coords, false);
+                
+                if (boardCluster != null) {
+                    rc.fitness += boardCluster.contents.size();
                 }
             }
         }
@@ -916,32 +918,29 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Gets the {@link BoardEdgePathFinder} for an {@link Entity} for their
-     * current movement mode.
-     * @param entity The entity to retrieve the {@link BoardEdgePathFinder}.
-     * @return The appropriate {@link BoardEdgePathFinder} for the given entity.
-     */
-    private BoardEdgePathFinder getBoardEdgePathFinder(Entity entity) {
-        return deploymentPathFinders.computeIfAbsent(entity.getMovementMode(), 
-            e -> new BoardEdgePathFinder());
-    }
-
-    // ToDo: Change this to 'hasSafePathToCenter' to account for buildings, lava and similar hazards.
-    /**
      * Determines if the given entity has a reasonable path to the "opposite" edge of the board from its
-     * current position.
-     * @param entity
-     * @param board
-     * @return
+     * current position. Returns 0 if this can be accomplished without destroying any terrain, 
+     * -50 if this can be accomplished but terrain must be destroyed,
+     * -100 if this cannot be accomplished at all
      */
-    private boolean hasPathToEdge(Entity entity, IBoard board) {
+    private int hasPathToEdge(Entity entity, IBoard board) {
         // Flying units can always get anywhere
         if (entity.isAirborne() || entity instanceof VTOL) {
-            return true;
+            return 0;
         }
         
-        MovePath mp = getBoardEdgePathFinder(entity).findPathToEdge(entity);
-        return mp != null;
+        CardinalEdge destinationEdge = BoardUtilities.determineOppositeEdge(entity);
+        
+        int noReductionZoneSize = getClusterTracker().getDestinationCoords(entity, destinationEdge, false).size();
+        int reductionZoneSize = getClusterTracker().getDestinationCoords(entity, destinationEdge, true).size();
+        
+        if(noReductionZoneSize > 0) {
+            return 0;
+        } else if(reductionZoneSize > 0) {
+            return -50;
+        } else {
+            return -100;
+        }
     }
 
     private double potentialBuildingDamage(int x, int y, Entity entity) {
@@ -1184,18 +1183,10 @@ public abstract class BotClient extends Client {
     @SuppressWarnings("unchecked")
     protected void receiveBuildingCollapse(Packet packet) {
         game.getBoard().collapseBuilding((Vector<Coords>) packet.getObject(0));
-        
-        // once we've updated the game board with the building collapse, it is time to update
-        // the board edge pathfinder by purging any paths that go through or next to the collapsed hexes
-        for(BoardEdgePathFinder edgePathFinder : deploymentPathFinders.values()) {
-            for(Coords coords : (Vector<Coords>) packet.getObject(0)) {
-                edgePathFinder.invalidatePaths(coords);
-                
-                for(Coords neighbor : coords.allAdjacent()) {
-                    edgePathFinder.invalidatePaths(neighbor);
-                }
-            }
-        }
+    }
+
+    public BoardClusterTracker getClusterTracker() {
+        return boardClusterTracker;
     }
 
     private class RankedCoords implements Comparable<RankedCoords> {

--- a/megamek/src/megamek/client/bot/TestBot.java
+++ b/megamek/src/megamek/client/bot/TestBot.java
@@ -52,6 +52,7 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.containers.PlayerIDandList;
 import megamek.common.event.GamePlayerChatEvent;
 import megamek.common.options.OptionsConstants;
+import megamek.common.pathfinder.BoardClusterTracker;
 
 public class TestBot extends BotClient {
 
@@ -70,7 +71,7 @@ public class TestBot extends BotClient {
 
     @Override
     public void initialize() {
-        // removed
+        boardClusterTracker = new BoardClusterTracker();
     }
 
     @Override

--- a/megamek/src/megamek/client/bot/princess/CardinalEdge.java
+++ b/megamek/src/megamek/client/bot/princess/CardinalEdge.java
@@ -65,7 +65,8 @@ public enum CardinalEdge {
     }
     
     public static CardinalEdge getOppositeEdge(CardinalEdge edge) {
-        switch(edge) {
+        switch (edge) {
+
         case NORTH:
             return SOUTH;
         case SOUTH:

--- a/megamek/src/megamek/client/bot/princess/CardinalEdge.java
+++ b/megamek/src/megamek/client/bot/princess/CardinalEdge.java
@@ -50,7 +50,8 @@ public enum CardinalEdge {
     }
     
     public static CardinalEdge getCardinalEdge(OffBoardDirection direction) {
-        switch(direction) {
+        switch (direction) {
+
         case NORTH:
             return NORTH;
         case SOUTH:

--- a/megamek/src/megamek/client/bot/princess/CardinalEdge.java
+++ b/megamek/src/megamek/client/bot/princess/CardinalEdge.java
@@ -13,6 +13,8 @@
  */
 package megamek.client.bot.princess;
 
+import megamek.common.OffBoardDirection;
+
 /**
  * Created with IntelliJ IDEA.
  *
@@ -45,6 +47,21 @@ public enum CardinalEdge {
             }
         }
         return null;
+    }
+    
+    public static CardinalEdge getCardinalEdge(OffBoardDirection direction) {
+        switch(direction) {
+        case NORTH:
+            return NORTH;
+        case SOUTH:
+            return SOUTH;
+        case EAST:
+            return EAST;
+        case WEST:
+            return WEST;
+        default:
+            return NEAREST_OR_NONE;
+        }
     }
     
     public static CardinalEdge getOppositeEdge(CardinalEdge edge) {

--- a/megamek/src/megamek/client/bot/princess/CardinalEdge.java
+++ b/megamek/src/megamek/client/bot/princess/CardinalEdge.java
@@ -46,4 +46,20 @@ public enum CardinalEdge {
         }
         return null;
     }
+    
+    public static CardinalEdge getOppositeEdge(CardinalEdge edge) {
+        switch(edge) {
+        case NORTH:
+            return SOUTH;
+        case SOUTH:
+            return NORTH;
+        case EAST:
+            return WEST;
+        case WEST:
+            return EAST;
+        default:
+            return NEAREST_OR_NONE;
+        }
+            
+    }
 }

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -43,6 +43,7 @@ import megamek.common.Terrains;
 import megamek.common.pathfinder.AbstractPathFinder.Filter;
 import megamek.common.pathfinder.AeroGroundPathFinder;
 import megamek.common.pathfinder.AeroGroundPathFinder.AeroGroundOffBoardFilter;
+import megamek.common.util.BoardUtilities;
 import megamek.common.pathfinder.AeroLowAltitudePathFinder;
 import megamek.common.pathfinder.AeroSpacePathFinder;
 import megamek.common.pathfinder.BoardEdgePathFinder;
@@ -332,23 +333,19 @@ public class PathEnumerator {
         // where are we going?
         Set<Coords> destinations = new HashSet<Coords>();
         // if we're going to an edge or can't see anyone, generate long-range paths to the opposite edge
-        // 
         switch(getOwner().getUnitBehaviorTracker().getBehaviorType(mover, getOwner())) {
             case ForcedWithdrawal:
             case MoveToDestination:
                 destinations = getOwner().getClusterTracker().getDestinationCoords(mover, getOwner().getHomeEdge(mover), true);
                 break;
             case MoveToContact:
-                // basically, we're translating the value produced by finding
-                // the Board.START_X direction into a cardinal edge
-                CardinalEdge oppositeEdge = 
-                    CardinalEdge.getCardinalEdge(OffBoardDirection.translateBoardStart(BoardEdgePathFinder.determineOppositeEdge(mover)).getValue());
+                CardinalEdge oppositeEdge = CardinalEdge.getOppositeEdge(BoardUtilities.determineOppositeEdge(mover));
                 destinations = getOwner().getClusterTracker().getDestinationCoords(mover, oppositeEdge, true);
                 break;
             default:
                 for(Targetable target : FireControl.getAllTargetableEnemyEntities(getOwner().getLocalPlayer(), getGame(), getOwner().getFireControlState())) {
                     destinations.add(target.getPosition());
-                    // we can easily shoot at an entity from 
+                    // we can easily shoot at an entity from right next to it as well
                     destinations.addAll(target.getPosition().allAdjacent());
                 }
                 break;

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -98,8 +98,6 @@ public class Princess extends BotClient {
     private HashMap<PathRankerType, IPathRanker> pathRankers;
     private HashMap<FireControlType, FireControl> fireControls;
     private UnitBehavior unitBehaviorTracker;
-    private BoardClusterTracker boardClusterTracker;
-    
     private FireControlState fireControlState;
     private PathRankerState pathRankerState;
     private ArtilleryTargetingControl atc;
@@ -296,10 +294,6 @@ public class Princess extends BotClient {
         return precognition;
     }
     
-    public BoardClusterTracker getClusterTracker() {
-        return boardClusterTracker;
-    }
-    
     public int getMaxWeaponRange(Entity entity) {
         return getMaxWeaponRange(entity, false);
     }
@@ -482,7 +476,7 @@ public class Princess extends BotClient {
                 return;
             }
             
-            // on the list to be deployed get a set of all the
+            // get a list of all coordinates to which we can deploy
             final List<Coords> startingCoords = getStartingCoordsArray(game.getEntity(entityNum));
             if (0 == startingCoords.size()) {
                 log(getClass(), METHOD_NAME, LogLevel.ERROR,
@@ -1497,8 +1491,11 @@ public class Princess extends BotClient {
         }
         
         BehaviorType behavior = forceMoveToContact ? BehaviorType.MoveToContact : unitBehaviorTracker.getBehaviorType(mover, this);
-        boardClusterTracker.clearMovableAreas();
-        boardClusterTracker.updateMovableAreas(mover);
+        // during the movement phase, it is technically necessary to clear this data between each unit
+        // as the state of the board may have changed due to crashes etc. 
+        // generating movable clusters is a relatively cheap operation, so it's not a big deal
+        getClusterTracker().clearMovableAreas();
+        getClusterTracker().updateMovableAreas(mover);
         
         // basic idea: 
         // if we're "in battle", just use the standard set of move paths

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1694,6 +1694,7 @@ public class Princess extends BotClient {
                     for (final Entity entity : game.getEntitiesVector(coords,
                                                                       true)) {
                         final Targetable bt = getAppropriateTarget(coords);
+                        
                         if (isEnemyGunEmplacement(entity, coords)) {
                             fireControlState.getAdditionalTargets().add(bt);
                             sendChat("Building in Hex " +
@@ -1839,17 +1840,20 @@ public class Princess extends BotClient {
     
     private boolean isEnemyGunEmplacement(final Entity entity,
                                           final Coords coords) {
+        // crippled gun turrets aren't worth shooting at, even if we're fighting to the death
         return entity.hasETypeFlag(Entity.ETYPE_GUN_EMPLACEMENT)
                && entity.getOwner().isEnemyOf(getLocalPlayer())
                && !getStrategicBuildingTargets().contains(coords)
-               && (null != entity.getCrew()) && !entity.getCrew().isDead();
+               && !entity.isCrippled();
     }
 
     private boolean isEnemyInfantry(final Entity entity,
                                     final Coords coords) {
+        // crippled infantry aren't worth shooting at, even if we're fighting to the death
         return entity.hasETypeFlag(Entity.ETYPE_INFANTRY) && !entity.hasETypeFlag(Entity.ETYPE_MECHWARRIOR)
                && entity.getOwner().isEnemyOf(getLocalPlayer())
-               && !getStrategicBuildingTargets().contains(coords);
+               && !getStrategicBuildingTargets().contains(coords)
+               && !entity.isCrippled();
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1388,7 +1388,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
 
         // debugging method that renders the bounding box of a unit's movement envelope.
-        //renderClusters((Graphics2D) g);
+        renderClusters((Graphics2D) g);
         //renderMovementBoundingBox((Graphics2D) g);
         //renderDonut(g, new Coords(10, 10), 2);
         //renderApproxHexDirection((Graphics2D) g);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1388,7 +1388,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
 
         // debugging method that renders the bounding box of a unit's movement envelope.
-        renderClusters((Graphics2D) g);
+        //renderClusters((Graphics2D) g);
         //renderMovementBoundingBox((Graphics2D) g);
         //renderDonut(g, new Coords(10, 10), 2);
         //renderApproxHexDirection((Graphics2D) g);

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -479,11 +479,14 @@ public class GunEmplacement extends Tank {
 
     @Override
     public boolean isCrippled(boolean checkCrew) {
-        return isCrippled();
-    }
-
-    @Override
-    public boolean isCrippled() {
+        if(checkCrew && (null != getCrew()) && getCrew().isDead()) {
+            if (PreferenceManager.getClientPreferences().debugOutputOn()) {
+                System.out.println(getDisplayName()
+                        + " CRIPPLED: crew dead.");
+            }
+            return true;
+        }
+        
         if (isMilitary() && !hasViableWeapons()) {
             if (PreferenceManager.getClientPreferences().debugOutputOn()) {
                 System.out.println(getDisplayName()
@@ -492,6 +495,11 @@ public class GunEmplacement extends Tank {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public boolean isCrippled() {
+        return isCrippled(true);
     }
 
     @Override

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -479,7 +479,7 @@ public class GunEmplacement extends Tank {
 
     @Override
     public boolean isCrippled(boolean checkCrew) {
-        if(checkCrew && (null != getCrew()) && getCrew().isDead()) {
+        if (checkCrew && (null != getCrew()) && getCrew().isDead()) {
             if (PreferenceManager.getClientPreferences().debugOutputOn()) {
                 System.out.println(getDisplayName()
                         + " CRIPPLED: crew dead.");

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -1197,16 +1197,6 @@ public class MovePath implements Cloneable, Serializable {
 
         pf.run(this.clone());
         MovePath finPath = pf.getComputedPath(dest);
-        // code that's useful to test the destruction-aware pathfinder
-        // remove when code review and testing complete
-        /*DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
-        Set<Coords> destinationSet = new HashSet<Coords>();
-        destinationSet.add(dest);
-        
-        long marker1 = System.currentTimeMillis();
-        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, true);
-        long marker2 = System.currentTimeMillis();
-        long marker3 = marker2 - marker1;*/
 
         if (timeoutCondition.timeoutEngaged || finPath == null) {
             /*
@@ -1839,5 +1829,23 @@ public class MovePath implements Cloneable, Serializable {
      */
     public boolean nextForwardStepOffBoard() {
         return !game.getBoard().contains(getFinalCoords().translated(getFinalFacing()));
+    }
+    
+    /**
+     * Debugging method that calculates a destruction-aware move path to the destination coordinates
+     */
+    public MovePath calculateDestructionAwarePath(Coords dest) {
+        // code that's useful to test the destruction-aware pathfinder
+        // remove when code review and testing complete
+        DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
+        Set<Coords> destinationSet = new HashSet<Coords>();
+        destinationSet.add(dest);
+        
+        long marker1 = System.currentTimeMillis();
+        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false);
+        long marker2 = System.currentTimeMillis();
+        long marker3 = marker2 - marker1;
+        
+        return finPath;
     }
 }

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -1199,6 +1199,7 @@ public class MovePath implements Cloneable, Serializable {
 
         pf.run(this.clone());
         MovePath finPath = pf.getComputedPath(dest);
+	// this can be used for debugging the "destruction aware pathfinder"
         //MovePath finPath = calculateDestructionAwarePath(dest);
 
         if (timeoutCondition.timeoutEngaged || finPath == null) {
@@ -1839,8 +1840,8 @@ public class MovePath implements Cloneable, Serializable {
      */
     public MovePath calculateDestructionAwarePath(Coords dest) {
         // code that's useful to test the destruction-aware pathfinder
-        // remove when code review and testing complete
         DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
+	// the destruction aware pathfinder takes either a CardinalEdge or an explicit set of coordinates
         //Set<Coords> destinationSet = new HashSet<Coords>();
         //destinationSet.add(dest);
         

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -31,7 +31,6 @@ import java.util.Vector;
 
 import megamek.client.bot.princess.CardinalEdge;
 import megamek.client.bot.princess.Princess;
-import megamek.common.MovePath.MoveStepType;
 import megamek.common.annotations.Nullable;
 import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
@@ -1188,7 +1187,7 @@ public class MovePath implements Cloneable, Serializable {
      * Extend the current path to the destination <code>Coords</code>.
      *
      * @param dest the destination <code>Coords</code> of the move.
-     * @param type the type of movment step required.
+     * @param type the type of movement step required.
      */
     public void findPathTo(final Coords dest, final MoveStepType type) {
         final int timeLimit = PreferenceManager.getClientPreferences().getMaxPathfinderTime();
@@ -1850,7 +1849,7 @@ public class MovePath implements Cloneable, Serializable {
         Set<Coords> destinationSet = princess.getClusterTracker().getDestinationCoords(entity, CardinalEdge.WEST, true);
         
         long marker1 = System.currentTimeMillis();
-        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false);
+        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, true);
         long marker2 = System.currentTimeMillis();
         long marker3 = marker2 - marker1;
         

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -29,8 +29,11 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.Vector;
 
+import megamek.client.bot.princess.CardinalEdge;
+import megamek.client.bot.princess.Princess;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.annotations.Nullable;
+import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.AbstractPathFinder;
 import megamek.common.pathfinder.CachedEntityState;
@@ -1197,6 +1200,7 @@ public class MovePath implements Cloneable, Serializable {
 
         pf.run(this.clone());
         MovePath finPath = pf.getComputedPath(dest);
+        //MovePath finPath = calculateDestructionAwarePath(dest);
 
         if (timeoutCondition.timeoutEngaged || finPath == null) {
             /*
@@ -1838,8 +1842,12 @@ public class MovePath implements Cloneable, Serializable {
         // code that's useful to test the destruction-aware pathfinder
         // remove when code review and testing complete
         DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
-        Set<Coords> destinationSet = new HashSet<Coords>();
-        destinationSet.add(dest);
+        //Set<Coords> destinationSet = new HashSet<Coords>();
+        //destinationSet.add(dest);
+        
+        // debugging code that can be used to find a path to a specific edge
+        Princess princess = new Princess("test", "test", 2020, LogLevel.OFF);
+        Set<Coords> destinationSet = princess.getClusterTracker().getDestinationCoords(entity, CardinalEdge.WEST, true);
         
         long marker1 = System.currentTimeMillis();
         MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false);

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -582,58 +582,59 @@ public class Tank extends Entity {
         boolean isAmphibious = hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS);
         boolean hexHasRoad =  hex.containsTerrain(Terrains.ROAD);
 
+        // roads allow movement through hexes that you normally couldn't go through
         switch (movementMode) {
             case TRACKED:
                 if (!isSuperHeavy()) {
-                    return (hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad
+                    return ((hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad)
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
+                            || (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad)
                             || (hex.terrainLevel(Terrains.MAGMA) > 1)
                             || (hex.terrainLevel(Terrains.ROUGH) > 1)
-                            || (hex.terrainLevel(Terrains.RUBBLE) > 5) && !hexHasRoad;
+                            || ((hex.terrainLevel(Terrains.RUBBLE) > 5) && !hexHasRoad);
                 } else {
-                    return (hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad
+                    return ((hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad)
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
+                            || (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad)
                             || (hex.terrainLevel(Terrains.MAGMA) > 1);
                 }
             case WHEELED:
                 if (!isSuperHeavy()) {
-                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
-                            || hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad
+                    return (hex.containsTerrain(Terrains.WOODS) && !hexHasRoad)
+                            || (hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad)
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad
+                            || (hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad)
                             || hex.containsTerrain(Terrains.MAGMA)
-                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
-                            || (hex.terrainLevel(Terrains.SNOW) > 1) && !hexHasRoad
+                            || (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad)
+                            || ((hex.terrainLevel(Terrains.SNOW) > 1) && !hexHasRoad)
                             || (hex.terrainLevel(Terrains.GEYSER) == 2);
                 } else {
-                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
-                            || hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad
+                    return (hex.containsTerrain(Terrains.WOODS) && !hexHasRoad)
+                            || (hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad)
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad
+                            || (hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad)
                             || hex.containsTerrain(Terrains.MAGMA)
-                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
+                            || (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad)
                             || (hex.terrainLevel(Terrains.GEYSER) == 2);
                 }
             case HOVER:
                 if (!isSuperHeavy()) {
-                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
-                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
+                    return (hex.containsTerrain(Terrains.WOODS) && !hexHasRoad)
+                            || (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad)
                             || (hex.terrainLevel(Terrains.MAGMA) > 1)
-                            || (hex.terrainLevel(Terrains.ROUGH) > 1) && !hexHasRoad
-                            || (hex.terrainLevel(Terrains.RUBBLE) > 5) && !hexHasRoad;
+                            || ((hex.terrainLevel(Terrains.ROUGH) > 1) && !hexHasRoad)
+                            || ((hex.terrainLevel(Terrains.RUBBLE) > 5) && !hexHasRoad);
                 } else {
-                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
-                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
+                    return (hex.containsTerrain(Terrains.WOODS) && !hexHasRoad)
+                            || (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad)
                             || (hex.terrainLevel(Terrains.MAGMA) > 1);
                 }
 

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -580,59 +580,60 @@ public class Tank extends Entity {
 
         boolean hasFlotationHull = hasWorkingMisc(MiscType.F_FLOTATION_HULL);
         boolean isAmphibious = hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS);
+        boolean hexHasRoad =  hex.containsTerrain(Terrains.ROAD);
 
         switch (movementMode) {
             case TRACKED:
                 if (!isSuperHeavy()) {
-                    return (hex.terrainLevel(Terrains.WOODS) > 1)
+                    return (hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.JUNGLE)
+                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
                             || (hex.terrainLevel(Terrains.MAGMA) > 1)
                             || (hex.terrainLevel(Terrains.ROUGH) > 1)
-                            || (hex.terrainLevel(Terrains.RUBBLE) > 5);
+                            || (hex.terrainLevel(Terrains.RUBBLE) > 5) && !hexHasRoad;
                 } else {
-                    return (hex.terrainLevel(Terrains.WOODS) > 1)
+                    return (hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.JUNGLE)
+                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
                             || (hex.terrainLevel(Terrains.MAGMA) > 1);
                 }
             case WHEELED:
                 if (!isSuperHeavy()) {
-                    return hex.containsTerrain(Terrains.WOODS)
-                            || hex.containsTerrain(Terrains.ROUGH)
+                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
+                            || hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.RUBBLE)
+                            || hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad
                             || hex.containsTerrain(Terrains.MAGMA)
-                            || hex.containsTerrain(Terrains.JUNGLE)
-                            || (hex.terrainLevel(Terrains.SNOW) > 1)
+                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
+                            || (hex.terrainLevel(Terrains.SNOW) > 1) && !hexHasRoad
                             || (hex.terrainLevel(Terrains.GEYSER) == 2);
                 } else {
-                    return hex.containsTerrain(Terrains.WOODS)
-                            || hex.containsTerrain(Terrains.ROUGH)
+                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
+                            || hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad
                             || ((hex.terrainLevel(Terrains.WATER) > 0)
                                     && !hex.containsTerrain(Terrains.ICE)
                                     && !hasFlotationHull && !isAmphibious)
-                            || hex.containsTerrain(Terrains.RUBBLE)
+                            || hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad
                             || hex.containsTerrain(Terrains.MAGMA)
-                            || hex.containsTerrain(Terrains.JUNGLE)
+                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
                             || (hex.terrainLevel(Terrains.GEYSER) == 2);
                 }
             case HOVER:
                 if (!isSuperHeavy()) {
-                    return hex.containsTerrain(Terrains.WOODS)
-                            || hex.containsTerrain(Terrains.JUNGLE)
+                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
+                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
                             || (hex.terrainLevel(Terrains.MAGMA) > 1)
-                            || (hex.terrainLevel(Terrains.ROUGH) > 1)
-                            || (hex.terrainLevel(Terrains.RUBBLE) > 5);
+                            || (hex.terrainLevel(Terrains.ROUGH) > 1) && !hexHasRoad
+                            || (hex.terrainLevel(Terrains.RUBBLE) > 5) && !hexHasRoad;
                 } else {
-                    return hex.containsTerrain(Terrains.WOODS)
-                            || hex.containsTerrain(Terrains.JUNGLE)
+                    return hex.containsTerrain(Terrains.WOODS) && !hexHasRoad
+                            || hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad
                             || (hex.terrainLevel(Terrains.MAGMA) > 1);
                 }
 

--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -161,11 +161,11 @@ public class BoardClusterTracker {
     public void updateMovableAreas(Entity entity) {
         MovementType movementType = MovementType.getMovementType(entity);
         
-        if(!movableAreas.containsKey(movementType)) {
+        if (!movableAreas.containsKey(movementType)) {
             movableAreas.put(movementType, generateClusters(entity, false));
         }
         
-        if(!movableAreasWithTerrainReduction.containsKey(movementType)) {
+        if (!movableAreasWithTerrainReduction.containsKey(movementType)) {
             movableAreasWithTerrainReduction.putIfAbsent(movementType, generateClusters(entity, true));
         }
     }
@@ -223,7 +223,7 @@ public class BoardClusterTracker {
                         // buildings require special handling - while a tank technically CAN plow through a building
                         // it is highly inadvisable and we will avoid it for now.
                         int elevationDiff = Math.abs(neighborElevation - myElevation);
-                        if((elevationDiff > entity.getMaxElevationChange())
+                        if ((elevationDiff > entity.getMaxElevationChange())
                                 || buildingPlowThroughRequired(entity, movementType, neighbor)) {
                             continue;
                         }
@@ -287,10 +287,10 @@ public class BoardClusterTracker {
             int buildingCF = board.getBuildingAt(coords).getCurrentCF(coords);
             
             return entity.getWeight() > buildingCF;            
-        } else if (relevantMovementType != MovementType.Flyer &&
-                relevantMovementType != MovementType.Jump &&
-                relevantMovementType != MovementType.None &&
-                relevantMovementType != MovementType.Water) {
+        } else if ((relevantMovementType != MovementType.Flyer) &&
+                (relevantMovementType != MovementType.Jump) &&
+                (relevantMovementType != MovementType.None) &&
+                (relevantMovementType != MovementType.Water)) {
             return true;
         } else {
             return false;

--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -198,7 +198,7 @@ public class BoardClusterTracker {
                                 movementType == MovementType.TrackedAmphi;
         
         for(int x = 0; x < board.getWidth(); x++) {
-            for(int y = 0; y < board.getHeight(); y++) {                
+            for(int y = 0; y < board.getHeight(); y++) {
                 Coords c = new Coords(x, y);
                 
                 // hex is either inaccessible

--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -89,6 +89,29 @@ public class BoardClusterTracker {
     private Map<MovementType, Map<Coords, BoardCluster>> movableAreasWithTerrainReduction = new HashMap<>();
 
     /**
+     * Returns the terrain-reduced or non-terrain-reduced 
+     * board cluster in which the given entity currently resides
+     */
+    public BoardCluster getCurrentBoardCluster(Entity entity, boolean terrainReduction) {
+        return getCurrentBoardCluster(entity, terrainReduction);
+    }
+    
+    /**
+     * Returns the terrain-reduced or non-terrain-reduced 
+     * board cluster in which the given coordinates currently reside
+     * Uses entity to determine movement type
+     */
+    public BoardCluster getCurrentBoardCluster(Entity entity, Coords actualCoords, boolean terrainReduction) {
+        MovementType movementType = MovementType.getMovementType(entity);
+
+        updateMovableAreas(entity);
+        
+        return terrainReduction ?
+                movableAreasWithTerrainReduction.get(movementType).get(actualCoords) :
+                movableAreas.get(movementType).get(actualCoords);
+    }
+    
+    /**
      * Returns a set of coordinates on a given board edge that intersects with the cluster
      * in which the given entity resides. May return an empty set.
      */
@@ -131,8 +154,13 @@ public class BoardClusterTracker {
     public void updateMovableAreas(Entity entity) {
         MovementType movementType = MovementType.getMovementType(entity);
         
-        movableAreas.putIfAbsent(movementType, generateClusters(entity, false));
-        movableAreasWithTerrainReduction.putIfAbsent(movementType, generateClusters(entity, true));
+        if(!movableAreas.containsKey(movementType)) {
+            movableAreas.put(movementType, generateClusters(entity, false));
+        }
+        
+        if(!movableAreasWithTerrainReduction.containsKey(movementType)) {
+            movableAreasWithTerrainReduction.putIfAbsent(movementType, generateClusters(entity, true));
+        }
     }
 
     /**

--- a/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
@@ -40,6 +40,8 @@ import megamek.common.MoveStep;
 /**
  * This class is intended to be used to find a (potentially long) legal path
  * given a movement type from a particular hex to the specified board edge
+ * 
+ * Note: This class is largely obsolete now, only used for its static methods
  * @author NickAragua
  *
  */
@@ -72,7 +74,7 @@ public class BoardEdgePathFinder {
      * @param entity Entity to evaluate
      * @return the Board.START_ constant representing the "opposite" edge
      */
-    public static int determineOppositeEdge(Entity entity) {
+    private int determineOppositeEdge(Entity entity) {
         IBoard board = entity.getGame().getBoard();
 
         // the easiest part is if the entity is supposed to start on a particular edge. Just return the opposite edge.

--- a/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
@@ -562,7 +562,8 @@ public class BoardEdgePathFinder {
         mli.destinationImpassable = destHex.containsTerrain(Terrains.IMPASSABLE);
         boolean destinationHasBuildingOrBridge = destinationBuilding != null;
         boolean destinationHasBridge = destinationHasBuildingOrBridge && destHex.containsTerrain(Terrains.BRIDGE_CF);
-        boolean destinationHasBuilding = destinationHasBuildingOrBridge && destHex.containsTerrain(Terrains.BLDG_CF);
+        boolean destinationHasBuilding = destinationHasBuildingOrBridge && 
+                (destHex.containsTerrain(Terrains.BLDG_CF) || destHex.containsTerrain(Terrains.FUEL_TANK_CF));
 
         // if we're going to step onto a bridge that will collapse, let's not consider going there
         mli.destinationHasWeakBridge =  destinationHasBridge && destinationBuilding.getCurrentCF(dest) < entity.getWeight();
@@ -588,7 +589,8 @@ public class BoardEdgePathFinder {
         // even if you level them they still turn to rubble. Additionally, they cannot go into deep snow.
         mli.wheeledTankRestriction = isWheeled &&
                 (destHex.containsTerrain(Terrains.ROUGH) || destHex.containsTerrain(Terrains.RUBBLE)
-                || destHex.containsTerrain(Terrains.BLDG_CF) || (destHex.containsTerrain(Terrains.SNOW) && destHex.terrainLevel(Terrains.SNOW) > 1));
+                || destinationHasBuilding
+                || (destHex.containsTerrain(Terrains.SNOW) && destHex.terrainLevel(Terrains.SNOW) > 1));
 
         // tracked and wheeled tanks cannot go into water without a bridge, unless amphibious
         mli.groundTankIntoWater = (isTracked || isWheeled) && 
@@ -622,7 +624,8 @@ public class BoardEdgePathFinder {
 
         int hexElevation = hex.getLevel();
 
-        if(entity.hasETypeFlag(Entity.ETYPE_MECH) && hex.containsTerrain(Terrains.BLDG_CF)) {
+        if(entity.hasETypeFlag(Entity.ETYPE_MECH) && 
+                (hex.containsTerrain(Terrains.BLDG_CF) || hex.containsTerrain(Terrains.FUEL_TANK_CF))) {
             hexElevation = hex.ceiling();
         } else if(entity.isNaval() && hex.containsTerrain(Terrains.BRIDGE)) {
             hexElevation = hex.getLevel();

--- a/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
@@ -587,7 +587,7 @@ public class BoardEdgePathFinder {
 
         // wheeled tanks cannot go into rough terrain or rubble of any kind, or buildings for that matter
         // even if you level them they still turn to rubble. Additionally, they cannot go into deep snow.
-        mli.wheeledTankRestriction = isWheeled &&
+        mli.wheeledTankRestriction = isWheeled && !destHexHasRoad &&
                 (destHex.containsTerrain(Terrains.ROUGH) || destHex.containsTerrain(Terrains.RUBBLE)
                 || destinationHasBuilding
                 || (destHex.containsTerrain(Terrains.SNOW) && destHex.terrainLevel(Terrains.SNOW) > 1));

--- a/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
@@ -590,7 +590,7 @@ public class BoardEdgePathFinder {
         mli.wheeledTankRestriction = isWheeled && !destHexHasRoad &&
                 (destHex.containsTerrain(Terrains.ROUGH) || destHex.containsTerrain(Terrains.RUBBLE)
                 || destinationHasBuilding
-                || (destHex.containsTerrain(Terrains.SNOW) && destHex.terrainLevel(Terrains.SNOW) > 1));
+                || (destHex.containsTerrain(Terrains.SNOW) && (destHex.terrainLevel(Terrains.SNOW) > 1)));
 
         // tracked and wheeled tanks cannot go into water without a bridge, unless amphibious
         mli.groundTankIntoWater = (isTracked || isWheeled) && 
@@ -624,7 +624,7 @@ public class BoardEdgePathFinder {
 
         int hexElevation = hex.getLevel();
 
-        if(entity.hasETypeFlag(Entity.ETYPE_MECH) && 
+        if (entity.hasETypeFlag(Entity.ETYPE_MECH) && 
                 (hex.containsTerrain(Terrains.BLDG_CF) || hex.containsTerrain(Terrains.FUEL_TANK_CF))) {
             hexElevation = hex.ceiling();
         } else if(entity.isNaval() && hex.containsTerrain(Terrains.BRIDGE)) {

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -100,14 +100,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
 
         while(!candidates.isEmpty()) {
             BulldozerMovePath currentPath = candidates.pollFirst();
-            
-            if(currentPath.getFinalCoords().getX() == 36 && currentPath.getFinalCoords().getY() == 21) {
-                int alpha = 2;
-            }
-            
-            candidates.addAll(generateChildNodes(currentPath, shortestPathsToCoords));
-            
-            
+            candidates.addAll(generateChildNodes(currentPath, shortestPathsToCoords));            
             
             if(destinationCoords.contains(currentPath.getFinalCoords()) &&
                     (bestPath == null || movePathComparator.compare(bestPath, currentPath) > 0)) {
@@ -203,11 +196,17 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
                 !mli.destinationHasWeakBridge &&
                 !mli.groundTankIntoWater;
         
+        // legal jump moves are simpler:
+        // can't go out of bounds, can't jump too high (unless we can destroy the obstacle)
+        boolean legalJumpMove = child.isJumping() &&
+                !mli.outOfBounds &&
+                (!mli.goingUpTooHigh || child.needsLeveling());
+        
         if((!shortestPathsToCoords.containsKey(child.getFinalCoords()) ||
                 // shorter path to these coordinates
                 (movePathComparator.compare(shortestPathsToCoords.get(child.getFinalCoords()), child) > 0)) &&
-                // legal or needs leveling and not off-board
-                (mli.isLegal() || canLevel) &&
+                // legal or needs leveling or jumping and not off-board
+                (mli.isLegal() || canLevel || legalJumpMove) &&
                 // better than existing path to ultimate destination
                 (child.getMpUsed() + child.getLevelingCost() < maximumCost)) {
             shortestPathsToCoords.put(child.getFinalCoords(), child);
@@ -236,11 +235,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
          * Favors paths that move closer to the destination edge first.
          * in case of tie, favors paths that cost less MP
          */
-        public int compare(BulldozerMovePath first, BulldozerMovePath second) {
-            if(first.getFinalCoords().getX() == 19 && first.getFinalCoords().getY() == 20) {
-                int alpha = 1;
-            }
-            
+        public int compare(BulldozerMovePath first, BulldozerMovePath second) {            
             IBoard board = first.getGame().getBoard();
             boolean backwards = false;
             int h1 = first.getFinalCoords().distance(destination)

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -103,7 +103,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
             candidates.addAll(generateChildNodes(currentPath, shortestPathsToCoords));            
             
             if(destinationCoords.contains(currentPath.getFinalCoords()) &&
-                    (bestPath == null || movePathComparator.compare(bestPath, currentPath) > 0)) {
+                    ((bestPath == null) || (movePathComparator.compare(bestPath, currentPath) > 0))) {
                 bestPath = currentPath;
                 maximumCost = bestPath.getMpUsed() + bestPath.getLevelingCost();
             }
@@ -261,7 +261,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
                 return dd;
             } else {
                 int tieBreakerDiff = first.getHexesMoved() - second.getHexesMoved();
-                if(tieBreakerDiff == 0) {
+                if (tieBreakerDiff == 0) {
                     tieBreakerDiff = first.getMpUsed() - second.getMpUsed();
                 }
                 

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -58,6 +58,10 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
     public BulldozerMovePath findPathToCoords(Entity entity, Set<Coords> destinationCoords, boolean jump) {
         BulldozerMovePath startPath = new BulldozerMovePath(entity.getGame(), entity);
         
+        if(entity.getDisplayName().contains("Locust")) {
+            int alpha = 1;
+        }
+        
         // if we're calculating a jump path and the entity has jump mp and can jump, start off with a jump
         // if we're trying to calc a jump path and the entity does not have jump mp, we're done
         if(jump && (startPath.getCachedEntityState().getJumpMPWithTerrain() > 0) &&

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -1599,7 +1599,7 @@ public class BoardUtilities {
 
         // the easiest part is if the entity is supposed to start on a particular edge. Just return the opposite edge.
         int oppositeEdge = board.getOppositeEdge(entity.getStartingPos());
-        if(oppositeEdge != Board.START_NONE) {
+        if (oppositeEdge != Board.START_NONE) {
             return CardinalEdge.getCardinalEdge(OffBoardDirection.translateBoardStart(oppositeEdge));
         }
 

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -1600,7 +1600,7 @@ public class BoardUtilities {
         // the easiest part is if the entity is supposed to start on a particular edge. Just return the opposite edge.
         int oppositeEdge = board.getOppositeEdge(entity.getStartingPos());
         if(oppositeEdge != Board.START_NONE) {
-            return CardinalEdge.getCardinalEdge(OffBoardDirection.translateBoardStart(oppositeEdge).getValue());
+            return CardinalEdge.getCardinalEdge(OffBoardDirection.translateBoardStart(oppositeEdge));
         }
 
         // otherwise, we determine which edge of the board is closest to current position and return the opposite edge

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -1568,7 +1568,7 @@ public class BoardUtilities {
     /**
      * Figures out the "closest" edge for the given entity on the entity's game board
      * @param entity Entity to evaluate
-     * @return the Board.START_ constant representing the "opposite" edge
+     * @return the Board.START_ constant representing the "closest" edge
      */
     public static CardinalEdge getClosestEdge(Entity entity) {
         int distanceToWest = entity.getPosition().getX();

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -35,8 +35,10 @@ import megamek.common.IHex;
 import megamek.common.ITerrain;
 import megamek.common.ITerrainFactory;
 import megamek.common.MapSettings;
+import megamek.common.OffBoardDirection;
 import megamek.common.PlanetaryConditions;
 import megamek.common.Terrains;
+import megamek.common.pathfinder.BoardEdgePathFinder;
 import megamek.common.util.generator.ElevationGenerator;
 import megamek.common.util.generator.SimplexGenerator;
 
@@ -1564,7 +1566,7 @@ public class BoardUtilities {
     }
 
     /**
-     * Figures out the "opposite" edge for the given entity on the entity's game board
+     * Figures out the "closest" edge for the given entity on the entity's game board
      * @param entity Entity to evaluate
      * @return the Board.START_ constant representing the "opposite" edge
      */
@@ -1585,6 +1587,26 @@ public class BoardUtilities {
         } else {
             return closerNorthThanSouth ? CardinalEdge.NORTH : CardinalEdge.SOUTH;
         }
+    }
+    
+    /**
+     * Figures out the "opposite" edge for the given entity.
+     * @param entity Entity to evaluate
+     * @return the Board.START_ constant representing the "opposite" edge
+     */
+    public static CardinalEdge determineOppositeEdge(Entity entity) {
+        IBoard board = entity.getGame().getBoard();
+
+        // the easiest part is if the entity is supposed to start on a particular edge. Just return the opposite edge.
+        int oppositeEdge = board.getOppositeEdge(entity.getStartingPos());
+        if(oppositeEdge != Board.START_NONE) {
+            return CardinalEdge.getCardinalEdge(OffBoardDirection.translateBoardStart(oppositeEdge).getValue());
+        }
+
+        // otherwise, we determine which edge of the board is closest to current position and return the opposite edge
+        // in case of tie, vertical distance wins over horizontal distance
+        CardinalEdge closestEdge = getClosestEdge(entity);
+        return CardinalEdge.getOppositeEdge(closestEdge);
     }
 
     protected static class Point {


### PR DESCRIPTION
This is a companion to my previous PR.

It uses the board clustering mechanism introduced there for a massive performance improvement in bot deployment speed. Additionally, it fixes some weird behaviors related to the long-range pathfinding algorithm generating highly sub-optimal paths and trying to blow up buildings it really didn't need to.

As a bonus, the bot should no longer fire on crippled turrets or crippled infantry in buildings (there were some cases where it still would).