### PR TITLE
Data: Remove weird 'Hardened' on the equipment section of some Combat Vehicles.

### DIFF
--- a/megamek/data/mechfiles/vehicles/3145/Davion/Ballista Artillery Trailer (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Davion/Ballista Artillery Trailer (Standard).blk
@@ -61,7 +61,6 @@ troopspace:4.0
 </armor>
 
 <Body Equipment>
-IS Hardened
 ISC3SlaveUnit
 Communications Equipment (4 ton)
 ISGuardianECMSuite

--- a/megamek/data/mechfiles/vehicles/3145/Davion/Destrier Siege Vehicle (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Davion/Destrier Siege Vehicle (Standard).blk
@@ -63,7 +63,6 @@ troopspace:4.0
 </armor>
 
 <Body Equipment>
-IS Hardened
 ISCASE
 Communications Equipment (1 ton)
 ISGuardianECMSuite

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Sniper Cannon).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Sniper Cannon).blk
@@ -57,7 +57,6 @@ Wheeled
 </armor>
 
 <Body Equipment>
-IS Hardened
 Hitch
 ISSniperCannonAmmo
 ISSniperCannonAmmo


### PR DESCRIPTION
Although Hardened armor do requires one crit of a CV, but such a weird equipment is not required at all. I have no idea why it is existed. Perhaps it is the old remnant on the change of the mechanism of hardened armor? But I don't know the past.

Even if it is removed, it doesn't affect and the other sections handles the type of armor so its armor is not changed. 

The only problem is, if some players are using either of vehicles on their MekHQ, the change cause the error for the number of slots of the ammunition is not match.