### PR TITLE
fix npe in long-range path decorator

### DIFF
--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -63,7 +63,8 @@ public class PathDecorator {
         }
         
         // if there is a bad guy in the last step, clip to one step short and see if we can't get around.
-        if (clippedSource.getGame().getFirstEnemyEntity(clippedSource.getLastStep().getPosition(), clippedSource.getEntity()) != null) {
+        if ((clippedSource.getLastStep() != null) &&
+        	clippedSource.getGame().getFirstEnemyEntity(clippedSource.getLastStep().getPosition(), clippedSource.getEntity()) != null) {
             clippedSource.removeLastStep();
             
             for (int desiredMP : desiredMPs) {


### PR DESCRIPTION
Sometimes, clipping a path to a certain MP leaves it with no steps, in which case, it is very unlikely that removing any additional steps will have any practical meaning. 