### PR TITLE
fix several minor npes and pathfinding issues

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -16,7 +16,6 @@ package megamek.client.bot.princess;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.nio.file.Paths;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1555,7 +1555,11 @@ public class Princess extends BotClient {
                     // Also set the behavior to "engaged"
                     // so it doesn't hump walls due to "self preservation mods"
                     if(los.canSee()) {
-                        getUnitBehaviorTracker().overrideBehaviorType(mover, BehaviorType.Engaged);
+                        // if we've explicitly forced 'move to contact' behavior, don't flip back to 'engaged'
+                        if(!forceMoveToContact) {
+                            getUnitBehaviorTracker().overrideBehaviorType(mover, BehaviorType.Engaged);
+                        }
+                        
                         return getPrecognition().getPathEnumerator()
                                 .getUnitPaths()
                                 .get(mover.getId());

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -84,6 +84,11 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         // if we're on the ground, let's try to get up first before moving 
         if(entity.isProne() || entity.isHullDown()) {
             startPath.addStep(MoveStepType.GET_UP);
+            
+            // if we can't even get up, no need to do anything else
+            if(!startPath.isMoveLegal()) {
+                return null;
+            }
         }
 
         Coords closest = getClosestCoords(destinationCoords, entity);

--- a/megamek/src/megamek/common/templates/InfantryTROView.java
+++ b/megamek/src/megamek/common/templates/InfantryTROView.java
@@ -185,7 +185,7 @@ public class InfantryTROView extends TROView {
             notes.add(String.format(Messages.getString("TROView.InfantryNote.SingleFieldGun"),
                     fieldGuns.get(0).getName(), shots, (int) fieldGuns.get(0).getTonnage(inf)));
         }
-        if (inf.getSecondaryN() > 1) {
+        if (inf.getSecondaryWeapon() != null) {
             if (inf.getSecondaryWeapon().hasFlag(WeaponType.F_INF_BURST)) {
                 notes.add(Messages.getString("TROView.InfantryNote.Burst"));
             }


### PR DESCRIPTION
what it says on the label.

- random NPE when trying to customize infantry unit in mekhq's meklab
- stack overflow when bot attempting to move legged mech with no LOS to anything
- efficiency improvement to skip pathfinding calculation for prone units that are technically not immobile but are practically immobile