### PR TITLE
fix one more NPE

### DIFF
--- a/megamek/src/megamek/common/templates/InfantryTROView.java
+++ b/megamek/src/megamek/common/templates/InfantryTROView.java
@@ -126,7 +126,7 @@ public class InfantryTROView extends TROView {
         setModelData("squadCount", inf.getSquadN());
         setModelData("armorDivisor", inf.getDamageDivisor());
         InfantryWeapon rangeWeapon = inf.getPrimaryWeapon();
-        if (inf.getSecondaryWeapon() != null) {
+        if ((inf.getSecondaryN() > 1) && (inf.getSecondaryWeapon() != null)) {
             rangeWeapon = inf.getSecondaryWeapon();
         }
 
@@ -185,7 +185,7 @@ public class InfantryTROView extends TROView {
             notes.add(String.format(Messages.getString("TROView.InfantryNote.SingleFieldGun"),
                     fieldGuns.get(0).getName(), shots, (int) fieldGuns.get(0).getTonnage(inf)));
         }
-        if (inf.getSecondaryWeapon() != null) {
+        if ((inf.getSecondaryN() > 1) && (inf.getSecondaryWeapon() != null)) {
             if (inf.getSecondaryWeapon().hasFlag(WeaponType.F_INF_BURST)) {
                 notes.add(Messages.getString("TROView.InfantryNote.Burst"));
             }

--- a/megamek/src/megamek/common/templates/InfantryTROView.java
+++ b/megamek/src/megamek/common/templates/InfantryTROView.java
@@ -126,7 +126,7 @@ public class InfantryTROView extends TROView {
         setModelData("squadCount", inf.getSquadN());
         setModelData("armorDivisor", inf.getDamageDivisor());
         InfantryWeapon rangeWeapon = inf.getPrimaryWeapon();
-        if (inf.getSecondaryN() > 1) {
+        if (inf.getSecondaryWeapon() != null) {
             rangeWeapon = inf.getSecondaryWeapon();
         }
 


### PR DESCRIPTION
Fix a subsequent NPE on the infantry TRO view, now it doesn't barf when setting # of secondary weapons to 0 without removing the secondary weapon (no idea why you'd want to do that, but there it is).