### PR TITLE
Turn fov issue 1014

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1777,8 +1777,6 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         } else if (b.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             Coords moveto = b.getCoords();
             clientgui.bv.drawMovementData(ce(), cmd);
-//            if (!shiftheld) {
-//            }
             if (shiftheld || (gear == MovementDisplay.GEAR_TURN)) {
                 butDone.setText("<html><b>"
                         + Messages.getString("MovementDisplay.Move")

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1777,9 +1777,8 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         } else if (b.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             Coords moveto = b.getCoords();
             clientgui.bv.drawMovementData(ce(), cmd);
-            if (!shiftheld) {
-                clientgui.getBoardView().select(b.getCoords());
-            }
+//            if (!shiftheld) {
+//            }
             if (shiftheld || (gear == MovementDisplay.GEAR_TURN)) {
                 butDone.setText("<html><b>"
                         + Messages.getString("MovementDisplay.Move")
@@ -1796,6 +1795,8 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     //$NON-NLS-1$
                 }
                 return;
+            } else {
+                clientgui.getBoardView().select(b.getCoords());
             }
             if (gear == MovementDisplay.GEAR_RAM) {
                 // check if target is valid


### PR DESCRIPTION
Resolves #1014 

Using shift-click to turn didnt have an issue but when turning a unit from the "Turn" button or the menu the FOV switched to the (irrelevant) hex that was clicked to affect the turn.