### PR TITLE
Fixes for loading older versions of variable-sized equipment.

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -7909,7 +7909,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Liquid Storage";
         misc.setInternalName(misc.name);
         misc.addLookupName("Liquid Storage (1 ton)");
-        misc.addLookupName("Liquid Storage (0.5 ton)");
+        misc.addLookupName("Liquid Storage (0.5 tons)");
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = CRITICALS_VARIABLE;
         misc.cost = 0;

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -107,7 +107,7 @@ public class BLKFile {
      */
     static double getLegacyVariableSize(String eqName) {
         if (eqName.startsWith("Cargo")
-                || eqName.startsWith("Liquid Cargo")
+                || eqName.startsWith("Liquid Storage")
                 || eqName.startsWith("Communications Equipment")) {
             return Double.parseDouble(eqName.substring(eqName.indexOf("(") + 1,
                     eqName.indexOf(" ton")));
@@ -116,8 +116,14 @@ public class BLKFile {
             return Double.parseDouble(eqName.substring(eqName.indexOf(":") + 1));
         }
         if (eqName.startsWith("Mission Equipment Storage")) {
-            return Double.parseDouble(eqName.substring(eqName.indexOf("(") + 1,
-                    eqName.indexOf("kg")).trim());
+            int pos = eqName.indexOf("(");
+            if (pos > 0) {
+                return Double.parseDouble(eqName.substring(pos + 1,
+                        eqName.indexOf("kg")).trim());
+            } else {
+                // If the internal name does not include a size, it's the original 20 kg version.
+                return 0.02;
+            }
         }
         if (eqName.startsWith("Ladder")) {
             return Double.parseDouble(eqName.substring(eqName.indexOf("(") + 1,


### PR DESCRIPTION
Fixes 2.5 cases where variable sized equipment in older unit files fails to load:
1. BA mission equipment storage does not account for the original internal name, which does not include the weight.
2. Liquid Storage incorrectly looked for the wrong name. It also has the lookup name wrong for the 0.5 ton version.

Fixes #681. See also #682.