### PR TITLE
Fix ArtilleryBayWeapon tech advancement

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -77,7 +77,6 @@ import megamek.common.QuadVee;
 import megamek.common.SmallCraft;
 import megamek.common.Tank;
 import megamek.common.TechConstants;
-import megamek.common.VTOL;
 import megamek.common.WeaponType;
 import megamek.common.enums.Gender;
 import megamek.common.options.IOption;
@@ -96,7 +95,7 @@ import megamek.common.verifier.TestInfantry;
 import megamek.common.verifier.TestMech;
 import megamek.common.verifier.TestSupportVehicle;
 import megamek.common.verifier.TestTank;
-import megamek.common.weapons.ArtilleryBayWeapon;
+import megamek.common.weapons.bayweapons.ArtilleryBayWeapon;
 import megamek.common.weapons.bayweapons.CapitalMissileBayWeapon;
 
 /**

--- a/megamek/src/megamek/common/BattleForceElement.java
+++ b/megamek/src/megamek/common/BattleForceElement.java
@@ -28,7 +28,7 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import megamek.common.weapons.ArtilleryBayWeapon;
+import megamek.common.weapons.bayweapons.ArtilleryBayWeapon;
 import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.missiles.MissileWeapon;

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -18,7 +18,7 @@ import java.math.BigInteger;
 
 import megamek.common.weapons.AlamoMissileWeapon;
 import megamek.common.weapons.AltitudeBombAttack;
-import megamek.common.weapons.ArtilleryBayWeapon;
+import megamek.common.weapons.bayweapons.ArtilleryBayWeapon;
 import megamek.common.weapons.DiveBombAttack;
 import megamek.common.weapons.LegAttack;
 import megamek.common.weapons.SpaceBombAttack;

--- a/megamek/src/megamek/common/weapons/bayweapons/ArtilleryBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/ArtilleryBayWeapon.java
@@ -14,11 +14,11 @@
  * Created on Sep 25, 2004
  *
  */
-package megamek.common.weapons;
+package megamek.common.weapons.bayweapons;
 
 import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.bayweapons.AmmoBayWeapon;
+import megamek.common.weapons.*;
 import megamek.server.Server;
 
 /**
@@ -49,10 +49,6 @@ public class ArtilleryBayWeapon extends AmmoBayWeapon {
         this.bv = 0;
         this.cost = 0;
         this.atClass = CLASS_ARTILLERY;
-        techAdvancement.setTechBase(TechAdvancement.TECH_BASE_ALL);
-        techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, 3071);
-        techAdvancement.setTechRating(RATING_C);
-        techAdvancement.setAvailability( new int[] { RATING_E, RATING_E, RATING_E, RATING_E });
     }
 
     /*
@@ -65,7 +61,7 @@ public class ArtilleryBayWeapon extends AmmoBayWeapon {
      */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
+                                              WeaponAttackAction waa, IGame game, Server server) {
         Entity ae = game.getEntity(waa.getEntityId());
         boolean useHoming = false;
         for (int wId : ae.getEquipment(waa.getWeaponId()).getBayWeapons()) {


### PR DESCRIPTION
ArtilleryBayWeapon still has interim tech progression data that was auto-generated from the previous system. I removed it so it will inherit the tech progression data of the base BayWeapon class. I also moved it to the megamek.common.weapons.bayweapons package, which is probably why it was not caught and fixed earlier.

Fixes MegaMek/megameklab#656