### PR TITLE
Ammo corrections

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -1360,7 +1360,7 @@ public class AmmoType extends EquipmentType {
                 .setISApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
         
         munitions.add(new MunitionMutator("Anti-personnel", 1, M_ANTI_PERSONNEL,
                 new TechAdvancement(TECH_BASE_IS)
@@ -1373,7 +1373,7 @@ public class AmmoType extends EquipmentType {
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
                 .setReintroductionFactions(F_FS,F_LC)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
         
         //Armor Piercing is the base ammo type see further down.
         
@@ -1388,7 +1388,7 @@ public class AmmoType extends EquipmentType {
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
                 .setReintroductionFactions(F_FS,F_LC)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
         
         munitions.add(new MunitionMutator("Semi-Guided", 1, M_SEMIGUIDED,
                 new TechAdvancement(TECH_BASE_IS)
@@ -1431,7 +1431,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
         
         munitions.add(new MunitionMutator("Anti-personnel", 1, M_ANTI_PERSONNEL,
                 new TechAdvancement(TECH_BASE_CLAN)
@@ -1443,7 +1443,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
         
         //Armor Piercing is the base ammo type see further down.
         
@@ -1457,7 +1457,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
         
         munitions.add(new MunitionMutator("Semi-Guided", 1, M_SEMIGUIDED,
                 new TechAdvancement(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -1388,7 +1388,7 @@ public class AmmoType extends EquipmentType {
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
                 .setReintroductionFactions(F_FS,F_LC)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"374,TO"));
         
         munitions.add(new MunitionMutator("Semi-Guided", 1, M_SEMIGUIDED,
                 new TechAdvancement(TECH_BASE_IS)
@@ -1457,7 +1457,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"374,TO"));
         
         munitions.add(new MunitionMutator("Semi-Guided", 1, M_SEMIGUIDED,
                 new TechAdvancement(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -1400,7 +1400,7 @@ public class AmmoType extends EquipmentType {
                 .setISApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_FW)
                 .setProductionFactions(F_FW)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD), "373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED), "374,TO"));
         
         munitions.add(new MunitionMutator("Smoke", 1, M_SMOKE_WARHEAD,
                 new TechAdvancement(TECH_BASE_IS)
@@ -1413,7 +1413,7 @@ public class AmmoType extends EquipmentType {
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
                 .setReintroductionFactions(F_FS,F_LC)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"375,TO"));
              
         // Walk through both the base types and the
         // mutators, and create munition types.
@@ -1467,7 +1467,7 @@ public class AmmoType extends EquipmentType {
                 .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
                 .setClanAdvancement(3055, 3064, DATE_NONE, DATE_NONE, DATE_NONE)
                 .setClanApproximate(true,false,false,false,false)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD), "373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED), "374,TO"));
                 
         munitions.add(new MunitionMutator("Smoke", 1, M_SMOKE_WARHEAD,
                 new TechAdvancement(TECH_BASE_CLAN)
@@ -1479,7 +1479,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"373,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"375,TO"));
 
         AmmoType.createMunitions(clanMortarAmmos, munitions);
         
@@ -1567,7 +1567,7 @@ public class AmmoType extends EquipmentType {
                 new TechAdvancement(TECH_BASE_IS).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_E)
                         .setAvailability(RATING_X, RATING_X, RATING_F, RATING_F)
                         .setISAdvancement(3053).setPrototypeFactions(F_FS, F_LC)
-                        .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL), "368,TO"));
+                        .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL), "367,TO"));
         
 /*              munitions.add(new MunitionMutator("Harpoon", 2, M_HARPOON,
                 new TechAdvancement(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_C)
@@ -1599,7 +1599,7 @@ public class AmmoType extends EquipmentType {
                 .setISApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"229,TM"));
+                .setStaticTechLevel(SimpleTechLevel.STANDARD),"231,TM"));
         
         
         munitions.add(new MunitionMutator("Smoke", 1, M_SMOKE_WARHEAD,
@@ -1651,7 +1651,7 @@ public class AmmoType extends EquipmentType {
                 .setISApproximate(false,false,false, true, false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"207,TM"));
+                .setStaticTechLevel(SimpleTechLevel.STANDARD),"230,TM"));
                 
         munitions.add(new MunitionMutator("Dead-Fire", 2, M_DEAD_FIRE,
                 new TechAdvancement(TECH_BASE_IS).setTechRating(RATING_C)
@@ -1679,7 +1679,8 @@ public class AmmoType extends EquipmentType {
                 .setAvailability(RATING_X, RATING_F, RATING_X, RATING_X)
                 .setISAdvancement(3037, DATE_NONE, DATE_NONE, 3040, DATE_NONE)
                 .setISApproximate(true,false,false,false,false)
-                .setPrototypeFactions(F_FS,F_LC), "230,TM"));
+                .setPrototypeFactions(F_FS,F_LC)
+                .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL), "105,IO"));
         
         //TODO Mag Pulse see IO pg 62
         
@@ -1726,7 +1727,7 @@ public class AmmoType extends EquipmentType {
                     .setTechRating(RATING_E)
                     .setAvailability(RATING_X, RATING_X, RATING_F, RATING_F)
                     .setClanAdvancement(3053).setPrototypeFactions(F_FS, F_LC)
-                    .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL),"368,TO"));
+                    .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL),"367,TO"));
                 
         /*              munitions.add(new MunitionMutator("Harpoon", 2, M_HARPOON,
         new TechAdvancement(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_C)
@@ -1758,7 +1759,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"229,TM"));
+                .setStaticTechLevel(SimpleTechLevel.STANDARD),"231,TM"));
         
         munitions.add(new MunitionMutator("(Clan) Smoke", 1, M_SMOKE_WARHEAD,
           
@@ -2130,13 +2131,13 @@ public class AmmoType extends EquipmentType {
                 .setISApproximate(false,false,false, true, false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"207,TM"));
+                .setStaticTechLevel(SimpleTechLevel.STANDARD),"230,TM"));
               
         munitions.add(new MunitionMutator("Dead-Fire", 2, M_DEAD_FIRE,
                 new TechAdvancement(TECH_BASE_IS).setTechRating(RATING_C)
                 .setAvailability(RATING_X, RATING_X, RATING_E, RATING_E)
                 .setISAdvancement(3052).setPrototypeFactions(F_DC)
-                .setStaticTechLevel(SimpleTechLevel.UNOFFICIAL), "131,IO"));
+                .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL), "131,IO"));
                 
         munitions.add(new MunitionMutator("Fragmentation", 1, M_FRAGMENTATION,
                 new TechAdvancement(TECH_BASE_IS)
@@ -2160,7 +2161,7 @@ public class AmmoType extends EquipmentType {
                 .setISAdvancement(3037, DATE_NONE, DATE_NONE, 3040, DATE_NONE)
                 .setISApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_FS,F_LC)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD), "230,TM"));
+                .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL), "105,IO"));
         
         //TODO Mag Pulse see IO pg 62        
         
@@ -2216,7 +2217,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(true,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"369,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"369,TO"));
         
         //TODO Incendiary LRMs - IO pg 61, TO pg 369
         
@@ -3180,7 +3181,8 @@ public class AmmoType extends EquipmentType {
                 .setISAdvancement(DATE_PS, DATE_PS, DATE_NONE, DATE_NONE, DATE_NONE)
                 .setISApproximate(false,false,false,false,false)
                 .setClanAdvancement(DATE_PS, DATE_PS, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false,false,false,false,false),"355,TO"));
+                .setClanApproximate(false,false,false,false,false)
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"356,TO"));
         
         
         munitions.add(new MunitionMutator("Fuel-Air", 1, M_FAE,
@@ -3270,7 +3272,7 @@ public class AmmoType extends EquipmentType {
                 .setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
                 .setClanAdvancement(DATE_PS, DATE_PS, DATE_NONE, DATE_NONE, DATE_NONE)
                 .setClanApproximate(false,false,false,false,false)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"356,TO"));
         //TODO:
         //Fuel-Air Mutators (See IO 165)
 
@@ -3290,7 +3292,7 @@ public class AmmoType extends EquipmentType {
                 .setISApproximate(false,false,false, true, false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"207,TM"));
+                .setStaticTechLevel(SimpleTechLevel.STANDARD),"230,TM"));
 
         // Walk through both the base types and the
         // mutators, and create munition types.
@@ -3320,7 +3322,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(false,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),"207,TM"));
+                .setStaticTechLevel(SimpleTechLevel.STANDARD),"230,TM"));
 
         // Walk through both the base types and the
         // mutators, and create munition types.


### PR DESCRIPTION
Adds and corrects a few techlevels in the Ammos. 

I was looking at #1078. This doesn't really resolve the issue because when "variable tech level" is off, all ammo within the Tech Level is available regardless of year and clan/IS and it seems intentional. So the question is rather if this is how it should be or if even without the "variable tech" setting IS weapons should be restricted to IS ammo. Comments welcome.