### PR TITLE
Respect deployment round for offboard entities #2020

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9344,7 +9344,9 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * Returns true if the entity should be deployed
      */
     public boolean shouldDeploy(int round) {
-        return (!deployed && (getDeployRound() <= round) && !isOffBoard());
+        return !isDeployed() 
+            && (getDeployRound() <= round)
+            && !isOffBoard();
     }
 
     /**
@@ -9353,8 +9355,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * @return True if and only if the offboard entity should deploy this
      *         round, otherwise false.
      */
-    public boolean shouldOffboardDeploy(int round) {
-        return (isOffBoard() && (!deployed && (getDeployRound() <= round)));
+    public boolean shouldOffBoardDeploy(int round) {
+        return isOffBoard() 
+            && !isDeployed() 
+            && (getDeployRound() <= round);
     }
 
     /**
@@ -10176,7 +10180,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
 
         // deploy the unit, but only if it should be deployed this round
-        setDeployed(shouldOffboardDeploy(round));
+        setDeployed(shouldOffBoardDeploy(round));
     }
 
     public Vector<Integer> getPickedUpMechWarriors() {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9348,6 +9348,16 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
 
     /**
+     * Returns true if the offboard entity should be deployed this round.
+     * @param round The current round number.
+     * @return True if and only if the offboard entity should deploy this
+     *         round, otherwise false.
+     */
+    public boolean shouldOffboardDeploy(int round) {
+        return (isOffBoard() && (!deployed && (getDeployRound() <= round)));
+    }
+
+    /**
      * Set the unit number for this entity.
      *
      * @param unit the number for the low-level unit that this
@@ -10127,8 +10137,9 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * <p/>
      * Onboard units (units with an offboard distance of zero and a direction of
      * <code>Entity.NONE</code>) will be unaffected by this method.
+     * @param round The current round number.
      */
-    public void deployOffBoard() {
+    public void deployOffBoard(int round) {
         if (null == game) {
             throw new IllegalStateException(
                     "game not set; possible serialization error");
@@ -10137,20 +10148,18 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         // add a bit (because 17 % 2 == 1 and 16 % 2 == 0).
         switch (offBoardDirection) {
             case NONE:
-                break;
+                return;
             case NORTH:
                 setPosition(new Coords((game.getBoard().getWidth() / 2)
                         + (game.getBoard().getWidth() % 2),
                         -getOffBoardDistance()));
                 setFacing(3);
-                setDeployed(true);
                 break;
             case SOUTH:
                 setPosition(new Coords((game.getBoard().getWidth() / 2)
                         + (game.getBoard().getWidth() % 2), game.getBoard()
                         .getHeight() + getOffBoardDistance()));
                 setFacing(0);
-                setDeployed(true);
                 break;
             case EAST:
                 setPosition(new Coords(game.getBoard().getWidth()
@@ -10158,15 +10167,16 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                         (game.getBoard().getHeight() / 2)
                                 + (game.getBoard().getHeight() % 2)));
                 setFacing(5);
-                setDeployed(true);
                 break;
             case WEST:
                 setPosition(new Coords(-getOffBoardDistance(), (game.getBoard()
                         .getHeight() / 2) + (game.getBoard().getHeight() % 2)));
                 setFacing(1);
-                setDeployed(true);
                 break;
         }
+
+        // deploy the unit, but only if it should be deployed this round
+        setDeployed(shouldOffboardDeploy(round));
     }
 
     public Vector<Integer> getPickedUpMechWarriors() {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1571,7 +1571,6 @@ public class Server implements Runnable {
 
     /**
      * Deploys elligible offboard entities.
-     * @param game The current game object.
      */
     private void deployOffBoardEntities() {
         // place off board entities actually off-board

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1570,6 +1570,21 @@ public class Server implements Runnable {
     }
 
     /**
+     * Deploys elligible offboard entities.
+     * @param game The current game object.
+     */
+    private void deployOffBoardEntities() {
+        // place off board entities actually off-board
+        Iterator<Entity> entities = game.getEntities();
+        while (entities.hasNext()) {
+            Entity en = entities.next();
+            if (en.isOffBoard() && !en.isDeployed()) {
+                en.deployOffBoard(game.getRoundCount());
+            }
+        }
+    }
+
+    /**
      * Called at the beginning of each phase. Sets and resets any entity
      * parameters that need to be reset.
      */
@@ -2319,12 +2334,7 @@ public class Server implements Runnable {
                 send(createTurnVectorPacket());
                 break;
             case PHASE_SET_ARTYAUTOHITHEXES:
-                // place off board entities actually off-board
-                Iterator<Entity> entities = game.getEntities();
-                while (entities.hasNext()) {
-                    Entity en = entities.next();
-                    en.deployOffBoard();
-                }
+                deployOffBoardEntities();
                 checkForObservers();
                 transmitAllPlayerUpdates();
                 resetActivePlayersDone();
@@ -2348,7 +2358,7 @@ public class Server implements Runnable {
                             return owner.equals(entity.getOwner()) && entity.isEligibleForArtyAutoHitHexes();
                         }
                     };
-                if (game.getSelectedEntities(playerArtySelector).hasNext()) {
+                    if (game.getSelectedEntities(playerArtySelector).hasNext()) {
                         // Yes, the player has arty-equipped units.
                         GameTurn gt = new GameTurn(p.getId());
                         turn.addElement(gt);
@@ -2366,6 +2376,8 @@ public class Server implements Runnable {
             case PHASE_PHYSICAL:
             case PHASE_TARGETING:
             case PHASE_OFFBOARD:
+                deployOffBoardEntities();
+
                 // Check for activating hidden units
                 if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_HIDDEN_UNITS)) {
                     for (Entity ent : game.getEntitiesVector()) {

--- a/megamek/src/megamek/test/entities/TestOffBoardEntity.java
+++ b/megamek/src/megamek/test/entities/TestOffBoardEntity.java
@@ -31,32 +31,33 @@ public class TestOffBoardEntity {
         // Now create an entity in the game.
         Entity entity = new BipedMech();
         entity.setGame(game);
+        entity.setDeployRound(1);
 
         // Deploy the entity 30 hexes north of
         // the board and check it's position.
         entity.setOffBoard(30, OffBoardDirection.NORTH);
-        entity.deployOffBoard();
+        entity.deployOffBoard(1);
         Coords north = new Coords(8, -30);
         testCoords(north, entity.getPosition());
 
         // Deploy the entity 45 hexes south of
         // the board and check it's position.
         entity.setOffBoard(45, OffBoardDirection.SOUTH);
-        entity.deployOffBoard();
+        entity.deployOffBoard(1);
         Coords south = new Coords(8, 62);
         testCoords(south, entity.getPosition());
 
         // Deploy the entity 105 hexes east of
         // the board and check it's position.
         entity.setOffBoard(105, OffBoardDirection.EAST);
-        entity.deployOffBoard();
+        entity.deployOffBoard(1);
         Coords east = new Coords(121, 9);
         testCoords(east, entity.getPosition());
 
         // Deploy the entity 3200 hexes west of
         // the board and check it's position.
         entity.setOffBoard(3200, OffBoardDirection.WEST);
-        entity.deployOffBoard();
+        entity.deployOffBoard(1);
         Coords west = new Coords(-3200, 9);
         testCoords(west, entity.getPosition());
 


### PR DESCRIPTION
This implements #2020 by respecting the deployment round for offboard entities. I added a `shouldDeployOffboard` method to compliment `shouldDeploy` but covering only offboard entities (to avoid scattering isOffboard checks and remembering to use them in the future).