### PR TITLE
Errata: Naval repair facility requires two hardpoints regardless of size.

### DIFF
--- a/megamek/src/megamek/common/NavalRepairFacility.java
+++ b/megamek/src/megamek/common/NavalRepairFacility.java
@@ -134,7 +134,7 @@ public class NavalRepairFacility extends Bay {
     
     @Override
     public int hardpointCost() {
-        return (int) Math.ceil(totalSpace / 50000);
+        return 2;
     }
     
     public static TechAdvancement techAdvancement() {


### PR DESCRIPTION
See TacOps errata v 3.03, p. 65. Quoted in linked issue.

Fixes MegaMek/megameklab#611