### PR TITLE
Add former lookup names

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -7291,6 +7291,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
         misc.name = "Fluid Suction System[Standard]";
         misc.setInternalName(misc.name);
+        misc.addLookupName("Fluid Suction System");
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
         misc.tankslots = 1;
@@ -8102,6 +8103,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(misc.name);
         misc.addLookupName("Extended Fuel Tank (1 ton)");
         misc.addLookupName("Extended Fuel Tank (0.5 tons)");
+        misc.addLookupName("Extended Fuel Tank (1.5 tons)");
         misc.addLookupName("Extended Fuel Tank (2 tons)");
         misc.addLookupName("Extended Fuel Tank (2.5 tons)");
         misc.addLookupName("Extended Fuel Tank (3 tons)");
@@ -9937,8 +9939,9 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Extended Life Support";
-        misc.setInternalName("ISBAExtendedLifeSupport");
+        misc.setInternalName("BAExtendedLifeSupport");
         misc.addLookupName("CLBAExtendedLifeSupport");
+        misc.addLookupName("ISBAExtendedLifeSupport");
         misc.cost = 10000;
         misc.tonnage = 0.025;
         misc.criticals = 1;

--- a/megamek/src/megamek/common/weapons/missiles/RocketLauncher10.java
+++ b/megamek/src/megamek/common/weapons/missiles/RocketLauncher10.java
@@ -34,6 +34,7 @@ public class RocketLauncher10 extends RLWeapon {
         addLookupName("RL 10");
         addLookupName("ISRocketLauncher10");
         addLookupName("IS RLauncher-10");
+        addLookupName("Rocket Launcher 10");
         heat = 3;
         rackSize = 10;
         shortRange = 5;

--- a/megamek/src/megamek/common/weapons/missiles/RocketLauncher15.java
+++ b/megamek/src/megamek/common/weapons/missiles/RocketLauncher15.java
@@ -34,6 +34,7 @@ public class RocketLauncher15 extends RLWeapon {
         addLookupName("ISRocketLauncher15");
         addLookupName("RL 15");
         addLookupName("IS RLauncher-15");
+        addLookupName("Rocket Launcher 15");
         heat = 4;
         rackSize = 15;
         shortRange = 4;

--- a/megamek/src/megamek/common/weapons/missiles/RocketLauncher20.java
+++ b/megamek/src/megamek/common/weapons/missiles/RocketLauncher20.java
@@ -34,6 +34,7 @@ public class RocketLauncher20 extends RLWeapon {
         addLookupName("ISRocketLauncher20");
         addLookupName("RL 20");
         addLookupName("IS RLauncher-20");
+        addLookupName("Rocket Launcher 20");
         heat = 5;
         rackSize = 20;
         shortRange = 3;


### PR DESCRIPTION
Along the way apparently the internal name of some equipment changed and the old value was not added as a lookup name.

Fixes MegaMek/megameklab#682