### PR TITLE
Validate minimum number of doors per transport bay

### DIFF
--- a/megamek/src/megamek/common/verifier/BayData.java
+++ b/megamek/src/megamek/common/verifier/BayData.java
@@ -91,11 +91,11 @@ public enum BayData {
     LIVESTOCK_CARGO ("Cargo Livestock)", 1/0.83, 0, CargoBay.techAdvancement(),
             (size, num) -> new LivestockCargoBay(size, 1, num));
     
-    private String name;
-    private double weight;
-    private int personnel;
-    private TechAdvancement techAdvancement;
-    private BiFunction<Double,Integer,Bay> init;
+    private final String name;
+    private final double weight;
+    private final int personnel;
+    private final TechAdvancement techAdvancement;
+    private final BiFunction<Double,Integer,Bay> init;
     
     BayData(String name, double weight, int personnel,
             TechAdvancement techAdvancement, BiFunction<Double,Integer,Bay> init) {
@@ -220,6 +220,14 @@ public enum BayData {
      */
     public boolean isCargoBay() {
         return ordinal() >= CARGO.ordinal();
+    }
+
+    /**
+     * @return true if the bay is an infantry transport bay (including battlearmor)
+     */
+    public boolean isInfantryBay() {
+        return (ordinal() >= INFANTRY_FOOT.ordinal())
+                && (ordinal() <= CS_BATTLE_ARMOR.ordinal());
     }
     
     /**

--- a/megamek/src/megamek/common/verifier/BayData.java
+++ b/megamek/src/megamek/common/verifier/BayData.java
@@ -156,7 +156,8 @@ public enum BayData {
      * Identifies the type of bay.
      * 
      * @param bay A <code>Bay</code> that is (or can be) mounted on a unit. 
-     * @return    The enum value for the bay.
+     * @return    The enum value for the bay. Returns null if the bay is not a transport by
+     *            (e.g. crew quarters)
      */
     public static @Nullable BayData getBayType(Bay bay) {
         if (bay instanceof MechBay) {
@@ -234,8 +235,8 @@ public enum BayData {
      * Determines whether the bay is legal to mount on a given <code>Entity</code>. Whether it is
      * technically possible or practical is another matter.
      * 
-     * @param en
-     * @return
+     * @param en The entity
+     * @return   Whether the bay is legal
      */
     public boolean isLegalFor(Entity en) {
         //TODO: Container cargo bays aren't implemented, but when added they can be carried by

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -958,8 +958,18 @@ public class TestAdvancedAerospace extends TestAero {
                 illegal = true;
             }
         }
-        
-        int bayDoors = vessel.getTransportBays().stream().mapToInt(Bay::getDoors).sum();
+
+        int bayDoors = 0;
+        for (Bay bay : vessel.getTransportBays()) {
+            bayDoors += bay.getDoors();
+            if (bay.getDoors() == 0) {
+                BayData data = BayData.getBayType(bay);
+                if ((data != null) && !data.isCargoBay() && !data.isInfantryBay()) {
+                    buff.append("Transport bays other than cargo and infantry require at least one door.\n");
+                    illegal = true;
+                }
+            }
+        }
         if (bayDoors > maxBayDoors(vessel)) {
             buff.append("Exceeds maximum number of bay doors.\n");
             illegal = true;

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -724,8 +724,18 @@ public class TestSmallCraft extends TestAero {
             buff.append("Left and right side weapon loads do not match.\n");
             illegal = true;
         }
-        
-        int bayDoors = smallCraft.getTransportBays().stream().mapToInt(Bay::getDoors).sum();
+
+        int bayDoors = 0;
+        for (Bay bay : smallCraft.getTransportBays()) {
+            bayDoors += bay.getDoors();
+            if (bay.getDoors() == 0) {
+                BayData data = BayData.getBayType(bay);
+                if ((data != null) && !data.isCargoBay() && !data.isInfantryBay()) {
+                    buff.append("Transport bays other than cargo and infantry require at least one door.\n");
+                    illegal = true;
+                }
+            }
+        }
         if (bayDoors > maxBayDoors(smallCraft)) {
             buff.append("Exceeds maximum number of bay doors.\n");
             illegal = true;


### PR DESCRIPTION
This adds a check for the required minimum number of doors for transport bays on aerospace units. It also adds a method to the bay construction data enum to check for an infantry bay as part of the fix for MegaMek/megameklab#661.