### PR TITLE
Allow units to flee if they made it into prohibited terrain #2005

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -3166,6 +3166,12 @@ public class MoveStep implements Serializable {
             return true;
         }
 
+        // If you want to flee, and you can flee, flee.
+        if ((type == MoveStepType.FLEE)
+                && entity.canFlee()) {
+            return true;
+        }
+
         // super-easy
         if (entity.isImmobile()) {
             // System.err.println("illegal - immobile");


### PR DESCRIPTION
This fixes #2005 by allowing any unit to flee that _could_ flee. This ignores how they may have gotten themselves into prohibited terrain.

This is one possibility for that issue. Another would be to disable the flee button for units which would be immobile (due to prohibited terrain).