### PR TITLE
fix NPE when battle armor taser shuts down a trooper

### DIFF
--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1526,18 +1526,8 @@ public class WeaponHandler implements AttackHandler, Serializable {
         int nDamage;
         missed = false;
 
-        hit = entityTarget.rollHitLocation(toHit.getHitTable(),
-                toHit.getSideTable(), waa.getAimedLocation(),
-                waa.getAimingMode(), toHit.getCover());
-        hit.setGeneralDamageType(generalDamageType);
-        hit.setCapital(wtype.isCapital());
-        hit.setBoxCars(roll == 12);
-        hit.setCapMisCritMod(getCapMisMod());
-        hit.setFirstHit(firstHit);
-        hit.setAttackerId(getAttackerId());
-        if (weapon.isWeaponGroup()) {
-            hit.setSingleAV(attackValue);
-        }
+        initHit(entityTarget);
+        
         boolean isIndirect = wtype.hasModes()
                 && weapon.curMode().equals("Indirect");
         IHex targetHex = game.getBoard().getHex(target.getPosition());
@@ -1834,6 +1824,26 @@ public class WeaponHandler implements AttackHandler, Serializable {
         }
     }
 
+    /**
+     * Worker function that initializes the actual hit, including a hit location and various other properties.
+     * @param entityTarget Entity being hit.
+     */
+    protected void initHit(Entity entityTarget) {
+        hit = entityTarget.rollHitLocation(toHit.getHitTable(),
+                toHit.getSideTable(), waa.getAimedLocation(),
+                waa.getAimingMode(), toHit.getCover());
+        hit.setGeneralDamageType(generalDamageType);
+        hit.setCapital(wtype.isCapital());
+        hit.setBoxCars(roll == 12);
+        hit.setCapMisCritMod(getCapMisMod());
+        hit.setFirstHit(firstHit);
+        hit.setAttackerId(getAttackerId());
+        
+        if (weapon.isWeaponGroup()) {
+            hit.setSingleAV(attackValue);
+        }
+    }
+    
     protected void useAmmo() {
         if (wtype.hasFlag(WeaponType.F_DOUBLE_ONESHOT)) {
             ArrayList<Mounted> chain = new ArrayList<>();

--- a/megamek/src/megamek/common/weapons/battlearmor/BATaserHandler.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BATaserHandler.java
@@ -69,6 +69,8 @@ public class BATaserHandler extends AmmoWeaponHandler {
         vPhaseReport.add(r);
         if (entityTarget instanceof BattleArmor) {
             if (taserRoll >= 9) {
+                initHit(entityTarget);
+            
                 r = new Report(3706);
                 r.addDesc(entityTarget);
                 // shut down for rest of scenario, so we actually kill it


### PR DESCRIPTION
Fixes #2071 

In the BA taser handler, if a trooper gets shut down from a taser attack, the "hit" object hasn't been initialized yet. This PR solves that problem by separating the hit object initialization and invoking it during this special case (processing of a hit stops after special resolution).