### PR TITLE
fix localload command

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -40,6 +40,11 @@ import java.util.zip.GZIPInputStream;
 import javax.swing.SwingUtilities;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
 import megamek.MegaMek;
 import megamek.client.commands.AddBotCommand;
@@ -112,6 +117,7 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.IBasicOption;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.StringUtil;
+import megamek.server.ServerNetworkHelper;
 import megamek.server.SmokeCloud;
 
 /**
@@ -912,9 +918,9 @@ public class Client implements IClientCommandHandler {
      */
     public void sendLoadGame(File f) {
         try (InputStream is = new GZIPInputStream(new FileInputStream(f))) {
-            XStream xstream = new XStream();
-
             game.reset();
+            
+            XStream xstream = ServerNetworkHelper.getXStream();            
             IGame newGame = (IGame) xstream.fromXML(is);
 
             send(new Packet(Packet.COMMAND_LOAD_GAME, new Object[] { newGame }));

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1344,46 +1344,7 @@ public class Server implements Runnable {
 
         IGame newGame;
         try (InputStream is = new FileInputStream(f); InputStream gzi = new GZIPInputStream(is)) {
-            XStream xstream = new XStream();
-
-            // This mirrors the settings is saveGame
-            xstream.setMode(XStream.ID_REFERENCES);
-
-            xstream.registerConverter(new Converter() {
-                @Override
-                public boolean canConvert(Class cls) {
-                    return (cls == Coords.class);
-                }
-
-                @Override
-                public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
-                    int x = 0, y = 0;
-                    boolean foundX = false, foundY = false;
-                    while(reader.hasMoreChildren()) {
-                        reader.moveDown();
-                        switch(reader.getNodeName()) {
-                            case "x":
-                                x = Integer.parseInt(reader.getValue());
-                                foundX = true;
-                                break;
-                            case "y":
-                                y = Integer.parseInt(reader.getValue());
-                                foundY = true;
-                                break;
-                            default:
-                                // Unknown node, or <hash>
-                                break;
-                        }
-                        reader.moveUp();
-                    }
-                    return (foundX && foundY) ? new Coords(x, y) : null;
-                }
-
-                @Override
-                public void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
-                    // Unused here
-                }
-            });
+            XStream xstream = ServerNetworkHelper.getXStream();
             newGame = (IGame) xstream.fromXML(gzi);
         } catch (Exception e) {
             getLogger().error(getClass(), METHOD_NAME, "Unable to load file: " + f, e); //$NON-NLS-1$

--- a/megamek/src/megamek/server/ServerNetworkHelper.java
+++ b/megamek/src/megamek/server/ServerNetworkHelper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package megamek.server;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+import megamek.common.Coords;
+
+/**
+ * Class that off-loads network related code from Server.java
+ */
+public class ServerNetworkHelper {
+    
+    /**
+     * Factory method that produces an XStream object suitable for loading MegaMek save games
+     */
+    public static XStream getXStream() {
+        XStream xstream = new XStream();
+
+        // This mirrors the settings is saveGame
+        xstream.setMode(XStream.ID_REFERENCES);
+
+        xstream.registerConverter(new Converter() {
+            @Override
+            public boolean canConvert(Class cls) {
+                return (cls == Coords.class);
+            }
+
+            @Override
+            public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+                int x = 0, y = 0;
+                boolean foundX = false, foundY = false;
+                while(reader.hasMoreChildren()) {
+                    reader.moveDown();
+                    switch(reader.getNodeName()) {
+                        case "x":
+                            x = Integer.parseInt(reader.getValue());
+                            foundX = true;
+                            break;
+                        case "y":
+                            y = Integer.parseInt(reader.getValue());
+                            foundY = true;
+                            break;
+                        default:
+                            // Unknown node, or <hash>
+                            break;
+                    }
+                    reader.moveUp();
+                }
+                return (foundX && foundY) ? new Coords(x, y) : null;
+            }
+
+            @Override
+            public void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+                // Unused here
+            }
+        });
+        
+        return xstream;
+    }
+}

--- a/megamek/src/megamek/server/victory/Victory.java
+++ b/megamek/src/megamek/server/victory/Victory.java
@@ -13,6 +13,7 @@
  */
 package megamek.server.victory;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,8 +23,9 @@ import megamek.common.Report;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 
-public class Victory {
-
+public class Victory implements Serializable {
+    private static final long serialVersionUID = -8633873540471130320L;
+    
     private boolean checkForVictory;
     private int neededVictoryConditions;
 


### PR DESCRIPTION
A probable fix for the localload command not working. The Server.loadGame() function was updated to change some properties of the XStream object, but the game.sendLoadGame() command wasn't updated to match that and so was failing.

It was also complaining about Victory being non-serializable.

While running this from a gui client, I observed that the unit images don't really update properly when loading the file (an Atlas showed up as a Vedette), but I'll address that in another pull request if necessary.