### PR TITLE
Consolidate IS and Clan artillery ammo types.

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -641,7 +641,6 @@ public class AmmoType extends EquipmentType {
         ArrayList<AmmoType> sniperCannonAmmos = new ArrayList<AmmoType>(3);
         ArrayList<AmmoType> longTomAmmos = new ArrayList<AmmoType>(4);
         ArrayList<AmmoType> longTomCannonAmmos = new ArrayList<AmmoType>(4);
-        ArrayList<AmmoType> clanArtyAmmos = new ArrayList<AmmoType>(6);
         ArrayList<AmmoType> mortarAmmos = new ArrayList<AmmoType>(4);
         ArrayList<AmmoType> clanMortarAmmos = new ArrayList<AmmoType>(4);
         ArrayList<AmmoType> lrtAmmos = new ArrayList<AmmoType>(26);
@@ -933,7 +932,7 @@ public class AmmoType extends EquipmentType {
         srmAmmos.add(base);
         EquipmentType.addType(base);
 
-        base = AmmoType.createISLongTomAmmo();
+        base = AmmoType.createLongTomAmmo();
         longTomAmmos.add(base);
         EquipmentType.addType(base);
         
@@ -945,7 +944,7 @@ public class AmmoType extends EquipmentType {
         longTomCannonAmmos.add(base);
         EquipmentType.addType(base);
         
-        base = AmmoType.createISSniperAmmo();
+        base = AmmoType.createSniperAmmo();
         sniperAmmos.add(base);
         EquipmentType.addType(base);
         
@@ -953,7 +952,7 @@ public class AmmoType extends EquipmentType {
         sniperCannonAmmos.add(base);
         EquipmentType.addType(base);
         
-        base = AmmoType.createISThumperAmmo();
+        base = AmmoType.createThumperAmmo();
         thumperAmmos.add(base);
         EquipmentType.addType(base);
         
@@ -1112,24 +1111,6 @@ public class AmmoType extends EquipmentType {
         acAmmos.add(base);
         EquipmentType.addType(base);
 
-        base = AmmoType.createCLLongTomAmmo();
-        clanArtyAmmos.add(base);
-        EquipmentType.addType(base);
-//        base = AmmoType.createCLLongTomCannonAmmo();
-        clanArtyAmmos.add(base);
-        EquipmentType.addType(base);
-        base = AmmoType.createCLSniperAmmo();
-        clanArtyAmmos.add(base);
-        EquipmentType.addType(base);
-//        base = AmmoType.createCLSniperCannonAmmo();
-        clanArtyAmmos.add(base);
-        EquipmentType.addType(base);
-        base = AmmoType.createCLThumperAmmo();
-        EquipmentType.addType(base);
-        clanArtyAmmos.add(base);
-//        base = AmmoType.createCLThumperCannonAmmo();
-        clanArtyAmmos.add(base);
-        EquipmentType.addType(base);
         base = AmmoType.createCLArrowIVAmmo();
         clanArrowAmmos.add(base);
         EquipmentType.addType(base);
@@ -3024,67 +3005,49 @@ public class AmmoType extends EquipmentType {
         // Create the munition types for Artillery launchers.
         munitions.clear();
         munitions.add(new MunitionMutator("Cluster", 1, M_CLUSTER,
-                new TechAdvancement(TECH_BASE_IS)
-                .setIntroLevel(false)
-                .setUnofficial(false)
+                new TechAdvancement(TECH_BASE_ALL)
                 .setTechRating(RATING_E)
                 .setAvailability(RATING_E, RATING_F, RATING_E, RATING_D)
                 .setISAdvancement(DATE_PS, DATE_PS, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setISApproximate(false,false,false,false,false)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),"354,TO"));
         
         munitions.add(new MunitionMutator("Copperhead", 1, M_HOMING,
-                new TechAdvancement(TECH_BASE_IS)
-                .setIntroLevel(false)
-                .setUnofficial(false)
+                new TechAdvancement(TECH_BASE_ALL)
                 .setTechRating(RATING_E)
                 .setAvailability(RATING_E, RATING_F, RATING_E, RATING_D)
                 .setISAdvancement(2640, 2645, DATE_NONE, 2800, 3051)
-                .setISApproximate(false,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),"354,TO"));
         
         munitions.add(new MunitionMutator("FASCAM", 1, M_FASCAM,
-                new TechAdvancement(TECH_BASE_IS)
-                .setIntroLevel(false)
-                .setUnofficial(false)
+                new TechAdvancement(TECH_BASE_ALL)
                 .setTechRating(RATING_C)
                 .setAvailability(RATING_E, RATING_F, RATING_D, RATING_D)
                 .setISAdvancement(2621, 2844, DATE_NONE, 2770, 3051)
-                .setISApproximate(false,false,false,false,false)
                 .setPrototypeFactions(F_TH)
                 .setProductionFactions(F_CC)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
         
         munitions.add(new MunitionMutator("Flechette", 1, M_FLECHETTE,
-                new TechAdvancement(TECH_BASE_IS)
-                .setIntroLevel(false)
-                .setUnofficial(false)
+                new TechAdvancement(TECH_BASE_ALL)
                 .setTechRating(RATING_C)
                 .setAvailability(RATING_E, RATING_F, RATING_D, RATING_D)
                 .setISAdvancement(DATE_ES, DATE_ES, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setISApproximate(false,false,false,false,false)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
         
         munitions.add(new MunitionMutator("Illumination", 1, M_FLARE,
-                new TechAdvancement(TECH_BASE_IS)
-                .setIntroLevel(false)
-                .setUnofficial(false)
+                new TechAdvancement(TECH_BASE_ALL)
                 .setTechRating(RATING_C)
                 .setAvailability(RATING_D, RATING_D, RATING_D, RATING_D)
                 .setISAdvancement(DATE_ES, DATE_ES, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setISApproximate(false,false,false,false,false)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
         
         munitions.add(new MunitionMutator("Smoke", 1, M_SMOKE,
-                new TechAdvancement(TECH_BASE_IS)
-                .setIntroLevel(false)
-                .setUnofficial(false)
+                new TechAdvancement(TECH_BASE_ALL)
                 .setTechRating(RATING_B)
                 .setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
                 .setISAdvancement(DATE_PS, DATE_PS, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setISApproximate(false,false,false,false,false)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
                      
         munitions.add(new MunitionMutator("Fuel-Air", 1, M_FAE,
@@ -3207,78 +3170,6 @@ public class AmmoType extends EquipmentType {
                     .setISAdvancement(2412, DATE_NONE, DATE_NONE, 2830, 3044)
                     .setStaticTechLevel(SimpleTechLevel.UNOFFICIAL), "174, IO"));
         AmmoType.createMunitions(longTomCannonAmmos, munitions);
-
-        // Create the munition types for Clan Artillery launchers.
-        munitions.clear();
-        munitions.add(new MunitionMutator("Cluster", 1, M_CLUSTER,
-                new TechAdvancement(TECH_BASE_CLAN)
-                .setIntroLevel(false)
-                .setUnofficial(false)
-                .setTechRating(RATING_E)
-                .setAvailability(RATING_E, RATING_F, RATING_E, RATING_D)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false,false,false,false,false)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"354,TO"));
-        
-        munitions.add(new MunitionMutator("Copperhead", 1, M_HOMING,
-                new TechAdvancement(TECH_BASE_CLAN)
-                .setIntroLevel(false)
-                .setUnofficial(false)
-                .setTechRating(RATING_E)
-                .setAvailability(RATING_E, RATING_F, RATING_E, RATING_D)
-                .setClanAdvancement(2640, 2645, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false,false,false,false,false)
-                .setPrototypeFactions(F_TH)
-                .setProductionFactions(F_TH)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"354,TO"));
-        
-        munitions.add(new MunitionMutator("FASCAM", 1, M_FASCAM,
-                new TechAdvancement(TECH_BASE_CLAN)
-                .setIntroLevel(false)
-                .setUnofficial(false)
-                .setTechRating(RATING_C)
-                .setAvailability(RATING_E, RATING_F, RATING_D, RATING_D)
-                .setClanAdvancement(2621, 2844, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false,false,false,false,false)
-                .setPrototypeFactions(F_TH)
-                .setProductionFactions(F_CHH)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
-        
-        munitions.add(new MunitionMutator("Flechette", 1, M_FLECHETTE,
-                new TechAdvancement(TECH_BASE_CLAN)
-                .setIntroLevel(false)
-                .setUnofficial(false)
-                .setTechRating(RATING_C)
-                .setAvailability(RATING_E, RATING_F, RATING_D, RATING_D)
-                .setClanAdvancement(DATE_ES, DATE_ES, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false,false,false,false,false)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
-        
-        munitions.add(new MunitionMutator("Illumination", 1, M_FLARE,
-                new TechAdvancement(TECH_BASE_CLAN)
-                .setIntroLevel(false)
-                .setUnofficial(false)
-                .setTechRating(RATING_C)
-                .setAvailability(RATING_D, RATING_D, RATING_D, RATING_D)
-                .setClanAdvancement(DATE_ES, DATE_ES, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false,false,false,false,false)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"355,TO"));
-        
-        munitions.add(new MunitionMutator("Smoke", 1, M_SMOKE,
-                new TechAdvancement(TECH_BASE_CLAN)
-                .setIntroLevel(false)
-                .setUnofficial(false)
-                .setTechRating(RATING_B)
-                .setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_NONE, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false,false,false,false,false)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED),"356,TO"));
-        //TODO:
-        //Fuel-Air Mutators (See IO 165)
-
-        // Walk through both the base types and the
-        // mutators, and create munition types.
-        AmmoType.createMunitions(clanArtyAmmos, munitions);
 
         // Create the munition types for SRT launchers.
         munitions.clear();
@@ -3516,7 +3407,7 @@ public class AmmoType extends EquipmentType {
         return ammo;
     }
 
-    private static AmmoType createISLongTomAmmo() {
+    private static AmmoType createLongTomAmmo() {
         AmmoType ammo = new AmmoType();
 
         ammo.name = "Long Tom Ammo";
@@ -3526,27 +3417,7 @@ public class AmmoType extends EquipmentType {
         ammo.addLookupName("ISLongTomArtillery Ammo");
         ammo.addLookupName("IS Ammo Long Tom");
         ammo.addLookupName("IS Long Tom Ammo");
-        ammo.damagePerShot = 1;
-        ammo.rackSize = 25;
-        ammo.ammoType = AmmoType.T_LONG_TOM;
-        ammo.shots = 5;
-        ammo.bv = 46;
-        ammo.cost = 10000;
-        ammo.rulesRefs = "284,TO";
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_B)
-                .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
-                .setISAdvancement(2445, 2500, 2520, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false).setPrototypeFactions(F_TH)
-                .setProductionFactions(F_TH);
-        return ammo;
-    }
-
-    private static AmmoType createCLLongTomAmmo() {
-        AmmoType ammo = new AmmoType();
-
-        ammo.name = "Long Tom Ammo";
-        ammo.shortName = "Long Tom";
-        ammo.setInternalName("CLLongTomAmmo");
+        ammo.addLookupName("CLLongTomAmmo");
         ammo.addLookupName("CLLongTom Ammo");
         ammo.addLookupName("CLLongTomArtillery Ammo");
         ammo.addLookupName("Clan Ammo Long Tom");
@@ -3558,15 +3429,14 @@ public class AmmoType extends EquipmentType {
         ammo.bv = 46;
         ammo.cost = 10000;
         ammo.rulesRefs = "284,TO";
-        ammo.techAdvancement.setTechBase(TECH_BASE_CLAN).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_B).setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
-                .setClanAdvancement(2445, 2500, 2520, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false).setPrototypeFactions(F_TH)
-                .setProductionFactions(F_TH);
+        ammo.techAdvancement.setTechBase(TECH_BASE_ALL).setTechRating(RATING_B)
+                .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
+                .setISAdvancement(2445, 2500, 2520, DATE_NONE, DATE_NONE)
+                .setPrototypeFactions(F_TH).setProductionFactions(F_TH);
         return ammo;
     }
 
-    private static AmmoType createISSniperAmmo() {
+    private static AmmoType createSniperAmmo() {
         AmmoType ammo = new AmmoType();
 
         ammo.name = "Sniper Ammo";
@@ -3576,27 +3446,7 @@ public class AmmoType extends EquipmentType {
         ammo.addLookupName("ISSniperArtillery Ammo");
         ammo.addLookupName("IS Ammo Sniper");
         ammo.addLookupName("IS Sniper Ammo");
-        ammo.damagePerShot = 1;
-        ammo.rackSize = 20;
-        ammo.ammoType = AmmoType.T_SNIPER;
-        ammo.shots = 10;
-        ammo.bv = 11;
-        ammo.cost = 6000;
-        ammo.rulesRefs = "284,TO";
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_B)
-                .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false).setPrototypeFactions(F_TH)
-                .setProductionFactions(F_TH);
-        return ammo;
-    }
-
-    private static AmmoType createCLSniperAmmo() {
-        AmmoType ammo = new AmmoType();
-
-        ammo.name = "Sniper Ammo";
-        ammo.shortName = "Sniper";
-        ammo.setInternalName("CLSniperAmmo");
+        ammo.addLookupName("CLSniperAmmo");
         ammo.addLookupName("CLSniper Ammo");
         ammo.addLookupName("CLSniperArtillery Ammo");
         ammo.addLookupName("Clan Ammo Sniper");
@@ -3608,15 +3458,14 @@ public class AmmoType extends EquipmentType {
         ammo.bv = 11;
         ammo.cost = 6000;
         ammo.rulesRefs = "284,TO";
-        ammo.techAdvancement.setTechBase(TECH_BASE_CLAN).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_B).setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false).setPrototypeFactions(F_TH)
-                .setProductionFactions(F_TH);
+        ammo.techAdvancement.setTechBase(TECH_BASE_ALL).setTechRating(RATING_B)
+                .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
+                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
+                .setPrototypeFactions(F_TH).setProductionFactions(F_TH);
         return ammo;
     }
 
-    private static AmmoType createISThumperAmmo() {
+    private static AmmoType createThumperAmmo() {
         AmmoType ammo = new AmmoType();
 
         ammo.name = "Thumper Ammo";
@@ -3626,27 +3475,7 @@ public class AmmoType extends EquipmentType {
         ammo.addLookupName("ISThumperArtillery Ammo");
         ammo.addLookupName("IS Ammo Thumper");
         ammo.addLookupName("IS Thumper Ammo");
-        ammo.damagePerShot = 1;
-        ammo.rackSize = 15;
-        ammo.ammoType = AmmoType.T_THUMPER;
-        ammo.shots = 20;
-        ammo.bv = 5;
-        ammo.cost = 4500;
-        ammo.rulesRefs = "284,TO";
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_B)
-                .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
-                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, false, false, false, false).setPrototypeFactions(F_TH)
-                .setProductionFactions(F_TH);
-        return ammo;
-    }
-
-    private static AmmoType createCLThumperAmmo() {
-        AmmoType ammo = new AmmoType();
-
-        ammo.name = "Thumper Ammo";
-        ammo.shortName = "Thumper";
-        ammo.setInternalName("CLThumperAmmo");
+        ammo.addLookupName("CLThumperAmmo");
         ammo.addLookupName("CLThumper Ammo");
         ammo.addLookupName("CLThumperArtillery Ammo");
         ammo.addLookupName("Clan Ammo Thumper");
@@ -3658,11 +3487,10 @@ public class AmmoType extends EquipmentType {
         ammo.bv = 5;
         ammo.cost = 4500;
         ammo.rulesRefs = "284,TO";
-        ammo.techAdvancement.setTechBase(TECH_BASE_CLAN).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_B).setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
-                .setClanAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, false, false, false, false).setPrototypeFactions(F_TH)
-                .setProductionFactions(F_TH);
+        ammo.techAdvancement.setTechBase(TECH_BASE_ALL).setTechRating(RATING_B)
+                .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
+                .setISAdvancement(DATE_PS, DATE_PS, DATE_PS, DATE_NONE, DATE_NONE)
+                .setPrototypeFactions(F_TH).setProductionFactions(F_TH);
         return ammo;
     }
 


### PR DESCRIPTION
There is no distinction between IS and Clan tube artillery, and there shouldn't be separate ammo types. Davy Crockett Long Tom, is IS only, but that's still not separate Clan and IS types and is handled automatically by the mutator.

Fixes MegaMek/megameklab#654