### PR TITLE
Update dermal armor implant to use IO rules for conventional infantry

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -1271,15 +1271,6 @@ public class CustomMechDialog extends ClientDialog implements ActionListener,
                 } else {
                     ((BattleArmor) entity).setInternal(1);
                 }
-            } else if (entity instanceof Infantry) {
-                // need to reset armor on conventional infantry
-                if (entity.hasAbility(OptionsConstants.MD_DERMAL_ARMOR)) {
-                    entity.initializeArmor(
-                            entity.getOInternal(Infantry.LOC_INFANTRY),
-                            Infantry.LOC_INFANTRY);
-                } else {
-                    entity.initializeArmor(0, Infantry.LOC_INFANTRY);
-                }
             }
         }
 

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1556,7 +1556,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 } else {
                     cbArmorKit.setSelectedIndex(armorKits.indexOf(kit) + 1);
                 }
-                fldDivisor.setText(Double.toString(inf.getDamageDivisor()));
+                fldDivisor.setText(Double.toString(inf.calcDamageDivisor()));
                 chEncumber.setSelected(inf.isArmorEncumbering());
                 chSpaceSuit.setSelected(inf.hasSpaceSuit());
                 chDEST.setSelected(inf.hasDEST());
@@ -1607,7 +1607,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                     inf.setArmorKit(armorKits.get(cbArmorKit.getSelectedIndex() - 1));
                 } else {
                     inf.setArmorKit(null);
-                    inf.setDamageDivisor(Double.valueOf(fldDivisor.getText()));
+                    inf.setArmorDamageDivisor(Double.valueOf(fldDivisor.getText()));
                     inf.setArmorEncumbering(chEncumber.isSelected());
                     inf.setSpaceSuit(chSpaceSuit.isSelected());
                     inf.setDEST(chDEST.isSelected());

--- a/megamek/src/megamek/common/AlphaStrikeElement.java
+++ b/megamek/src/megamek/common/AlphaStrikeElement.java
@@ -72,7 +72,7 @@ public class AlphaStrikeElement extends BattleForceElement {
         super(en);
         asUnitType = ASUnitType.getUnitType(en);
         if (en.getEntityType() == Entity.ETYPE_INFANTRY) {
-            double divisor = ((Infantry)en).calcDamageDivisor();
+            double divisor = ((Infantry) en).calcDamageDivisor();
             if (((Infantry)en).isMechanized()) {
                 divisor /= 2.0;
             }

--- a/megamek/src/megamek/common/AlphaStrikeElement.java
+++ b/megamek/src/megamek/common/AlphaStrikeElement.java
@@ -72,7 +72,7 @@ public class AlphaStrikeElement extends BattleForceElement {
         super(en);
         asUnitType = ASUnitType.getUnitType(en);
         if (en.getEntityType() == Entity.ETYPE_INFANTRY) {
-            double divisor = ((Infantry)en).getDamageDivisor();
+            double divisor = ((Infantry)en).calcDamageDivisor();
             if (((Infantry)en).isMechanized()) {
                 divisor /= 2.0;
             }

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -808,9 +808,9 @@ public class EntityListFile {
             if ((entity instanceof Infantry)
                     && !(entity instanceof BattleArmor)) {
                 Infantry inf = (Infantry) entity;
-                if (inf.getDamageDivisor() != 1) {
+                if (inf.getArmorDamageDivisor() != 1) {
                     output.write("\" " + MULParser.ARMOR_DIVISOR + "=\"");
-                    output.write(inf.getDamageDivisor() + "");
+                    output.write(inf.getArmorDamageDivisor() + "");
                 }
                 if (inf.isArmorEncumbering()) {
                     output.write("\" " + MULParser.ARMOR_ENC + "=\"1");

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -908,7 +908,7 @@ public class Infantry extends Entity {
 
         double dbr = 0; //defensive battle rating
 
-        dbr = men * 1.5 * getDamageDivisor();
+        dbr = men * 1.5 * calcDamageDivisor();
         int tmmRan = Compute.getTargetMovementModifier(getRunMP(false, true, true), false, false, game)
                 .getValue();
 
@@ -1020,7 +1020,7 @@ public class Infantry extends Entity {
         bvText.append(startColumn);
         bvText.append(endColumn);
         bvText.append(startColumn);
-        bvText.append(df.format(getDamageDivisor()));
+        bvText.append(df.format(calcDamageDivisor()));
         bvText.append(endColumn);
         bvText.append(endRow);
 
@@ -1032,7 +1032,7 @@ public class Infantry extends Entity {
         bvText.append(" x 1.5 x ");
         bvText.append(tmmFactor);
         bvText.append(" x ");
-        bvText.append(getDamageDivisor());
+        bvText.append(calcDamageDivisor());
         bvText.append(endColumn);
         bvText.append(startColumn);
 
@@ -1966,11 +1966,24 @@ public class Infantry extends Entity {
     	}
     }
 
-    public double getDamageDivisor() {
+    public double calcDamageDivisor() {
+        double divisor = damageDivisor;
+        // TSM implant reduces divisor to 0.5 if no other armor is worn
+        if ((divisor == 1.0) && hasAbility(OptionsConstants.MD_TSM_IMPLANT)) {
+            divisor = 0.5;
+        }
+        // Dermal armor adds one to the divisor, cumulative with armor kit and TSM implant
+        if (hasAbility(OptionsConstants.MD_DERMAL_ARMOR)) {
+            divisor += 1.0;
+        }
+        return divisor;
+    }
+
+    public double getArmorDamageDivisor() {
     	return damageDivisor;
     }
 
-    public void setDamageDivisor(double d) {
+    public void setArmorDamageDivisor(double d) {
         damageDivisor = d;
     }
 
@@ -2420,20 +2433,7 @@ public class Infantry extends Entity {
 
     public String getArmorDesc() {
         StringBuffer sArmor = new StringBuffer();
-        double divisor = getDamageDivisor();
-        if (getCrew() != null) {
-	    	// TSM reduces divisor to 0.5 if no other armor is worn.
-	    	if (hasAbility(OptionsConstants.MD_TSM_IMPLANT)) {
-	    		if (getArmorKit() == null) {
-	    			divisor = 0.5;
-	    		}
-	    	}
-	    	// Dermal armor adds one, cumulative with TSM (which gives a total of 1.5 if unarmored).
-	    	if (hasAbility(OptionsConstants.MD_DERMAL_ARMOR)) {
-	    		divisor++;
-	    	}
-        }
-        sArmor.append(divisor);
+        sArmor.append(calcDamageDivisor());
         if(isArmorEncumbering()) {
             sArmor.append("E");
         }

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -417,8 +417,8 @@ public class Infantry extends Entity {
             mp = Math.max(mp - 1, 1);
         }
         if((getSecondaryN() > 1)
-                && ((null == getCrew()) || !hasAbility(OptionsConstants.MD_TSM_IMPLANT))
-                && ((null == getCrew()) || !hasAbility(OptionsConstants.MD_DERMAL_ARMOR))
+                && !hasAbility(OptionsConstants.MD_TSM_IMPLANT)
+                && !hasAbility(OptionsConstants.MD_DERMAL_ARMOR)
                 && (null != secondW) && secondW.hasFlag(WeaponType.F_INF_SUPPORT)
                 && (getMovementMode() != EntityMovementMode.TRACKED)
                 && (getMovementMode() != EntityMovementMode.INF_JUMP)) {
@@ -487,8 +487,8 @@ public class Infantry extends Entity {
             mp = getOriginalJumpMP();
         }
         if ((getSecondaryN() > 1)
-                && ((null == getCrew()) || !hasAbility(OptionsConstants.MD_TSM_IMPLANT))
-                && ((null == getCrew()) || !hasAbility(OptionsConstants.MD_DERMAL_ARMOR))
+                && !hasAbility(OptionsConstants.MD_TSM_IMPLANT)
+                && !hasAbility(OptionsConstants.MD_DERMAL_ARMOR)
                 && (getMovementMode() != EntityMovementMode.SUBMARINE)
                 && (null != secondW) && secondW.hasFlag(WeaponType.F_INF_SUPPORT)) {
             mp = Math.max(mp - 1, 0);

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -753,7 +753,7 @@ public class MULParser {
             Infantry inf = (Infantry) entity;
             String armorDiv = entityTag.getAttribute(ARMOR_DIVISOR);
             if (armorDiv.length() > 0) {
-                inf.setDamageDivisor(Double.parseDouble(armorDiv));
+                inf.setArmorDamageDivisor(Double.parseDouble(armorDiv));
             }
             if (entityTag.getAttribute(ARMOR_ENC).length() > 0) {
                 inf.setArmorEncumbering(true);

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -884,9 +884,9 @@ public class BLKFile {
             if (et != null) {
             	blk.writeBlockData("armorKit", et.getInternalName());
             }
-            if (infantry.getDamageDivisor() != 1) {
+            if (infantry.getArmorDamageDivisor() != 1) {
                 blk.writeBlockData("armordivisor",
-                        Double.toString(infantry.getDamageDivisor()));
+                        Double.toString(infantry.getArmorDamageDivisor()));
             }
             if (infantry.isArmorEncumbering()) {
                 blk.writeBlockData("encumberingarmor", "true");

--- a/megamek/src/megamek/common/loaders/BLKInfantryFile.java
+++ b/megamek/src/megamek/common/loaders/BLKInfantryFile.java
@@ -76,7 +76,7 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
         t.autoSetInternal();
 
         if (dataFile.exists("InfantryArmor")) {
-            t.setDamageDivisor(dataFile.getDataAsInt("InfantryArmor")[0]);
+            t.setArmorDamageDivisor(dataFile.getDataAsInt("InfantryArmor")[0]);
         }
 
         if (!dataFile.exists("motion_type")) {
@@ -179,7 +179,7 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
             t.setSneakECM(true);
         }
         if (dataFile.exists("armordivisor")) {
-            t.setDamageDivisor(Double.valueOf(dataFile.getDataAsString("armordivisor")[0]));
+            t.setArmorDamageDivisor(Double.valueOf(dataFile.getDataAsString("armordivisor")[0]));
         }
         // get field guns
         loadEquipment(t, "Field Guns", Infantry.LOC_FIELD_GUNS);

--- a/megamek/src/megamek/common/templates/InfantryTROView.java
+++ b/megamek/src/megamek/common/templates/InfantryTROView.java
@@ -124,7 +124,7 @@ public class InfantryTROView extends TROView {
         }
         setModelData("squadSize", inf.getSquadSize());
         setModelData("squadCount", inf.getSquadN());
-        setModelData("armorDivisor", inf.getDamageDivisor());
+        setModelData("armorDivisor", inf.calcDamageDivisor());
         InfantryWeapon rangeWeapon = inf.getPrimaryWeapon();
         if ((inf.getSecondaryN() > 1) && (inf.getSecondaryWeapon() != null)) {
             rangeWeapon = inf.getSecondaryWeapon();

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -22557,12 +22557,12 @@ public class Server implements Runnable {
         }
 
         // infantry armor can reduce damage
-        if (isPlatoon && (((Infantry) te).getDamageDivisor() != 1.0)) {
+        if (isPlatoon && (((Infantry) te).calcDamageDivisor() != 1.0)) {
             r = new Report(6074);
             r.subject = te_n;
             r.indent(2);
             r.add(damage);
-            damage = (int) Math.ceil((damage) / ((Infantry) te).getDamageDivisor());
+            damage = (int) Math.ceil((damage) / ((Infantry) te).calcDamageDivisor());
             r.add(damage);
             vDesc.addElement(r);
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -22422,19 +22422,6 @@ public class Server implements Runnable {
         // We're actually going to abuse this for AX-head warheads, too, so as
         // to not add another parameter.
         switch (bFrag) {
-            case ANTI_INFANTRY:
-                if (isPlatoon
-                    && te.hasAbility(OptionsConstants.MD_DERMAL_ARMOR)) {
-                    int reduce = Math.min(damage - 1, Compute.d6());
-                    damage -= reduce;
-                    r = new Report(6042);
-                    r.subject = te_n;
-                    r.add(reduce);
-                    r.add(damage);
-                    r.indent(2);
-                    vDesc.addElement(r);
-                }
-                break;
             case FRAGMENTATION:
                 // Fragmentation missiles deal full damage to conventional
                 // infantry

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -29,8 +29,7 @@ public class ServerHelper {
             boolean isPlatoon, boolean ammoExplosion, boolean ignoreInfantryDoubleDamage) {
         
         if (isPlatoon && !te.isDestroyed() && !te.isDoomed() && !ignoreInfantryDoubleDamage
-                && (((Infantry) te).getDugIn() != Infantry.DUG_IN_COMPLETE)
-                && !te.hasAbility(OptionsConstants.MD_DERMAL_ARMOR)) {
+                && (((Infantry) te).getDugIn() != Infantry.DUG_IN_COMPLETE)) {
         	
         	if(te_hex == null) {
         		te_hex = game.getBoard().getHex(te.getPosition());


### PR DESCRIPTION
This updates the rules for the dermal armor implant augmentation from the original version in Jihad Hot Spots: 3072 to the current rules in Interstellar Operations. In the original version, conventional infantry with dermal armor implants took 1d6 less damage from burst fire weapons, did not take x2 damage when caught in the open, and each soldier took two points of damage to eliminate. In the current rules, the damage divisor is increased by one. I also incorporated the reduction to damage divisor for unarmored conventional infantry with the TSM implant.

MM allows infantry to be configured with custom armor settings, so the damage divisor from the armor needs to be tracked separately (or at least it's a lot simpler to do it that way). To make a clear distinction between what part of the damage divisor is from the armor and what is the total I renamed getDamageDivisor() to getArmorDamageDivisor() (and equivalent for the setter) and added a calcDamageDivisor() method that's used when the effective value is needed. This will require changes in MML and MHQ to reflect the new method name.

Fixes MegaMek/megameklab#689