### PR TITLE
Don't add extra vehicular stealth mounts

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKAeroFile.java
+++ b/megamek/src/megamek/common/loaders/BLKAeroFile.java
@@ -278,6 +278,11 @@ public class BLKAeroFile extends BLKFile implements IMechLoader {
                     addedCase = true;
                 }
 
+                // The stealth armor mount is added when the armor type is set
+                if ((etype instanceof MiscType) && etype.hasFlag(MiscType.F_STEALTH)) {
+                    continue;
+                }
+
                 if (etype == null) {
                     // try w/ prefix
                     etype = EquipmentType.get(prefix + equipName);

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -197,6 +197,11 @@ public class BLKFile {
                     continue;
                 }
 
+                // The stealth armor mount is added when the armor type is set
+                if ((etype instanceof MiscType) && etype.hasFlag(MiscType.F_STEALTH)) {
+                    continue;
+                }
+
                 if (etype != null) {
                     try {
                         Mounted mount = t.addEquipment(etype, nLoc, false,


### PR DESCRIPTION
When the armor type is set to vehicular stealth armor on a vehicle or fighter, there is a mount added for it automatically. Each time a unit is saved and reloaded (such as when modifying in MML), a new one gets added. This has no effect on function, but is unorderly. My solution is to skip all stealth armor loaded as equipment.

Fixes MegaMek/megameklab#662