### PR TITLE
Long range logic tweaks

### DIFF
--- a/megamek/src/megamek/common/templates/InfantryTROView.java
+++ b/megamek/src/megamek/common/templates/InfantryTROView.java
@@ -126,7 +126,7 @@ public class InfantryTROView extends TROView {
         setModelData("squadCount", inf.getSquadN());
         setModelData("armorDivisor", inf.getDamageDivisor());
         InfantryWeapon rangeWeapon = inf.getPrimaryWeapon();
-        if (inf.getSecondaryWeapon() != null) {
+        if ((inf.getSecondaryN() > 1) && (inf.getSecondaryWeapon() != null)) {
             rangeWeapon = inf.getSecondaryWeapon();
         }
 
@@ -185,7 +185,7 @@ public class InfantryTROView extends TROView {
             notes.add(String.format(Messages.getString("TROView.InfantryNote.SingleFieldGun"),
                     fieldGuns.get(0).getName(), shots, (int) fieldGuns.get(0).getTonnage(inf)));
         }
-        if (inf.getSecondaryWeapon() != null) {
+        if ((inf.getSecondaryN() > 1) && (inf.getSecondaryWeapon() != null)) {
             if (inf.getSecondaryWeapon().hasFlag(WeaponType.F_INF_BURST)) {
                 notes.add(Messages.getString("TROView.InfantryNote.Burst"));
             }

--- a/megamek/src/megamek/common/templates/InfantryTROView.java
+++ b/megamek/src/megamek/common/templates/InfantryTROView.java
@@ -126,7 +126,7 @@ public class InfantryTROView extends TROView {
         setModelData("squadCount", inf.getSquadN());
         setModelData("armorDivisor", inf.getDamageDivisor());
         InfantryWeapon rangeWeapon = inf.getPrimaryWeapon();
-        if (inf.getSecondaryN() > 1) {
+        if (inf.getSecondaryWeapon() != null) {
             rangeWeapon = inf.getSecondaryWeapon();
         }
 


### PR DESCRIPTION
Fixes a pair of issues I noticed during "playtesting":

- infantry would fail to identify long range paths and mill around as usual instead
- long range paths for the "engaged" behavior would direct towards crippled units

Got lazy and branched this branch off my other outstanding PR, so no need to bother reviewing the infantry TRO view file.