### PR TITLE
fix game-blocking npe when arty lands from destroyed launcher

### DIFF
--- a/megamek/src/megamek/common/actions/AbstractAttackAction.java
+++ b/megamek/src/megamek/common/actions/AbstractAttackAction.java
@@ -28,7 +28,6 @@ import megamek.common.PlanetaryConditions;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.options.OptionsConstants;
-import megamek.common.options.PilotOptions;
 
 /**
  * Abstract superclass for any action where an entity is attacking another
@@ -76,12 +75,24 @@ public abstract class AbstractAttackAction extends AbstractEntityAction
         return g.getTarget(getTargetType(), getTargetId());
     }
 
+    /**
+     * Gets the entity associated with this attack action, using the passed-in game object.
+     * Returns the entity even if it was destroyed or fled.
+     */
     public Entity getEntity(IGame g) {
-        Entity e = g.getEntity(getEntityId());
+        return getEntity(g, getEntityId());
+    }
+    
+    /**
+     * Gets an entity with the given ID, using the passed-in game object.
+     * Returns the entity even if it was destroyed or fled.
+     */
+    public Entity getEntity(IGame g, int entityID) {
+        Entity e = g.getEntity(entityID);
         // if we have an artyattack, we might need to get an out-of-game entity
         // if it died or fled
         if (e == null) {
-            e = g.getOutOfGameEntity(getEntityId());
+            e = g.getOutOfGameEntity(entityID);
         }
         return e;
     }

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -152,12 +152,13 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             System.err.println("Artillery Entity is null!");
             return true;
         }
+        
         //Trailers can share ammo, which means the entity carrying the ammo might not be
-        //the firing entity
-        Entity ammoCarrier = game.getEntity(aaa.getAmmoCarrier());
-        Mounted ammoUsed = ammoCarrier == null ? null : ammoCarrier.getEquipment(aaa.getAmmoId());
-        final AmmoType atype = ammoUsed == null ? null : (AmmoType) ammoUsed
-                .getType();
+        //the firing entity, so we get the specific ammo used from the ammo carrier
+        Entity ammoCarrier = aaa.getEntity(game, aaa.getAmmoCarrier());
+        Mounted ammoUsed = ammoCarrier.getEquipment(aaa.getAmmoId());
+        final AmmoType atype = (AmmoType) ammoUsed.getType();
+        
         // Are there any valid spotters?
         if ((null != spottersBefore) && !isFlak) {
             // fetch possible spotters now


### PR DESCRIPTION
What the title says. 

The new AbstractAttackAction logic renders the null checks moot, and also having no ammo type associated with an artillery attack action is no good, because properties of the ammo type are used in calculations further along.