### PR TITLE
long range bridge + deep water handling

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -901,11 +901,7 @@ public abstract class BotClient extends Client {
         // attempt to deploy in the biggest area this unit can access instead
         if(highestFitness < -10) {
             for(RankedCoords rc : validCoords) {
-                BoardCluster boardCluster = getClusterTracker().getCurrentBoardCluster(deployed_ent, rc.coords, false);
-                
-                if (boardCluster != null) {
-                    rc.fitness += boardCluster.contents.size();
-                }
+                rc.fitness += getClusterTracker().getBoardClusterSize(deployed_ent, rc.coords, false);
             }
         }
         

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -742,7 +742,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                                         new EntityState(path),
                                         target,
                                         null,
-                                        FireControl.DOES_NOT_TRACK_HEAT,
+                                        Entity.DOES_NOT_TRACK_HEAT,
                                         null);
             FiringPlan myFiringPlan = getFireControl(path.getEntity()).determineBestFiringPlan(guess);
             

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -94,7 +94,6 @@ public class FireControl {
     protected static final double EJECTED_PILOT_DISUTILITY = 1000.0;
     protected static final double CIVILIAN_TARGET_DISUTILITY = 250.0;
     protected static final double TARGET_HP_FRACTION_DEALT_UTILITY = -30.0;
-    static final int DOES_NOT_TRACK_HEAT = 999;
 
     private static final double TARGET_POTENTIAL_DAMAGE_UTILITY = 1.0;
     static final double COMMANDER_UTILITY = 0.5;
@@ -1646,7 +1645,7 @@ public class FireControl {
         // the "alpha strike" may be a bombing plan.
         if(shooter.isAirborneAeroOnGroundMap()) {
             final FiringPlan bombingPlan = this.getDiveBombPlan(shooter, null, target, game, shooter.passedOver(target), true);
-            calculateUtility(bombingPlan, DOES_NOT_TRACK_HEAT, true); // bomb drops never cause heat
+            calculateUtility(bombingPlan, Entity.DOES_NOT_TRACK_HEAT, true); // bomb drops never cause heat
             
             if(bombingPlan.getUtility() > myPlan.getUtility()) {
                 return bombingPlan;
@@ -1738,7 +1737,7 @@ public class FireControl {
         
         // if we are here, we have already confirmed the target is under the flight path and are guessing
         final FiringPlan bombPlan = getDiveBombPlan(shooter, flightPath, target, game, true, true);
-        calculateUtility(bombPlan, DOES_NOT_TRACK_HEAT, shooter.isAero()); // bombs don't generate heat so don't bother with this calculation
+        calculateUtility(bombPlan, Entity.DOES_NOT_TRACK_HEAT, shooter.isAero()); // bombs don't generate heat so don't bother with this calculation
         
         // Rank how useful this plan is.
         calculateUtility(myPlan, calcHeatTolerance(shooter, null), shooter.isAero());
@@ -1875,7 +1874,7 @@ public class FireControl {
         
         if(shooter.isAero()) {
             final FiringPlan bombingPlan = this.getDiveBombPlan(shooter, null, target, game, shooter.passedOver(target), false);
-            calculateUtility(bombingPlan, DOES_NOT_TRACK_HEAT, true); // bomb drops never cause heat
+            calculateUtility(bombingPlan, Entity.DOES_NOT_TRACK_HEAT, true); // bomb drops never cause heat
             
             // if the bombing plan actually involves doing something
             if((bombingPlan.size() > 0) && 
@@ -1891,8 +1890,8 @@ public class FireControl {
                                   @Nullable Boolean isAero) {
 
         // If the unit doesn't track heat, we won't worry about it.
-        if (DOES_NOT_TRACK_HEAT == entity.getHeatCapacity()) {
-            return DOES_NOT_TRACK_HEAT;
+        if (Entity.DOES_NOT_TRACK_HEAT == entity.getHeatCapacity()) {
+            return Entity.DOES_NOT_TRACK_HEAT;
         }
 
         int baseTolerance = entity.getHeatCapacity() - entity.getHeat();
@@ -2038,7 +2037,7 @@ public class FireControl {
             final FiringPlan diveBombPlan = this.getDiveBombPlan(shooter, null, target,
                                                                  shooter.getGame(), shooter.passedOver(target), false);
             
-            calculateUtility(diveBombPlan, DOES_NOT_TRACK_HEAT, true);
+            calculateUtility(diveBombPlan, Entity.DOES_NOT_TRACK_HEAT, true);
             if(diveBombPlan.getUtility() > bestPlans[0].getUtility()) {
                 bestPlans[0] = diveBombPlan;
             }
@@ -2085,7 +2084,7 @@ public class FireControl {
         // heat-tracking units.
         
         // conventional fighters can drop bombs
-        if (DOES_NOT_TRACK_HEAT == shooter.getHeatCapacity()
+        if (Entity.DOES_NOT_TRACK_HEAT == shooter.getHeatCapacity()
             && ((shooter.getEntityType() & Entity.ETYPE_INFANTRY) == 0)) {
             return alphaStrike; // No need to worry about heat if the unit
                                 // doesn't track it.

--- a/megamek/src/megamek/client/bot/princess/FiringPlanCalculationParameters.java
+++ b/megamek/src/megamek/client/bot/princess/FiringPlanCalculationParameters.java
@@ -43,7 +43,7 @@ public final class FiringPlanCalculationParameters {
         private EntityState shooterState = null;
         private Targetable target = null;
         private EntityState targetState = null;
-        private int maxHeat = FireControl.DOES_NOT_TRACK_HEAT;
+        private int maxHeat = Entity.DOES_NOT_TRACK_HEAT;
         private Map<Mounted, Double> ammoConservation = new HashMap<>();
         private FiringPlanCalculationType calculationType = GUESS;
 

--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -101,7 +101,7 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
                       new EntityState(path),
                       enemy,
                       null,
-                      FireControl.DOES_NOT_TRACK_HEAT,
+                      Entity.DOES_NOT_TRACK_HEAT,
                       null);
         myFiringPlan = getFireControl(path.getEntity()).determineBestFiringPlan(guess);
 

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -356,14 +356,14 @@ public class PathEnumerator {
         }
         
         // calculate a ground-bound long range path
-        BulldozerMovePath bmp = dpf.findPathToCoords(mover, destinations);
+        BulldozerMovePath bmp = dpf.findPathToCoords(mover, destinations, owner.getClusterTracker());
         
         if(bmp != null) {
             getLongRangePaths().get(mover.getId()).add(bmp);
         }
         
         // calculate a jumping long range path
-        BulldozerMovePath jmp = dpf.findPathToCoords(mover, destinations, true); 
+        BulldozerMovePath jmp = dpf.findPathToCoords(mover, destinations, owner.getClusterTracker()); 
         if(jmp != null) {
             getLongRangePaths().get(mover.getId()).add(jmp);
         }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1518,7 +1518,7 @@ public class Princess extends BotClient {
                 getLongRangePaths().get(mover.getId());
             
             // for whatever reason (most likely it's wheeled), there are no long-range paths for this unit, 
-            // so just have it mill around in place as usual. Also set the behavior to "engaged"
+            // so just have it mill around in place as usual. Also set the behavior to "no path to destination"
             // so it doesn't hump the walls due to "self preservation mods"
             if ((bulldozerPaths == null) || (bulldozerPaths.size() == 0)) {
                 getUnitBehaviorTracker().overrideBehaviorType(mover, BehaviorType.NoPathToDestination);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1483,7 +1483,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         Map<Coords, BoardCluster> clusterMap = bct.generateClusters(selectedEntity, false, true);
         
         for(BoardCluster cluster : clusterMap.values().stream().distinct().collect(Collectors.toList())) {
-            for(Coords coords : cluster.contents.keySet()) {
+            for (Coords coords : cluster.contents.keySet()) {
                 Point p = getCentreHexLocation(coords.getX(), coords.getY(), true);
                 p.translate(HEX_W  / 2, HEX_H  / 2);
                 drawHexBorder(g, p, new Color(0, 0, (20 * cluster.id) % 255), 0, 6);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1480,13 +1480,13 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     @SuppressWarnings("unused")
     private void renderClusters(Graphics2D g) {
         BoardClusterTracker bct = new BoardClusterTracker();
-        Map<Coords, BoardCluster> clusterMap = bct.generateClusters(selectedEntity, false);
+        Map<Coords, BoardCluster> clusterMap = bct.generateClusters(selectedEntity, false, true);
         
         for(BoardCluster cluster : clusterMap.values().stream().distinct().collect(Collectors.toList())) {
             for(Coords coords : cluster.contents) {
                 Point p = getCentreHexLocation(coords.getX(), coords.getY(), true);
                 p.translate(HEX_W  / 2, HEX_H  / 2);
-                drawHexBorder(g, p, Color.PINK, 0, 6);
+                drawHexBorder(g, p, new Color(0, 0, (20 * cluster.id) % 255), 0, 6);
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1483,7 +1483,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         Map<Coords, BoardCluster> clusterMap = bct.generateClusters(selectedEntity, false, true);
         
         for(BoardCluster cluster : clusterMap.values().stream().distinct().collect(Collectors.toList())) {
-            for(Coords coords : cluster.contents) {
+            for(Coords coords : cluster.contents.keySet()) {
                 Point p = getCentreHexLocation(coords.getX(), coords.getY(), true);
                 p.translate(HEX_W  / 2, HEX_H  / 2);
                 drawHexBorder(g, p, new Color(0, 0, (20 * cluster.id) % 255), 0, 6);

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3172,7 +3172,7 @@ public class Aero extends Entity implements IAero, IBomber {
     @Override
     public int getMaxElevationChange() {
         if (isAirborne()) {
-            return 999;
+            return UNLIMITED_JUMP_DOWN;
         }
         return 1;
     }

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -108,12 +108,12 @@ public class BulldozerMovePath extends MovePath {
             // if we are jumping, but not on top of a bridge (because jumping always goes to the top of a bridge)
             // and are jumping into terrain that would impede jump jet functionality (aka water)
             // then we are impeding future jump movement and should add an extra cost to this step
-            if((hex != null) && !hex.containsTerrain(Terrains.BRIDGE)) {
+            if ((hex != null) && !hex.containsTerrain(Terrains.BRIDGE)) {
                 // special case - mech jumping into depth 1 water might not be all that bad, jump mp cost wise
-                if(hexWaterDepth == 1) {
+                if (hexWaterDepth == 1) {
                     additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP() - mp.getCachedEntityState().getTorsoJumpJets());
                 // jumping into water that submerges you entirely pretty much ruins jump MP for at least a turn while you clamber out
-                } else {
+                } else if (hexWaterDepth > 1) {
                     additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP());
                 }
             }

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -79,7 +79,7 @@ public class BulldozerMovePath extends MovePath {
     public MovePath addStep(final MoveStepType type) {
         BulldozerMovePath mp = (BulldozerMovePath) super.addStep(type);
         IHex hex = mp.getGame().getBoard().getHex(mp.getFinalCoords());
-        int hexWaterDepth = (hex != null) && hex.containsTerrain(Terrains.WATER) ?
+        int hexWaterDepth = ((hex != null) && hex.containsTerrain(Terrains.WATER)) ?
                 hex.depth() : Integer.MIN_VALUE;
         
         if (!mp.isMoveLegal() && !mp.isJumping()) {

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -105,12 +105,17 @@ public class BulldozerMovePath extends MovePath {
         }
 
         if (mp.isJumping()) {
-            // special case - mech jumping into depth 1 water might not be all that bad, jump mp cost wise
-            if(hexWaterDepth == 1) {
-                additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP() - mp.getCachedEntityState().getTorsoJumpJets());
-            // jumping into water that submerges you entirely pretty much ruins jump MP for at least a turn while you clamber out
-            } else {
-                additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP());
+            // if we are jumping, but not on top of a bridge (because jumping always goes to the top of a bridge)
+            // and are jumping into terrain that would impede jump jet functionality (aka water)
+            // then we are impeding future jump movement and should add an extra cost to this step
+            if((hex != null) && !hex.containsTerrain(Terrains.BRIDGE)) {
+                // special case - mech jumping into depth 1 water might not be all that bad, jump mp cost wise
+                if(hexWaterDepth == 1) {
+                    additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP() - mp.getCachedEntityState().getTorsoJumpJets());
+                // jumping into water that submerges you entirely pretty much ruins jump MP for at least a turn while you clamber out
+                } else {
+                    additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP());
+                }
             }
         }
 

--- a/megamek/src/megamek/common/ConvFighter.java
+++ b/megamek/src/megamek/common/ConvFighter.java
@@ -47,7 +47,7 @@ public class ConvFighter extends Aero {
 
     @Override
     public int getHeatCapacity() {
-        return 999;
+        return DOES_NOT_TRACK_HEAT;
     }
     
     @Override

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -97,6 +97,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     private static final long serialVersionUID = 1430806396279853295L;
 
     public static final int DOES_NOT_TRACK_HEAT = 999;
+    public static final int UNLIMITED_JUMP_DOWN = 999;
 
     /**
      * Entity Type Id Definitions These are used to identify the type of Entity,

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -361,7 +361,7 @@ public class GunEmplacement extends Tank {
 
     @Override
     public int getHeatCapacity() {
-        return 999;
+        return DOES_NOT_TRACK_HEAT;
     }
 
     @Override

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -845,7 +845,7 @@ public class Infantry extends Entity {
      */
     @Override
     public int getHeatCapacity(boolean radicalHeatSinks) {
-        return 999;
+        return DOES_NOT_TRACK_HEAT;
     }
 
     /**

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -211,7 +211,6 @@ public abstract class Mech extends Entity {
     public static final int HAS_UNKNOWN = 0;
 
     public static final int HAS_TRUE = 1;
-    
     // rear armor
     private int[] rearArmor;
 

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -211,7 +211,7 @@ public abstract class Mech extends Entity {
     public static final int HAS_UNKNOWN = 0;
 
     public static final int HAS_TRUE = 1;
-
+    
     // rear armor
     private int[] rearArmor;
 
@@ -5743,7 +5743,7 @@ public abstract class Mech extends Entity {
     @Override
     public int getMaxElevationDown(int currElevation) {
         if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_LEAPING)) {
-            return 999;
+            return UNLIMITED_JUMP_DOWN;
         }
         return getMaxElevationChange();
     }

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -1197,10 +1197,10 @@ public class MovePath implements Cloneable, Serializable {
         AbstractPathFinder.StopConditionTimeout<MovePath> timeoutCondition = new AbstractPathFinder.StopConditionTimeout<>(timeLimit);
         pf.addStopCondition(timeoutCondition);
 
-        pf.run(this.clone());
-        MovePath finPath = pf.getComputedPath(dest);
+        //pf.run(this.clone());
+        //MovePath finPath = pf.getComputedPath(dest);
 	// this can be used for debugging the "destruction aware pathfinder"
-        //MovePath finPath = calculateDestructionAwarePath(dest);
+        MovePath finPath = calculateDestructionAwarePath(dest);
 
         if (timeoutCondition.timeoutEngaged || finPath == null) {
             /*
@@ -1842,15 +1842,15 @@ public class MovePath implements Cloneable, Serializable {
         // code that's useful to test the destruction-aware pathfinder
         DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
 	// the destruction aware pathfinder takes either a CardinalEdge or an explicit set of coordinates
-        //Set<Coords> destinationSet = new HashSet<Coords>();
-        //destinationSet.add(dest);
+        Set<Coords> destinationSet = new HashSet<Coords>();
+        destinationSet.add(dest);
         
         // debugging code that can be used to find a path to a specific edge
-        Princess princess = new Princess("test", "test", 2020, LogLevel.OFF);
-        Set<Coords> destinationSet = princess.getClusterTracker().getDestinationCoords(entity, CardinalEdge.WEST, true);
+        //Princess princess = new Princess("test", "test", 2020, LogLevel.OFF);
+        //Set<Coords> destinationSet = princess.getClusterTracker().getDestinationCoords(entity, CardinalEdge.WEST, true);
         
         long marker1 = System.currentTimeMillis();
-        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false);
+        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, true);
         long marker2 = System.currentTimeMillis();
         long marker3 = marker2 - marker1;
         

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -1850,7 +1850,7 @@ public class MovePath implements Cloneable, Serializable {
         Set<Coords> destinationSet = princess.getClusterTracker().getDestinationCoords(entity, CardinalEdge.WEST, true);
         
         long marker1 = System.currentTimeMillis();
-        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, true);
+        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false);
         long marker2 = System.currentTimeMillis();
         long marker3 = marker2 - marker1;
         

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -1838,6 +1838,7 @@ public class MovePath implements Cloneable, Serializable {
     /**
      * Debugging method that calculates a destruction-aware move path to the destination coordinates
      */
+    @SuppressWarnings("unused")
     public MovePath calculateDestructionAwarePath(Coords dest) {
         // code that's useful to test the destruction-aware pathfinder
         DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -1197,10 +1197,10 @@ public class MovePath implements Cloneable, Serializable {
         AbstractPathFinder.StopConditionTimeout<MovePath> timeoutCondition = new AbstractPathFinder.StopConditionTimeout<>(timeLimit);
         pf.addStopCondition(timeoutCondition);
 
-        //pf.run(this.clone());
-        //MovePath finPath = pf.getComputedPath(dest);
-	// this can be used for debugging the "destruction aware pathfinder"
-        MovePath finPath = calculateDestructionAwarePath(dest);
+        pf.run(this.clone());
+        MovePath finPath = pf.getComputedPath(dest);
+        // this can be used for debugging the "destruction aware pathfinder"
+        //MovePath finPath = calculateDestructionAwarePath(dest);
 
         if (timeoutCondition.timeoutEngaged || finPath == null) {
             /*
@@ -1841,16 +1841,16 @@ public class MovePath implements Cloneable, Serializable {
     public MovePath calculateDestructionAwarePath(Coords dest) {
         // code that's useful to test the destruction-aware pathfinder
         DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
-	// the destruction aware pathfinder takes either a CardinalEdge or an explicit set of coordinates
+        // the destruction aware pathfinder takes either a CardinalEdge or an explicit set of coordinates
         Set<Coords> destinationSet = new HashSet<Coords>();
         destinationSet.add(dest);
         
         // debugging code that can be used to find a path to a specific edge
-        //Princess princess = new Princess("test", "test", 2020, LogLevel.OFF);
+        Princess princess = new Princess("test", "test", 2020, LogLevel.OFF);
         //Set<Coords> destinationSet = princess.getClusterTracker().getDestinationCoords(entity, CardinalEdge.WEST, true);
         
         long marker1 = System.currentTimeMillis();
-        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, true);
+        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false, princess.getClusterTracker());
         long marker2 = System.currentTimeMillis();
         long marker3 = marker2 - marker1;
         

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -486,11 +486,11 @@ public class Protomech extends Entity {
     /**
      * Returns the amount of heat that the entity can sink each turn. Pmechs
      * have no heat. //FIXME However, the number of heat sinks they have IS
-     * importnat... For cost and validation purposes.
+     * important... For cost and validation purposes.
      */
     @Override
     public int getHeatCapacity(boolean radicalHeatSinks) {
-        return 999;
+        return DOES_NOT_TRACK_HEAT;
     }
 
     @Override

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2292,7 +2292,7 @@ public class Tank extends Entity {
 
     @Override
     public int getHeatCapacity(boolean radicalHeatSinks) {
-        return 999;
+        return DOES_NOT_TRACK_HEAT;
     }
 
     @Override

--- a/megamek/src/megamek/common/VTOL.java
+++ b/megamek/src/megamek/common/VTOL.java
@@ -109,7 +109,7 @@ public class VTOL extends Tank implements IBomber {
 
     @Override
     public int getMaxElevationChange() {
-        return 999;
+        return UNLIMITED_JUMP_DOWN;
     }
 
     @Override

--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -115,7 +115,7 @@ public class BoardClusterTracker {
         
         updateMovableAreas(entity);
         
-        if(terrainReduction) {
+        if (terrainReduction) {
             BoardCluster noBridgeCluster = movableAreasWithTerrainReduction.get(movementType).get(actualCoords);
             int noBridgeClusterSize = noBridgeCluster == null ? 0 : noBridgeCluster.contents.size();
             
@@ -185,14 +185,14 @@ public class BoardClusterTracker {
         }
         
         // try with bridges
-        if(retVal.size() == 0) {
-            if(terrainReduction) {
+        if (retVal.size() == 0) {
+            if (terrainReduction) {
                 entityCluster = movableAreasBridgesWithTerrainReduction.get(movementType).get(entity.getPosition());
             } else {
                 entityCluster = movableAreasBridges.get(movementType).get(entity.getPosition());
             }
             
-            if(entityCluster != null) {
+            if (entityCluster != null) {
                 retVal = entityCluster.getIntersectingHexes(actualEdge, entity.getGame().getBoard());
             }
         }
@@ -277,7 +277,7 @@ public class BoardClusterTracker {
                 int myElevation = 0; 
                         
                 if (useBridgeTop && board.getHex(c).containsTerrain(Terrains.BRIDGE) &&
-                        canUseBridge && entity.getWeight() <= board.getBuildingAt(c).getCurrentCF(c)) {
+                        canUseBridge && (entity.getWeight() <= board.getBuildingAt(c).getCurrentCF(c))) {
                     myElevation = board.getHex(c).ceiling();
                 } else {
                     myElevation = BoardEdgePathFinder.calculateUnitElevationInHex(board.getHex(c), entity, isHovercraft, isAmphibious);
@@ -294,7 +294,7 @@ public class BoardClusterTracker {
                         int neighborElevation = 0;
                         
                         if (useBridgeTop && board.getHex(neighbor).containsTerrain(Terrains.BRIDGE) &&
-                                canUseBridge && entity.getWeight() <= board.getBuildingAt(neighbor).getCurrentCF(neighbor)) {
+                                canUseBridge && (entity.getWeight() <= board.getBuildingAt(neighbor).getCurrentCF(neighbor))) {
                             neighborElevation = board.getHex(neighbor).ceiling();
                         } else {
                             neighborElevation = BoardEdgePathFinder.calculateUnitElevationInHex(board.getHex(neighbor), entity, isHovercraft, isAmphibious);
@@ -444,7 +444,7 @@ public class BoardClusterTracker {
             for(int x = xStart; x < xEnd; x++) {
                 for(int y = yStart; y < yEnd; y++) {
                     Coords coords = new Coords(x, y);
-                    if(contents.containsKey(coords)) {
+                    if (contents.containsKey(coords)) {
                         retVal.add(coords);
                     }
                 }

--- a/megamek/src/megamek/common/pathfinder/CachedEntityState.java
+++ b/megamek/src/megamek/common/pathfinder/CachedEntityState.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import megamek.common.Entity;
 import megamek.common.Mech;
+import megamek.common.MiscType;
 
 /**
  * A transient class used to lazy-load "calculated" information from an entity
@@ -103,5 +104,14 @@ public class CachedEntityState {
         }
         
         return torsoJumpJets;
+    }
+    
+    /**
+     * Convenience property to determine if the backing entity is amphibious.
+     */
+    public boolean isAmphibious() {
+        return hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS) || 
+                hasWorkingMisc(MiscType.F_AMPHIBIOUS) ||
+                hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS);
     }
 }

--- a/megamek/src/megamek/common/pathfinder/CachedEntityState.java
+++ b/megamek/src/megamek/common/pathfinder/CachedEntityState.java
@@ -112,6 +112,6 @@ public class CachedEntityState {
     public boolean isAmphibious() {
         return hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS) || 
                 hasWorkingMisc(MiscType.F_AMPHIBIOUS) ||
-                hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS);
+                hasWorkingMisc(MiscType.F_LIMITED_AMPHIBIOUS);
     }
 }

--- a/megamek/src/megamek/common/pathfinder/CachedEntityState.java
+++ b/megamek/src/megamek/common/pathfinder/CachedEntityState.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import megamek.common.Entity;
+import megamek.common.Mech;
 
 /**
  * A transient class used to lazy-load "calculated" information from an entity
@@ -21,6 +22,7 @@ public class CachedEntityState {
     private Integer jumpMP;
     private Integer jumpMPWithTerrain;
     private Map<BigInteger, Boolean> hasWorkingMisc;
+    private Integer torsoJumpJets;
     
     public CachedEntityState(Entity entity) {
         backingEntity = entity;
@@ -89,5 +91,17 @@ public class CachedEntityState {
         }
         
         return hasWorkingMisc.get(flag);
+    }
+    
+    public int getTorsoJumpJets() {
+        if(torsoJumpJets == null) {
+            if(backingEntity instanceof Mech) {
+                torsoJumpJets = ((Mech) backingEntity).torsoJumpJets();
+            } else {
+                torsoJumpJets = 0;
+            }
+        }
+        
+        return torsoJumpJets;
     }
 }

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -175,7 +175,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * to the list of child paths.
      */
     protected void processChild(BulldozerMovePath child, List<BulldozerMovePath> children, 
-            Map<Coords, BulldozerMovePath> shortestPathsToCoords) {
+            Map<Coords, BulldozerMovePath> shortestPathsToCoords) {        
         // (if we haven't visited these coordinates before
         // or we have, and this is a shorter path)
         // and (it is a legal move

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -27,10 +27,15 @@ import megamek.client.bot.princess.AeroPathUtil;
 import megamek.common.BulldozerMovePath;
 import megamek.common.Coords;
 import megamek.common.Entity;
+import megamek.common.EntityMovementMode;
 import megamek.common.IBoard;
+import megamek.common.IHex;
+import megamek.common.MiscType;
 import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
+import megamek.common.MoveStep;
 import megamek.common.PlanetaryConditions;
+import megamek.common.Terrains;
 
 /**
  * Handles the generation of ground-based move paths that contain information relating to the destruction 
@@ -46,8 +51,8 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * Ignores move cost and makes note of hexes that need to be cleared for the path to
      * be viable.
      */
-    public BulldozerMovePath findPathToCoords(Entity entity, Set<Coords> destinationCoords) {
-        return findPathToCoords(entity, destinationCoords, false);
+    public BulldozerMovePath findPathToCoords(Entity entity, Set<Coords> destinationCoords, BoardClusterTracker clusterTracker) {
+        return findPathToCoords(entity, destinationCoords, false, clusterTracker);
     }
     
     /**
@@ -55,7 +60,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * Ignores move cost and makes note of hexes that need to be cleared for the path to
      * be viable.
      */
-    public BulldozerMovePath findPathToCoords(Entity entity, Set<Coords> destinationCoords, boolean jump) {
+    public BulldozerMovePath findPathToCoords(Entity entity, Set<Coords> destinationCoords, boolean jump, BoardClusterTracker clusterTracker) {
         BulldozerMovePath startPath = new BulldozerMovePath(entity.getGame(), entity);
         
         // if we're calculating a jump path and the entity has jump mp and can jump, start off with a jump
@@ -100,11 +105,8 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
 
         while(!candidates.isEmpty()) {
             BulldozerMovePath currentPath = candidates.pollFirst();
-            if(currentPath.getFinalCoords().getX() == 24 && currentPath.getFinalCoords().getY() == 30) {
-                int alpha = 1;
-            }
             
-            candidates.addAll(generateChildNodes(currentPath, shortestPathsToCoords));      
+            candidates.addAll(generateChildNodes(currentPath, shortestPathsToCoords, clusterTracker, closest));      
             
             if(destinationCoords.contains(currentPath.getFinalCoords()) &&
                     ((bestPath == null) || (movePathComparator.compare(bestPath, currentPath) > 0))) {
@@ -151,7 +153,8 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * @param visitedCoords Set of visited coordinates so we don't loop around
      * @return List of valid children. Between 0 and 3 inclusive.
      */
-    protected List<BulldozerMovePath> generateChildNodes(BulldozerMovePath parentPath, Map<Coords, BulldozerMovePath> shortestPathsToCoords) {
+    protected List<BulldozerMovePath> generateChildNodes(BulldozerMovePath parentPath, Map<Coords, BulldozerMovePath> shortestPathsToCoords,
+            BoardClusterTracker clusterTracker, Coords destinationCoords) {
         List<BulldozerMovePath> children = new ArrayList<>();
 
         // there are six possible children of a move path, defined in AeroPathUtil.TURNS
@@ -168,7 +171,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
             
             // move forward and process the generated child path
             childPath.addStep(MoveStepType.FORWARDS);
-            processChild(childPath, children, shortestPathsToCoords);
+            processChild(childPath, children, shortestPathsToCoords, clusterTracker, destinationCoords);
         }
 
         return children;
@@ -179,11 +182,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * to the list of child paths.
      */
     protected void processChild(BulldozerMovePath child, List<BulldozerMovePath> children, 
-            Map<Coords, BulldozerMovePath> shortestPathsToCoords) {
-        
-        if(child.getFinalCoords().getX() == 24 && child.getFinalCoords().getY() == 30) {
-            int alpha = 1;
-        }
+            Map<Coords, BulldozerMovePath> shortestPathsToCoords, BoardClusterTracker clusterTracker, Coords destinationCoords) {
         // (if we haven't visited these coordinates before
         // or we have, and this is a shorter path)
         // and (it is a legal move
@@ -209,6 +208,25 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         boolean legalJumpMove = child.isJumping() &&
                 !mli.outOfBounds &&
                 (!mli.goingUpTooHigh || child.needsLeveling());
+        
+        // this is true if we're jumping down further down than our max jump MP
+        // or jumping down lower than our max elevation change
+        boolean irreversibleJumpDown = 
+                (child.isJumping() && (Math.abs(mli.elevationChange) > child.getCachedEntityState().getJumpMP())) ||
+                (child.getEntity().getMaxElevationDown() == Entity.UNLIMITED_JUMP_DOWN) && (Math.abs(mli.elevationChange) > child.getEntity().getMaxElevationChange());
+        
+        boolean destinationUseBridge = child.getGame().getBoard().getHex(destinationCoords).getTerrain(Terrains.BRIDGE) != null;
+        int destHexElevation = calculateUnitElevationInHex(child.getGame().getBoard().getHex(destinationCoords), 
+                child.getEntity(), child.getEntity().getMovementMode() == EntityMovementMode.HOVER, child.getCachedEntityState().isAmphibious(),
+                destinationUseBridge);
+        
+        // if we jumped into a hole and this results into us moving into a different cluster than the destination,
+        // that's not great and we should not consider the possibility for long range path finding.
+        if(irreversibleJumpDown && 
+                !clusterTracker.coordinatesShareCluster(child.getEntity(), child.getFinalCoords(), destinationCoords,
+                        mli.destHexElevation, destHexElevation)) {
+            return;
+        }
         
         if((!shortestPathsToCoords.containsKey(child.getFinalCoords()) ||
                 // shorter path to these coordinates
@@ -243,14 +261,14 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
          * Favors paths that move closer to the destination edge first.
          * in case of tie, favors paths that cost less MP
          */
-        public int compare(BulldozerMovePath first, BulldozerMovePath second) {            
+        public int compare(BulldozerMovePath first, BulldozerMovePath second) {
             IBoard board = first.getGame().getBoard();
             boolean backwards = false;
             int h1 = first.getFinalCoords().distance(destination)
-                    + ShortestPathFinder.getLevelDiff(first, destination, board)
+                    + ShortestPathFinder.getLevelDiff(first, destination, board, false)
                     + ShortestPathFinder.getElevationDiff(first, destination, board, first.getEntity());
             int h2 = second.getFinalCoords().distance(destination)
-                    + ShortestPathFinder.getLevelDiff(second, destination, board)
+                    + ShortestPathFinder.getLevelDiff(second, destination, board, false)
                     + ShortestPathFinder.getElevationDiff(second, destination, board, second.getEntity());
     
             int dd = (first.getMpUsed() + first.getLevelingCost() + first.getAdditionalCost() + h1) 

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -222,7 +222,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         
         // if we jumped into a hole and this results into us moving into a different cluster than the destination,
         // that's not great and we should not consider the possibility for long range path finding.
-        if(irreversibleJumpDown && 
+        if (irreversibleJumpDown && 
                 !clusterTracker.coordinatesShareCluster(child.getEntity(), child.getFinalCoords(), destinationCoords,
                         mli.destHexElevation, destHexElevation)) {
             return;

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -100,7 +100,11 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
 
         while(!candidates.isEmpty()) {
             BulldozerMovePath currentPath = candidates.pollFirst();
-            candidates.addAll(generateChildNodes(currentPath, shortestPathsToCoords));            
+            if(currentPath.getFinalCoords().getX() == 24 && currentPath.getFinalCoords().getY() == 30) {
+                int alpha = 1;
+            }
+            
+            candidates.addAll(generateChildNodes(currentPath, shortestPathsToCoords));      
             
             if(destinationCoords.contains(currentPath.getFinalCoords()) &&
                     ((bestPath == null) || (movePathComparator.compare(bestPath, currentPath) > 0))) {
@@ -175,7 +179,11 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * to the list of child paths.
      */
     protected void processChild(BulldozerMovePath child, List<BulldozerMovePath> children, 
-            Map<Coords, BulldozerMovePath> shortestPathsToCoords) {        
+            Map<Coords, BulldozerMovePath> shortestPathsToCoords) {
+        
+        if(child.getFinalCoords().getX() == 24 && child.getFinalCoords().getY() == 30) {
+            int alpha = 1;
+        }
         // (if we haven't visited these coordinates before
         // or we have, and this is a shorter path)
         // and (it is a legal move

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -261,6 +261,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
          * Favors paths that move closer to the destination edge first.
          * in case of tie, favors paths that cost less MP
          */
+        @Override
         public int compare(BulldozerMovePath first, BulldozerMovePath second) {
             IBoard board = first.getGame().getBoard();
             boolean backwards = false;

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -63,10 +63,10 @@ public class PathDecorator {
         }
         
         // if there is a bad guy in the last step, clip to one step short and see if we can't get around.
-        if(clippedSource.getGame().getFirstEnemyEntity(clippedSource.getLastStep().getPosition(), clippedSource.getEntity()) != null) {
+        if (clippedSource.getGame().getFirstEnemyEntity(clippedSource.getLastStep().getPosition(), clippedSource.getEntity()) != null) {
             clippedSource.removeLastStep();
             
-            for(int desiredMP : desiredMPs) {
+            for (int desiredMP : desiredMPs) {
                 List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
                 retVal.addAll(clippedPaths);
             }

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -62,6 +62,16 @@ public class PathDecorator {
             retVal.addAll(clippedPaths);
         }
         
+        // if there is a bad guy in the last step, clip to one step short and see if we can't get around.
+        if(clippedSource.getGame().getFirstEnemyEntity(clippedSource.getLastStep().getPosition(), clippedSource.getEntity()) != null) {
+            clippedSource.removeLastStep();
+            
+            for(int desiredMP : desiredMPs) {
+                List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
+                retVal.addAll(clippedPaths);
+            }
+        }
+        
         return retVal;
     }
     

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -365,11 +365,11 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
      * goal location. This prevents the heuristic from under-estimating when a
      * unit is on top of a hill.
      * 
-     * @param mp
-     * @param dest
-     * @param board
-     * @param ignore
-     * @return
+     * @param mp MovePath to evaluate
+     * @param dest Destination coordinates
+     * @param board Board on which the move path takes place
+     * @param ignore Whether to ignore this calculation and return 0
+     * @return level difference between the final coordinates of the given move path and the destination coordinates
      */
     public static int getLevelDiff(final MovePath mp, Coords dest, IBoard board, boolean ignore) {
         // Ignore level differences if we're not on the ground

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -209,12 +209,12 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
                 boolean backwards = stepType == MoveStepType.BACKWARDS;
                 h1 = first.getFinalCoords().distance(destination)
                         + getFacingDiff(first, destination, backwards)
-                        + getLevelDiff(first, destination, board)
+                        + getLevelDiff(first, destination, board, first.isJumping())
                         + getElevationDiff(first, destination, board,
                                 first.getEntity());
                 h2 = second.getFinalCoords().distance(destination)
                         + getFacingDiff(second, destination, backwards)
-                        + getLevelDiff(second, destination, board)
+                        + getLevelDiff(second, destination, board, second.isJumping())
                         + getElevationDiff(second, destination, board,
                                 second.getEntity());
             }
@@ -370,13 +370,9 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
      * @param board
      * @return
      */
-    public static int getLevelDiff(final MovePath mp, Coords dest, IBoard board) {
+    public static int getLevelDiff(final MovePath mp, Coords dest, IBoard board, boolean ignore) {
         // Ignore level differences if we're not on the ground
-        if (mp.getFinalElevation() != 0) {
-            return 0;
-        }
-        // Jumping should ignore level differences
-        if (mp.isJumping()) {
+        if (ignore || (mp.getFinalElevation() != 0)) {
             return 0;
         }
         IHex currHex = board.getHex(mp.getFinalCoords());

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -368,6 +368,7 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
      * @param mp
      * @param dest
      * @param board
+     * @param ignore
      * @return
      */
     public static int getLevelDiff(final MovePath mp, Coords dest, IBoard board, boolean ignore) {


### PR DESCRIPTION
Three changes:
- long range path clipping would get "stuck" on hostile units if the moving entity could enter the hex - since you can't both enter and exit a hostile unit's hex on the same turn, we need to apply "decorations" to the hex prior to the hostile entity, so that we can go around it.

- bridges (and theoretically building tops, but we're skipping that for now) higher than 2 hexes off the ground wouldn't correctly join movable area clusters. Required some data structure changes but now bot units properly consider "tall" bridges.

- jumping units are discouraged from completely submerging themselves at the end of a jump