### PR TITLE
no spotting option for sprinting units

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9192,15 +9192,14 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
     /**
      * Um, basically everything can spot for LRM indirect fire.
+     * Except for off-board units and units that sprinted.
      *
-     * @return true, if the entity is active
+     * @return true, if the entity is eligible to spot
      */
     public boolean canSpot() {
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_PILOTS_CANNOT_SPOT)
-            && (this instanceof MechWarrior)) {
-            return false;
-        }
-        return isActive() && !isOffBoard();
+        return isActive() && !isOffBoard() && 
+        		(moved != EntityMovementType.MOVE_SPRINT) && 
+        		(moved != EntityMovementType.MOVE_VTOL_SPRINT);
     }
 
     @Override
@@ -9740,8 +9739,9 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
 
     /**
-     * An entity is eligible if its to-hit number is anything but impossible.
-     * This is only really an issue if friendly fire is turned off.
+     * An entity is eligible for firing if it's not taking some kind of action
+     * that prevents it from firing, such as a full-round physical attack
+     * or sprinting.
      */
     public boolean isEligibleForFiring() {
         // if you're charging, no shooting
@@ -9763,18 +9763,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         if (!isActive()) {
             return false;
         }
-
-        // Check for weapons. If we find them, return true. Otherwise... we
-        // return false.
-        // Bug 3648: No, no, no - you cannot skip units with no weapons - what
-        // about spotting, unjamming, etc.?
-        /*
-         * for (Mounted mounted : getWeaponList()) { WeaponType wtype =
-         * (WeaponType) mounted.getType(); if ((wtype != null) &&
-         * (!wtype.hasFlag(WeaponType.F_AMS) && !wtype.hasFlag(WeaponType.F_TAG)
-         * && mounted.isReady() && ((mounted.getLinked() == null) || (mounted
-         * .getLinked().getUsableShotsLeft() > 0)))) { return true; } }
-         */
 
         return true;
     }

--- a/megamek/src/megamek/common/MechWarrior.java
+++ b/megamek/src/megamek/common/MechWarrior.java
@@ -13,6 +13,8 @@
  */
 package megamek.common;
 
+import megamek.common.options.OptionsConstants;
+
 /**
  * @author Sebastian Brocks This class describes a MechWarrior that has ejected
  *         from its ride.
@@ -123,7 +125,7 @@ public class MechWarrior extends EjectedCrew {
 
     @Override
     public boolean isCrippled() {
-        return true; //Ejected mchwarriors should always attempt to flee according to Forced Withdrawal.
+        return true; //Ejected mechwarriors should always attempt to flee according to Forced Withdrawal.
     }
     
     @Override
@@ -134,5 +136,10 @@ public class MechWarrior extends EjectedCrew {
 
     public long getEntityType(){
         return Entity.ETYPE_INFANTRY | Entity.ETYPE_MECHWARRIOR;
+    }
+    
+    @Override
+    public boolean canSpot() {
+    	return super.canSpot() && !game.getOptions().booleanOption(OptionsConstants.ADVANCED_PILOTS_CANNOT_SPOT);
     }
 }


### PR DESCRIPTION
I noticed during some gameplay that the bot would attempt to spot with units that sprinted. Which, according to Compute.getSpotterMovementModifier() invalidates the spotting attempt.

So, the "canSpot" logic for Entity has been adjusted, so that a sprinting unit does not report itself as being able to spot.

Also a minor refactoring to move MechWarrior-specific logic to the MechWarrior class, rather than have an instanceof check in entity.