### PR TITLE
Variable equipment size, part 2

### DIFF
--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -452,3 +452,5 @@ MiscType.drones=drones
 MiscType.drone=drone
 MiscType.theaters=theaters
 MiscType.theater=theater
+MiscType.tons=tons
+MiscType.ton=ton

--- a/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
@@ -360,7 +360,7 @@ public class UnitEditorDialog extends JDialog {
                     || !m.getType().isHittable() || m.isWeaponGroup()) {
                 continue;
             }
-            int nCrits = m.getType().getCriticals(entity);
+            int nCrits = m.getCriticals();
             int eqNum = entity.getEquipmentNum(m);
             int hits = entity.getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT,
                     eqNum, m.getLocation());

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -378,6 +378,10 @@ public class EquipmentType implements ITechnology {
     }
 
     public int getCriticals(Entity entity) {
+        return getCriticals(entity, 1.0);
+    }
+
+    public int getCriticals(Entity entity, double size) {
         return criticals;
     }
 

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -2002,7 +2002,7 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
             if (type >= 0) {
                 slots = BombType.getBombCost(type);
             } else {
-                slots = mounted.getType().getCriticals(this);
+                slots = mounted.getCriticals();
             }
         }
         for (int i = 0; i < crits[loc].length; i++) {

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3014,7 +3014,7 @@ public abstract class Mech extends Entity {
         // spreadable or split equipment only gets added to 1 crit at a time,
         // since we don't know how many are in this location
         int reqSlots = mounted.getType().getCriticals(this);
-        if (mounted.getType().isSpreadable() || mounted.isSplitable()) {
+        if (mounted.getType().isSpreadable() || mounted.isSplitable() || mounted.getType().isVariableSize()) {
             reqSlots = 1;
         }
         if (isSuperHeavy()) {

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3013,7 +3013,7 @@ public abstract class Mech extends Entity {
 
         // spreadable or split equipment only gets added to 1 crit at a time,
         // since we don't know how many are in this location
-        int reqSlots = mounted.getType().getCriticals(this);
+        int reqSlots = mounted.getCriticals();
         if (mounted.getType().isSpreadable() || mounted.isSplitable() || mounted.getType().isVariableSize()) {
             reqSlots = 1;
         }
@@ -3792,7 +3792,7 @@ public abstract class Mech extends Entity {
             }
 
             // we subtract per critical slot
-            toSubtract *= etype.getCriticals(this);
+            toSubtract *= mounted.getCriticals();
             ammoPenalty += toSubtract;
         }
         if (getJumpType() == JUMP_PROTOTYPE_IMPROVED) {
@@ -6722,7 +6722,7 @@ public abstract class Mech extends Entity {
             sb.append(newLine);
         }
         for (Mounted mounted : getMisc()) {
-            if ((mounted.getType().getCriticals(this) == 0)
+            if ((mounted.getCriticals() == 0)
                     && !mounted.getType().hasFlag(MiscType.F_CASE)
                     && !EquipmentType.isArmorType(mounted.getType())
                     && !EquipmentType.isStructureType(mounted.getType())) {
@@ -8050,11 +8050,11 @@ public abstract class Mech extends Entity {
                     && (mount.getLinkedBy() != null)) {
                 mountBv += ((MiscType) mount.getLinkedBy().getType()).getBV(
                         this, mount);
-                bv += mountBv * 0.05 * (mount.getType().getCriticals(this) + 1);
+                bv += mountBv * 0.05 * (mount.getCriticals() + 1);
             } else if (mountBv > 0) {
-                bv += mountBv * 0.05 * mount.getType().getCriticals(this);
+                bv += mountBv * 0.05 * mount.getCriticals();
             } else {
-                bv += 5 * mount.getType().getCriticals(this);
+                bv += 5 * mount.getCriticals();
             }
         }
 

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3014,7 +3014,7 @@ public abstract class Mech extends Entity {
         // spreadable or split equipment only gets added to 1 crit at a time,
         // since we don't know how many are in this location
         int reqSlots = mounted.getCriticals();
-        if (mounted.getType().isSpreadable() || mounted.isSplitable() || mounted.getType().isVariableSize()) {
+        if (mounted.getType().isSpreadable() || mounted.isSplitable()) {
             reqSlots = 1;
         }
         if (isSuperHeavy()) {

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -941,7 +941,7 @@ public class MechView {
             String name = mounted.getName();
             if ((((mounted.getLocation() == Entity.LOC_NONE)
                         // Mechs can have zero-slot equipment in LOC_NONE that needs to be shown.
-                        && (!isMech || mounted.getType().getCriticals(entity) > 0)))
+                        && (!isMech || mounted.getCriticals() > 0)))
                     || name.contains("Jump Jet")
                     || (name.contains("CASE")
                         && !name.contains("II")

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -884,6 +884,9 @@ public class MiscType extends EquipmentType {
         } else if (hasFlag(F_LADDER)) {
             // 0.1 tons per 20 meters
             return RoundWeight.nearestKg(size / 200.0);
+        } else if (hasFlag(F_BA_MISSION_EQUIPMENT)) {
+            // Size is weight in kg
+            return RoundWeight.nearestKg(size / 1000.0);
         }
        // okay, I'm out of ideas
         return 1.0f;
@@ -1721,9 +1724,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createBAPowerPack());
         EquipmentType.addType(MiscType.createBAShotgunMicrophone());
         EquipmentType.addType(MiscType.createISBAMineDispenser());
-        EquipmentType.addType(MiscType.createBAMissionEquipStorage200());
-        EquipmentType.addType(MiscType.createBAMissionEquipStorage20());
-        EquipmentType.addType(MiscType.createBAMissionEquipStorage5());
+        EquipmentType.addType(MiscType.createBAMissionEquipStorage());
         EquipmentType.addType(MiscType.createISBADropChuteCamo());
         EquipmentType.addType(MiscType.createISBADropChuteCamo());
         EquipmentType.addType(MiscType.createISBADropChuteStd());
@@ -10836,65 +10837,26 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createBAMissionEquipStorage20() {
+    public static MiscType createBAMissionEquipStorage() {
         MiscType misc = new MiscType();
         // Not Covered in IO so using the old stats from TO.
-        misc.name = "Mission Equipment Storage (20 kg)";
-        misc.addLookupName("Mission Equipment Storage");
+        misc.name = "Mission Equipment Storage";
+        misc.addLookupName("Mission Equipment Storage (20 kg)");
+        misc.addLookupName("Mission Equipment Storage (5kg)");
+        misc.addLookupName("Mission Equipment Storage (200 kg)");
         misc.setInternalName(misc.name);
-        misc.tonnage = 0.02;
+        misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
-        misc.flags = misc.flags.or(F_BA_EQUIPMENT).or(F_BA_MISSION_EQUIPMENT)
+        misc.flags = misc.flags.or(F_VARIABLE_SIZE).or(F_BA_EQUIPMENT).or(F_BA_MISSION_EQUIPMENT)
                 .andNot(F_MECH_EQUIPMENT).andNot(F_TANK_EQUIPMENT).andNot(F_FIGHTER_EQUIPMENT);
         misc.bv = 0;
         misc.cost = 750;
 
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false);
-        misc.techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, 2720);
-        misc.techAdvancement.setTechRating(RATING_C);
-        misc.techAdvancement.setAvailability(new int[] { RATING_C, RATING_C, RATING_C, RATING_C });
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setAdvancement(DATE_NONE, DATE_NONE, 2720)
+                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_C, RATING_C, RATING_C);
         return misc;
     }
     
-    public static MiscType createBAMissionEquipStorage5() {
-        MiscType misc = new MiscType();
-        // Not Covered in IO so using the old stats from TO.
-        misc.name = "Mission Equipment Storage (5kg)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 0.005;
-        misc.criticals = 1;
-        misc.flags = misc.flags.or(F_BA_EQUIPMENT).or(F_BA_MISSION_EQUIPMENT)
-                .andNot(F_MECH_EQUIPMENT).andNot(F_TANK_EQUIPMENT).andNot(F_FIGHTER_EQUIPMENT);
-        misc.bv = 0;
-        misc.cost = 750;
-
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false);
-        misc.techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, 2720);
-        misc.techAdvancement.setTechRating(RATING_C);
-        misc.techAdvancement.setAvailability(new int[] { RATING_C, RATING_C, RATING_C, RATING_C });
-        return misc;
-    }
-    
-    public static MiscType createBAMissionEquipStorage200() {
-        MiscType misc = new MiscType();
-        // Not Covered in IO so using the old stats from TO.
-        misc.name = "Mission Equipment Storage (200 kg)";
-        misc.addLookupName("Mission Equipment Storage");
-        misc.setInternalName(misc.name);
-        misc.tonnage = 0.2;
-        misc.criticals = 1;
-        misc.flags = misc.flags.or(F_BA_EQUIPMENT).or(F_BA_MISSION_EQUIPMENT)
-                .andNot(F_MECH_EQUIPMENT).andNot(F_TANK_EQUIPMENT).andNot(F_FIGHTER_EQUIPMENT);
-        misc.bv = 0;
-        misc.cost = 750;
-
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false);
-        misc.techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, 2720);
-        misc.techAdvancement.setTechRating(RATING_C);
-        misc.techAdvancement.setAvailability(new int[] { RATING_C, RATING_C, RATING_C, RATING_C });
-        return misc;
-    }
-
     /*
      * // TODO Warrior Augmentations - IO pg 58. A lot of these are already in game
      * as SPA's. Should be reviewed and determine if they need a piece of equipment.

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1052,7 +1052,7 @@ public class MiscType extends EquipmentType {
             if (isArmored) {
                 double armoredCost = costValue;
 
-                armoredCost += 150000 * getCriticals(entity);
+                armoredCost += 150000 * getCriticals(entity, size);
 
                 return armoredCost;
             }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -468,6 +468,9 @@ public class MiscType extends EquipmentType {
         if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO)) {
             return 0.5;
         }
+        if (hasFlag(F_LADDER)) {
+            return 20.0;
+        }
         return super.variableStepSize();
     }
 
@@ -878,6 +881,9 @@ public class MiscType extends EquipmentType {
             }
         } else if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO) || hasFlag(F_COMMUNICATIONS)) {
             return defaultRounding.round(size, entity);
+        } else if (hasFlag(F_LADDER)) {
+            // 0.1 tons per 20 meters
+            return RoundWeight.nearestKg(size / 200.0);
         }
        // okay, I'm out of ideas
         return 1.0f;
@@ -1047,6 +1053,8 @@ public class MiscType extends EquipmentType {
                     weaponCost += mount.getCost();
                 }
                 costValue = weaponCost * 0.1;
+            } else if (hasFlag(F_LADDER)) {
+                costValue = size * 5;
             }
             
             if (isArmored) {
@@ -1766,11 +1774,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createBulldozer());
         EquipmentType.addType(MiscType.createExternalStoresHardpoint());
         EquipmentType.addType(MiscType.createManipulator());
-        EquipmentType.addType(MiscType.create20mLadder());
-        EquipmentType.addType(MiscType.create40mLadder());
-        EquipmentType.addType(MiscType.create60mLadder());
-        EquipmentType.addType(MiscType.create80mLadder());
-        EquipmentType.addType(MiscType.create100mLadder());
+        EquipmentType.addType(MiscType.createLadder());
         EquipmentType.addType(MiscType.createMaritimeLifeboat());
         EquipmentType.addType(MiscType.createMaritimeEscapePod());
         EquipmentType.addType(MiscType.createAtmossphericLifeboat());
@@ -7325,96 +7329,21 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType create20mLadder() {
+    public static MiscType createLadder() {
         MiscType misc = new MiscType();
-        misc.name = "Ladder (20m)";
+        misc.name = "Ladder";
         misc.setInternalName(misc.name);
+        misc.addLookupName("Ladder (20m)");
+        misc.addLookupName("Ladder (40m)");
+        misc.addLookupName("Ladder (60m)");
+        misc.addLookupName("Ladder (80m)");
+        misc.addLookupName("Ladder (100m)");
         misc.tankslots = 1;
         misc.criticals = 1;
-        misc.tonnage = 0.1;
-        misc.cost = 100;
-        misc.flags = misc.flags.or(F_LADDER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT)
-                .andNot(F_FIGHTER_EQUIPMENT);
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType create40mLadder() {
-        MiscType misc = new MiscType();
-        misc.name = "Ladder (40m)";
-        misc.setInternalName(misc.name);
-        misc.tankslots = 1;
-        misc.criticals = 1;
-        misc.tonnage = 0.2;
-        misc.cost = 200;
-        misc.flags = misc.flags.or(F_LADDER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_LADDER)
-                .andNot(F_FIGHTER_EQUIPMENT);
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType create60mLadder() {
-        MiscType misc = new MiscType();
-        misc.name = "Ladder (60m)";
-        misc.setInternalName(misc.name);
-        misc.tankslots = 1;
-        misc.criticals = 1;
-        misc.tonnage = 0.3;
-        misc.cost = 300;
-        misc.flags = misc.flags.or(F_LADDER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_LADDER)
-                .andNot(F_FIGHTER_EQUIPMENT);
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType create80mLadder() {
-        MiscType misc = new MiscType();
-        misc.name = "Ladder (80m)";
-        misc.setInternalName(misc.name);
-        misc.tankslots = 1;
-        misc.criticals = 1;
-        misc.tonnage = 0.4;
-        misc.cost = 400;
-        misc.flags = misc.flags.or(F_LADDER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_LADDER)
-                .andNot(F_FIGHTER_EQUIPMENT);
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType create100mLadder() {
-        MiscType misc = new MiscType();
-        misc.name = "Ladder (100m)";
-        misc.setInternalName(misc.name);
-        misc.tankslots = 1;
-        misc.criticals = 1;
-        misc.tonnage = 0.5;
-        misc.cost = 500;
-        misc.flags = misc.flags.or(F_LADDER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_LADDER)
-                .andNot(F_FIGHTER_EQUIPMENT);
+        misc.tonnage = TONNAGE_VARIABLE;
+        misc.cost = COST_VARIABLE;
+        misc.flags = misc.flags.or(F_LADDER).or(F_VARIABLE_SIZE).or(F_MECH_EQUIPMENT)
+                .or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).andNot(F_FIGHTER_EQUIPMENT);
         misc.rulesRefs = "244,TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
                 .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * * MegaMek - Copyright (C) 2000,2001,2002,2003,2004,2005 Ben Mazur
  * (bmazur@sev.org)
  *
@@ -13,7 +13,7 @@
  * details.
  */
 
-/**
+/*
  * MiscType.java
  *
  * Created on April 2, 2002, 12:15 PM
@@ -434,7 +434,7 @@ public class MiscType extends EquipmentType {
         return damageDivisor;
     }
 
-    private String sizeSuffix(double size) {
+    private String sizeSuffix(double size, boolean shortName) {
         if (hasFlag(F_VARIABLE_SIZE)) {
             if (hasFlag(MiscType.F_DRONE_CARRIER_CONTROL)
                     || hasFlag(MiscType.F_ATAC) || hasFlag(MiscType.F_DTAC)) {
@@ -447,6 +447,12 @@ public class MiscType extends EquipmentType {
                         Messages.getString("MiscType.theater"));
             } else if (hasFlag(MiscType.F_LADDER)) {
                 return String.format(" (%d m)", (int) size);
+            } else if (shortName) {
+                return String.format(":%.1ft", size);
+            } else {
+                    return String.format(" (%d %s)", (int) size, size > 1 ?
+                            Messages.getString("MiscType.tons") :
+                            Messages.getString("MiscType.ton"));
             }
         }
         return "";
@@ -458,18 +464,26 @@ public class MiscType extends EquipmentType {
     }
 
     @Override
+    public Double variableStepSize() {
+        if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO)) {
+            return 0.5;
+        }
+        return super.variableStepSize();
+    }
+
+    @Override
     public String getName(double size) {
-        return getName() + sizeSuffix(size);
+        return getName() + sizeSuffix(size, false);
     }
 
     @Override
     public String getShortName(double size) {
-        return getShortName() + sizeSuffix(size);
+        return getShortName() + sizeSuffix(size, true);
     }
 
     @Override
     public String getDesc(double size) {
-        return getDesc() + sizeSuffix(size);
+        return getDesc() + sizeSuffix(size, false);
     }
 
     @Override
@@ -862,6 +876,8 @@ public class MiscType extends EquipmentType {
             } else {
                 return 0.0;
             }
+        } else if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO) || hasFlag(F_COMMUNICATIONS)) {
+            return defaultRounding.round(size, entity);
         }
        // okay, I'm out of ideas
         return 1.0f;
@@ -1023,14 +1039,14 @@ public class MiscType extends EquipmentType {
                 for (Mounted mount : entity.getWeaponList()) {
                     weaponCost += mount.getCost();
                 }
-                return weaponCost * 0.05;
+                costValue = weaponCost * 0.05;
             } else if (hasFlag(F_ADVANCED_FIRECONTROL)) {
                 // 10% of weapon cost
                 double weaponCost = 0;
                 for (Mounted mount : entity.getWeaponList()) {
                     weaponCost += mount.getCost();
                 }
-                return weaponCost * 0.1;
+                costValue = weaponCost * 0.1;
             }
             
             if (isArmored) {
@@ -1045,7 +1061,7 @@ public class MiscType extends EquipmentType {
     }
 
     @Override
-    public int getCriticals(Entity entity) {
+    public int getCriticals(Entity entity, double size) {
         if ((criticals != CRITICALS_VARIABLE) || (null == entity)) {
             return criticals;
         }
@@ -1290,6 +1306,8 @@ public class MiscType extends EquipmentType {
             // Clan Endo Composite doesn't have variable crits
         } else if (hasFlag(F_FUEL)) {
             return (int) Math.ceil(getTonnage(entity));
+        } else if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO) || hasFlag(F_COMMUNICATIONS)) {
+            return (int) Math.ceil(size);
         }
         // right, well I'll just guess then
         return 1;
@@ -1565,49 +1583,13 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createCLCASEII());
         EquipmentType.addType(MiscType.createISAES());
         EquipmentType.addType(MiscType.createISModularArmor());
-        EquipmentType.addType(MiscType.createCommsGear1());
-        EquipmentType.addType(MiscType.createCommsGear2());
-        EquipmentType.addType(MiscType.createCommsGear3());
-        EquipmentType.addType(MiscType.createCommsGear4());
-        EquipmentType.addType(MiscType.createCommsGear5());
-        EquipmentType.addType(MiscType.createCommsGear6());
-        EquipmentType.addType(MiscType.createCommsGear7());
-        EquipmentType.addType(MiscType.createCommsGear8());
-        EquipmentType.addType(MiscType.createCommsGear9());
-        EquipmentType.addType(MiscType.createCommsGear10());
-        EquipmentType.addType(MiscType.createCommsGear11());
-        EquipmentType.addType(MiscType.createCommsGear12());
-        EquipmentType.addType(MiscType.createCommsGear13());
-        EquipmentType.addType(MiscType.createCommsGear14());
-        EquipmentType.addType(MiscType.createCommsGear15());
+        EquipmentType.addType(MiscType.createCommsGear());
         EquipmentType.addType(MiscType.createISGroundMobileHPG());
         EquipmentType.addType(MiscType.createISMobileHPG());
         EquipmentType.addType(MiscType.createISPartialWing());
         EquipmentType.addType(MiscType.createCLPartialWing());
-        EquipmentType.addType(MiscType.createCargo1());
-        EquipmentType.addType(MiscType.createHalfCargo());
-        EquipmentType.addType(MiscType.createCargo15());
-        EquipmentType.addType(MiscType.createCargo2());
-        EquipmentType.addType(MiscType.createCargo25());
-        EquipmentType.addType(MiscType.createCargo3());
-        EquipmentType.addType(MiscType.createCargo35());
-        EquipmentType.addType(MiscType.createCargo4());
-        EquipmentType.addType(MiscType.createCargo45());
-        EquipmentType.addType(MiscType.createCargo5());
-        EquipmentType.addType(MiscType.createCargo55());
-        EquipmentType.addType(MiscType.createCargo6());
-        EquipmentType.addType(MiscType.createCargo65());
-        EquipmentType.addType(MiscType.createCargo7());
-        EquipmentType.addType(MiscType.createCargo75());
-        EquipmentType.addType(MiscType.createCargo8());
-        EquipmentType.addType(MiscType.createCargo85());
-        EquipmentType.addType(MiscType.createCargo9());
-        EquipmentType.addType(MiscType.createCargo95());
-        EquipmentType.addType(MiscType.createCargo10());
-        EquipmentType.addType(MiscType.createCargo105());
-        EquipmentType.addType(MiscType.createCargo11());
-        EquipmentType.addType(MiscType.createLiquidCargo1());
-        EquipmentType.addType(MiscType.createHalfLiquidCargo());
+        EquipmentType.addType(MiscType.createCargo());
+        EquipmentType.addType(MiscType.createLiquidCargo());
         EquipmentType.addType(MiscType.createCargoContainer());
         EquipmentType.addType(MiscType.createMechSprayer());
         EquipmentType.addType(MiscType.createTankSprayer());
@@ -7947,459 +7929,63 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createCargo1() {
+    public static MiscType createCargo() {
         MiscType misc = new MiscType();
 
-        misc.name = "Cargo (1 ton)";
+        misc.name = "Cargo";
         misc.setInternalName(misc.name);
-        misc.tonnage = 1;
-        misc.criticals = 1;
+        misc.addLookupName("Cargo (1 ton)");
+        misc.addLookupName("Cargo (0.5 tons)");
+        misc.addLookupName("Cargo (1.5 tons)");
+        misc.addLookupName("Cargo (2 tons)");
+        misc.addLookupName("Cargo (2.5 tons)");
+        misc.addLookupName("Cargo (3 tons)");
+        misc.addLookupName("Cargo (3.5 tons)");
+        misc.addLookupName("Cargo (4 tons)");
+        misc.addLookupName("Cargo (4.5 tons)");
+        misc.addLookupName("Cargo (5 tons)");
+        misc.addLookupName("Cargo (5.5 tons)");
+        misc.addLookupName("Cargo (6 tons)");
+        misc.addLookupName("Cargo (6.5 tons)");
+        misc.addLookupName("Cargo (7 tons)");
+        misc.addLookupName("Cargo (7.5 tons)");
+        misc.addLookupName("Cargo (8 ton)");
+        misc.addLookupName("Cargo (8.5 tons)");
+        misc.addLookupName("Cargo (9 tons)");
+        misc.addLookupName("Cargo (9.5 tons)");
+        misc.addLookupName("Cargo (10 tons)");
+        misc.addLookupName("Cargo (10.5 tons)");
+        misc.addLookupName("Cargo (11 tons)");
+        misc.tonnage = TONNAGE_VARIABLE;
+        misc.criticals = CRITICALS_VARIABLE;
         misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
+        misc.flags = misc.flags.or(F_CARGO).or(F_VARIABLE_SIZE).or(F_MECH_EQUIPMENT)
+                .or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
         misc.industrial = true;
         misc.tankslots = 1;
         misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setAdvancement(DATE_PS, DATE_PS, DATE_PS)
+                .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A);
         return misc;
     }
 
-    public static MiscType createHalfCargo() {
+    public static MiscType createLiquidCargo() {
         MiscType misc = new MiscType();
 
-        misc.name = "Cargo (0.5 tons)";
+        misc.name = "Liquid Storage";
         misc.setInternalName(misc.name);
-        misc.tonnage = 0.5;
-        misc.criticals = 1;
+        misc.addLookupName("Liquid Storage (1 ton)");
+        misc.addLookupName("Liquid Storage (0.5 ton)");
+        misc.tonnage = TONNAGE_VARIABLE;
+        misc.criticals = CRITICALS_VARIABLE;
         misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
+        misc.flags = misc.flags.or(F_LIQUID_CARGO).or(F_VARIABLE_SIZE).or(F_MECH_EQUIPMENT)
+                .or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
         misc.industrial = true;
         misc.tankslots = 1;
         misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo15() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (1.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 1.5;
-        misc.criticals = 2;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo2() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (2 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 2;
-        misc.criticals = 2;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo25() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (2.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 2.5;
-        misc.criticals = 3;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo3() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (3 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 3;
-        misc.criticals = 3;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo35() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (3.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 3.5;
-        misc.criticals = 4;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo4() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (4 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 4;
-        misc.criticals = 4;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo45() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (4.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 4.5;
-        misc.criticals = 5;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo5() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 5;
-        misc.criticals = 5;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo55() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (5.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 5.5;
-        misc.criticals = 6;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo6() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (6 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 6;
-        misc.criticals = 6;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo65() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (6.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 6.5;
-        misc.criticals = 7;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo7() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (7 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 7;
-        misc.criticals = 7;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo75() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (7.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 7.5;
-        misc.criticals = 8;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo8() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (8 ton)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 8;
-        misc.criticals = 8;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo85() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (8.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 8.5;
-        misc.criticals = 9;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo9() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (9 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 9;
-        misc.criticals = 9;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo95() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (9.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 9.5;
-        misc.criticals = 10;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo10() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (10 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 10;
-        misc.criticals = 10;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo105() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (10.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 10.5;
-        misc.criticals = 11;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createCargo11() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Cargo (11 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 11;
-        misc.criticals = 11;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createLiquidCargo1() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Liquid Storage (1 ton)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 1;
-        misc.criticals = 1;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_LIQUID_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
-        return misc;
-    }
-
-    public static MiscType createHalfLiquidCargo() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Liquid Storage (0.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 0.5;
-        misc.criticals = 1;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_LIQUID_CARGO).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
-        misc.industrial = true;
-        misc.tankslots = 1;
-        misc.rulesRefs = "239,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setAdvancement(DATE_PS, DATE_PS, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_A);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_A });
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setAdvancement(DATE_PS, DATE_PS, DATE_PS)
+            .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A);
         return misc;
     }
 
@@ -8471,20 +8057,51 @@ public class MiscType extends EquipmentType {
     }
 
     // CommsGear
-    public static MiscType createCommsGear1() {
+    public static MiscType createCommsGear() {
         MiscType misc = new MiscType();
 
-        misc.name = "Communications Equipment (1 ton)";
+        misc.name = "Communications Equipment";
         misc.setInternalName(misc.name);
+        misc.addLookupName("CommsGear");
+        misc.addLookupName("Communications Equipment (1 ton)");
+        misc.addLookupName("Communications Equipment (2 ton)");
+        misc.addLookupName("Communications Equipment (3 ton)");
+        misc.addLookupName("Communications Equipment (4 ton)");
+        misc.addLookupName("Communications Equipment (5 ton)");
+        misc.addLookupName("Communications Equipment (6 ton)");
+        misc.addLookupName("Communications Equipment (7 ton)");
+        misc.addLookupName("Communications Equipment (8 ton)");
+        misc.addLookupName("Communications Equipment (9 ton)");
+        misc.addLookupName("Communications Equipment (10 ton)");
+        misc.addLookupName("Communications Equipment (11 ton)");
+        misc.addLookupName("Communications Equipment (12 ton)");
+        misc.addLookupName("Communications Equipment (13 ton)");
+        misc.addLookupName("Communications Equipment (14 ton)");
+        misc.addLookupName("Communications Equipment (15 ton)");
         misc.addLookupName("CommsGear:1");
-        misc.shortName = "CommsGear:1t";
-        misc.tonnage = 1;
-        misc.criticals = 1;
+        misc.addLookupName("CommsGear:2");
+        misc.addLookupName("CommsGear:3");
+        misc.addLookupName("CommsGear:4");
+        misc.addLookupName("CommsGear:5");
+        misc.addLookupName("CommsGear:6");
+        misc.addLookupName("CommsGear:7");
+        misc.addLookupName("CommsGear:8");
+        misc.addLookupName("CommsGear:9");
+        misc.addLookupName("CommsGear:10");
+        misc.addLookupName("CommsGear:11");
+        misc.addLookupName("CommsGear:12");
+        misc.addLookupName("CommsGear:13");
+        misc.addLookupName("CommsGear:14");
+        misc.addLookupName("CommsGear:15");
+        misc.shortName = "CommsGear";
+        misc.tonnage = TONNAGE_VARIABLE;
+        misc.criticals = CRITICALS_VARIABLE;
         misc.svslots = 1;
         misc.tankslots = 1;
         misc.cost = 10000;
         misc.bv = 0;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
+        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_VARIABLE_SIZE).or(F_MECH_EQUIPMENT)
+                .or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
         String[] modes = { "Default", "ECCM", "Ghost Targets" };
         misc.setModes(modes);
         misc.setInstantModeSwitch(false);
@@ -8498,398 +8115,6 @@ public class MiscType extends EquipmentType {
                 .setClanApproximate(false, false, false, false, false);
         return misc;
     }
-
-    public static MiscType createCommsGear2() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (2 ton)";
-        misc.setInternalName(misc.name);
-        misc.shortName = "CommsGear:2t";
-        misc.tonnage = 2;
-        misc.criticals = 2;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 20000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear3() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (3 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:3");
-        misc.shortName = "CommsGear:3t";
-        misc.tonnage = 3;
-        misc.criticals = 3;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 30000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear4() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (4 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:4");
-        misc.shortName = "CommsGear:4t";
-        misc.tonnage = 4;
-        misc.criticals = 4;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 40000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear5() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (5 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:5");
-        misc.shortName = "CommsGear:5t";
-        misc.tonnage = 5;
-        misc.criticals = 5;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;        
-        misc.cost = 50000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear6() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (6 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:6");
-        misc.shortName = "CommsGear:6t";
-        misc.tonnage = 6;
-        misc.criticals = 6;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 60000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear7() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (7 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:7");
-        misc.shortName = "CommsGear:7t";
-        misc.tonnage = 7;
-        misc.criticals = 7;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 70000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear8() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (8 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:8");
-        misc.shortName = "CommsGear:8t";
-        misc.tonnage = 8;
-        misc.criticals = 8;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 80000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear9() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (9 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:9");
-        misc.shortName = "CommsGear:9t";
-        misc.tonnage = 9;
-        misc.criticals = 9;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 90000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear10() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (10 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:10");
-        misc.shortName = "CommsGear:10t";
-        misc.tonnage = 10;
-        misc.criticals = 10;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 100000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear11() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (11 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:11");
-        misc.shortName = "CommsGear:11t";
-        misc.tonnage = 11;
-        misc.criticals = 11;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 110000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear12() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (12 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:12");
-        misc.shortName = "CommsGear:12t";
-        misc.tonnage = 12;
-        misc.criticals = 12;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 120000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear13() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (13 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:13");
-        misc.shortName = "CommsGear:13t";
-        misc.tonnage = 13;
-        misc.criticals = 13;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 120000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear14() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (14 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:14");
-        misc.shortName = "CommsGear:14t";
-        misc.tonnage = 14;
-        misc.criticals = 14;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 140000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
-    public static MiscType createCommsGear15() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Communications Equipment (15 ton)";
-        misc.setInternalName(misc.name);
-        misc.addLookupName("CommsGear:15");
-        misc.shortName = "CommsGear:15t";
-        misc.tonnage = 15;
-        misc.criticals = 15;
-        misc.svslots = 1;
-        misc.tankslots = 1;
-        misc.bv = 0;
-        misc.cost = 150000;
-        misc.flags = misc.flags.or(F_COMMUNICATIONS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
-        String[] modes = { "Default", "ECCM", "Ghost Targets" };
-        misc.setModes(modes);
-        misc.setInstantModeSwitch(false);
-        misc.industrial = true;
-        misc.rulesRefs = "212,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_D, RATING_C, RATING_B)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_ES, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false);
-        return misc;
-    }
-
     public static MiscType createISCollapsibleCommandModule() {
         MiscType misc = new MiscType();
         misc.name = "Collapsible Command Module";

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -582,6 +582,10 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         return retVal;
     }
 
+    public int getCriticals() {
+        return getType().getCriticals(getEntity(), getSize());
+    }
+
     /**
      * @return The cost of the mounted equipment
      */

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -2257,7 +2257,7 @@ public class WeaponType extends EquipmentType {
     public double getCost(Entity entity, boolean isArmored, int loc, double size) {
         if (isArmored) {
             double armoredCost = cost;
-            armoredCost += 150000 * getCriticals(entity);
+            armoredCost += 150000 * getCriticals(entity, size);
 
             return armoredCost;
         }

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -112,6 +112,9 @@ public class BLKFile {
             return Double.parseDouble(eqName.substring(eqName.indexOf("(") + 1,
                     eqName.indexOf(" ton")));
         }
+        if (eqName.startsWith("CommsGear")) {
+            return Double.parseDouble(eqName.substring(eqName.indexOf(":") + 1));
+        }
         if (eqName.startsWith("Mission Equipment Storage")) {
             return Double.parseDouble(eqName.substring(eqName.indexOf("(") + 1,
                     eqName.indexOf(" kg")));

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -117,7 +117,7 @@ public class BLKFile {
         }
         if (eqName.startsWith("Mission Equipment Storage")) {
             return Double.parseDouble(eqName.substring(eqName.indexOf("(") + 1,
-                    eqName.indexOf(" kg")));
+                    eqName.indexOf("kg")).trim());
         }
         if (eqName.startsWith("Ladder")) {
             return Double.parseDouble(eqName.substring(eqName.indexOf("(") + 1,

--- a/megamek/src/megamek/common/loaders/HmpFile.java
+++ b/megamek/src/megamek/common/loaders/HmpFile.java
@@ -715,7 +715,7 @@ implements IMechLoader
                                 }
                                 if (bFound) {
                                     m.setFoundCrits(m.getFoundCrits() + 1);
-                                    if (m.getFoundCrits() >= equipment.getCriticals(mech)) {
+                                    if (m.getFoundCrits() >= m.getCriticals()) {
                                         vSplitWeapons.removeElement(m);
                                     }
                                     // if we're in a new location, set the

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -722,12 +722,6 @@ public class MtfFile implements IMechLoader {
                                               BattleArmor.MOUNT_LOC_NONE, isArmored,
                                               isTurreted);
                         m.setOmniPodMounted(isOmniPod);
-                        if (etype.isVariableSize()) {
-                            if (size == 0.0) {
-                                size = BLKFile.getLegacyVariableSize(critName);
-                            }
-                            m.setSize(size);
-                        }
                         hSharedEquip.put(etype, m);
                     } else if (((etype instanceof WeaponType) && ((WeaponType) etype).isSplitable()) || ((etype instanceof MiscType) && etype.hasFlag(MiscType.F_SPLITABLE))) {
                         // do we already have this one in this or an outer
@@ -788,6 +782,18 @@ public class MtfFile implements IMechLoader {
                             }
                             mount = mech.addEquipment(etype, etype2, loc, isOmniPod);
                         }
+                        if (etype.isVariableSize()) {
+                            if (size == 0.0) {
+                                size = BLKFile.getLegacyVariableSize(critName);
+                            }
+                            mount.setSize(size);
+                            // THe size may require additional critical slots
+                            for (int c = 1; c < mount.getCriticals(); c++) {
+                                CriticalSlot cs = new CriticalSlot(mount);
+                                mech.addCritical(loc, cs, i + c);
+                            }
+                        }
+
                         // vehicular grenade launchers need to have their facing
                         // set
                         if ((etype instanceof WeaponType) && etype.hasFlag(WeaponType.F_VGL)) {

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -738,7 +738,7 @@ public class MtfFile implements IMechLoader {
                         }
                         if (bFound) {
                             m.setFoundCrits(m.getFoundCrits() + (mech.isSuperHeavy()? 2 : 1));
-                            if (m.getFoundCrits() >= etype.getCriticals(mech)) {
+                            if (m.getFoundCrits() >= m.getCriticals()) {
                                 vSplitWeapons.remove(m);
                             }
                             // if we're in a new location, set the weapon as

--- a/megamek/src/megamek/common/loaders/TdbFile.java
+++ b/megamek/src/megamek/common/loaders/TdbFile.java
@@ -409,7 +409,7 @@ public class TdbFile implements IMechLoader {
                         }
                         if (bFound) {
                             m.setFoundCrits(m.getFoundCrits() + 1);
-                            if (m.getFoundCrits() >= etype.getCriticals(mech)) {
+                            if (m.getFoundCrits() >= m.getCriticals()) {
                                 vSplitWeapons.remove(m);
                             }
                             // if we're in a new location, set the

--- a/megamek/src/megamek/common/templates/BattleArmorTROView.java
+++ b/megamek/src/megamek/common/templates/BattleArmorTROView.java
@@ -162,7 +162,7 @@ public class BattleArmorTROView extends TROView {
             if (name.length() >= nameWidth) {
                 nameWidth = name.length() + 1;
             }
-            row.put("slots", m.getType().getCriticals(ba));
+            row.put("slots", m.getCriticals());
             if (m.getType() instanceof AmmoType) {
                 row.put("mass", ((AmmoType) m.getType()).getKgPerShot() * m.getOriginalShots());
             } else {

--- a/megamek/src/megamek/common/templates/MechTROView.java
+++ b/megamek/src/megamek/common/templates/MechTROView.java
@@ -250,7 +250,7 @@ public class MechTROView extends TROView {
         if (mount.getLocation() == Entity.LOC_NONE) {
             // Skip heat sinks, Clan CASE, armor, and structure. We do want to show things
             // like robotic control systems.
-            return (mount.getType().getCriticals(mech) > 0)
+            return (mount.getCriticals() > 0)
                     || mount.getType().hasFlag(MiscType.F_CASE)
                     || EquipmentType.isArmorType(mount.getType())
                     || EquipmentType.isStructureType(mount.getType());

--- a/megamek/src/megamek/common/templates/SupportVeeTROView.java
+++ b/megamek/src/megamek/common/templates/SupportVeeTROView.java
@@ -177,9 +177,9 @@ public class SupportVeeTROView extends TROView {
                 if (name.length() >= nameWidth) {
                     nameWidth = name.length() + 1;
                 }
-                fields.put("tonnage", adjustWeight(eq.getTonnage(entity) * count));
+                fields.put("tonnage", adjustWeight(eq.getTonnage(entity, entry.getValue()) * count));
                 fields.put("location", loc);
-                fields.put("slots", eq.getCriticals(entity) * count);
+                fields.put("slots", eq.getCriticals(entity, entry.getValue()) * count);
                 weaponList.add(fields);
             }
         }

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -484,7 +484,7 @@ public class TROView {
                     fields.put("slots", crits.toString());
                 } else {
                     fields.put("location", loc);
-                    fields.put("slots", eq.getCriticals(entity) * count);
+                    fields.put("slots", eq.getCriticals(entity, entry.getValue()) * count);
                 }
                 eqList.add(fields);
             }

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -756,7 +756,7 @@ public class TestAero extends TestEntity {
                     continue;
                 }
                 if ((entity instanceof Aero) && 
-                        (m.getType().getCriticals(entity) == 0)) {
+                        (m.getCriticals() == 0)) {
                     continue;
                 }
                 if (!(m.getType() instanceof MiscType)) {

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -355,7 +355,7 @@ public class TestBattleArmor extends TestEntity {
                 if (m.getType().isSpreadable()) {
                     numUsedCrits++;
                 } else {
-                    numUsedCrits += m.getType().getCriticals(ba);
+                    numUsedCrits += m.getCriticals();
                 }
             }
         }
@@ -387,7 +387,7 @@ public class TestBattleArmor extends TestEntity {
         if (newMount.getType().isSpreadable()) {
             newCrits = 1;
         } else {
-            newCrits = newMount.getType().getCriticals(ba);
+            newCrits = newMount.getCriticals();
         }
         if ((numUsedCrits + newCrits) <= ba.getNumCrits(loc)) {
             // Weapons require extra criticism
@@ -787,7 +787,7 @@ public class TestBattleArmor extends TestEntity {
             if (m.getType().isSpreadable()) {
                 critSize = 1;
             } else {
-                critSize = m.getType().getCriticals(ba);
+                critSize = m.getCriticals();
             }
             
             // Manipulators don't take up slots in BA
@@ -1015,7 +1015,7 @@ public class TestBattleArmor extends TestEntity {
                 }
 
                 // Equipment taking up no slots doesn't need to be mounted
-                if ((m.getType().getCriticals(entity) == 0) 
+                if ((m.getCriticals() == 0)
                         && !((m.getType() instanceof InfantryWeapon) 
                                 && !m.isAPMMounted())) {
                     continue;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -709,7 +709,7 @@ public abstract class TestEntity implements TestEntityOption {
         return buff.toString();
     }
 
-    public int calcMiscCrits(MiscType mt) {
+    public int calcMiscCrits(MiscType mt, double size) {
         if (mt.hasFlag(MiscType.F_CLUB)
                 && (mt.hasSubType(MiscType.S_HATCHET)
                         || mt.hasSubType(MiscType.S_SWORD)
@@ -818,7 +818,7 @@ public abstract class TestEntity implements TestEntityOption {
             }
             return 10;
         }
-        return mt.getCriticals(getEntity());
+        return mt.getCriticals(getEntity(), size);
     }
 
     /**

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -492,9 +492,9 @@ public class TestMech extends TestEntity {
         EquipmentType et = mounted.getType();
         int criticals = 0;
         if (et instanceof MiscType) {
-            criticals = calcMiscCrits((MiscType) et);
+            criticals = calcMiscCrits((MiscType) et, mounted.getSize());
         } else {
-            criticals = et.getCriticals(entity);
+            criticals = mounted.getCriticals();
         }
         int count = 0;
 
@@ -552,7 +552,7 @@ public class TestMech extends TestEntity {
                         && (m.getUsableShotsLeft() <= 1)) {
                     continue;
                 }
-                if (m.getType().getCriticals(mech) == 0) {
+                if (m.getCriticals() == 0) {
                     continue;
                 }
                 if (!(m.getType() instanceof MiscType)) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -567,7 +567,7 @@ public class TestTank extends TestEntity {
         boolean correct = true;
 
         for (Mounted mount : tank.getMisc()) {
-            if (mount.getLocation() == Entity.LOC_NONE && !(mount.getType().getCriticals(tank) == 0)) {
+            if (mount.getLocation() == Entity.LOC_NONE && !(mount.getCriticals() == 0)) {
                 unallocated.add(mount);
             }
         }


### PR DESCRIPTION
This builds on #1902 by using the size field in Mounted to consolidate cargo, liquid cargo, communications gear, ladders, and BA mission equipment to one MiscType each. This allows BA mission equipment in any arbitrary size (in 1 kg lots) and liquid cargo as a single equipment mount rather than a multiple of single-ton mounts with a possible half-ton. Because cargo and communications equipment size determine the number of critical slots on a mech, the slot count has been changed to query Mounted instead of the EquipmentType, which accounts for most of the changes. There are also some changes in MtfFile that allocate any additional critical slots needed after the size has been set, and the code that sets the size has been moved to the correct place.