### PR TITLE
fix aero damaged heat sink display

### DIFF
--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -365,7 +365,7 @@ public class MechView {
                         .append(a.getHeatCapacity()).append("]"); //$NON-NLS-1$
             }
             if (a.getHeatSinkHits() > 0) {
-                hsString.append(" ").append(warningStart()).append(a.getHeatSinkHits())
+                hsString.append(warningStart()).append(" (").append(a.getHeatSinkHits())
                         .append(" damaged)").append(warningEnd());
             }
             sBasic.add(new LabeledElement(Messages.getString("MechView.HeatSinks"), hsString.toString())); //$NON-NLS-1$


### PR DESCRIPTION
For aerospace units, the heat sink "Mech View" was displaying damaged heat sinks with a missing paren: ("Heat Sinks: 13 1 damaged)"). This PR simply adds the missing paren.