### PR TITLE
no minimum range restriction for arty flak attacks vs ASF

### DIFF
--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -405,6 +405,13 @@ public class WeaponFireInfo {
             return 7D;
         }
 
+        // artillery and cluster table use the rack size as the base damage amount
+        // a little inaccurate, but better than ignoring those weapons entirely       
+        if((weaponType.getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE) ||
+           (weaponType.getDamage() == WeaponType.DAMAGE_ARTILLERY)) {
+            return weaponType.getRackSize();
+        }
+        
         if (getTarget() instanceof Entity) {
             double dmg = Compute.getExpectedDamage(getGame(), getAction(),
                     true, owner.getPrecognition().getECMInfo());
@@ -412,11 +419,6 @@ public class WeaponFireInfo {
                 dmg += 3; // Account for potential plasma heat.
             }
             return dmg;
-        }
-        
-        // a little inaccurate, but better than ignoring cluster weapons entirely
-        if(weaponType.getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE) {
-            return weaponType.getRackSize();
         }
                 
         return weaponType.getDamage();

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1780,7 +1780,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     return Messages.getString("WeaponAttackAction.NoDirectCruiseMissile");
                 }
                 // Direct fire artillery cannot be fired at less than 6 hexes
-                if (isArtilleryDirect && (Compute.effectiveDistance(game, ae, target) <= 6)) {
+                if (isArtilleryDirect && !target.isAirborne() && (Compute.effectiveDistance(game, ae, target) <= 6)) {
                     return Messages.getString("WeaponAttackAction.TooShortForDirectArty");
                 }
                 // ...or more than 17 hexes


### PR DESCRIPTION
Two changes:
- per TacOps page 185, there is no "minimum range" for artillery flak attacks vs airborne aerospace units
- allow the bot to properly compute expected damage for direct-fire artillery attacks, so she can potentially use artillery in an AA role

Addresses #2042 