### PR TITLE
make LAMs more rare in rat generator; actual bomb bays for Mk I WSP-100

### DIFF
--- a/megamek/data/forcegenerator/2398.xml
+++ b/megamek/data/forcegenerator/2398.xml
@@ -168,29 +168,29 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
+		<model name='(Wheeled Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:9</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>IS.pm:3</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Hover Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -308,40 +308,40 @@
 	</chassis>
 	<chassis name='Estevez MBT' unitType='Tank'>
 		<availability>FWL:6,FS:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Aircraft)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -354,9 +354,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -364,17 +361,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
@@ -392,21 +392,21 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane Conventional Fighter' unitType='Conventional Fighter'>
@@ -431,19 +431,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -494,35 +494,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -530,20 +527,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -551,8 +551,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -579,7 +579,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -588,14 +588,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>

--- a/megamek/data/forcegenerator/2440.xml
+++ b/megamek/data/forcegenerator/2440.xml
@@ -188,29 +188,29 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
+		<model name='(Wheeled Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:9</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>IS.pm:3</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Hover Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
@@ -370,12 +370,12 @@
 	</chassis>
 	<chassis name='Estevez MBT' unitType='Tank'>
 		<availability>FWL:4,FS:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Aircraft)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Farragut Battleship' unitType='Warship'>
@@ -387,30 +387,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -423,9 +423,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -433,17 +430,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
@@ -461,21 +461,21 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane Conventional Fighter' unitType='Conventional Fighter'>
@@ -500,19 +500,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -574,13 +574,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:8,Periphery.Deep:6,Periphery:6</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -591,35 +591,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -627,20 +624,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -648,8 +648,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -676,7 +676,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -685,14 +685,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>

--- a/megamek/data/forcegenerator/2460.xml
+++ b/megamek/data/forcegenerator/2460.xml
@@ -188,29 +188,29 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
+		<model name='(Wheeled Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:9</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>IS.pm:3</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Hover Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
@@ -399,12 +399,12 @@
 	</chassis>
 	<chassis name='Estevez MBT' unitType='Tank'>
 		<availability>FWL:2,FS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Aircraft)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Farragut Battleship' unitType='Warship'>
@@ -416,18 +416,26 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
@@ -435,20 +443,9 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -456,17 +453,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -496,21 +496,21 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -542,19 +542,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -634,13 +634,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -657,35 +657,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -693,20 +690,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -714,8 +714,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -745,7 +745,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -754,14 +754,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mustang Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2470.xml
+++ b/megamek/data/forcegenerator/2470.xml
@@ -198,33 +198,33 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:9</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
 		<model name='(Hover)'>
 			<roles>apc,support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>IS.pm:3</availability>
 		</model>
 		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Tracked Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:9</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>IS.pm:3</availability>
+		</model>
 		<model name='(Hover Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
@@ -295,11 +295,11 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:1,IS:1,FS:8</availability>
-		<model name='CNT-1D'>
-			<availability>LA:4,Periphery.HR:4,FS:4,MERC:4,Periphery.OS:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:4,Periphery.HR:4,FS:4,MERC:4,Periphery.OS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chi-Ha Infantry Combat Vehicle' unitType='Tank'>
@@ -346,14 +346,14 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-X'>
 			<availability>General:4</availability>
 		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -402,10 +402,10 @@
 	</chassis>
 	<chassis name='DroST IIb Transport' unitType='Dropship'>
 		<availability>TH:4</availability>
-		<model name='(2445)'>
+		<model name='(2470)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2470)'>
+		<model name='(2445)'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -444,12 +444,12 @@
 	</chassis>
 	<chassis name='Estevez MBT' unitType='Tank'>
 		<availability>FWL:1,FS:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Aircraft)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Farragut Battleship' unitType='Warship'>
@@ -461,30 +461,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -497,9 +497,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -507,17 +504,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -546,34 +546,42 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:2,TH:7,LA:1,FWL:2,IS:1,FS:2,DC:2</availability>
-		<model name='HMR-HA'>
-			<availability>TH:6</availability>
-		</model>
 		<model name='HMR-HC'>
 			<availability>TH:4,IS:8</availability>
+		</model>
+		<model name='HMR-HA'>
+			<availability>TH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:3-,IS.pm:2,Periphery:3-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,Periphery.Deep:4-,IS.pm:2,Periphery:4-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:3-,IS.pm:2,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -581,33 +589,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -662,19 +662,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -751,31 +751,31 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:6-,LA:5,IS:4,FWL:4,Periphery:3</availability>
-		<model name='MSK-7A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:5,FWL:5</availability>
+		</model>
+		<model name='MSK-7A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='II (Primitive)'>
 			<availability>General:3</availability>
@@ -789,35 +789,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -825,20 +822,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -846,8 +846,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -877,7 +877,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -886,14 +886,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mustang Fighter' unitType='Conventional Fighter'>
@@ -1040,6 +1040,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:1,DC:1</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -1047,10 +1051,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2490.xml
+++ b/megamek/data/forcegenerator/2490.xml
@@ -206,27 +206,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
 		</model>
@@ -234,37 +214,57 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,General:6</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Tracked Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:4,General:6</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
 		</model>
 		<model name='(Hover Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,General:6</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
@@ -342,11 +342,11 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,IS:2,FS:8</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:3</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -407,11 +407,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -478,11 +478,11 @@
 	</chassis>
 	<chassis name='DroST IIb Transport' unitType='Dropship'>
 		<availability>TH:4</availability>
-		<model name='(2445)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(2470)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2445)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='DroST Light Bulk Transport' unitType='Dropship'>
@@ -501,14 +501,14 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,General:6,FS:6</availability>
-		</model>
 		<model name='EGL-R1'>
 			<availability>General:4</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:6,FS:4</availability>
+		</model>
+		<model name='EGL-R4'>
+			<availability>LA:6,General:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -519,11 +519,11 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>TH:6</availability>
-		<model name='EMP-5A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='EMP-1A'>
 			<availability>TH:5,General:8</availability>
+		</model>
+		<model name='EMP-5A'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -535,12 +535,12 @@
 	</chassis>
 	<chassis name='Estevez MBT' unitType='Tank'>
 		<availability>FS:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Aircraft)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Farragut Battleship' unitType='Warship'>
@@ -552,30 +552,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -594,9 +594,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -604,17 +601,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Frogmen' unitType='Infantry'>
@@ -629,23 +629,15 @@
 		<model name='GLD-3R'>
 			<availability>General:8,MERC:8</availability>
 		</model>
-		<model name='GLD-2R'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='GLD-4R'>
 			<availability>General:4,MERC:4</availability>
+		</model>
+		<model name='GLD-2R'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>FS:4</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>FS:5</availability>
@@ -654,14 +646,22 @@
 			<roles>apc,urban</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:2,TH:8,LA:2,IS:2,DC:2</availability>
-		<model name='GRF-1A'>
-			<availability>LA:6,IS:6,Periphery.Deep:8,MERC:6,Periphery:8,TC:8</availability>
-		</model>
 		<model name='GRF-1N'>
 			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='GRF-1A'>
+			<availability>LA:6,IS:6,Periphery.Deep:8,MERC:6,Periphery:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -682,11 +682,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
-		<model name='HMR-HA'>
-			<availability>TH:5</availability>
-		</model>
 		<model name='HMR-HC'>
 			<availability>TH:6,IS:8</availability>
+		</model>
+		<model name='HMR-HA'>
+			<availability>TH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -698,25 +698,33 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -724,33 +732,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -824,19 +824,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -928,13 +928,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:5</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -946,31 +946,31 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:5-,LA:5-,IS:3-,FWL:3-,Periphery.Deep:4,Periphery:4</availability>
-		<model name='MSK-7A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:4,FWL:4</availability>
+		</model>
+		<model name='MSK-7A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:6,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='II (Primitive)'>
 			<availability>General:2</availability>
@@ -984,14 +984,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:3</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -1003,35 +1003,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1039,20 +1036,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1060,8 +1060,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1103,7 +1103,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -1112,14 +1112,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mustang Fighter' unitType='Conventional Fighter'>
@@ -1340,11 +1340,11 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:4</availability>
-		<model name='TDR-1C'>
-			<availability>CC:8,Periphery.Deep:8,TC:8,Periphery:8</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:6,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:8,Periphery.Deep:8,TC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -1363,6 +1363,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:2,DC:2</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -1370,10 +1374,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2520.xml
+++ b/megamek/data/forcegenerator/2520.xml
@@ -189,11 +189,11 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>TH:4</availability>
-		<model name='Mk II'>
-			<availability>TH:4</availability>
-		</model>
 		<model name='Mk I'>
 			<availability>TH:3</availability>
+		</model>
+		<model name='Mk II'>
+			<availability>TH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -231,27 +231,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -259,37 +239,57 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Tracked Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Hover Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Athena Cruiser' unitType='Warship'>
@@ -374,13 +374,13 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Caravan Heavy Transport' unitType='Conventional Fighter'>
@@ -406,11 +406,11 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,IS:2,FS:8,MERC:3,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -484,11 +484,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -543,11 +543,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>LA:4,RWR:2,FS:3</availability>
-		<model name='DV-6M'>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='DV-1S'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dreadnought Battleship' unitType='Warship'>
@@ -568,11 +568,11 @@
 	</chassis>
 	<chassis name='DroST IIb Transport' unitType='Dropship'>
 		<availability>TH:2</availability>
-		<model name='(2445)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(2470)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2445)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DroST Light Bulk Transport' unitType='Dropship'>
@@ -598,14 +598,14 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:3,MOC:1,OA:1,LA:3,FWL:8,IS:1,FS:3,DC:3,TC:1</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,General:5,FS:6</availability>
-		</model>
 		<model name='EGL-R1'>
 			<availability>General:2</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:8,FS:4</availability>
+		</model>
+		<model name='EGL-R4'>
+			<availability>LA:6,General:5,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -616,19 +616,15 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>TH:6</availability>
-		<model name='EMP-5A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='EMP-1A'>
 			<availability>TH:4,General:8</availability>
+		</model>
+		<model name='EMP-5A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -636,6 +632,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -654,18 +654,26 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
@@ -673,21 +681,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
 		<availability>CC:7</availability>
-		<model name='FRB-1E (WAM-B)'>
+		<model name='FRB-2E'>
 			<availability>General:6</availability>
 		</model>
-		<model name='FRB-2E'>
+		<model name='FRB-1E (WAM-B)'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -706,21 +706,18 @@
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:4-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -728,17 +725,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Frogmen' unitType='Infantry'>
@@ -760,23 +760,15 @@
 		<model name='GLD-3R'>
 			<availability>General:8,MERC:8</availability>
 		</model>
-		<model name='GLD-2R'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='GLD-4R'>
 			<availability>General:4,MERC:4</availability>
+		</model>
+		<model name='GLD-2R'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,FS:5,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -785,14 +777,22 @@
 			<roles>apc,urban</roles>
 			<availability>CC:2,LA:2,FS:4,DC:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:4,TH:8,LA:4,IS:4,DC:3</availability>
-		<model name='GRF-1A'>
-			<availability>LA:4,IS:4,Periphery.Deep:8,MERC:4,Periphery:8,TC:8</availability>
-		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='GRF-1A'>
+			<availability>LA:4,IS:4,Periphery.Deep:8,MERC:4,Periphery:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -813,11 +813,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
-		<model name='HMR-HA'>
-			<availability>TH:4</availability>
-		</model>
 		<model name='HMR-HC'>
 			<availability>TH:6,IS:8</availability>
+		</model>
+		<model name='HMR-HA'>
+			<availability>TH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -829,25 +829,33 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -855,33 +863,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -956,19 +956,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -983,11 +983,11 @@
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:7</availability>
-		<model name='KRV-2'>
-			<availability>CC:8-</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>CC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -1050,13 +1050,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>TH:8,IS:7,Periphery:2</availability>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7</availability>
-		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LCT-1V'>
+			<roles>recon</roles>
+			<availability>LA:4,General:8,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -1068,12 +1068,12 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>FWL:9</availability>
-		<model name='LGB-0C'>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LGB-0C'>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -1084,13 +1084,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -1102,31 +1102,31 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:4-,LA:4-,IS:3-,FWL:3-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='MSK-7A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:3,FWL:3</availability>
+		</model>
+		<model name='MSK-7A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='II (Primitive)'>
 			<availability>General:1</availability>
@@ -1140,14 +1140,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -1159,35 +1159,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1195,20 +1192,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1216,8 +1216,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1256,7 +1256,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -1265,14 +1265,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mustang Fighter' unitType='Conventional Fighter'>
@@ -1350,13 +1350,13 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:4</availability>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery:8</availability>
+		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -1562,20 +1562,20 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:6</availability>
-		<model name='TDR-1C'>
-			<availability>CC:6,MOC:8,Periphery.Deep:8,TC:8,Periphery:8</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:6,MOC:8,Periphery.Deep:8,TC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
 		<availability>TC:8</availability>
-		<model name='TR-A-6'>
+		<model name='TR-A-1'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='TR-A-1'>
+		<model name='TR-A-6'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1596,6 +1596,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:2,DC:2</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -1603,10 +1607,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>
@@ -1617,13 +1617,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>TH:4</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,IS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:1,IS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:1,IS:1,FS:1</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2571.xml
+++ b/megamek/data/forcegenerator/2571.xml
@@ -208,7 +208,7 @@
 		<salvage pct='5'></salvage>
 	</faction>
 	<faction key='SL.R'>
-		<salvage pct='5'></salvage>
+		<salvage pct='5'>CC:10,LA:10,FWL:9,FS:4,DC:7</salvage>
 	</faction>
 	<faction key='FWL.SD'>
 		<salvage pct='5'></salvage>
@@ -265,14 +265,14 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>TH:5,SL:6</availability>
+		<model name='Mk I'>
+			<availability>TH:1</availability>
+		</model>
 		<model name='Mk II'>
 			<availability>TH:2</availability>
 		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk I'>
-			<availability>TH:1</availability>
 		</model>
 		<model name='Mk IV'>
 			<availability>General:2</availability>
@@ -317,23 +317,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -341,33 +325,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:2</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Athena Cruiser' unitType='Warship'>
@@ -396,11 +396,11 @@
 		<model name='BNC-1E'>
 			<availability>TH:2,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:3</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -464,13 +464,13 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -508,30 +508,30 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>TH:5,SL:7</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,SL:4,FWL:4,SL.R:4</availability>
 		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cestus' unitType='Mek'>
@@ -583,23 +583,23 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,LA:4,SL:5,FWL:4,SL.R:4,FS:6,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:2,SL:2,FS:2</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>TH:6,SL:6</availability>
-		<model name='(Original)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Original)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Command)'>
@@ -682,11 +682,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -760,13 +760,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:6</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dreadnought Battleship' unitType='Warship'>
@@ -811,14 +811,14 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:2,OA:1,LA:4,SL:5,FWL:8,IS:2,FS:4,DC:4,TC:2</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,General:3,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:8,FS:4</availability>
+		</model>
+		<model name='EGL-R4'>
+			<availability>LA:6,General:3,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -829,22 +829,18 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>TH:6,SL:6</availability>
+		<model name='EMP-1A'>
+			<availability>TH:3,General:6,SL:2</availability>
+		</model>
 		<model name='EMP-5A'>
 			<availability>General:8,SL:8,SL.R:8</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>SL:4+,SL.R:5</availability>
 		</model>
-		<model name='EMP-1A'>
-			<availability>TH:3,General:6,SL:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -852,6 +848,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -874,11 +874,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>SL:6</availability>
-		<model name='EXT-4D'>
-			<availability>General:8+,SL.R:8</availability>
-		</model>
 		<model name='EXT-4C'>
 			<availability>SL.R:2</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>General:8+,SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
@@ -896,18 +896,26 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>SL:3,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
@@ -915,22 +923,14 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
 		<availability>CC:7</availability>
-		<model name='FRB-1E (WAM-B)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FRB-2E'>
 			<availability>General:8</availability>
+		</model>
+		<model name='FRB-1E (WAM-B)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
@@ -948,6 +948,10 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
@@ -956,36 +960,29 @@
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:4-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -993,17 +990,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1055,23 +1055,15 @@
 		<model name='GLD-3R'>
 			<availability>General:8,MERC:8</availability>
 		</model>
-		<model name='GLD-2R'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='GLD-4R'>
 			<availability>General:4,MERC:4</availability>
+		</model>
+		<model name='GLD-2R'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1080,14 +1072,22 @@
 			<roles>apc,urban</roles>
 			<availability>CC:2,LA:2,FS:4,DC:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:5,MOC:3,OA:3,TH:8,LA:5,SL:7,IS:5,RWR:2,MERC:3,TC:3,DC:4</availability>
-		<model name='GRF-1A'>
-			<availability>LA:2,IS:2,Periphery.Deep:6,MERC:2,Periphery:6,TC:6</availability>
-		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
+		</model>
+		<model name='GRF-1A'>
+			<availability>LA:2,IS:2,Periphery.Deep:6,MERC:2,Periphery:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1124,25 +1124,33 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1150,33 +1158,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1265,20 +1265,20 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:6,LA:6,SL:7,FWL:6,IS:4,FS:6</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>SL:6</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
@@ -1298,19 +1298,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -1345,11 +1345,11 @@
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:7</availability>
-		<model name='KRV-2'>
-			<availability>CC:8-</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>CC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -1370,12 +1370,12 @@
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
 		<availability>TH:6,SL:6</availability>
-		<model name='KY2-D-01'>
-			<availability>TH:8,SL:8,SL.R:0</availability>
-		</model>
 		<model name='KY2-D-02'>
 			<roles>fire_support</roles>
 			<availability>SL:4</availability>
+		</model>
+		<model name='KY2-D-01'>
+			<availability>TH:8,SL:8,SL.R:0</availability>
 		</model>
 	</chassis>
 	<chassis name='LRM Carrier' unitType='Tank'>
@@ -1397,13 +1397,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:2,LA:2,SL:5,IS:2,MERC:2,DC:2</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>SL:8,IS:8,DC:8</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1458,6 +1458,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>TH:9,SL:8,IS:9,Periphery.Deep:4,Periphery:4</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:6</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:6</availability>
@@ -1465,10 +1469,6 @@
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:4,General:8,SL.R:8,FS:7</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -1480,16 +1480,16 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:3,CC:4,IS:4,RWR:3,FS:5,Periphery:2,TC:3,OA:3,LA:6,SL:5,FWL:9,SL.R:4,DC:4</availability>
-		<model name='LGB-0C'>
-			<availability>FWL:4-,IS:4-,Periphery.Deep:8,Periphery:8</availability>
+		<model name='LGB-7Q'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='LGB-7Q'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='LGB-0C'>
+			<availability>FWL:4-,IS:4-,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -1503,13 +1503,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -1521,28 +1521,28 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:4-,LA:2-,SL:2-,IS:2-,FWL:2-,Periphery.Deep:5,SL.R:0,TH.HM:4-,Periphery:5</availability>
-		<model name='MSK-7A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:2,FWL:2</availability>
-		</model>
-		<model name='MSK-9H'>
-			<availability>General:6</availability>
 		</model>
 		<model name='MSK-8B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='MSK-7A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='MSK-9H'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:4,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
@@ -1553,11 +1553,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:4,LA:5,Periphery.MW:4,Periphery.HR:3,Periphery.CM:3,IS:4,Periphery:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -1575,14 +1575,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -1594,35 +1594,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>SL:5,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1630,20 +1627,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1651,8 +1651,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1676,15 +1676,15 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:6,General:4,MERC:2,DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
 		</model>
@@ -1726,7 +1726,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -1735,14 +1735,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mustang Fighter' unitType='Conventional Fighter'>
@@ -1818,11 +1818,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:2</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,SL:0</availability>
-		</model>
 		<model name='OWR-2Mb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,SL:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -1861,21 +1861,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:4,SL:6,IS:4,FWL:4,Periphery:3</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>SL:8,SL.R:8</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>General:8,SL:4,Periphery:8</availability>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -2112,11 +2112,11 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,LA:4,SL:8,FWL:4,DC:4</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:1,OA:1,IS:1,TC:1</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -2133,13 +2133,13 @@
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:4,TH:9,SL:8,IS:9,SL.R:7,MERC:4,Periphery:3,DC:6</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
-		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>SL:3,IS:3,Periphery:3</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stoat Scout Car' unitType='Tank'>
@@ -2232,22 +2232,22 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,LA:5,SL:6,IS:4,FS:5,MERC:4,DC:5,Periphery:3,TC:3</availability>
-		<model name='TDR-1C'>
-			<availability>CC:4,MOC:8,Periphery.Deep:8,TC:8,Periphery:8</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:4,MOC:8,Periphery.Deep:8,TC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
 		<availability>TC:8</availability>
-		<model name='TR-A-6'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='TR-A-1'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='TR-A-6'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tracker Surveillance' unitType='Warship'>
@@ -2283,6 +2283,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:1,DC:1</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -2290,10 +2294,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>
@@ -2304,13 +2304,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:2,CC:2,IS:2,RWR:2,FS:2,Periphery.OS:2,Periphery:2,TC:2,OA:2,TH:4,LA:2,Periphery.HR:2,SL:6,FWL:2,SL.R:2,DC:2</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,SL:2,IS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:1,SL:2,IS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:1,SL:2,IS:1,FS:1</availability>
 		</model>
 	</chassis>
@@ -2411,10 +2411,10 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:5</availability>
-		<model name='XNT-2O'>
+		<model name='XNT-3O'>
 			<availability>General:6</availability>
 		</model>
-		<model name='XNT-3O'>
+		<model name='XNT-2O'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -2436,19 +2436,19 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>SL:7</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>SL.R:8</availability>
+			<availability>General:4,SL.R:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>General:8,SL.R:4,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>General:4,SL.R:2</availability>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2650.xml
+++ b/megamek/data/forcegenerator/2650.xml
@@ -210,7 +210,7 @@
 		<salvage pct='5'></salvage>
 	</faction>
 	<faction key='SL.R'>
-		<salvage pct='5'></salvage>
+		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:3,DC:6</salvage>
 	</faction>
 	<faction key='FWL.SD'>
 		<salvage pct='5'></salvage>
@@ -316,23 +316,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -340,33 +324,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:2</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -410,11 +410,11 @@
 		<model name='BNC-1E'>
 			<availability>TH:2,Periphery:2</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:3,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:3,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -485,13 +485,13 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
@@ -535,34 +535,34 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:2,RWR:2,FS:2,MERC:2,TC:2,Periphery:2,TH:6,LA:2,SL:7,FWL:2,DC:2</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>SL.R:6</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,SL:4,FWL:4,SL.R:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>SL.R:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:6,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cestus' unitType='Mek'>
@@ -580,12 +580,12 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:4,LA:4,SL:7,FWL:3,IS:3,FS:3,MERC:2,DC:3</availability>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,LA:4+,SL.R:4</availability>
-		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:8+,SL:8,SL.R:8</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,LA:4+,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -624,21 +624,18 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,LA:5,SL:4,FWL:5,IS:3,SL.R:4,FS:7,MERC:3,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>TH:5,SL:7</availability>
-		<model name='(Original)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(MASH)'>
 			<roles>support</roles>
 			<availability>SL:2</availability>
@@ -646,6 +643,9 @@
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Command)'>
 			<roles>support</roles>
@@ -734,11 +734,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -808,13 +808,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:6</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -833,18 +833,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:2,LA:4,SL:5,FWL:8,IS:3,RWR:2,FS:4,DC:4,Periphery:2,TC:3</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,General:2,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,General:2,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -855,22 +855,18 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:3,MOC:3,OA:3,TH:5,SL:7,FWL:3,RWR:3,FS:3,MERC:3,TC:3</availability>
+		<model name='EMP-1A'>
+			<availability>TH:3,General:4</availability>
+		</model>
 		<model name='EMP-5A'>
 			<availability>General:8,SL:6,SL.R:6</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>SL:6+,SL.R:6</availability>
 		</model>
-		<model name='EMP-1A'>
-			<availability>TH:3,General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -878,6 +874,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -900,11 +900,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>SL:7</availability>
-		<model name='EXT-4D'>
-			<availability>General:8+,SL.R:8</availability>
-		</model>
 		<model name='EXT-4C'>
 			<availability>SL.R:2</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>General:8+,SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
@@ -922,18 +922,26 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>SL:3,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
@@ -941,22 +949,14 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
 		<availability>CC:7</availability>
-		<model name='FRB-1E (WAM-B)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='FRB-2E'>
 			<availability>General:8</availability>
+		</model>
+		<model name='FRB-1E (WAM-B)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
@@ -981,6 +981,10 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
@@ -989,36 +993,29 @@
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:3-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1026,17 +1023,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1092,14 +1092,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1107,6 +1099,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,LA:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1118,23 +1118,23 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:3,MOC:2,OA:2,LA:2,SL:8,IS:2,FWL:8,RWR:2,FS:2,MERC:2,TC:2,DC:2</availability>
-		<model name='GTHA-500'>
-			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:6,MERC:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:6,SL.R:6</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>SL:6,FWL:6,SL.R:6</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:6,SL.R:6</availability>
+		<model name='GTHA-500'>
+			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:6,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:5,OA:4,TH:8,LA:7,SL:7,IS:7,RWR:4,MERC:4,DC:6,TC:5</availability>
-		<model name='GRF-1A'>
-			<availability>Periphery.Deep:5,Periphery:5,TC:5</availability>
-		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
+		</model>
+		<model name='GRF-1A'>
+			<availability>Periphery.Deep:5,Periphery:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1158,10 +1158,10 @@
 		<model name='HMR-HC'>
 			<availability>TH:5,SL:4,IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
+		<model name='HMR-HD'>
 			<availability>General:6,SL.R:6</availability>
 		</model>
-		<model name='HMR-HD'>
+		<model name='HMR-HE'>
 			<availability>General:6,SL.R:6</availability>
 		</model>
 	</chassis>
@@ -1174,21 +1174,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
@@ -1199,6 +1199,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1206,33 +1214,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1325,10 +1325,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:7,MOC:6,IS:6,Periphery.Deep:5,RWR:6,FS:7,Periphery:5,TC:6,OA:6,LA:7,PIR:2,SL:8,FWL:7</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1337,11 +1337,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:2,LA:2,SL:7,FWL:2,IS:2,FWL.OH:2,RWR:2,FS:2,DC:2,TC:2</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
@@ -1366,19 +1366,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -1419,11 +1419,11 @@
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:7,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
-		<model name='KRV-2'>
-			<availability>CC:5-,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>CC:5-,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -1444,12 +1444,12 @@
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
 		<availability>TH:5,SL:6,SL.R:3</availability>
-		<model name='KY2-D-01'>
-			<availability>TH:8,SL:5,SL.R:0</availability>
-		</model>
 		<model name='KY2-D-02'>
 			<roles>fire_support</roles>
 			<availability>SL:6</availability>
+		</model>
+		<model name='KY2-D-01'>
+			<availability>TH:8,SL:5,SL.R:0</availability>
 		</model>
 	</chassis>
 	<chassis name='LRM Carrier' unitType='Tank'>
@@ -1471,13 +1471,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:4,MOC:2,OA:2,LA:4,SL:6,IS:4,RWR:2,MERC:4,DC:4,TC:2</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>SL:8,IS:8,DC:8</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1541,6 +1541,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>TH:9,SL:7,IS:9,Periphery.Deep:5,Periphery:5</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:4</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
@@ -1548,10 +1552,6 @@
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:4,General:8,SL.R:6,FS:7</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:8,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -1570,16 +1570,16 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:5,CC:5,IS:6,RWR:5,FS:6,Periphery:3,TC:5,OA:6,LA:7,SL:5,FWL:9,SL.R:4,DC:6</availability>
-		<model name='LGB-0C'>
-			<availability>FWL:2-,IS:2-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LGB-7Q'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='LGB-7Q'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='LGB-0C'>
+			<availability>FWL:2-,IS:2-,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -1593,13 +1593,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -1618,17 +1618,17 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:3-,LA:1-,IS:1-,FWL:1-,Periphery.Deep:4,SL.R:0,TH.HM:4-,Periphery:4</availability>
-		<model name='MSK-7A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:1,FWL:1</availability>
 		</model>
-		<model name='MSK-9H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MSK-8B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='MSK-7A'>
+			<availability>General:4</availability>
+		</model>
+		<model name='MSK-9H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mako Corvette' unitType='Warship'>
@@ -1640,13 +1640,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:2,Periphery:3</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -1669,11 +1669,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:4,LA:4,Periphery.MW:4,Periphery.HR:3,Periphery.CM:3,IS:4,Periphery:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -1691,14 +1691,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -1724,35 +1724,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>SL:5,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1760,20 +1757,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1781,8 +1781,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1806,15 +1806,15 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:6,General:4,MERC:2,DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
 		</model>
@@ -1863,7 +1863,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -1872,14 +1872,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mustang Fighter' unitType='Conventional Fighter'>
@@ -1955,11 +1955,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:2</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,SL:0</availability>
-		</model>
 		<model name='OWR-2Mb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,SL:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -1998,32 +1998,32 @@
 	</chassis>
 	<chassis name='Pentagon' unitType='Dropship'>
 		<availability>TH:6,SL:6</availability>
-		<model name='Mk I'>
+		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='Mk I'>
 			<roles>assault</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:5,SL:6,FWL:5,IS:5,Periphery.Deep:4,Periphery:4</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>SL:8,SL.R:8</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>General:8,SL:4,Periphery:8</availability>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -2147,13 +2147,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:3+,LA:3+,SL:5,FWL:3+,FS:3+,DC:3+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -2243,11 +2243,11 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:2,LA:7,SL:4,FWL:2,RWR:2,FS:2,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>LA:4+,SL:6,FWL:4+,SL.R:8,RWR:4,FS:4+,MERC:4+</availability>
-		</model>
 		<model name='STN-1S'>
 			<availability>LA:6,SL:4,FWL:4,FS:4</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>LA:4+,SL:6,FWL:4+,SL.R:8,RWR:4,FS:4+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -2319,11 +2319,11 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:5,MOC:6,IS:5,Periphery.Deep:6,RWR:6,FS:5,Periphery:6,TC:6,OA:6,LA:5,SL:10,FWL:6,DC:5</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -2338,15 +2338,18 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>SL:1</availability>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:4,TH:9,SL:8,IS:9,Periphery.Deep:4,SL.R:7,MERC:4,Periphery:4,DC:6</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
-		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stoat Scout Car' unitType='Tank'>
@@ -2454,11 +2457,11 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,LA:6,SL:8,IS:5,Periphery.Deep:4,FS:7,MERC:5,DC:6,Periphery:4,TC:4</availability>
-		<model name='TDR-1C'>
-			<availability>CC:2,MOC:6,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:2,MOC:6,Periphery.Deep:6,TC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
@@ -2470,10 +2473,6 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>SL:8</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>SL:4,IS:4</availability>
-		</model>
 		<model name='THK-33'>
 			<availability>General:3</availability>
 		</model>
@@ -2481,16 +2480,20 @@
 			<roles>escort</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>SL:4,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
 		<availability>TC:4</availability>
-		<model name='TR-A-6'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TR-A-1'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='TR-A-6'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
@@ -2519,6 +2522,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -2526,10 +2533,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
@@ -2554,13 +2557,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery.OS:4,Periphery:4,TC:4,OA:4,TH:5,LA:4,Periphery.HR:4,SL:8,FWL:4,SL.R:2,DC:4</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,SL:2,IS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:1,SL:2,IS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:1,SL:2,IS:1,FS:1</availability>
 		</model>
 	</chassis>
@@ -2623,12 +2626,12 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>SL:4</availability>
-		<model name='WSP-100A'>
-			<availability>SL:4</availability>
-		</model>
+		<availability>SL:2</availability>
 		<model name='WSP-100'>
 			<availability>SL:5</availability>
+		</model>
+		<model name='WSP-100A'>
+			<availability>SL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
@@ -2673,13 +2676,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,SL:5,DC:4</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -2691,11 +2694,11 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:5</availability>
-		<model name='XNT-2O'>
-			<availability>General:5</availability>
-		</model>
 		<model name='XNT-3O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='XNT-2O'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -2716,19 +2719,19 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:5+,LA:5+,SL:8,FWL:5+,RWR:4+,FS:5+,DC:5+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>SL.R:8</availability>
+			<availability>General:4,SL.R:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>General:8,SL.R:4,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>General:4,SL.R:2</availability>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2700.xml
+++ b/megamek/data/forcegenerator/2700.xml
@@ -233,7 +233,7 @@
 		<salvage pct='5'></salvage>
 	</faction>
 	<faction key='SL.R'>
-		<salvage pct='5'></salvage>
+		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:3,DC:6</salvage>
 	</faction>
 	<faction key='FWL.SD'>
 		<salvage pct='5'></salvage>
@@ -335,13 +335,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,TH:7,LA:9,SL:5,IS:5,FWL:9,Periphery.Deep:4,RWR:5,FS:8,Periphery:4,DC:8</availability>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:6,DC:8,Periphery:8</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -352,23 +352,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -376,33 +360,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -446,11 +446,11 @@
 		<model name='BNC-1E'>
 			<availability>TH:1,Periphery:1</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:4,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -471,20 +471,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,LA:5,PIR:4,SL:7,FWL:5,IS:5,RWR:4,FS:5,DC:5,TC:4</availability>
-		<model name='BLR-1Gc'>
-			<availability>SL:4</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:3+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>SL:2</availability>
-		</model>
 		<model name='BLR-1G'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:6,FS:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:3+</availability>
+		<model name='BLR-1Gc'>
+			<availability>SL:4</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>SL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -510,11 +510,11 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>SL:8,FWL:4,FWL.OH:4,RWR:3,FS:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='BL-6-KNT'>
 			<availability>SL:8,FWL:8+,RWR:4+,FS:8+</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -563,13 +563,13 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
@@ -606,34 +606,34 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:4,RWR:3,FS:4,MERC:3,TC:2,Periphery:2,TH:6,LA:4,SL:6,FWL:4,DC:4</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>SL.R:8,DC:2+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,SL:4,FWL:4,SL.R:2,RWR:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>SL.R:8,DC:2+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cestus' unitType='Mek'>
@@ -654,12 +654,12 @@
 		<model name='CHP-1Nb'>
 			<availability>SL.R:4</availability>
 		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,LA:4+,SL.R:2</availability>
-		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:8+,SL:8,SL.R:8,RWR:6</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,LA:4+,SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -692,26 +692,26 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,FWL:4,RWR:3,FS:4,MERC:4,DC:4,Periphery:2,TC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>SL:5</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>SL:5</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,MOC:2,OA:2,LA:5,SL:4,IS:4,FWL:5,RWR:3,FS:7,MERC:4,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,RWR:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -779,13 +779,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:5,MOC:3,OA:3,LA:4,SL:7,FWL:4,IS:5,RWR:3,FS:5,DC:4,TC:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -819,16 +819,16 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>SL:5,IS:2,FWL:2,MERC:2,DC:2,Periphery:2</availability>
-		<model name='CRB-27b'>
-			<roles>raider</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='CRB-27'>
 			<roles>raider</roles>
 			<availability>CC:8+,LA:8+,FWL:8+,SL.R:4,DC:8+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>SL:4,RWR:3</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -842,11 +842,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:2</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -858,6 +858,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>SL.R:7</availability>
+		<model name='CRD-3D'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:7</availability>
@@ -867,9 +870,6 @@
 		</model>
 		<model name='CRD-2R'>
 			<availability>SL.R:8</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
@@ -883,12 +883,12 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:6,MOC:6,OA:6,LA:6,SL:7,FWL:6,IS:4,RWR:6,FS:6,DC:6,TC:6,Periphery:2</availability>
-		<model name='(Fury)'>
-			<availability>SL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Fury)'>
+			<availability>SL:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
@@ -973,13 +973,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:5,IS:4</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1004,38 +1004,34 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,OA:3,LA:4,SL:4,IS:4,FWL:8,RWR:3,FS:4,Periphery:3,TC:4,DC:4</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,General:1,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
-			<availability>LA:4,General:4,FS:4</availability>
-		</model>
-		<model name='EGL-R10'>
-			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:8,FS:4</availability>
 		</model>
+		<model name='EGL-R10'>
+			<roles>ground_support</roles>
+			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R4'>
+			<availability>LA:6,General:1,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,TH:5,SL:7,FWL:5,RWR:4,FS:5,MERC:5,TC:4</availability>
+		<model name='EMP-1A'>
+			<availability>TH:2</availability>
+		</model>
 		<model name='EMP-5A'>
 			<availability>General:8,SL:5,SL.R:4</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>SL:8+,SL.R:8</availability>
 		</model>
-		<model name='EMP-1A'>
-			<availability>TH:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1043,6 +1039,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -1061,10 +1061,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>SL:5+,FS:2+,DC:2+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>LA:0,General:8</availability>
@@ -1072,6 +1068,10 @@
 		<model name='EXC-B1'>
 			<roles>fire_support</roles>
 			<availability>SL:3</availability>
+		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1083,14 +1083,14 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>SL:8</availability>
-		<model name='EXT-4D'>
-			<availability>General:8+,SL.R:6</availability>
+		<model name='EXT-4C'>
+			<availability>SL:1+,SL.R:2</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>SL:1+,SL.R:2</availability>
+		<model name='EXT-4D'>
+			<availability>General:8+,SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
@@ -1108,34 +1108,34 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>SL:3,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:3</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1160,15 +1160,15 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:1,SL:2,RWR:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:7,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:1,SL:2,RWR:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
@@ -1179,6 +1179,10 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
@@ -1187,36 +1191,29 @@
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:3,OA:3,FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:3-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1224,17 +1221,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1253,12 +1253,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:2,LA:2,SL:6,FWL:2,RWR:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>SL:8</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:4</availability>
@@ -1303,14 +1303,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1318,6 +1310,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,LA:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1329,29 +1329,29 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:4,MOC:3,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9,DC:3</availability>
-		<model name='GTHA-500b'>
-			<availability>SL.R:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:6,MERC:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:6,SL.R:6</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>SL:6,FWL:6,SL.R:6</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:6,SL.R:6</availability>
+		<model name='GTHA-500'>
+			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,OA:5,TH:8,LA:9,SL:6,IS:9,RWR:6,MERC:5,DC:8,TC:7</availability>
-		<model name='GRF-2N'>
-			<availability>SL:3+,SL.R:6</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:8-,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>Periphery.Deep:4,Periphery:4,TC:4</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:8-,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
+		<model name='GRF-2N'>
+			<availability>SL:3+,SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1375,14 +1375,14 @@
 		<model name='HMR-HC'>
 			<availability>TH:4,SL:2,IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>General:6,SL.R:5</availability>
+		<model name='HMR-HDb'>
+			<availability>SL.R:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,SL.R:8</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>SL.R:4</availability>
+		<model name='HMR-HE'>
+			<availability>General:6,SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1394,21 +1394,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
@@ -1419,6 +1419,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1426,33 +1434,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1471,6 +1471,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>SL:5</availability>
+		<model name='HCT-214'>
+			<availability>IS:4,SL.R:3</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>SL.R:6</availability>
 		</model>
@@ -1478,14 +1481,14 @@
 			<roles>recon</roles>
 			<availability>SL:8,IS:8,SL.R:6,DC:8,Periphery:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>IS:4,SL.R:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:4-,OA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,MERC:6-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:5,FS:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
@@ -1494,19 +1497,16 @@
 		<model name='HCT-213'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:4,OA:4,SL:4,FWL:5,SL.R:5,RWR:4,DC:4</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>General:8-</availability>
-		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>General:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1588,10 +1588,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:8,MOC:6,IS:7,Periphery.Deep:6,RWR:6,FS:8,Periphery:6,TC:6,OA:6,LA:8,PIR:4,SL:9,FWL:8</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1600,11 +1600,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:3,MOC:2,OA:2,LA:3,SL:7,FWL:3,IS:3,FWL.OH:3,RWR:2,FS:3,DC:3,TC:2</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>SL.R:3</availability>
@@ -1646,19 +1646,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -1693,14 +1693,14 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>SL:5</availability>
+		<model name='KGC-010'>
+			<availability>SL.R:2</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>SL.R:4</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>General:8,SL:8,SL.R:4</availability>
-		</model>
-		<model name='KGC-010'>
-			<availability>SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -1714,22 +1714,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:5,MOC:3,Periphery.CM:3,Periphery.HR:2,Periphery.ME:3,TC:2</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -1737,10 +1737,10 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
+		<model name='KSC-3I'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='KSC-3I'>
+		<model name='KSC-4I'>
 			<availability>CC:6</availability>
 		</model>
 	</chassis>
@@ -1753,12 +1753,12 @@
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
 		<availability>TH:4,SL:5,SL.R:4</availability>
-		<model name='KY2-D-01'>
-			<availability>TH:8,SL.R:0</availability>
-		</model>
 		<model name='KY2-D-02'>
 			<roles>fire_support</roles>
 			<availability>SL:8,IS:8</availability>
+		</model>
+		<model name='KY2-D-01'>
+			<availability>TH:8,SL.R:0</availability>
 		</model>
 	</chassis>
 	<chassis name='LRM Carrier' unitType='Tank'>
@@ -1776,13 +1776,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:7,IS:5,RWR:3,MERC:5,DC:5,TC:3</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>SL:8,IS:8,DC:8</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1817,34 +1817,34 @@
 		<model name='Owl'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,LA:4</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>SL:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>SL.R:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -1859,6 +1859,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>TH:9,SL:6,IS:9,Periphery.Deep:5,Periphery:5</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:4</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
@@ -1870,10 +1874,6 @@
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:4,General:8,SL.R:5,FS:7</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:8,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -1899,16 +1899,16 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,IS:7,Periphery.Deep:5,RWR:7,FS:8,Periphery:5,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:2,DC:6</availability>
-		<model name='LGB-0C'>
-			<availability>Periphery.Deep:5,Periphery:5</availability>
+		<model name='LGB-7Q'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='LGB-7Q'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='LGB-0C'>
+			<availability>Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -1922,13 +1922,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Luxor Heavy Cruiser' unitType='Warship'>
@@ -1960,14 +1960,14 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:3-,SL.R:0,TH.HM:4-,Periphery:3</availability>
+		<model name='MSK-8B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='MSK-7A'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MSK-8B'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -1985,13 +1985,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:2,Periphery:3</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -2008,11 +2008,11 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:3,LA:4,SL:8,FWL:4,IS:2,RWR:2+,FS:4,DC:4</availability>
-		<model name='MAD-2R'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>SL:8,IS:8+,SL.R:8,RWR:8,MERC:0</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2024,11 +2024,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3,Periphery:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2046,14 +2046,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -2079,35 +2079,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>SL:5,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2115,20 +2112,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2136,8 +2136,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2174,15 +2174,15 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:6,General:4,MERC:2,DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
 		</model>
@@ -2239,7 +2239,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -2248,14 +2248,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
@@ -2307,12 +2307,12 @@
 		<model name='Mk. XXX' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
+		<model name='Mk. XXII' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
 		<model name='Mk. XXI' mechanized='true'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk. XXII' mechanized='true'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -2374,11 +2374,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:1</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,SL:0</availability>
-		</model>
 		<model name='OWR-2Mb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,SL:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -2397,12 +2397,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>SL:4,SL.R:0</availability>
-		<model name='PNT-8Z'>
-			<availability>SL:2-</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>SL:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>SL:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2438,11 +2438,11 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>SL:4,IS:2+</availability>
-		<model name='PHX-HK1'>
-			<availability>SL:5,IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>SL:3,IS:2+</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
@@ -2453,28 +2453,28 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:6,SL:6,FWL:6,IS:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4-,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:2+,MOC:2+,OA:2+,SL:8,FWL:2+,SL.R:7</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:2+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>SL.R:5</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1Kk'>
+			<availability>DC:2+</availability>
+		</model>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>General:8,SL:4-,Periphery:8</availability>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -2563,11 +2563,11 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,SL.R:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>General:8,SL.R:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>SL.R:3</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>General:8,SL.R:8</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>SL.R:4</availability>
@@ -2575,6 +2575,10 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,OA:7,LA:7,SL:8,Periphery.Deep:7,IS:7,RWR:7,FS:7,MERC:7,Periphery:7,TC:7,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>SL.R:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -2582,10 +2586,6 @@
 		<model name='(MG)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -2622,13 +2622,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:4+,LA:4+,SL:5,FWL:4+,RWR:2+,FS:5+,DC:4+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -2644,9 +2644,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
-		<model name='RGU-133Eb'>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
 		</model>
@@ -2655,6 +2652,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>General:6,SL.R:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -2690,11 +2690,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
-		<model name='SB-27'>
-			<availability>General:8,SL:8,SL.R:6</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>SL:4</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,SL:8,SL.R:6</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>SL.R:6</availability>
@@ -2745,14 +2745,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:2,LA:7,SL:5,FWL:2,RWR:3,FS:2,DC:2</availability>
+		<model name='STN-1S'>
+			<availability>LA:4,SL:4,FWL:4,RWR:4,FS:4</availability>
+		</model>
 		<model name='STN-3L'>
 			<availability>LA:8+,SL:8,FWL:8+,SL.R:8,RWR:6,FS:8+,MERC:8+</availability>
 		</model>
 		<model name='STN-3Lb'>
 			<availability>SL.R:4</availability>
-		</model>
-		<model name='STN-1S'>
-			<availability>LA:4,SL:4,FWL:4,RWR:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -2764,14 +2764,14 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>TH:7,LA:6,SL:7,IS:7,Periphery:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>SL.R:4</availability>
+		</model>
 		<model name='SHD-1R'>
 			<availability>MOC:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
@@ -2850,17 +2850,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,RWR:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:9,FWL:6,DC:6</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>SL.R:8</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -2875,19 +2875,28 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>SL:1+,IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A5'>
+			<availability>IS:1</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:4,TH:9,SL:7-,IS:9,Periphery.Deep:4,SL.R:5,MERC:4,Periphery:4,DC:6</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
+			<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>SL.R:5</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
@@ -2922,17 +2931,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,CC:5,RWR:2,MERC:4,Periphery.OS:2,FS:5,TC:2,Periphery:2,OA:2,LA:5,Periphery.HR:2,SL:8,FWL:4,DC:4</availability>
-		<model name='STU-K5b2'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>SL.R:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -2979,11 +2988,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:2,MOC:4+,OA:4+,TH:4,SL:6,FWL:4,FS:4,MERC:4,DC:4,Periphery:4+,TC:4+</availability>
-		<model name='THE-Nb'>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='THE-F'>
 			<availability>TH:8,SL:2</availability>
+		</model>
+		<model name='THE-Nb'>
+			<availability>SL.R:4</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>General:4+,SL:8</availability>
@@ -3013,13 +3022,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:6,Periphery:6,TC:6,DC:6</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>LA:4+,SL:4+,SL.R:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>LA:4+,SL:4+,SL.R:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3028,14 +3037,14 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,LA:8,SL:7-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5,TC:5</availability>
-		<model name='TDR-1C'>
-			<availability>MOC:4,Periphery.Deep:4,TC:4,Periphery:4</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:3+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:7,Periphery:8</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:3+</availability>
+		<model name='TDR-1C'>
+			<availability>MOC:4,Periphery.Deep:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>SL.R:4</availability>
@@ -3050,16 +3059,8 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,OA:2,LA:4,SL:9,FWL:3,RWR:2,FS:2,MERC:2,DC:2,TC:2</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>SL:2,IS:4</availability>
-		</model>
 		<model name='THK-33'>
 			<availability>General:1</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:3</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -3068,16 +3069,24 @@
 		<model name='THK-63b'>
 			<availability>SL.R:4</availability>
 		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>SL:2,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
 		<availability>TC:2</availability>
-		<model name='TR-A-6'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TR-A-1'>
 			<roles>fire_support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='TR-A-6'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tracker Surveillance' unitType='Warship'>
@@ -3134,6 +3143,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:3</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3141,10 +3154,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3177,13 +3186,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:5,CC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery.OS:5,Periphery:5,TC:5,OA:5,TH:5,LA:5,Periphery.HR:5,SL:7,FWL:5,SL.R:1,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,SL:2,IS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:1,SL:2,IS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:1,SL:2,IS:1,FS:1</availability>
 		</model>
 	</chassis>
@@ -3213,11 +3222,11 @@
 		<model name='VNL-K65N'>
 			<availability>SL:4,IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>SL:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>SL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -3248,33 +3257,33 @@
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>TH:6,LA:9,SL:7,FWL:9,IS:8,RWR:3,TC:2,Periphery:2</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:3+</availability>
-		</model>
 		<model name='WHM-7A'>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:3+,LA:3+,FWL:3+,SL.R:8,FS:3+</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>SL:4,IS:3</availability>
-		<model name='WSP-100A'>
-			<availability>SL:4,IS:3</availability>
+		<availability>SL:3,IS:1</availability>
+		<model name='WSP-100'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>SL:2+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>SL:5,IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>SL:4,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>SL:3,IS:4</availability>
+		<availability>SL:2,IS:1</availability>
 		<model name='WSP-105'>
 			<availability>SL:4,IS:4</availability>
 		</model>
@@ -3299,6 +3308,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,OA:1,FS.CMM:4,SL:5,SL.R:2,RWR:1,MERC:3,DC:6</availability>
+		<model name='WTH-0'>
+			<availability>RWR:5</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -3306,9 +3318,6 @@
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>SL:3,RWR:2,DC:6</availability>
-		</model>
-		<model name='WTH-0'>
-			<availability>RWR:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
@@ -3324,16 +3333,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:6,SL:6,RWR:3,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>SL:8</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -3345,11 +3354,11 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:5</availability>
-		<model name='XNT-2O'>
-			<availability>General:4</availability>
-		</model>
 		<model name='XNT-3O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='XNT-2O'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -3373,28 +3382,28 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:6+,LA:6+,SL:8,FWL:6+,RWR:5+,FS:6+,DC:6+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>SL.R:8</availability>
+			<availability>General:4,SL.R:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>General:8,SL.R:4,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>General:4,SL.R:2</availability>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CC:3,MOC:2,OA:2,LA:3,SL:4,FWL:3,IS:3,RWR:2,FS:3,DC:4,Periphery:2,TC:2</availability>
-		<model name='ZRO-114'>
-			<availability>General:8,SL.R:6</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>General:8,SL.R:6</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2765.xml
+++ b/megamek/data/forcegenerator/2765.xml
@@ -247,7 +247,7 @@
 		<salvage pct='5'></salvage>
 	</faction>
 	<faction key='SL.R'>
-		<salvage pct='5'></salvage>
+		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:4,DC:6</salvage>
 	</faction>
 	<faction key='FWL.SD'>
 		<salvage pct='5'></salvage>
@@ -349,13 +349,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,TH:7,LA:9,SL:3,IS:6,FWL:9,Periphery.Deep:5,RWR:6,FS:8,Periphery:5,DC:8</availability>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>SL.R:7</availability>
-		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:5,DC:8,Periphery:8</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>SL.R:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -366,23 +366,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -390,33 +374,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -472,11 +472,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,OA:10-,TH:4,LA:7-,Periphery.Deep:10-,RWR:10-,FS:6-,MERC:7-,Periphery:10-,TC:10-,DC:6-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:4,OA:3,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,OA:3,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -497,20 +497,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,LA:7,PIR:5,SL:5,FWL:7,IS:7,RWR:4,FS:7,DC:6,TC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:2+,LA:2+,SL:4,FWL:2+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:3+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:2+,SL.R:8</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>SL:2</availability>
-		</model>
 		<model name='BLR-1G'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,FS:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:3+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:2+,LA:2+,SL:4,FWL:2+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>SL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -536,11 +536,11 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>SL:9,FWL:5,FWL.OH:5,RWR:4,FS:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>FWL:2+,SL.R:5,RWR:4+</availability>
-		</model>
 		<model name='BL-6-KNT'>
 			<availability>SL:8,FWL:7+,RWR:6+,FS:7+</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>FWL:2+,SL.R:5,RWR:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -589,13 +589,13 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
@@ -632,34 +632,34 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:4,RWR:4,FS:4,MERC:3,TC:2,Periphery:2,TH:6,LA:4,SL:4,FWL:4,DC:4</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:2,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>SL.R:8,DC:2+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,SL:4,FWL:4,SL.R:1,RWR:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>SL.R:8,DC:2+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:2,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,IS:2,FS:6,MERC:4,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cestus' unitType='Mek'>
@@ -683,12 +683,12 @@
 		<model name='CHP-1Nb'>
 			<availability>SL.R:5</availability>
 		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,LA:4+</availability>
-		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:8+,SL:8,SL.R:6,RWR:8</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,LA:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -721,14 +721,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,CC:5,OA:3,LA:5,SL:7,FWL:5,RWR:3,MERC:5,FS:5,Periphery:2,TC:3,DC:4</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>SL:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>SL.R:8</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>SL:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -740,14 +740,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,MOC:3,OA:3,LA:5,SL:4,IS:5,FWL:5,RWR:5,FS:7,MERC:5,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,RWR:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -795,13 +795,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:3</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -819,13 +819,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:6,MOC:3,OA:3,LA:4,SL:7,FWL:4,IS:6,RWR:3,FS:5,DC:4,TC:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -859,25 +859,25 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>SL:6</availability>
-		<model name='CSR-V12b'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>SL:5,IS:3,FWL:3,RWR:2,MERC:3,DC:3,Periphery:3</availability>
-		<model name='CRB-27b'>
-			<roles>raider</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='CRB-27'>
 			<roles>raider</roles>
 			<availability>CC:8+,LA:8+,FWL:8+,SL.R:4,DC:8+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>SL:4,RWR:4</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -891,11 +891,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:2</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -907,6 +907,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>SL:7,IS:6,Periphery.Deep:4,SL.R:7,Periphery:4</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -914,14 +920,8 @@
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>IS:2+,SL.R:8,Periphery:2+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
@@ -935,12 +935,12 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:6,MOC:6,OA:6,LA:6,SL:7,IS:4,FWL:6,RWR:6,FS:6,TC:6,Periphery:2,DC:6</availability>
-		<model name='(Fury)'>
-			<availability>SL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Fury)'>
+			<availability>SL:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
@@ -1025,13 +1025,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:5,IS:4,RWR:2</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1059,21 +1059,21 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,OA:4,LA:4,SL:4-,IS:4,FWL:8,RWR:4,FS:4,Periphery:3,TC:4,DC:4</availability>
-		<model name='EGL-R6b'>
-			<availability>SL.R:4</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
+		</model>
+		<model name='EGL-R6b'>
+			<availability>SL.R:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1093,10 +1093,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1104,6 +1100,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -1122,10 +1122,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>SL:5+,RWR:3+,FS:3+,DC:3+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>SL.R:5</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>LA:0,General:8</availability>
@@ -1133,6 +1129,10 @@
 		<model name='EXC-B1'>
 			<roles>fire_support</roles>
 			<availability>SL:2</availability>
+		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1144,55 +1144,55 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CC:2,LA:2,SL:8,FWL:2,RWR:4,FS:2,DC:2</availability>
-		<model name='EXT-4D'>
-			<availability>General:8+,SL.R:5</availability>
+		<model name='EXT-4C'>
+			<availability>SL:1+,SL.R:2</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>SL.R:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>SL:1+,SL.R:2</availability>
+		<model name='EXT-4D'>
+			<availability>General:8+,SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,LA:7,SL:5,FWL:5,FS:5,MERC:5,Periphery:3,TC:4</availability>
-		<model name='FLC-4N'>
-			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FLC-4Nb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='FLC-4N'>
+			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>SL:3,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1217,15 +1217,15 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:1,SL:2,RWR:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:1,SL:2,RWR:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
@@ -1236,6 +1236,10 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
@@ -1244,36 +1248,29 @@
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:4,OA:4,FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1281,17 +1278,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1310,12 +1310,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:3,LA:3,SL:7,FWL:3,RWR:3,FS:4,MERC:3,DC:3</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>SL:8</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
@@ -1360,14 +1360,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1375,6 +1367,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,LA:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1386,29 +1386,29 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:4,MOC:4,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,DC:3</availability>
-		<model name='GTHA-500b'>
-			<availability>SL.R:5</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:5,MERC:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:6,SL.R:5</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>SL:6,FWL:6,SL.R:5</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:6,SL.R:5</availability>
+		<model name='GTHA-500'>
+			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:5,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,OA:6,TH:8,LA:9,SL:5,IS:9,RWR:6,MERC:5,DC:8,TC:7</availability>
-		<model name='GRF-2N'>
-			<availability>CC:2+,LA:2+,SL:5+,FWL:2+,SL.R:8,FS:2+</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:7-,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>Periphery:3,TC:3</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:7-,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
+		<model name='GRF-2N'>
+			<availability>CC:2+,LA:2+,SL:5+,FWL:2+,SL.R:8,FS:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1432,14 +1432,14 @@
 		<model name='HMR-HC'>
 			<availability>TH:4,IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>General:6,SL.R:4</availability>
+		<model name='HMR-HDb'>
+			<availability>SL.R:5</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,SL.R:7</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>SL.R:5</availability>
+		<model name='HMR-HE'>
+			<availability>General:6,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1451,37 +1451,45 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,RWR:5,FS:3,MERC:4,TC:5</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1489,33 +1497,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1534,6 +1534,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:2,MOC:2+,OA:2+,LA:2,SL:5,FWL:2,IS:2,RWR:2,FS:2,DC:2,TC:2+</availability>
+		<model name='HCT-214'>
+			<availability>IS:4,SL.R:3</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>SL.R:8</availability>
 		</model>
@@ -1541,14 +1544,14 @@
 			<roles>recon</roles>
 			<availability>SL:8,IS:8,SL.R:5,DC:8,Periphery:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>IS:4,SL.R:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:4-,OA:4-,LA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,FS:4-,MERC:6-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
@@ -1557,19 +1560,16 @@
 		<model name='HCT-213'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,CC:4,OA:5,SL:3,FWL:5,SL.R:6,RWR:4,DC:4</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>General:8-</availability>
-		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>FWL:3+,SL.R:8</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>General:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1651,10 +1651,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:7,IS:7,Periphery.Deep:6,RWR:7,FS:9,Periphery:6,TC:7,OA:7,LA:9,PIR:4,SL:9,FWL:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1663,11 +1663,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,IS:3,FWL:4,FWL.OH:4,RWR:3,FS:4,TC:3,DC:4</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>SL.R:4</availability>
@@ -1688,33 +1688,33 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,OA:5,LA:5,FWL:4,SL.R:0,DC:7</availability>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>RWR:6</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
-			<availability>General:6</availability>
-		</model>
 		<model name='JKR-8T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='JKR-9R &apos;Joker&apos;'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>SL:4,FS:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
@@ -1733,19 +1733,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -1780,14 +1780,14 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,LA:2+,SL:6,FWL:2+,IS:2+,RWR:2+,FS:2+,MERC:1+,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>SL.R:2</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>SL.R:5</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>General:8,SL:8,SL.R:4</availability>
-		</model>
-		<model name='KGC-010'>
-			<availability>SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -1801,22 +1801,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,Periphery.CM:3,Periphery.HR:2,Periphery.ME:3,TC:2</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:7,Periphery:7</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -1824,11 +1824,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -1840,12 +1840,12 @@
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
 		<availability>TH:4,SL:5,FWL:3+,SL.R:4,FS:3+</availability>
-		<model name='KY2-D-01'>
-			<availability>TH:8,SL.R:0</availability>
-		</model>
 		<model name='KY2-D-02'>
 			<roles>fire_support</roles>
 			<availability>SL:8,IS:8</availability>
+		</model>
+		<model name='KY2-D-01'>
+			<availability>TH:8,SL.R:0</availability>
 		</model>
 	</chassis>
 	<chassis name='LRM Carrier' unitType='Tank'>
@@ -1863,13 +1863,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,LA:5,SL:7,IS:5,RWR:5,MERC:5,DC:5,TC:4</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>SL:8,IS:8,DC:8</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1902,34 +1902,34 @@
 		<model name='Owl'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,LA:4</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:6,LA:6,SL:7,FWL:6,RWR:6,FS:6,DC:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>SL.R:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:3,FS:3,DC:3,Periphery:2,TC:2</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -1944,6 +1944,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>TH:9,SL:5,IS:9,Periphery.Deep:5,Periphery:5</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:4</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
@@ -1955,10 +1959,6 @@
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:4,General:8,SL.R:4,FS:7</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:8,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -1984,16 +1984,16 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,IS:7,Periphery.Deep:7,RWR:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:1,DC:6</availability>
-		<model name='LGB-0C'>
-			<availability>Periphery.Deep:4,Periphery:4</availability>
+		<model name='LGB-7Q'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='LGB-7Q'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='LGB-0C'>
+			<availability>Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2007,13 +2007,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Luxor Heavy Cruiser' unitType='Warship'>
@@ -2045,14 +2045,14 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:2-,TH.HM:2-,Periphery:2</availability>
+		<model name='MSK-8B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='MSK-7A'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MSK-8B'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -2070,13 +2070,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>IS:1,Periphery:2</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -2093,11 +2093,11 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:5,MOC:2+,LA:5,SL:8,FWL:5,IS:3,RWR:4+,FS:5,DC:5,TC:2+</availability>
-		<model name='MAD-2R'>
-			<availability>SL.R:8,FS:3+</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>MOC:8,SL:8,IS:8+,SL.R:6,RWR:8,MERC:0,TC:8+</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>SL.R:8,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2109,11 +2109,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3-,Periphery:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2131,14 +2131,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -2164,35 +2164,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>SL:5,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2200,20 +2197,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2221,8 +2221,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2265,9 +2265,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(LRM)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -2277,11 +2277,11 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
 		</model>
@@ -2351,7 +2351,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -2360,14 +2360,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
@@ -2389,13 +2389,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block II)'>
-			<roles>destroyer</roles>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>destroyer</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='New Syrtis Carrier' unitType='Warship'>
@@ -2424,12 +2424,12 @@
 		<model name='Mk. XXX' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='Mk. XXII' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='Mk. XXI' mechanized='true'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk. XXII' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -2497,11 +2497,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:1-</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,SL:0</availability>
-		</model>
 		<model name='OWR-2Mb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,SL:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
@@ -2527,12 +2527,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:2,LA:2,SL:5-,FS.DMM:2,FWL:2,SL.R:0,MERC:2,Periphery.OS:2,FS:2,DC:2,Periphery:2</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,SL:2-,RWR:8,DC:2,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>SL:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,SL:2-,RWR:8,DC:2,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2562,11 +2562,11 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>SL:4,IS:2+</availability>
-		<model name='PHX-HK1'>
-			<availability>SL:5,IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>SL:3,IS:2+</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
@@ -2577,28 +2577,28 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:7,SL:4,IS:7,FWL:7,Periphery.Deep:5,Periphery:5</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4-,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:4+,MOC:4+,OA:4+,SL:8,FWL:4+,SL.R:6</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:3+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>SL.R:6</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1Kk'>
+			<availability>DC:3+</availability>
+		</model>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>General:8,SL:4-,Periphery:8</availability>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -2696,11 +2696,11 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,SL.R:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>General:8,SL.R:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>General:8,SL.R:8</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>SL.R:5</availability>
@@ -2708,6 +2708,10 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,OA:7,LA:7,SL:9,Periphery.Deep:8,IS:7,RWR:7,FS:7,MERC:7,Periphery:8,TC:7,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>SL.R:7</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -2715,10 +2719,6 @@
 		<model name='(MG)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>SL.R:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -2734,13 +2734,13 @@
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery:5</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='RFL-1N'>
 			<roles>fire_support</roles>
 			<availability>MOC:3,Periphery:3</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -2759,13 +2759,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5+,LA:5+,SL:5,FWL:5+,RWR:4+,FS:6+,DC:5+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -2781,9 +2781,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
-		<model name='RGU-133Eb'>
-			<availability>SL.R:5</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:7</availability>
 		</model>
@@ -2792,6 +2789,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>General:6,SL.R:5</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -2827,11 +2827,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
-		<model name='SB-27'>
-			<availability>General:8,SL:6,SL.R:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>SL:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,SL:6,SL.R:4</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>SL.R:8</availability>
@@ -2886,14 +2886,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:2,LA:7,SL:6,FWL:3,RWR:4,FS:3,DC:3</availability>
+		<model name='STN-1S'>
+			<availability>LA:4,SL:2,FWL:2,RWR:4,FS:2</availability>
+		</model>
 		<model name='STN-3L'>
 			<availability>LA:8+,SL:8,FWL:8+,SL.R:7,RWR:8,FS:8+,MERC:8+</availability>
 		</model>
 		<model name='STN-3Lb'>
 			<availability>SL.R:5</availability>
-		</model>
-		<model name='STN-1S'>
-			<availability>LA:4,SL:2,FWL:2,RWR:4,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -2909,14 +2909,14 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>TH:7,LA:6,SL:6-,IS:7,Periphery.Deep:4,Periphery:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>SL.R:5</availability>
+		</model>
 		<model name='SHD-1R'>
 			<availability>MOC:3,Periphery:3</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -2952,13 +2952,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>SL:2,RWR:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>SL:4,RWR:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3019,17 +3019,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:7,MOC:8,IS:7,Periphery.Deep:8,RWR:7,FS:7,Periphery:8,TC:8,OA:8,LA:7,SL:9-,FWL:8,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>SL.R:8</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -3051,19 +3051,28 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>SL:1+,IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:2</availability>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:4,TH:9,SL:6-,IS:9,Periphery.Deep:4,SL.R:4,MERC:4,Periphery:4,DC:6</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
+			<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
@@ -3098,17 +3107,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:3,CC:5,RWR:3,MERC:4,Periphery.OS:3,FS:5,TC:3,Periphery:2,OA:3,LA:5,Periphery.HR:3,SL:8,FWL:4,DC:4</availability>
-		<model name='STU-K5b2'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3155,11 +3164,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:3,MOC:4+,OA:4+,TH:4,SL:6,FWL:4,FS:4,MERC:4,DC:4,Periphery:3+,TC:4+</availability>
-		<model name='THE-Nb'>
-			<availability>SL.R:5</availability>
-		</model>
 		<model name='THE-F'>
 			<availability>TH:8,SL:1</availability>
+		</model>
+		<model name='THE-Nb'>
+			<availability>SL.R:5</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>General:6+,SL:8</availability>
@@ -3195,13 +3204,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:7,Periphery:6,TC:7,DC:6</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>LA:6+,SL:6+,SL.R:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>LA:6+,SL:6+,SL.R:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3210,14 +3219,14 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,LA:8,SL:6-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5,TC:5</availability>
-		<model name='TDR-1C'>
-			<availability>MOC:2,TC:2,Periphery:2</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:3+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:3+</availability>
+		<model name='TDR-1C'>
+			<availability>MOC:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>SL.R:5</availability>
@@ -3232,20 +3241,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:5,MOC:3,OA:3,LA:6,SL:9,FWL:5,RWR:3,FS:3,MERC:3,DC:3,TC:3</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>SL:1,IS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,SL.R:6</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>SL.R:5</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>SL:1,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -3309,6 +3318,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:3</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3316,10 +3329,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3352,13 +3361,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:6,CC:6,IS:5,Periphery.Deep:5,RWR:6,FS:6,Periphery.OS:6,Periphery:5,TC:6,OA:6,TH:5,LA:6,Periphery.HR:6,SL:6-,FWL:6,SL.R:1,DC:6</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,SL:2,IS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:1,SL:2,IS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:1,SL:2,IS:1,FS:1</availability>
 		</model>
 	</chassis>
@@ -3388,11 +3397,11 @@
 		<model name='VNL-K65N'>
 			<availability>SL:2,IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CC:2,LA:2,SL:8,FWL:2,FS:2,DC:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CC:2,LA:2,SL:8,FWL:2,FS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -3406,13 +3415,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>SL:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>PIR:2,IS:2,FS:4</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -3434,33 +3443,33 @@
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>TH:6,LA:9,SL:6,FWL:9,IS:8,RWR:5,TC:3,Periphery:3</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,SL:7-,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:3+</availability>
-		</model>
 		<model name='WHM-7A'>
 			<availability>SL:3,SL.R:6</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,SL:7-,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:3+,LA:3+,FWL:3+,SL.R:7,FS:3+</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>SL:4,IS:3</availability>
-		<model name='WSP-100A'>
-			<availability>SL:4,IS:3</availability>
+		<availability>SL:3,IS:2</availability>
+		<model name='WSP-100'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>SL:2+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>SL:5,IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>SL:4,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>SL:3,IS:4</availability>
+		<availability>SL:2,IS:2</availability>
 		<model name='WSP-105'>
 			<availability>SL:4,IS:4</availability>
 		</model>
@@ -3471,13 +3480,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:8</availability>
-		</model>
 		<model name='WSP-1'>
 			<roles>recon</roles>
 			<availability>MOC:2,Periphery:2</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -3489,6 +3498,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,OA:1,FS.CMM:4,SL:5-,RWR:1,MERC:3,DC:6</availability>
+		<model name='WTH-0'>
+			<availability>RWR:5</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -3496,9 +3508,6 @@
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>SL:3,DC:6</availability>
-		</model>
-		<model name='WTH-0'>
-			<availability>RWR:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine II' unitType='Mek'>
@@ -3520,16 +3529,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:6,SL:6,RWR:5,DC:6,TC:3</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>SL:8</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -3566,28 +3575,28 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:6+,LA:6+,SL:8,FWL:6+,RWR:5+,FS:6+,DC:6+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>SL.R:8</availability>
+			<availability>General:4,SL.R:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>General:8,SL.R:4,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>General:4,SL.R:2</availability>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:3,SL:6,IS:3,FWL:3,RWR:2,FS:3,Periphery:2,TC:2,DC:5</availability>
-		<model name='ZRO-114'>
-			<availability>General:8,SL.R:5</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>General:8,SL.R:5</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2780.xml
+++ b/megamek/data/forcegenerator/2780.xml
@@ -257,7 +257,7 @@
 		<salvage pct='5'></salvage>
 	</faction>
 	<faction key='SL.R'>
-		<salvage pct='5'></salvage>
+		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:4,DC:6</salvage>
 	</faction>
 	<faction key='FWL.SD'>
 		<salvage pct='5'></salvage>
@@ -361,13 +361,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,SL:2,IS:6,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>SLIE:4,LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,DC:8,Periphery:8</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -378,23 +378,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>PP:10,CC:10,MOC:10,SLIE:10,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:3,PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -402,33 +386,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PP:6,PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PP:6,PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PP:3,PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PP:6,PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -446,11 +446,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>SL:3,SL.R:5</availability>
-		<model name='AS7-D-H2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -487,11 +487,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:4,OA:4,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,OA:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -512,20 +512,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,CS:8-,MOC:4,LA:8,PIR:6,SL:4,FWL:8,IS:7,NIOPS:8-,FS:7,DC:7,TC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:3+,LA:3+,SL:4,FWL:3+,FS:2+,DC:2+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:3+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>PP:4,CC:2+,SLIE:8,SL.R:8</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>PP:2,SLIE:2,SL:2</availability>
-		</model>
 		<model name='BLR-1G'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,FS:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:3+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:3+,LA:3+,SL:4,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>PP:2,SLIE:2,SL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -551,14 +551,14 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CS:7,SL:10,FWL:6,NIOPS:7,FWL.OH:6,FS:6</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,NIOPS:4,FWL:2+,SL.R:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:6-</availability>
 		</model>
 		<model name='BL-6-KNT'>
 			<availability>CS:8,SL:8,FWL:6+,NIOPS:8,FS:6+</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:6-</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,NIOPS:4,FWL:2+,SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -600,25 +600,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,Periphery.Deep:7,FWL:8,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -636,11 +636,11 @@
 	</chassis>
 	<chassis name='Buster XV HaulerMech' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='(PPC)'>
-			<availability>PP:6</availability>
-		</model>
 		<model name='(AC)'>
 			<availability>PP:8</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>PP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -664,34 +664,34 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,SL:3-,FWL:4,NIOPS:2,DC:6</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CC:1+,SL.R:8,DC:2+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,SL:4,FWL:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:1+,SL.R:8,DC:2+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
@@ -722,12 +722,12 @@
 		<model name='CHP-1Nb'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,CS:4,LA:4+</availability>
-		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:8+,CS:8,SL:8,NIOPS:8,SL.R:4</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,CS:4,LA:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -746,13 +746,13 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,SL:2-,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -764,14 +764,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:5,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,OA:3,SLIE:6,LA:8,SL:7,FWL:6,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>PP:3,:0,SLIE:3,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>PP:6,SL:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>PP:6,SL:6</availability>
+		<model name='CHP-W5'>
+			<availability>PP:3,:0,SLIE:3,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -783,14 +783,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,MOC:4,CS:3-,OA:4,LA:5,SL:3,IS:5,FWL:5,NIOPS:3-,FS:7,MERC:5,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>PP:8,SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>PP:8,SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -834,13 +834,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:4</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -865,13 +865,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:6,MOC:3,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,SL:7,FWL:4,NIOPS:6,DC:4</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -905,25 +905,25 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:3,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,SLIE:6,LA:4,SL:6,FWL:5,DC:3</availability>
-		<model name='CSR-V12b'>
-			<availability>PP:4,SLIE:6,SL.R:6</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>PP:8,SLIE:4,SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>PP:4,SLIE:6,SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CS:5,SL:5,NIOPS:5,IS:3,FWL:3,MERC:3,DC:3,Periphery:3</availability>
-		<model name='CRB-27b'>
-			<roles>raider</roles>
-			<availability>CC:3+,FWL:3+,SL.R:8</availability>
-		</model>
 		<model name='CRB-27'>
 			<roles>raider</roles>
 			<availability>CS:8,CC:6+,LA:6+,NIOPS:8,FWL:6+,SL.R:4,DC:6+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:3+,SL:4,DC:3+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CC:3+,FWL:3+,SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -937,11 +937,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crosscut' unitType='Mek'>
@@ -962,6 +962,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,SL:7,IS:8,NIOPS:6-,Periphery.Deep:6,SL.R:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -969,23 +975,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>IS:2+,SL.R:8,Periphery:2+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,LA:5,SL:4,IS:3,FWL:4,NIOPS:3,SL.R:5,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1106,13 +1106,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:4,IS:4</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1140,21 +1140,21 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,SLIE:4,LA:4,SL:4-,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R6b'>
-			<availability>SLIE:6,SL.R:6</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
+		</model>
+		<model name='EGL-R6b'>
+			<availability>SLIE:6,SL.R:6</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1174,10 +1174,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1185,6 +1181,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -1210,10 +1210,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:3+,SL:5+,NIOPS:5,FS:3+,DC:3+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,NIOPS:8</availability>
@@ -1222,69 +1218,73 @@
 			<roles>fire_support</roles>
 			<availability>LA:8,SL:2</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>SL.R:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,SL:3,FWL:3,IS:2,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CC:3,CS:4,LA:3,SL:8,FWL:3,NIOPS:4,FS:3,DC:3</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,NIOPS:8,SL.R:4</availability>
+		<model name='EXT-4C'>
+			<availability>SL:1+,SL.R:2</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>SL.R:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>SL:1+,SL.R:2</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,NIOPS:8,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,LA:7,SL:4,FWL:5,FS:5,MERC:5,TC:4</availability>
-		<model name='FLC-4N'>
-			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FLC-4Nb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='FLC-4N'>
+			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>SL:3,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1309,28 +1309,32 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CS:5,Periphery.R:4,LA:6,SL:8,FWL:5,NIOPS:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:4-</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
@@ -1339,36 +1343,29 @@
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:4,OA:4,FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1376,17 +1373,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1405,12 +1405,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:5,LA:5,SL:7,FWL:5,FS:6,MERC:5,DC:5</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>SL:8</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:6</availability>
@@ -1455,14 +1455,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1470,6 +1462,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1481,17 +1481,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
-		<model name='GTHA-500b'>
-			<availability>SL.R:6</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,SL:8,FWL:6,NIOPS:6,Periphery.Deep:6,SL.R:3,MERC:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:6,SL.R:4</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>SL:6,FWL:6,SL.R:4</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:6,SL.R:4</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,SL:8,FWL:6,NIOPS:6,Periphery.Deep:6,SL.R:3,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -1502,14 +1502,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,SL:4-,NIOPS:4,DC:8</availability>
-		<model name='GRF-2N'>
-			<availability>CC:4+,LA:4+,SL:6,FWL:4+,SL.R:8,FS:4+</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:6-,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>Periphery:2,TC:2</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:6-,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
+		<model name='GRF-2N'>
+			<availability>CC:4+,LA:4+,SL:6,FWL:4+,SL.R:8,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1533,24 +1533,24 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:6,NIOPS:8,SL.R:2</availability>
+		<model name='HMR-HDb'>
+			<availability>SL.R:6</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,SL.R:6</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>SL.R:6</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:6,NIOPS:8,SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Harvester Ant' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='KIC-3 Agromech(LRM)'>
-			<roles>fire_support</roles>
-			<availability>PP:8</availability>
-		</model>
 		<model name='KIC-3 Agromech(MG)'>
 			<roles>anti_infantry</roles>
+			<availability>PP:8</availability>
+		</model>
+		<model name='KIC-3 Agromech(LRM)'>
+			<roles>fire_support</roles>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -1563,37 +1563,45 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1601,33 +1609,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1646,6 +1646,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:4,MOC:3+,IS:3,FS:4,TC:3+,CS:6,OA:3+,SLIE:6,LA:4,SL:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,PP:4,SLIE:4,IS:4,NIOPS:4,SL.R:2</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>PP:4,SLIE:6,SL.R:8</availability>
 		</model>
@@ -1653,14 +1656,14 @@
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,SLIE:8,SL:8,IS:8,SL.R:4,DC:8,Periphery:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,PP:4,SLIE:4,IS:4,NIOPS:4,SL.R:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
@@ -1669,9 +1672,6 @@
 		<model name='HCT-213'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>FWL:10</availability>
@@ -1679,24 +1679,24 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,CC:4,CS:3,OA:5,SL:3,FWL:5,NIOPS:3,SL.R:6,DC:4</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:8-,NIOPS:8</availability>
-		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>FWL:3+,SL.R:8</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,General:8-,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1790,10 +1790,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,IS:7,Periphery.Deep:8,FS:9,CIR:8,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,SL:9,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1802,11 +1802,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:6,MOC:3,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,SL:7,FWL:6,NIOPS:6,DC:6</availability>
-		<model name='IRN-SD2'>
-			<availability>SLIE:2,General:4</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>SLIE:2,General:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>SL.R:5</availability>
@@ -1827,37 +1827,37 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CS:3,NIOPS:3,FS:8,MERC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>SL:4,FS:4</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
@@ -1887,19 +1887,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -1937,14 +1937,14 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,SL:6,FWL:2+,IS:2+,NIOPS:6,FS:2+,MERC:2+,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>SL.R:2</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>SL.R:6</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,General:7,SL:8,NIOPS:8,SL.R:4</availability>
-		</model>
-		<model name='KGC-010'>
-			<availability>SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -1952,31 +1952,31 @@
 		<model name='KTO-19'>
 			<availability>CS:8,General:4,NIOPS:8,SL.R:2,FS:4,MERC:4</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:2</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,Periphery.CM:3,Periphery.HR:2,Periphery.ME:3,TC:2</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -1984,11 +1984,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:4+</availability>
@@ -2023,13 +2023,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:6,OA:4,LA:6,SL:6,IS:6,NIOPS:6,MERC:6,CIR:4,TC:4,DC:6</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>CS:8,SLIE:8,SL:8,IS:8,NIOPS:8,DC:8</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2062,10 +2062,6 @@
 		<model name='Owl'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2075,24 +2071,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:4</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:5,CS:5,LA:5,SL:8,FWL:5,NIOPS:5,FS:5,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>SL.R:7</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,SL:5,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2107,6 +2107,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,SL:3,IS:9,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:4</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
@@ -2118,10 +2122,6 @@
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:4,General:8,SL.R:4,FS:7</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:8,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -2147,16 +2147,16 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,SL:3,FWL:9,NIOPS:4,DC:6</availability>
-		<model name='LGB-0C'>
-			<availability>Periphery:2</availability>
+		<model name='LGB-7Q'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,OA:6,General:6,TC:6</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='LGB-7Q'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		<model name='LGB-0C'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2174,13 +2174,13 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
@@ -2209,14 +2209,14 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>Periphery:1</availability>
+		<model name='MSK-8B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='MSK-7A'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MSK-8B'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -2234,13 +2234,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>Periphery:1</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -2257,20 +2257,20 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:5,CS:8,MOC:2+,LA:6,SL:8,FWL:6,IS:3,NIOPS:8,FS:6,DC:6,TC:2+</availability>
-		<model name='MAD-2R'>
-			<availability>SL.R:8,FS:4+</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:8,SL:8,IS:8+,NIOPS:8,SL.R:4,MERC:0,TC:8+</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>SL.R:8,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Marco' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='MR-8E'>
-			<availability>PP:7</availability>
-		</model>
 		<model name='MR-8D'>
 			<availability>PP:8</availability>
+		</model>
+		<model name='MR-8E'>
+			<availability>PP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2282,11 +2282,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2304,14 +2304,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -2337,35 +2337,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>SL:5,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2373,20 +2370,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2394,8 +2394,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2432,9 +2432,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(LRM)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -2444,11 +2444,11 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
 		</model>
@@ -2515,7 +2515,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -2524,14 +2524,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
@@ -2546,13 +2546,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block II)'>
-			<roles>destroyer</roles>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>destroyer</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -2587,12 +2587,12 @@
 		<model name='Mk. XXX' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='Mk. XXII' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='Mk. XXI' mechanized='true'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk. XXII' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -2632,12 +2632,12 @@
 			<roles>urban</roles>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:5,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>SL.R:6</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -2659,11 +2659,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:1-</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,SL:0</availability>
-		</model>
 		<model name='OWR-2Mb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,SL:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
@@ -2693,12 +2693,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,SL:5-,FWL:3,NIOPS:2,SL.R:0,DC:8</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,DC:1,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>PP:8,SL:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,DC:1,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2735,11 +2735,11 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>SL:4,IS:2+</availability>
-		<model name='PHX-HK1'>
-			<availability>SL:5,IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>SL:3,IS:2+</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
@@ -2750,32 +2750,32 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,SL:3,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4-,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:4+,MOC:4+,OA:4+,SL:8,FWL:4+,SL.R:6</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:3+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>SL.R:7</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,SL:4-,Periphery:8</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>SL.R:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -2870,11 +2870,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:4,General:4,SL.R:3</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:8,NIOPS:8,SL.R:7</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:8,NIOPS:8,SL.R:7</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>SL.R:6</availability>
@@ -2882,6 +2882,10 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,SL:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>SL.R:7</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -2889,10 +2893,6 @@
 		<model name='(MG)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>SL.R:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -2908,13 +2908,13 @@
 			<roles>fire_support</roles>
 			<availability>IS:2,Periphery:4</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='RFL-1N'>
 			<roles>fire_support</roles>
 			<availability>MOC:2,Periphery:2</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga II Destroyer/Carrier' unitType='Warship'>
@@ -2926,13 +2926,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:4+,CS:5,LA:4+,SL:5,FWL:4+,NIOPS:5,FS:5+,DC:4+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>SL.R:9</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -2948,9 +2948,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:4,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,LA:4,SL:5,FWL:4,NIOPS:4,DC:3</availability>
-		<model name='RGU-133Eb'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8,SL.R:6</availability>
 		</model>
@@ -2960,11 +2957,16 @@
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6,SL.R:4</availability>
 		</model>
+		<model name='RGU-133Eb'>
+			<availability>SL.R:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
 		<availability>CS:2,SL:3,NIOPS:2</availability>
-		<model name='RND-J-1-11 (LRM)'>
-			<availability>PP:5</availability>
+		<model name='RND-J-1-11'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='RND-J-1-11 (RL)'>
 			<availability>PP:5</availability>
@@ -2972,10 +2974,8 @@
 		<model name='RND-J-1-11 (SRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+		<model name='RND-J-1-11 (LRM)'>
+			<availability>PP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
@@ -2999,11 +2999,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
-		<model name='SB-27'>
-			<availability>General:8,SL:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,SL:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,SL:4</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>SL.R:8</availability>
@@ -3058,14 +3058,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1,CS:4,LA:6,SL:6,FWL:3,NIOPS:4,FS:3,DC:3</availability>
+		<model name='STN-1S'>
+			<availability>LA:2,SL:2,FWL:2,FS:2</availability>
+		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:8+,SL:8,NIOPS:8,FWL:8+,SL.R:6,FS:8+,MERC:8+</availability>
 		</model>
 		<model name='STN-3Lb'>
 			<availability>SL.R:6</availability>
-		</model>
-		<model name='STN-1S'>
-			<availability>LA:2,SL:2,FWL:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3081,20 +3081,20 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,SL:4-,IS:7,NIOPS:6-,Periphery.Deep:4,Periphery:4</availability>
-		<model name='SHD-2K'>
-			<availability>DC:7</availability>
+		<model name='SHD-2Hb'>
+			<availability>SL.R:6,FS:2+</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>MOC:2,Periphery:2</availability>
 		</model>
-		<model name='SHD-2D'>
-			<availability>FS:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:7</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>SL.R:6,FS:2+</availability>
+		<model name='SHD-2D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3142,13 +3142,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>PP:3,SLIE:3,SL:3</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>SL:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3209,17 +3209,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,SL:9-,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>SL.R:8</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -3241,19 +3241,28 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>SL:1+,IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:2</availability>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:5,CS:4-,SL:5-,IS:9,NIOPS:4-,Periphery.Deep:5,SL.R:3,MERC:5,Periphery:5,DC:6</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
+			<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>SL.R:7</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
@@ -3281,17 +3290,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,SLIE:8,LA:4,Periphery.HR:3,SL:7,FWL:3,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>PP:6,SLIE:6,SL.R:8</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>PP:8,SLIE:4,SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>PP:6,SLIE:6,SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3335,11 +3344,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:4,CS:6,MOC:4+,OA:4+,SL:6,FWL:6,NIOPS:6,FS:4,MERC:4,Periphery:2+,TC:4+</availability>
-		<model name='THE-Nb'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='THE-F'>
 			<availability>CC:2,FWL:2,FS:2</availability>
+		</model>
+		<model name='THE-Nb'>
+			<availability>SL.R:6</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:8,General:6+,SL:8,NIOPS:8</availability>
@@ -3347,12 +3356,12 @@
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+		<model name='TR-5'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='TR-5'>
-			<availability>CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -3379,13 +3388,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,SL:5,FWL:6,NIOPS:5-,DC:6</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>PP:4,SLIE:6,LA:6+,SL:6+,SL.R:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>PP:4,SLIE:6,LA:6+,SL:6+,SL.R:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3394,14 +3403,14 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,CS:5-,LA:8,SL:5-,IS:5,NIOPS:5-,Periphery.Deep:5,FS:7,MERC:5,Periphery:5,TC:5,DC:8</availability>
-		<model name='TDR-1C'>
-			<availability>MOC:1,TC:1,Periphery:1</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:3+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,SLIE:5,LA:8,General:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:3+</availability>
+		<model name='TDR-1C'>
+			<availability>MOC:1,TC:1,Periphery:1</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>SL.R:6</availability>
@@ -3428,20 +3437,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:5,MOC:2,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,LA:6,SL:9,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,SL:1,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,SL.R:5</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,SL:1,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -3461,25 +3470,25 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CS:2,CC:2,MOC:2,NIOPS:2,FWL:2,MERC:2</availability>
-		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:6+,CS:6,FWL:6+,NIOPS:6</availability>
 		</model>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CS:2,CC:2,MOC:2,NIOPS:2,FWL:2,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:6,MOC:5,FS:6,MERC:6,CIR:4,TC:5,CS:7,OA:5,LA:3,SL:7,FWL:4,NIOPS:7,DC:6</availability>
+		<model name='TRN-3U'>
+			<availability>IS:4-,Periphery:4-</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:7,SL:8,IS:7,NIOPS:8,Periphery.Deep:7,SL.R:4,Periphery:7</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>SL.R:8</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -3498,6 +3507,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3505,10 +3518,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3548,14 +3557,14 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:7,Periphery.HR:6,SL:5-,FWL:7,NIOPS:5-,DC:7</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:2,SL:2,IS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
 			<availability>CC:1,CS:1,SL:2,IS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:2,SL:2,IS:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vigilant Corvette' unitType='Warship'>
@@ -3584,11 +3593,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CC:2,LA:2,SL:8,FWL:2,FS:2,DC:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CC:2,LA:2,SL:8,FWL:2,FS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -3599,13 +3608,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:3,LA:7,SL:5,FWL:7,IS:5,NIOPS:3,CIR:3,TC:3</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>PIR:2,IS:2,FS:6</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -3630,33 +3639,33 @@
 		<model name='WHM-6L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,SL:6-,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:3+</availability>
-		</model>
 		<model name='WHM-7A'>
 			<availability>SL:5,SL.R:8</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,SL:6-,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:4+,LA:4+,FWL:4+,SL.R:6,FS:4+</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>SL:4,IS:3</availability>
-		<model name='WSP-100A'>
-			<availability>SL:4,IS:3</availability>
+		<availability>SL:3,IS:2</availability>
+		<model name='WSP-100'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>SL:2+,IS:1+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>SL:5,IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>SL:4,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>SL:3,IS:4</availability>
+		<availability>SL:2,IS:2</availability>
 		<model name='WSP-105'>
 			<availability>SL:4,IS:4</availability>
 		</model>
@@ -3671,6 +3680,10 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>MOC:1,Periphery:1</availability>
+		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:3</availability>
@@ -3678,10 +3691,6 @@
 		<model name='WSP-1D'>
 			<roles>recon</roles>
 			<availability>FS:3</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>MOC:1,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -3710,13 +3719,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,SLIE:3,LA:7,SL:3,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:7,TC:4,DC:6</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -3725,16 +3734,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,SL:6,NIOPS:6,FS:4,DC:6,TC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CC:8,SL:8,NIOPS:8,SL.R:4,FS:8,DC:8,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,SL:8,FWL:3+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CC:8,SL:8,NIOPS:8,SL.R:4,FS:8,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -3775,36 +3784,36 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>PP:8,CC:6+,CS:8,SLIE:8,LA:6+,SL:8,FWL:6+,NIOPS:8,FS:6+,DC:6+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>SL.R:8</availability>
+			<availability>General:3,SL.R:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,General:8,NIOPS:8,SL.R:4,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>General:3,SL.R:1</availability>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CC:2,MOC:2,IS:2,FS:2,Periphery:2,TC:2,CS:5,OA:2,LA:2,SL:6,FWL:2,NIOPS:5,DC:4</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,NIOPS:8,SL.R:4</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,NIOPS:8,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>LA:6</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:6+</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:6+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -358,13 +358,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>PP:3,CC:7,CS:5-,LA:9,IS:6,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>PP:4</availability>
-		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -375,23 +375,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:3,PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -399,33 +383,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PP:6,PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PP:6,PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PP:3,PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PP:6,PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -443,11 +443,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>PP:3,CLAN:5</availability>
-		<model name='AS7-D-H2'>
-			<availability>General:4,CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>General:4,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -477,11 +477,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:4,OA:4,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,OA:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -502,20 +502,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>PP:4,CC:7,CS:8-,MOC:5,LA:8,PIR:6,IS:7,FWL:8,NIOPS:8-,FS:7,DC:7,TC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>PP:4,CC:3+,LA:3+,FWL:3+,FS:2+,DC:2+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:2+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>PP:4,CC:2+</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>PP:2</availability>
-		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:2+</availability>
+		<model name='BLR-1Gc'>
+			<availability>PP:4,CC:3+,LA:3+,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>PP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -541,17 +541,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>PP:10,CS:7,LA:4,FWL:6,NIOPS:7,FWL.OH:6,MERC:4,FS:6,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>PP:4,CS:4,NIOPS:4,FWL:2+</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:6-</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:6-</availability>
+		<model name='BL-6-KNT'>
+			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>PP:4,CS:4,NIOPS:4,FWL:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -593,34 +593,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,TC:8,Periphery:7,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>PP:8,CC:6,CS:7,LA:6,FWL:6,NIOPS:7,FS:6,MERC:6,DC:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -632,11 +632,11 @@
 	</chassis>
 	<chassis name='Buster XV HaulerMech' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='(PPC)'>
-			<availability>PP:6</availability>
-		</model>
 		<model name='(AC)'>
 			<availability>PP:8</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>PP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -660,34 +660,34 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>PP:2,CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>PP:4,CC:2+,CLAN:6,DC:3+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:4,DC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>PP:4,CC:2+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
@@ -715,15 +715,15 @@
 		<model name='CHP-1Nb'>
 			<availability>PP:4</availability>
 		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>PP:8,CC:7+,CS:8,NIOPS:8</availability>
+		</model>
 		<model name='CHP-2N'>
 			<availability>IS:4-,NIOPS:0</availability>
 		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:4+,CS:4,LA:4+</availability>
-		</model>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>PP:8,CC:7+,CS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -742,13 +742,13 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -760,14 +760,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:5,OA:3,LA:8,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>PP:6,LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>PP:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>PP:6,LA:3,FS:3,MERC:3</availability>
+		<model name='CHP-W5'>
+			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -779,14 +779,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,LA:5,FWL:5,NIOPS:3-,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -819,13 +819,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:4</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -850,13 +850,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>PP:7,CC:6,MOC:3,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -890,29 +890,29 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:3,OA:3,LA:4,FWL:5,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,DC:3</availability>
-		<model name='CSR-V12b'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>PP:5,CS:5,NIOPS:5,IS:3,FWL:3,MERC:3,DC:3,Periphery:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>PP:4,CC:3+,FWL:3+</availability>
+			<availability>PP:8,CS:8,CC:6+,LA:6+,NIOPS:8,FWL:6+,DC:6+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:4,Periphery.Deep:4,NIOPS:0,Periphery:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>PP:8,CS:8,CC:6+,LA:6+,NIOPS:8,FWL:6+,DC:6+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>PP:4,LA:4+,DC:4+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>PP:4,CC:3+,FWL:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -926,11 +926,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crosscut' unitType='Mek'>
@@ -951,6 +951,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>PP:6,CS:6-,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -958,23 +964,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>PP:4,IS:3+,Periphery:3+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>PP:4,CC:5,CS:3,OA:3,LA:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1047,12 +1047,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1092,13 +1092,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1126,18 +1126,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1157,10 +1157,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1168,6 +1164,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -1193,10 +1193,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>PP:5,CS:5,LA:3+,NIOPS:5,FS:3+,DC:3+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>PP:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,NIOPS:8</availability>
@@ -1205,72 +1201,76 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>PP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:3,IS:2,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>PP:7,CC:2,CS:4,LA:2,FWL:2,NIOPS:4,FS:2,DC:2</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,NIOPS:8</availability>
-		</model>
 		<model name='EXT-4Db'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>PP:4,CC:5,MOC:4,OA:4,LA:7,FWL:5,FS:5,MERC:5,TC:4</availability>
-		<model name='FLC-4N'>
-			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>PP:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>PP:2</availability>
 		</model>
-		<model name='FLC-4Nb-PP2'>
-			<availability>PP:2</availability>
+		<model name='FLC-4N'>
+			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='FLC-4Nb'>
+		<model name='FLC-4Nb-PP2'>
 			<availability>PP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1292,12 +1292,12 @@
 		<model name='FFL-3PP2'>
 			<availability>PP:2</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>PP:2</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>PP:4,CC:8,FS:8</availability>
+		</model>
+		<model name='FFL-3PP3'>
+			<availability>PP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
@@ -1307,74 +1307,71 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>PP:8,CS:5,Periphery.R:4,LA:6,FWL:5,NIOPS:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:4-</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>PP:6,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(RL)'>
 			<roles>cargo</roles>
 			<availability>PP:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>PP:6,IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:4,OA:4,Periphery.MW:2,Periphery.ME:2,FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1382,17 +1379,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1411,12 +1411,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>PP:7,CC:5,LA:5,FWL:5,FS:6,MERC:5,DC:5</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>PP:4</availability>
@@ -1464,14 +1464,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1479,6 +1471,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1490,17 +1490,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>PP:9,CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
-		<model name='GTHA-500b'>
-			<availability>PP:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>PP:6,CS:6,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>PP:6,General:6</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>PP:6,FWL:6</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>PP:6,General:6</availability>
+		<model name='GTHA-500'>
+			<availability>PP:6,CS:6,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -1511,11 +1511,11 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>PP:4,CC:7,MOC:7,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,NIOPS:4,DC:8</availability>
-		<model name='GRF-2N'>
-			<availability>PP:4,CC:4+,LA:4+,FWL:4+,FS:4+</availability>
-		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>PP:4,CC:4+,LA:4+,FWL:4+,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1539,35 +1539,35 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:6,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>PP:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>PP:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:4,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Harvester Ant' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='KIC-3 Agromech(LRM)'>
-			<roles>fire_support</roles>
-			<availability>PP:8</availability>
-		</model>
 		<model name='KIC-3 Agromech(MG)'>
 			<roles>anti_infantry</roles>
+			<availability>PP:8</availability>
+		</model>
+		<model name='KIC-3 Agromech(LRM)'>
+			<roles>fire_support</roles>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -1580,37 +1580,45 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1618,33 +1626,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -1657,6 +1657,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>PP:6,CC:4,MOC:3+,CS:6,OA:3+,LA:4,IS:3,FWL:4,NIOPS:6,FS:4,TC:3+,DC:4</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,PP:4,IS:4,NIOPS:4</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>PP:4,CLAN:8</availability>
 		</model>
@@ -1664,14 +1667,14 @@
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,IS:8,DC:8,Periphery:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,PP:4,IS:4,NIOPS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
@@ -1680,9 +1683,6 @@
 		<model name='HCT-213'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>FWL:10</availability>
@@ -1690,24 +1690,24 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,PP:4,CC:4,CS:3,OA:5,FWL:5,NIOPS:3,DC:4</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>PP:8,CS:8,General:8-,NIOPS:8</availability>
-		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>PP:4,FWL:4+</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>PP:8,CS:8,General:8-,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1721,14 +1721,14 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>PP:3,CC:6,MOC:4,OA:4,LA:6,FWL:6,FS:6,DC:4,TC:6</availability>
-		<model name='HOP-4Bb'>
-			<availability>PP:6</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
+		</model>
+		<model name='HOP-4Bb'>
+			<availability>PP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -1804,10 +1804,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>PP:9,CC:9,MOC:8,IS:7,Periphery.Deep:8,FS:9,CIR:8,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1816,11 +1816,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>PP:7,CC:6,MOC:3,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,FWL:6,NIOPS:6,DC:6</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>PP:4</availability>
@@ -1841,37 +1841,37 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CS:3,NIOPS:3,FWL:3,FS:8,MERC:3,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:4,DC:8</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
@@ -1901,19 +1901,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -1963,31 +1963,31 @@
 		<model name='KTO-19'>
 			<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:2</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,Periphery.CM:3,Periphery.HR:2,Periphery.ME:3,TC:2</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -1995,11 +1995,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:4+</availability>
@@ -2034,13 +2034,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>PP:6,CC:6,MOC:4,CS:6,OA:4,LA:6,IS:6,NIOPS:6,MERC:6,CIR:4,TC:4,DC:6</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>PP:6,CS:8,IS:8,NIOPS:8,DC:8</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2073,10 +2073,6 @@
 		<model name='Owl'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2086,24 +2082,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:4</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>PP:8,CC:5,CS:5,LA:5,FWL:5,NIOPS:5,FS:5,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>PP:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>PP:5,CC:8,MOC:2,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2118,6 +2118,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>PP:5,CS:6-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:4</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>PP:4</availability>
@@ -2126,17 +2130,13 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:4</availability>
+			<availability>LA:4,General:8,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -2162,13 +2162,13 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2186,13 +2186,13 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
@@ -2241,13 +2241,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>Periphery:1</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
@@ -2258,20 +2258,20 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>PP:8,CC:5,CS:8,MOC:2+,LA:6,FWL:6,IS:3,NIOPS:8,FS:6,DC:6,TC:2+</availability>
-		<model name='MAD-2R'>
-			<availability>PP:4,FS:4+</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>PP:8,CS:8,MOC:8,IS:7+,NIOPS:8,MERC:0,TC:8+</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>PP:4,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Marco' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='MR-8E'>
-			<availability>PP:7</availability>
-		</model>
 		<model name='MR-8D'>
 			<availability>PP:8</availability>
+		</model>
+		<model name='MR-8E'>
+			<availability>PP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2286,11 +2286,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2308,14 +2308,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -2341,35 +2341,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2377,20 +2374,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2398,8 +2398,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2440,9 +2440,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>PP:2,IS:2,MERC:2,DC:2</availability>
-		<model name='(LRM)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -2452,11 +2452,11 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
 		</model>
@@ -2513,7 +2513,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -2522,14 +2522,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
@@ -2541,13 +2541,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block II)'>
-			<roles>destroyer</roles>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>destroyer</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -2607,12 +2607,12 @@
 			<roles>urban</roles>
 			<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>PP:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -2659,12 +2659,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,DC:1,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>PP:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,DC:1,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2713,28 +2713,28 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>PP:5,CS:7,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>PP:6,General:8,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>PP:4,CC:4+,MOC:4+,OA:4+,FWL:4+</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:3+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>PP:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1Kk'>
+			<availability>DC:3+</availability>
+		</model>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>PP:6,General:8,Periphery:8</availability>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>PP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -2829,11 +2829,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:4,General:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>PP:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>PP:4</availability>
@@ -2841,6 +2841,10 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>PP:9,MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>PP:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -2848,10 +2852,6 @@
 		<model name='(MG)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -2877,13 +2877,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>PP:5,CC:4+,CS:5,LA:4+,FWL:4+,NIOPS:5,FS:4+,DC:4+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>PP:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -2899,9 +2899,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>PP:5,CC:4,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,LA:4,FWL:4,NIOPS:4,DC:3</availability>
-		<model name='RGU-133Eb'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
@@ -2911,11 +2908,16 @@
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
 		</model>
+		<model name='RGU-133Eb'>
+			<availability>PP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
 		<availability>PP:3,CS:2,NIOPS:2,IS:2</availability>
-		<model name='RND-J-1-11 (LRM)'>
-			<availability>PP:5</availability>
+		<model name='RND-J-1-11'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>PP:2,General:8</availability>
 		</model>
 		<model name='RND-J-1-11 (RL)'>
 			<availability>PP:5</availability>
@@ -2923,10 +2925,8 @@
 		<model name='RND-J-1-11 (SRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>PP:2,General:8</availability>
+		<model name='RND-J-1-11 (LRM)'>
+			<availability>PP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
@@ -2950,11 +2950,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -2994,11 +2994,11 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,LA:6,FWL:6,IS:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3022,14 +3022,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>PP:6,CC:1,CS:4,LA:6,FWL:3,NIOPS:4,FS:3,DC:3</availability>
+		<model name='STN-1S'>
+			<availability>LA:2,FWL:2,FS:2</availability>
+		</model>
 		<model name='STN-3L'>
 			<availability>PP:8,CS:8,LA:8+,NIOPS:8,FWL:8+,FS:8+,MERC:8+</availability>
 		</model>
 		<model name='STN-3Lb'>
 			<availability>PP:4</availability>
-		</model>
-		<model name='STN-1S'>
-			<availability>LA:2,FWL:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3045,17 +3045,17 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>PP:4,CS:6-,LA:6,IS:7,NIOPS:6-,Periphery.Deep:4,Periphery:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>PP:4,FS:3+</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:8</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>PP:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>PP:4,FS:3+</availability>
+		<model name='SHD-2D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3103,13 +3103,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>PP:3,CC:3+,LA:3+,CSJ:3</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>PP:4,LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3170,17 +3170,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>PP:9,CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>PP:4</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3196,19 +3196,28 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:2</availability>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>PP:5,MOC:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>PP:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
@@ -3236,17 +3245,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>PP:6</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>PP:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>PP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3290,11 +3299,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>PP:6,CC:4,CS:6,MOC:4+,OA:4+,FWL:6,NIOPS:6,FS:4,MERC:4,TC:4+</availability>
-		<model name='THE-Nb'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='THE-F'>
 			<availability>CC:2,FWL:2,FS:2</availability>
+		</model>
+		<model name='THE-Nb'>
+			<availability>PP:4</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>PP:6,CS:8,General:6+,NIOPS:8</availability>
@@ -3302,12 +3311,12 @@
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+		<model name='TR-5'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='TR-5'>
-			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -3334,13 +3343,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>PP:5,CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>PP:4,LA:6+</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>PP:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>PP:4,LA:6+</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3349,11 +3358,11 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>PP:5,CC:8,CS:5-,LA:8,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>PP:4</availability>
@@ -3380,20 +3389,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>PP:9,CC:5,MOC:2,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,LA:6,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -3410,22 +3419,22 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
-		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:5+,CS:6,FWL:5+,NIOPS:6</availability>
 		</model>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>PP:7,CC:6,MOC:5,FS:6,MERC:6,CIR:4,TC:5,CS:7,OA:5,LA:3,FWL:4,NIOPS:7,DC:6</availability>
-		<model name='TRN-3T'>
-			<availability>PP:8,CS:8,OA:6,IS:6,NIOPS:8,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='TRN-3U'>
 			<availability>IS:4-,Periphery:4-</availability>
+		</model>
+		<model name='TRN-3T'>
+			<availability>PP:8,CS:8,OA:6,IS:6,NIOPS:8,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -3451,6 +3460,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3458,10 +3471,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3501,13 +3510,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -3537,11 +3546,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>PP:8,CC:2,LA:2,FWL:2,FS:2,DC:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>PP:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>PP:8,CC:2,LA:2,FWL:2,FS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -3552,13 +3561,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>PP:5,CC:4,CS:3,MOC:3,LA:7,FWL:7,IS:5,NIOPS:3,CIR:3,TC:3</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -3583,33 +3592,33 @@
 		<model name='WHM-6L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:2+</availability>
-		</model>
 		<model name='WHM-7A'>
 			<availability>PP:2</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>PP:4,CC:4+,LA:4+,FWL:4+,FS:4+</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-100A'>
+		<availability>IS:2</availability>
+		<model name='WSP-100'>
 			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -3642,6 +3651,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -3650,19 +3662,16 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>PP:5,CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:7,TC:5,DC:6</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -3671,16 +3680,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>PP:6,CS:6,CC:6,NIOPS:6,FS:6,DC:6,TC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:4+,FWL:4+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>PP:4</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -3721,36 +3730,36 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>PP:8,CC:6+,CS:8,LA:6+,FWL:6+,NIOPS:8,FS:6+,DC:6+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>PP:4,IS:4</availability>
+			<availability>General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,General:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>General:3</availability>
+			<availability>PP:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:2,PP:6,CC:1,IS:1,FS:1,TC:2,Periphery:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:4</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>LA:8</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:6+</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:6+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -538,13 +538,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>PP:3,CC:7,CS:5-,LA:9,FWL:9,IS:6,NIOPS:5-,Periphery.Deep:6,FS:8,DC:8,Periphery:6</availability>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -555,23 +555,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:3,PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -579,33 +563,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PP:6,PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PP:6,PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PP:3,PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PP:6,PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -623,11 +623,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>PP:3,CLAN:5</availability>
-		<model name='AS7-D-H2'>
-			<availability>PP:2,CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>PP:6,General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>PP:2,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -662,11 +662,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>PP:8,CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,Periphery:4,TC:6,CS:8,OA:6,LA:7,FWL:8,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -674,11 +674,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:4,OA:4,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,OA:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -699,20 +699,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>PP:4,CC:7,MOC:6,CLAN:4,IS:7,FS:7,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
-		<model name='BLR-1Gc'>
-			<availability>PP:4,CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:2+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>PP:2,CC:2+,CLAN:8</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:2+</availability>
+		<model name='BLR-1Gc'>
+			<availability>PP:4,CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -738,17 +738,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>PP:10,CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:6,FS:5,MERC:4,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:4,CNC:10,FWL:6,NIOPS:7,CJF:8,CGB:10,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>PP:2,CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:6-</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:6-</availability>
+		<model name='BL-6-KNT'>
+			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>PP:2,CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -790,34 +790,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>PP:8,CC:6,CHH:8,CLAN:6,FS:6,MERC:6,CS:7,CDS:6,LA:6,CNC:6,FWL:6,NIOPS:7,CJF:6,DC:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>PP:4,CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -829,11 +829,11 @@
 	</chassis>
 	<chassis name='Buster XV HaulerMech' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='(PPC)'>
-			<availability>PP:6</availability>
-		</model>
 		<model name='(AC)'>
 			<availability>PP:8</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>PP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -857,34 +857,34 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>PP:2,CC:6,MOC:2,CLAN:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>PP:2,CC:2+,CLAN:6,DC:3+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:4,DC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>PP:2,CC:2+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
-		<model name='CNT-1D'>
-			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
-		</model>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CNT-1D'>
+			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
@@ -912,15 +912,15 @@
 		<model name='CHP-1Nb'>
 			<availability>PP:2,CLAN:8</availability>
 		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>PP:8,CC:6+,CS:8,NIOPS:8</availability>
+		</model>
 		<model name='CHP-2N'>
 			<availability>IS:5-,NIOPS:0</availability>
 		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:4+,CS:4,LA:4+</availability>
-		</model>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>PP:8,CC:6+,CS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -939,13 +939,13 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -957,14 +957,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>PP:6,CC:5,MOC:3,CLAN:5,FS:5,MERC:5,CIR:3,Periphery:2,TC:3,OA:3,LA:8,FWL:6,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>PP:6,LA:4,CLAN:6,FS:4,MERC:4</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>PP:2,CLAN:8,CGS:6</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>PP:6,LA:4,CLAN:6,FS:4,MERC:4</availability>
+		<model name='CHP-W5'>
+			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -979,41 +979,41 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1021,14 +1021,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1039,32 +1039,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1072,11 +1072,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1084,32 +1084,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,LA:5,FWL:5,NIOPS:3-,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1142,13 +1142,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:4</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -1173,13 +1173,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>PP:7,CC:6,MOC:3,CLAN:5,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6,CLAN:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1213,29 +1213,29 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>PP:6,CC:3,MOC:3,CLAN:5,FS:6,MERC:3,CIR:2,Periphery:2,TC:3,OA:3,LA:4,FWL:5,DC:3</availability>
-		<model name='CSR-V12b'>
-			<availability>PP:2,CLAN:6</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>PP:2,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>PP:5,CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>PP:2,CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
+			<availability>PP:8,CS:8,CC:5+,LA:5+,CLAN:4,NIOPS:8,FWL:5+,DC:5+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:5,Periphery.Deep:5,NIOPS:0,Periphery:5</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>PP:8,CS:8,CC:5+,LA:5+,CLAN:4,NIOPS:8,FWL:5+,DC:5+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>PP:4,LA:4+,CLAN:4,DC:4+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>PP:2,CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1249,11 +1249,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crosscut' unitType='Mek'>
@@ -1274,6 +1274,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>PP:6,CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1281,23 +1287,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>PP:4,CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>PP:4,CC:5,CS:3,OA:3,LA:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1377,12 +1377,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1422,13 +1422,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1456,18 +1456,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:3,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1487,10 +1487,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1498,6 +1494,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -1523,10 +1523,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>PP:5,CS:5,LA:3+,CLAN:5,NIOPS:5,FS:3+,DC:3+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>PP:2,CLAN:8,CGS:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
@@ -1535,75 +1531,79 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>PP:2,CLAN:8,CGS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:3,IS:2,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>PP:7,CC:1,CS:4,LA:1,CLAN:6,FWL:1,NIOPS:4,FS:1,DC:1</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:4,NIOPS:8</availability>
+		<model name='EXT-4C'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>PP:2,CLAN:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>CLAN:2</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:4,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>PP:4,CC:5,MOC:4,OA:4,CIH:6,LA:7,CLAN:4,FWL:5,FS:5,MERC:5,CGS:5,TC:4</availability>
-		<model name='FLC-4N'>
-			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>PP:1,CLAN:8</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>PP:4</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>PP:4</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>PP:1,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1625,12 +1625,12 @@
 		<model name='FFL-3PP2'>
 			<availability>PP:3</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>PP:3</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>PP:4,CC:8,FS:8</availability>
+		</model>
+		<model name='FFL-3PP3'>
+			<availability>PP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
@@ -1640,74 +1640,71 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>PP:8,CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:5,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:5-</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:8+,CLAN:8,FWL:8+,NIOPS:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>PP:6,IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>PP:6,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(RL)'>
 			<roles>cargo</roles>
 			<availability>PP:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>PP:6,IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:4,OA:4,Periphery.MW:2,Periphery.ME:2,FWL:6</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1715,17 +1712,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1744,12 +1744,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>PP:7,CC:4,CHH:8,CW:8,LA:4,CLAN:8,FWL:4,FS:4,MERC:4,CJF:8,DC:4,CGB:8</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>PP:4,CLAN:8</availability>
@@ -1797,14 +1797,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1812,6 +1804,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1823,17 +1823,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>PP:9,CC:4,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:9,NIOPS:9,DC:2</availability>
-		<model name='GTHA-500b'>
-			<availability>PP:4,CLAN:8</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>PP:6,CS:6,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>PP:6,General:6</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>PP:6,FWL:6</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>PP:6,General:6</availability>
+		<model name='GTHA-500'>
+			<availability>PP:6,CS:6,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>PP:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -1844,11 +1844,11 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>PP:4,CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
-		<model name='GRF-2N'>
-			<availability>PP:2,CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+</availability>
-		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>PP:2,CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1872,35 +1872,35 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:6,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>PP:2,CSR:8,CLAN:8</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>PP:2,CSR:8,CLAN:8</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Harvester Ant' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='KIC-3 Agromech(LRM)'>
-			<roles>fire_support</roles>
-			<availability>PP:8</availability>
-		</model>
 		<model name='KIC-3 Agromech(MG)'>
 			<roles>anti_infantry</roles>
+			<availability>PP:8</availability>
+		</model>
+		<model name='KIC-3 Agromech(LRM)'>
+			<roles>fire_support</roles>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -1913,37 +1913,45 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1951,33 +1959,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -1990,6 +1990,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>PP:6,CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,PP:4,CLAN:2,IS:4,NIOPS:4</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>PP:4,CLAN:8</availability>
 		</model>
@@ -1997,14 +2000,14 @@
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,IS:8,DC:8,Periphery:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,PP:4,CLAN:2,IS:4,NIOPS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
@@ -2013,9 +2016,6 @@
 		<model name='HCT-213'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>FWL:10</availability>
@@ -2023,24 +2023,24 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,PP:4,CC:4,CS:3,CHH:5,OA:5,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:4,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>PP:8,CS:8,General:6-,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>PP:2,CLAN:8,FWL:4+</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>PP:8,CS:8,General:6-,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2054,17 +2054,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>PP:3,CC:5,MOC:4,CHH:4,CSR:0,CLAN:3,FS:5,CGS:5,TC:5,OA:4,LA:5,FWL:5,DC:4</availability>
-		<model name='HOP-4Bb'>
-			<availability>PP:4,CLAN:6</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8</availability>
+		<model name='HOP-4Bb'>
+			<availability>PP:4,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2088,11 +2088,11 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>PP:5,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2124,11 +2124,11 @@
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>PP:2,CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1A'>
-			<availability>PP:8,CLAN:8</availability>
-		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1A'>
+			<availability>PP:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -2140,10 +2140,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>PP:9,CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -2152,11 +2152,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>PP:7,CC:6,MOC:3,CLAN:7,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,CNC:7,FWL:6,NIOPS:6,DC:6</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>PP:2,CSR:8,CLAN:8</availability>
@@ -2177,48 +2177,48 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CS:3,NIOPS:3,FWL:3,FS:8,MERC:3,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:4,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FS:5</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2241,19 +2241,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2291,17 +2291,17 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>PP:5,CC:2+,CLAN:6,IS:2+,FS:2+,MERC:2+,CGS:7,CS:6,LA:2+,FWL:2+,NIOPS:6,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>PP:4,CLAN:8,CGS:8</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:4</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,General:5,NIOPS:8</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
+		<model name='KGC-0000'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2309,31 +2309,31 @@
 		<model name='KTO-19'>
 			<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:2</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>PP:2,CLAN:8,CGS:8</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,Periphery.CM:3,Periphery.HR:2,Periphery.ME:3,TC:2</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2341,11 +2341,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:4+</availability>
@@ -2380,13 +2380,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:4,PP:6,CC:6,CIH:6,CLAN:6,IS:6,CFM:6,MERC:6,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:6,NIOPS:6,DC:6</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>PP:6,CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2419,10 +2419,6 @@
 		<model name='Owl'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2432,24 +2428,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:4</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>PP:8,CC:4,CS:5,CIH:8,LA:4,CLAN:8,FWL:4,NIOPS:5,FS:4,CJF:8,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>PP:4,CLAN:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>PP:5,CC:8,MOC:2,CLAN:5,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2464,6 +2464,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>PP:5,CS:6-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:4</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>PP:2,CLAN:8</availability>
@@ -2472,17 +2476,13 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:4</availability>
+			<availability>LA:4,General:8,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -2508,13 +2508,13 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2532,13 +2532,13 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
@@ -2587,13 +2587,13 @@
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
 		<availability>Periphery:1</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
@@ -2607,20 +2607,20 @@
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:6,Periphery.Deep:8,TC:4</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>PP:2,CLAN:8,FS:4+,CGS:8</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>PP:8,CS:8,MOC:8,IS:6+,NIOPS:8,MERC:0,TC:8+</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>PP:2,CLAN:8,FS:4+,CGS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marco' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='MR-8E'>
-			<availability>PP:7</availability>
-		</model>
 		<model name='MR-8D'>
 			<availability>PP:8</availability>
+		</model>
+		<model name='MR-8E'>
+			<availability>PP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2635,11 +2635,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -2651,14 +2651,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -2684,35 +2684,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2720,20 +2717,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2741,8 +2741,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2783,9 +2783,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>PP:2,IS:2,MERC:2,DC:2</availability>
-		<model name='(LRM)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -2795,11 +2795,11 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
 		</model>
@@ -2827,10 +2827,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>PP:6,MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:6+,NIOPS:6,CJF:7,CGB:5,DC:6+</availability>
-		<model name='MON-70'>
-			<roles>recon</roles>
-			<availability>IS:5</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>PP:2,CLAN:9,CGS:9</availability>
@@ -2839,6 +2835,10 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='MON-70'>
+			<roles>recon</roles>
+			<availability>IS:5</availability>
+		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,NIOPS:8,IS:6+,Periphery:6+</availability>
@@ -2846,11 +2846,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>PP:2,CLAN:2,IS:3</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mosquito Light Fighter' unitType='Conventional Fighter'>
@@ -2867,7 +2867,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -2876,14 +2876,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
@@ -2895,13 +2895,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block II)'>
-			<roles>destroyer</roles>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>destroyer</roles>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -2972,12 +2972,12 @@
 			<roles>urban</roles>
 			<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>PP:4,CLAN:8</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3031,12 +3031,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,DC:1,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>PP:8,CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,DC:1,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3085,32 +3085,32 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>PP:5,CS:7,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>PP:6,General:8,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>PP:4,CC:4+,MOC:4+,OA:4+,FWL:4+</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:2+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>PP:2,CLAN:7</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>PP:6,General:8,Periphery:8</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:5</availability>
+		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>PP:2,CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3205,11 +3205,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:4,General:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>PP:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>PP:2,CLAN:8</availability>
@@ -3217,6 +3217,10 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>PP:9,MOC:8,CLAN:9,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>PP:2,CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -3225,18 +3229,14 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:4,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:4,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100'>
 			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -3262,13 +3262,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>PP:5,CC:3+,CS:5,CHH:5,LA:3+,FWL:3+,NIOPS:5,FS:4+,DC:3+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>PP:4,CHH:8,CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -3284,9 +3284,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>PP:5,CC:3,MOC:2,CLAN:4,IS:3,FS:3,CIR:2,TC:2,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:2</availability>
-		<model name='RGU-133Eb'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
@@ -3296,14 +3293,19 @@
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
 		</model>
+		<model name='RGU-133Eb'>
+			<availability>PP:2,CLAN:8</availability>
+		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
 		<availability>PP:3,CS:2,NIOPS:2,IS:2</availability>
-		<model name='RND-J-1-11 (LRM)'>
-			<availability>PP:5</availability>
+		<model name='RND-J-1-11'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>PP:2,General:8</availability>
 		</model>
 		<model name='RND-J-1-11 (RL)'>
 			<availability>PP:5</availability>
@@ -3311,10 +3313,8 @@
 		<model name='RND-J-1-11 (SRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>PP:2,General:8</availability>
+		<model name='RND-J-1-11 (LRM)'>
+			<availability>PP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
@@ -3338,11 +3338,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,CLAN:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:8</availability>
@@ -3385,11 +3385,11 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,LA:6,FWL:6,IS:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3420,14 +3420,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>PP:6,CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:6,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+		<model name='STN-1S'>
+			<availability>LA:2,FWL:2,FS:2</availability>
+		</model>
 		<model name='STN-3L'>
 			<availability>PP:8,CS:8,LA:8+,NIOPS:8,FWL:8+,FS:8+,MERC:8+</availability>
 		</model>
 		<model name='STN-3Lb'>
 			<availability>PP:2,CLAN:8</availability>
-		</model>
-		<model name='STN-1S'>
-			<availability>LA:2,FWL:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3443,17 +3443,17 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>PP:4,CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5,CGB:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>PP:2,CLAN:8,FS:3+</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:8</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>PP:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>PP:2,CLAN:8,FS:3+</availability>
+		<model name='SHD-2D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3501,13 +3501,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>PP:3,CC:4+,LA:4+,CSJ:3</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>PP:4,LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3568,17 +3568,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>PP:9,CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3594,19 +3594,28 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>PP:5,MOC:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,DC:6,Periphery:5</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>PP:2,CLAN:8</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
@@ -3634,17 +3643,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:3,PP:8,CC:4,CLAN:6,MERC:4,Periphery.OS:3,FS:6,CIR:2,TC:3,Periphery:2,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>PP:4,CLAN:6,CGS:6</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>PP:2,CLAN:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>PP:4,CLAN:6,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -3696,11 +3705,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>PP:6,CC:4,CS:6,MOC:4+,OA:4+,FWL:6,NIOPS:6,FS:4,MERC:4,TC:4+</availability>
-		<model name='THE-Nb'>
-			<availability>PP:2,CLAN:8,CGS:8</availability>
-		</model>
 		<model name='THE-F'>
 			<availability>CC:2,FWL:2,FS:2</availability>
+		</model>
+		<model name='THE-Nb'>
+			<availability>PP:2,CLAN:8,CGS:8</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>PP:6,CS:8,General:6+,NIOPS:8</availability>
@@ -3708,12 +3717,12 @@
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+		<model name='TR-5'>
+			<availability>CC:4-</availability>
+		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='TR-5'>
-			<availability>CC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -3740,13 +3749,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>PP:5,CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>PP:4,LA:6+,CLAN:7</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>PP:4,LA:6+,CLAN:7</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3755,11 +3764,11 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>PP:5,CC:8,CLAN:5,IS:6,Periphery.Deep:6,FS:7,MERC:6,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,DC:8</availability>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>PP:2,CHH:8,CSR:8,CDS:8,CW:8,CLAN:8,CNC:8,CJF:8,CGB:8</availability>
@@ -3786,20 +3795,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>PP:9,CC:5,MOC:2,CLAN:9,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:6,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -3819,25 +3828,25 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
-		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:4+,CS:6,FWL:4+,NIOPS:6</availability>
 		</model>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>PP:7,CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
+		<model name='TRN-3U'>
+			<availability>IS:4-,Periphery:4-</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>PP:8,CS:8,OA:5+,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:8</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -3863,6 +3872,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3870,10 +3883,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3913,13 +3922,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -3949,11 +3958,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>PP:8,CC:2,LA:2,CLAN:8,FWL:2,FS:2,DC:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>PP:5,CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>PP:8,CC:2,LA:2,CLAN:8,FWL:2,FS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -3964,13 +3973,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>PP:5,CC:4,CS:3,MOC:4,LA:7,FWL:7,IS:5,NIOPS:3,CIR:4,TC:4</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -3995,33 +4004,33 @@
 		<model name='WHM-6L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:2+</availability>
-		</model>
 		<model name='WHM-7A'>
 			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>PP:2,CC:4+,LA:4+,CLAN:4,FWL:4+,FS:4+</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-100A'>
-			<availability>IS:3</availability>
+		<availability>IS:2</availability>
+		<model name='WSP-100'>
+			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4054,6 +4063,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4061,9 +4073,6 @@
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine II' unitType='Mek'>
@@ -4074,13 +4083,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>PP:5,CC:7,CWOV:6,CLAN:3,IS:7,Periphery.Deep:6,FS:7,TC:5,CS:5-,LA:7,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4089,16 +4098,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>PP:6,CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:4+,FWL:4+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>PP:2,CLAN:8,CFM:8,CGS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4139,36 +4148,36 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>PP:8,CC:6+,CS:8,LA:6+,CLAN:8,FWL:6+,NIOPS:8,FS:6+,DC:6+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>PP:2,CHH:8,CLAN:8,IS:4</availability>
+			<availability>CHH:4,General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,General:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4,General:3</availability>
+			<availability>PP:2,CHH:8,CLAN:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:2,PP:6,CC:1,CLAN:6,IS:1,FS:1,Periphery:2,TC:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:3</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>PP:2,CSR:6</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>LA:8</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:6+</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:6+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -588,17 +588,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CSR:3,CLAN:3,CCO:3,CGB:3</availability>
-		<model name='C 2'>
-			<availability>CLAN:3</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:6,CCO:6</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CSA:2,CLAN:6,CCO:2</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:6,CCO:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -617,17 +617,17 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,CLAN:5,IS:8,Periphery.Deep:8,DC:7,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -641,23 +641,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -665,33 +649,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -709,11 +709,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:5</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -748,11 +748,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>CC:7,MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -760,11 +760,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:4,OA:4,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,OA:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -785,20 +785,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:4,IS:6,FS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:2+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:2+,CLAN:8</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:2+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -824,17 +824,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:5,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8-</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8-</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -880,34 +880,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:5,CHH:8,CLAN:6,FS:5,MERC:5,CS:7,CDS:6,LA:5,CNC:6,FWL:5,NIOPS:7,CJF:6,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -932,36 +932,36 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,TC:1,Periphery:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CC:2+,CLAN:6,DC:3+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:4,DC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:2+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,IS:3,Periphery.Deep:4,FS:4,MERC:2,Periphery:4</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='CNT-1A'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -990,18 +990,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:6-,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:2+,CS:4,LA:2+,CLAN:2,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:4,CLAN:6,CGB:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:4+,CS:8,CHH:6,CLAN:6,NIOPS:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CLAN:6,CGB:4</availability>
+		<model name='CHP-2N'>
+			<availability>IS:6-,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:2+,CS:4,LA:2+,CLAN:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1020,16 +1020,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1041,14 +1041,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:3,LA:8,CLAN:5,FWL:5,FS:5,MERC:4,CIR:3,Periphery:2,TC:3,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:4,CLAN:6,FS:4,MERC:4</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:8,CGS:6</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:4,CLAN:6,FS:4,MERC:4</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1057,13 +1057,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1084,41 +1084,41 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1126,14 +1126,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1144,32 +1144,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1177,11 +1177,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1189,32 +1189,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:3-,OA:4,LA:5,CLAN:3-,IS:5,FWL:5,NIOPS:3-,FS:6,MERC:5,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1247,13 +1247,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:2</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -1278,13 +1278,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:5,MOC:3,CLAN:4,IS:5,FS:4,CIR:2,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6,CLAN:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1318,29 +1318,29 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
+			<availability>CS:8,CC:4+,LA:4+,CLAN:6,NIOPS:8,FWL:4+,DC:4+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:4+,LA:4+,CLAN:6,NIOPS:8,FWL:4+,DC:4+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:4+,CLAN:4,DC:4+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1354,11 +1354,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1370,6 +1370,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1377,23 +1383,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:4,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:3,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1433,13 +1433,13 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:5</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
@@ -1465,12 +1465,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1507,13 +1507,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1541,18 +1541,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:3,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1572,10 +1572,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1583,6 +1579,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -1608,10 +1608,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:2+,CLAN:5,NIOPS:5,FS:2+,DC:2+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8,CGS:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
@@ -1620,37 +1616,41 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,CGS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:2,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:6,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8</availability>
+		<model name='EXT-4C'>
+			<availability>CLAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>CLAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:3,MOC:2,OA:2,CIH:6,LA:4,CLAN:4,FWL:3,FS:3,MERC:3,CGS:5,TC:2</availability>
-		<model name='FLC-4N'>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FLC-4Nb'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='FLC-4N'>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1662,34 +1662,34 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:2</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1717,70 +1717,67 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:6-</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:4,OA:4,Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:1-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1788,17 +1785,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1817,12 +1817,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:4,CHH:8,CW:8,LA:4,CLAN:8,FWL:4,FS:4,MERC:4,CJF:8,DC:4,CGB:8</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8</availability>
@@ -1867,14 +1867,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1882,6 +1874,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1893,17 +1893,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:6,CLAN:4</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:2,FWL:6</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:6,CLAN:4</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -1914,25 +1914,25 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:6,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:7,CS:7,CHH:9,CSR:9,CLAN:9,IS:7,FWL:7,NIOPS:7,FS:6,MERC:7,DC:7</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>FWL:5-,NIOPS:0,MERC:5-</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2-,Periphery.ME:2-,FWL:2-,NIOPS:0,MERC:2-</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>FWL:5-,NIOPS:0,MERC:5-</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -1953,25 +1953,25 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:6,CLAN:2,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:8</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:8</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:6,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1983,37 +1983,45 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2021,33 +2029,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2060,6 +2060,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:2,IS:2,NIOPS:4</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:8</availability>
 		</model>
@@ -2067,14 +2070,14 @@
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:6,DC:6,Periphery:6</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:2,IS:2,NIOPS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
@@ -2082,9 +2085,6 @@
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2099,32 +2099,32 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:5,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:4</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:6</availability>
 		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,FWL:3+</availability>
 		</model>
-		<model name='HER-1A'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>:0,FWL:6</availability>
+			<availability>CS:8,General:5,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2138,17 +2138,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:5,MOC:3,CHH:4,OA:3,LA:5,CLAN:3,FWL:5,FS:5,CGS:5,DC:3,TC:5</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:1</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2172,11 +2172,11 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>CC:5,MOC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2208,14 +2208,14 @@
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1A'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:8,CLAN:4</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='IMP-1A'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -2227,10 +2227,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -2239,11 +2239,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:3,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4,CLAN:2</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4,CLAN:2</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:8</availability>
@@ -2271,48 +2271,48 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CS:3,NIOPS:3,FWL:3,FS:8,MERC:3,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:4,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FS:5</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2335,19 +2335,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2382,17 +2382,17 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:2+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:8,CGS:8</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:5,CLAN:6,NIOPS:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
+		<model name='KGC-0000'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2400,11 +2400,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:2</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:8,CGS:8</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2416,22 +2416,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,Periphery.CM:3,Periphery.HR:2,Periphery.ME:3,TC:2</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2439,11 +2439,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:3</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2484,13 +2484,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:4,IS:3,NIOPS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:4,IS:3,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2523,10 +2523,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2536,24 +2532,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:4,CS:5,CIH:9,LA:4,CLAN:8,FWL:4,NIOPS:5,FS:4,CJF:8,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -2568,6 +2568,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:4</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8</availability>
@@ -2576,17 +2580,13 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,CLAN:4-,FS:7</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:4</availability>
+			<availability>LA:4,General:8,CLAN:4-,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -2612,13 +2612,13 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2636,22 +2636,22 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:4+,CLAN:4,FWL:4+,DC:4+</availability>
-		<model name='LNX-8Q'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='LNX-9Q'>
 			<availability>CLAN:8,IS:6+</availability>
+		</model>
+		<model name='LNX-8Q'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2712,17 +2712,17 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:5,CS:8,MOC:2+,LA:6,CLAN:8,FWL:5,IS:3,NIOPS:8,FS:6,DC:6,TC:3+,CGB:8</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:8,Periphery.Deep:8,TC:5</availability>
+		</model>
+		<model name='MAD-1R'>
+			<availability>CS:8,MOC:6,CLAN:4,IS:6+,NIOPS:8,MERC:0,TC:6+</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>CLAN:8,FS:4+,CGS:8</availability>
 		</model>
-		<model name='MAD-1R'>
-			<availability>CS:8,MOC:6,CLAN:4,IS:6+,NIOPS:8,MERC:0,TC:6+</availability>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2734,11 +2734,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -2750,14 +2750,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -2783,35 +2783,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2819,20 +2816,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2840,8 +2840,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2888,13 +2888,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:7,General:4,MERC:2,DC:7</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -2904,11 +2900,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:4,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:7,General:4,MERC:2,DC:7</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:7,General:4,MERC:2,DC:7</availability>
 		</model>
@@ -2936,10 +2936,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CJF:7,CGB:5,DC:5+</availability>
-		<model name='MON-70'>
-			<roles>recon</roles>
-			<availability>IS:3</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:9,CGS:9</availability>
@@ -2948,6 +2944,10 @@
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='MON-70'>
+			<roles>recon</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,IS:6+,Periphery:6+</availability>
@@ -2955,11 +2955,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:3</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mosquito Light Fighter' unitType='Conventional Fighter'>
@@ -2976,7 +2976,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -2985,14 +2985,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
@@ -3004,11 +3004,11 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:3</availability>
-		<model name='(Block II)'>
+		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='(Block I)'>
+		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:6</availability>
 		</model>
@@ -3081,12 +3081,12 @@
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3144,12 +3144,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:4-,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3175,10 +3175,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3186,6 +3182,10 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
@@ -3202,32 +3202,32 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:8,FWL:8,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:2+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:7</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,Periphery:8</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:6</availability>
+		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3322,11 +3322,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:2,CLAN:3,General:2</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:4,CNC:4</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:4</availability>
@@ -3337,6 +3337,10 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
@@ -3345,21 +3349,17 @@
 			<roles>fire_support</roles>
 			<availability>General:6,CLAN:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -3385,13 +3385,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:3+,CS:5,CHH:5,CSR:4,LA:3+,CLAN:4,FWL:3+,NIOPS:5,FS:4+,CJF:4,DC:3+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -3407,9 +3407,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
@@ -3418,6 +3415,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:6</availability>
@@ -3452,11 +3452,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:8</availability>
@@ -3503,11 +3503,11 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
@@ -3541,23 +3541,23 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:6,DC:6</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:2</availability>
+		<model name='STN-1S'>
+			<availability>LA:1,FWL:1,FS:1</availability>
 		</model>
 		<model name='STN-3KB'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='STN-1S'>
-			<availability>LA:1,FWL:1,FS:1</availability>
+		<model name='STN-3KA'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3573,17 +3573,17 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5,CGB:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:8,FS:3+</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,CLAN:6-,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:8,FS:3+</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3631,13 +3631,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:4+,LA:4+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3712,17 +3712,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3738,19 +3738,31 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A10'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:5,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6,CGB:3-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>CLAN:2-,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>CLAN:2-,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
@@ -3781,17 +3793,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,TC:3,Periphery:2,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:6,CGS:6</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:6,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -3806,15 +3818,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3855,11 +3867,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
-		<model name='THE-Nb'>
-			<availability>CLAN:8,CGS:8</availability>
-		</model>
 		<model name='THE-F'>
 			<availability>CC:2+,FWL:2+,FS:2+</availability>
+		</model>
+		<model name='THE-Nb'>
+			<availability>CLAN:8,CGS:8</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:8,General:5+,CLAN:6,NIOPS:8</availability>
@@ -3867,12 +3879,12 @@
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+		<model name='TR-5'>
+			<availability>CC:3-</availability>
+		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='TR-5'>
-			<availability>CC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -3899,13 +3911,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>LA:3+,CLAN:5</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>LA:3+,CLAN:5</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3914,11 +3926,11 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:8,CSR:8,CDS:8,CW:8,CLAN:8,CNC:8,CJF:8,CGB:8</availability>
@@ -3945,20 +3957,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -3978,10 +3990,6 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
-		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:3+,CS:6,FWL:3+,NIOPS:6</availability>
@@ -3989,17 +3997,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:2,TC:4,CS:7,OA:4,LA:2,FWL:3,NIOPS:7,DC:5</availability>
+		<model name='TRN-3U'>
+			<availability>IS:6-,Periphery:6-</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:5+,CLAN:6,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:8</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4025,6 +4037,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -4032,10 +4048,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4082,13 +4094,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -4108,11 +4120,11 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:8</availability>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4127,11 +4139,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CC:1,LA:1,CLAN:8,FWL:1,FS:1,DC:1</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CC:1,LA:1,CLAN:8,FWL:1,FS:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4142,13 +4154,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:4,LA:7,CLAN:4-,FWL:7,IS:5,NIOPS:3,CIR:4,TC:4</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -4183,39 +4195,39 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:2+</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:4+,LA:4+,CLAN:4,FWL:4+,FS:4+</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-100A'>
-			<availability>IS:3</availability>
+		<availability>IS:2</availability>
+		<model name='WSP-100'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4248,6 +4260,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4255,9 +4270,6 @@
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine II' unitType='Mek'>
@@ -4268,13 +4280,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,CWOV:6,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,TC:5,DC:7</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4283,16 +4295,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,DC:5+,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,FWL:3+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:8,CFM:8,CGS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,DC:5+,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4339,36 +4351,36 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:4+,CS:8,LA:4+,CLAN:8,FWL:4+,NIOPS:8,FS:4+,DC:4+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:8,IS:3</availability>
+			<availability>CHH:4,General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4,General:2</availability>
+			<availability>CHH:8,CLAN:8,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:3,Periphery:1,TC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:6</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>LA:9</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:6+</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:6+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -587,17 +587,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CSR:3,CLAN:3,CCO:3,BAN:1,CGB:3</availability>
-		<model name='C 2'>
-			<availability>CLAN:4,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:6,CCO:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CSA:2,CLAN:6,CCO:2,BAN:8</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:6,CCO:6,BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:6,BAN:1</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -616,17 +616,17 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,CLAN:5,IS:8,Periphery.Deep:8,BAN:8,DC:7,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -640,23 +640,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -664,33 +648,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -708,11 +708,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:5</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -747,11 +747,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -759,11 +759,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:4,OA:4,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,OA:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -784,20 +784,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:4,IS:6,FS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:2+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:2+,CLAN:8,BAN:4</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:2+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -823,17 +823,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:4,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8-</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8-</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -886,34 +886,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:5,CHH:8,CLAN:6,FS:5,MERC:5,CS:7,CDS:6,LA:5,CNC:6,FWL:5,NIOPS:7,CJF:6,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -938,36 +938,36 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CC:2+,CLAN:6,DC:2+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:3,DC:3</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:2+,CLAN:6,DC:2+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,IS:3,Periphery.Deep:4,FS:4,MERC:2,Periphery:4</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='CNT-1A'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -996,18 +996,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:7,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:2+,CS:4,LA:2+,CLAN:2,BAN:2,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:4,CLAN:6,CGB:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CLAN:6,CGB:4</availability>
+		<model name='CHP-2N'>
+			<availability>IS:7,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:2+,CS:4,LA:2+,CLAN:2,BAN:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1026,16 +1026,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:4</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1047,14 +1047,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,CC:4,OA:3,LA:8,CLAN:4,FWL:5,MERC:4,FS:5,CIR:3,TC:3,Periphery:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:4,CLAN:6,FS:4,MERC:4,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:8,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:4,CLAN:6,FS:4,MERC:4,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1063,13 +1063,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1090,41 +1090,41 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1132,14 +1132,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1150,32 +1150,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1183,11 +1183,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1195,20 +1195,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1219,14 +1219,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:3-,OA:4,LA:5,CLAN:3-,IS:5,FWL:5,NIOPS:3-,FS:6,MERC:5,DC:5</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1259,13 +1259,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:2</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -1290,13 +1290,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:5,MOC:3,CLAN:4,IS:5,FS:4,CIR:1,BAN:4,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6,CLAN:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1330,29 +1330,29 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CC:3+,CLAN:8,FWL:3+,CGS:8,BAN:4</availability>
+			<availability>CS:8,CC:3+,LA:3+,CLAN:6,NIOPS:8,FWL:3+,BAN:8,DC:3+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:3+,LA:3+,CLAN:6,NIOPS:8,FWL:3+,BAN:8,DC:3+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:3+,CLAN:4,DC:3+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CC:3+,CLAN:8,FWL:3+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1366,11 +1366,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CRS-6C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1382,6 +1382,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1389,23 +1395,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:4,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:8,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:3,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1445,13 +1445,13 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:5</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
@@ -1477,12 +1477,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1519,13 +1519,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1553,18 +1553,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:3,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1584,10 +1584,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1595,6 +1591,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
@@ -1613,10 +1613,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:2+,CLAN:5,NIOPS:5,FS:2+,DC:2+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8,CGS:8,BAN:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
@@ -1625,43 +1621,47 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,CGS:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:2,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:6,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		<model name='EXT-4C'>
+			<availability>CLAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>CLAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:3,MOC:2,OA:2,CIH:6,LA:4,CLAN:4,FWL:3,FS:3,MERC:3,CGS:5,TC:2</availability>
-		<model name='FLC-4N'>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1673,34 +1673,34 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:2</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1722,12 +1722,12 @@
 		<model name='FFL-3PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>CC:8,FS:8</availability>
+		</model>
+		<model name='FFL-3PP3'>
+			<availability>BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
@@ -1737,70 +1737,67 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:6-</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:3,OA:3,Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:1-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1808,17 +1805,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1837,12 +1837,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:3,CHH:8,CW:8,LA:3,CLAN:8,FWL:3,FS:4,MERC:3,CJF:8,DC:3,CGB:8</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8,BAN:4</availability>
@@ -1893,14 +1893,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1908,6 +1900,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1919,17 +1919,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:5,CLAN:4</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:2,FWL:6,BAN:6</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:5,CLAN:4</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -1940,14 +1940,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -1959,13 +1959,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:7,CS:7,CHH:9,CSR:9,CLAN:9,IS:7,FWL:7,NIOPS:7,FS:6,MERC:7,DC:7</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -1986,25 +1986,25 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:4,CLAN:2,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:8,BAN:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:8,BAN:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:4,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2016,37 +2016,45 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2054,33 +2062,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2093,6 +2093,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:2,IS:2,NIOPS:4,BAN:4</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
@@ -2100,14 +2103,14 @@
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:6,DC:6,Periphery:5</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:2,IS:2,NIOPS:4,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
@@ -2115,9 +2118,6 @@
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2132,32 +2132,32 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:5,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:4</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:6</availability>
 		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,FWL:3+,BAN:4</availability>
 		</model>
-		<model name='HER-1A'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>:0,FWL:6</availability>
+			<availability>CS:8,General:5,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2171,17 +2171,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:4,MOC:3,CHH:4,OA:3,LA:4,CLAN:3,FWL:4,FS:4,CGS:5,DC:3,TC:4</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:1</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2205,20 +2205,20 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:2,CLAN:1,CGS:2,CCO:2,CGB:3</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2257,14 +2257,14 @@
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1A'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:8,CLAN:4</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='IMP-1A'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -2276,26 +2276,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4,CLAN:2</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4,CLAN:2</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:8,BAN:4</availability>
@@ -2328,48 +2328,48 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CS:3,NIOPS:3,FWL:3,FS:8,MERC:3,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:4,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2392,19 +2392,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2442,17 +2442,17 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:2+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:6</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
+		<model name='KGC-0000'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2460,11 +2460,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:2</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2476,22 +2476,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,Periphery.CM:3,Periphery.HR:2,Periphery.ME:3,TC:2</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2499,11 +2499,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:3</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2544,13 +2544,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,BAN:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:4,IS:2,NIOPS:4</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>CS:8,CLAN:8,IS:6,NIOPS:8,BAN:6,DC:6</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:4,IS:2,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2583,10 +2583,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2596,24 +2592,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:3,CS:5,CIH:9,LA:3,CLAN:8,FWL:3,NIOPS:5,FS:3,CJF:8,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -2634,6 +2634,10 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:3</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
@@ -2642,17 +2646,13 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,CLAN:4-,FS:7,BAN:6</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:3</availability>
+			<availability>LA:4,General:8,CLAN:4-,FS:7,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -2678,13 +2678,13 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2702,22 +2702,22 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:4+,CLAN:4,FWL:4+,DC:4+</availability>
-		<model name='LNX-8Q'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='LNX-9Q'>
 			<availability>CLAN:8,IS:5+</availability>
+		</model>
+		<model name='LNX-8Q'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2774,17 +2774,17 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:5,MOC:2+,CLAN:8,IS:3,FS:6,TC:3+,Periphery:2,CS:8,LA:6,FWL:5,NIOPS:8,DC:6,CGB:8</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:8,Periphery.Deep:8,TC:6</availability>
+		</model>
+		<model name='MAD-1R'>
+			<availability>CS:8,MOC:5,CLAN:4,IS:5+,NIOPS:8,MERC:0,BAN:4,TC:5+</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>CLAN:8,FS:3+,CGS:8,BAN:8</availability>
 		</model>
-		<model name='MAD-1R'>
-			<availability>CS:8,MOC:5,CLAN:4,IS:5+,NIOPS:8,MERC:0,BAN:4,TC:5+</availability>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2796,11 +2796,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -2812,14 +2812,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
@@ -2845,35 +2845,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2881,20 +2878,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2902,8 +2902,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2944,13 +2944,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:7,General:4,MERC:2,DC:7</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -2960,11 +2956,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:4,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:7,General:4,MERC:2,DC:7</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:7,General:4,MERC:2,DC:7</availability>
 		</model>
@@ -2992,21 +2992,21 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CJF:7,CGB:5,DC:5+</availability>
-		<model name='MON-70'>
-			<roles>recon</roles>
-			<availability>IS:3</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:9,CGS:9,BAN:4</availability>
 		</model>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>MOC:4,OA:4,FWL:4,NIOPS:0,MERC:4,FS:4,DC:4,TC:4</availability>
-		</model>
 		<model name='MON-69'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='MON-70'>
+			<roles>recon</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>MOC:4,OA:4,FWL:4,NIOPS:0,MERC:4,FS:4,DC:4,TC:4</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
@@ -3015,11 +3015,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mosquito Light Fighter' unitType='Conventional Fighter'>
@@ -3042,7 +3042,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3051,14 +3051,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
@@ -3070,13 +3070,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:3</availability>
-		<model name='(Block II)'>
-			<roles>destroyer</roles>
-			<availability>DC:5</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:7</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>destroyer</roles>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3153,12 +3153,12 @@
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3209,23 +3209,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:2+,CS:4,CW:3,CLAN:3,NIOPS:4,BAN:3</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3251,10 +3251,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3262,6 +3258,10 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
@@ -3278,32 +3278,32 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:8,FWL:8,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:3</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+,BAN:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:1+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:1+</availability>
 		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:6</availability>
+		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3392,11 +3392,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:2,CLAN:3,General:2</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:4,CNC:4</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:4</availability>
@@ -3407,6 +3407,10 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
@@ -3415,21 +3419,17 @@
 			<roles>fire_support</roles>
 			<availability>General:6,CLAN:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -3455,13 +3455,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:2+,CS:5,CHH:5,CSR:4,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:3+,CJF:4,DC:2+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:6,BAN:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:6,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -3477,9 +3477,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
@@ -3488,6 +3485,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:6</availability>
@@ -3522,11 +3522,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:8</availability>
@@ -3573,11 +3573,11 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
@@ -3611,23 +3611,23 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:6,DC:6</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:2</availability>
+		<model name='STN-1S'>
+			<availability>LA:1,FWL:1,FS:1</availability>
 		</model>
 		<model name='STN-3KB'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='STN-1S'>
-			<availability>LA:1,FWL:1,FS:1</availability>
+		<model name='STN-3KA'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3649,17 +3649,17 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:8,FS:3+,BAN:4</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:8,FS:3+,BAN:4</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3707,13 +3707,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:3+,LA:3+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3782,17 +3782,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3808,19 +3808,31 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A10'>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
@@ -3851,17 +3863,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,Periphery:2,TC:3,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:2</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:6,CGS:6</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:6,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -3876,15 +3888,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3928,11 +3940,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
-		<model name='THE-Nb'>
-			<availability>CLAN:8,CGS:8,BAN:4</availability>
-		</model>
 		<model name='THE-F'>
 			<availability>CC:2+,FWL:2+,FS:2+</availability>
+		</model>
+		<model name='THE-Nb'>
+			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:8,General:5+,CLAN:6,NIOPS:8,BAN:6</availability>
@@ -3940,12 +3952,12 @@
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+		<model name='TR-5'>
+			<availability>CC:2-</availability>
+		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='TR-5'>
-			<availability>CC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -3972,13 +3984,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,TC:7,Periphery:6,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>LA:3+,CLAN:5</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>LA:3+,CLAN:5</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3987,11 +3999,11 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:7,CSR:7,CDS:7,CW:7,CLAN:7,CNC:7,CJF:7,BAN:4,CGB:7</availability>
@@ -4018,20 +4030,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -4051,10 +4063,6 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
-		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:3+,CS:6,FWL:3+,NIOPS:6</availability>
@@ -4062,17 +4070,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,CIR:2,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
+		<model name='TRN-3U'>
+			<availability>IS:6-,Periphery:6-</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:4+,CLAN:6,IS:4+,NIOPS:8,Periphery.Deep:4+,BAN:8,Periphery:4+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:8,BAN:4</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4098,6 +4110,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -4105,10 +4121,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4155,13 +4167,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:6,CC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -4181,11 +4193,11 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4200,11 +4212,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CC:1,LA:1,CLAN:8,FWL:1,FS:1,DC:1</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CC:1,LA:1,CLAN:8,FWL:1,FS:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4215,13 +4227,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:3-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -4262,39 +4274,36 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:2+</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-100A'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:2</availability>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4327,6 +4336,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4335,19 +4347,16 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,DC:7,TC:5</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4356,16 +4365,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,BAN:8,DC:5+,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,FWL:3+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:8,CFM:8,CGS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,BAN:8,DC:5+,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4409,36 +4418,36 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:4+,CS:8,LA:4+,CLAN:8,FWL:4+,NIOPS:8,FS:4+,DC:4+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:8,IS:3,BAN:4</availability>
+			<availability>CHH:4,General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4,General:2</availability>
+			<availability>CHH:8,CLAN:8,IS:3,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:2,Periphery:1,TC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:6</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>LA:9</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:6+</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:6+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -552,13 +552,13 @@
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
 		</model>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,CLAN:4</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -591,17 +591,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:5</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -620,9 +620,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -632,21 +632,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:4,IS:8,Periphery.Deep:8,BAN:7,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
+		<model name='Mark VII-C'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='Mk.III'>
 			<availability>General:4</availability>
 		</model>
 		<model name='Mark VII'>
 			<availability>General:7</availability>
-		</model>
-		<model name='Mark VII-C'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -657,23 +657,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -681,33 +665,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -732,11 +732,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -771,11 +771,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,CLAN:4-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -783,11 +783,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:4,OA:4,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:4,OA:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -799,23 +799,23 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:2+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:2+,CLAN:8,BAN:4</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:2+</availability>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -853,17 +853,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:3,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:7,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:7,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -920,34 +920,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:4,CHH:8,CLAN:6,FS:4,MERC:4,CS:7,CDS:6,LA:4,CNC:6,FWL:4,NIOPS:7,CJF:6,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -976,36 +976,36 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CC:2+,CLAN:6,DC:2+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:3,DC:3</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:2+,CLAN:6,DC:2+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:3,IS:3,FS:4,MERC:2,Periphery:3</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='CNT-1A'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -1040,18 +1040,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:7,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:7,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1070,16 +1070,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:4</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1091,14 +1091,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:4,FWL:4,MERC:3,FS:4,CIR:2,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1107,13 +1107,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1134,41 +1134,41 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1176,14 +1176,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1194,32 +1194,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1227,11 +1227,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1239,20 +1239,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1263,14 +1263,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:3-,OA:4,LA:4,CLAN:3-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1303,13 +1303,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:2</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:6</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -1321,11 +1321,11 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1340,13 +1340,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:3,MOC:2,CLAN:2,IS:3,FS:3,CIR:1,BAN:3,TC:2,CS:6,OA:2,LA:3,FWL:3,NIOPS:6,DC:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6,CLAN:5</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,CLAN:7</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6,CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1380,11 +1380,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
@@ -1398,20 +1398,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
+			<availability>CS:8,CC:2+,LA:2+,CLAN:6,NIOPS:8,FWL:2+,BAN:8,DC:2+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:2+,LA:2+,CLAN:6,NIOPS:8,FWL:2+,BAN:8,DC:2+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:3+,CLAN:4,DC:3+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1419,11 +1419,11 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1435,6 +1435,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1442,23 +1448,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:3,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:7,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1498,16 +1498,16 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
@@ -1533,12 +1533,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1575,13 +1575,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1609,18 +1609,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:2,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1640,10 +1640,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1651,6 +1647,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
@@ -1669,10 +1669,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
@@ -1681,43 +1677,47 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:6,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1,CIH:6,LA:2,CLAN:4,FWL:1,FS:2,MERC:1,CGS:5,TC:1</availability>
-		<model name='FLC-4N'>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1729,30 +1729,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1784,20 +1784,16 @@
 		<model name='C'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>CC:8,FS:8</availability>
 		</model>
+		<model name='FFL-3PP3'>
+			<availability>BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -1808,60 +1804,61 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:6</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:3+,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:3,OA:3,Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 		<model name='FLE-14'>
 			<availability>FWL:1-</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1869,17 +1866,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1898,12 +1898,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:2,CHH:8,CW:8,LA:2,CLAN:7,FWL:2,FS:3,MERC:2,CJF:8,DC:2,CGB:8</availability>
-		<model name='(Fury II)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:4</availability>
@@ -1954,14 +1954,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1969,6 +1961,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1980,17 +1980,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:2,MOC:3,CLAN:8,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:8,LA:2,Periphery.MW:2,Periphery.ME:2,CNC:8,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:4,CLAN:3</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:2,FWL:5,BAN:4</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:4,CLAN:3</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -2013,14 +2013,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:2+,LA:2+,CLAN:6,FWL:2+,FS:2+,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -2032,13 +2032,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:9,CSR:9,CLAN:8,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:3,Periphery.ME:3,FWL:3,NIOPS:0,MERC:3</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2066,25 +2066,25 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:4,CLAN:2,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:7,BAN:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:5,CNC:5</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:4,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2099,21 +2099,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2124,21 +2124,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2146,33 +2154,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2185,18 +2185,18 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:2,MOC:3+,CLAN:5,IS:3,FS:3,TC:3+,CS:6,OA:3+,LA:3,CNC:5,FWL:2,NIOPS:6,DC:3</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:2,NIOPS:4,BAN:4</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='HCT-212'>
-			<availability>LA:6,IS:6,FS:6,Periphery:6</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:4+,DC:4+,Periphery:4+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:2,NIOPS:4,BAN:4</availability>
+		<model name='HCT-212'>
+			<availability>LA:6,IS:6,FS:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2204,15 +2204,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2227,32 +2227,32 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:3,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:8</availability>
 		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>CLAN:7,FWL:3+,BAN:4</availability>
 		</model>
-		<model name='HER-1A'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>:0,FWL:8</availability>
+			<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2266,14 +2266,14 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:3,MOC:1,CHH:4,OA:1,LA:3,CLAN:3,FWL:3,FS:3,CGS:5,DC:2,TC:3</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2304,20 +2304,20 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:4,CLAN:3,CGS:4,CCO:4,BAN:2,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2362,14 +2362,14 @@
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1A'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1A'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -2387,26 +2387,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:6,IS:3,FWL.OH:5,FS:4,CIR:2,TC:2,CS:6,OA:2,LA:4,CNC:6,FWL:5,NIOPS:6,DC:4</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4,CLAN:2</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:5,CNC:5</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4,CLAN:2</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2427,6 +2427,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2436,11 +2441,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2457,48 +2457,48 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FWL:3,FS:8,MERC:3,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:3,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2521,19 +2521,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2571,17 +2571,17 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:6</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
+		<model name='KGC-0000'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2589,11 +2589,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:2</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2605,22 +2605,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:1,MOC:2,Periphery.CM:2,Periphery.HR:1,Periphery.ME:2,TC:1</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2628,11 +2628,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2679,17 +2679,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:5</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8-</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:5+,NIOPS:8,BAN:6,DC:5+</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:2,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:5+,NIOPS:8,BAN:6,DC:5+</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2722,10 +2722,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2735,24 +2731,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:2+,CS:5,CIH:9,LA:2+,CLAN:8,FWL:2+,NIOPS:5,FS:2+,CJF:8,DC:2+</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -2771,18 +2771,22 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:5,CW:5,CLAN:5,CJF:5,CGB:5</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:3</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
@@ -2791,17 +2795,13 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,CLAN:4-,FS:7,BAN:6</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:3</availability>
+			<availability>LA:4,General:8,CLAN:4-,FS:7,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola II Destroyer' unitType='Warship'>
@@ -2813,24 +2813,24 @@
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8,CLAN:6</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2848,22 +2848,22 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:3,CLAN:4,FWL:3,DC:3</availability>
-		<model name='LNX-8Q'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='LNX-9Q'>
 			<availability>CLAN:8,IS:5+</availability>
+		</model>
+		<model name='LNX-8Q'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2920,23 +2920,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CLAN:7,IS:4,FS:5,TC:3+,Periphery:2,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:7</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:8,Periphery.Deep:8,TC:7</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:7,FS:3+,CGS:8,BAN:7</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:4,CLAN:4,IS:4+,NIOPS:8,MERC:0,BAN:4,TC:4+</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:7,FS:3+,CGS:8,BAN:7</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2954,11 +2954,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:2,Periphery.CM:2,IS:2-,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -2976,36 +2976,36 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CSJ:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -3017,35 +3017,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3053,20 +3050,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3074,8 +3074,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3134,13 +3134,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3150,11 +3146,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3186,13 +3186,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>MOC:6,OA:6,FWL:6,NIOPS:0,MERC:8,FS:6,DC:6,TC:6</availability>
-		</model>
 		<model name='MON-69'>
 			<roles>recon</roles>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>MOC:6,OA:6,FWL:6,NIOPS:0,MERC:8,FS:6,DC:6,TC:6</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
@@ -3201,11 +3201,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mosquito Light Fighter' unitType='Conventional Fighter'>
@@ -3228,7 +3228,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3237,14 +3237,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3263,13 +3263,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:2</availability>
-		<model name='(Block II)'>
-			<roles>destroyer</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>destroyer</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3357,22 +3357,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:7,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3412,13 +3412,13 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3427,23 +3427,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:1+,CS:4,CW:3,CLAN:3,NIOPS:4,BAN:3</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3469,14 +3469,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3484,6 +3476,14 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -3506,32 +3506,32 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:2+,MOC:2+,OA:2+,CLAN:4,FWL:2+,BAN:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:1+</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:1+</availability>
 		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:6</availability>
+		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3620,11 +3620,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:3</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:5,General:3+,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:4,CNC:4</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:5,General:3+,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -3635,6 +3635,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
@@ -3647,25 +3655,17 @@
 			<roles>fire_support</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:3,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
@@ -3697,13 +3697,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:2+,CS:5,CHH:5,CSR:4,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:2+,CJF:4,DC:2+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:5,BAN:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:5,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -3719,9 +3719,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:3,CS:4,OA:3,LA:3,CLAN:3,FWL:3,IS:3,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
@@ -3730,6 +3727,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
@@ -3764,11 +3764,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:8</availability>
@@ -3815,17 +3815,17 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3856,20 +3856,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:2-,CGS:5,CS:4,CDS:5,CW:5,LA:5-,CBS:5,FWL:2-,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:7,BAN:4</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3878,37 +3878,37 @@
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:8,FS:3+,BAN:4</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:8,FS:3+,BAN:4</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3922,11 +3922,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,CIH:3,CBS:3,CLAN:3,FWL:3+,CCO:3,CB:3</availability>
-		<model name='SHG-2H'>
-			<availability>General:8,CLAN:8,BAN:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='SHG-2H'>
+			<availability>General:8,CLAN:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -3964,28 +3964,28 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:3+,LA:3+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -4058,17 +4058,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4084,29 +4084,41 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A10'>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>CC:4,MOC:2,IS:2,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:2</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -4131,17 +4143,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,CC:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:2,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:5,CGS:5</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:5,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4169,15 +4181,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -4185,11 +4197,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4203,13 +4215,13 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -4243,12 +4255,12 @@
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+		<model name='TR-5'>
+			<availability>CC:2-</availability>
+		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='TR-5'>
-			<availability>CC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -4278,13 +4290,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4293,17 +4305,17 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:2+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:2+</availability>
-		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:7,CSR:7,CDS:7,CW:7,CLAN:7,CNC:7,CJF:7,BAN:4,CGB:7</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4327,20 +4339,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:8,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:8,LA:2,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -4354,19 +4366,15 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
-		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:2+,CS:6,FWL:2+,NIOPS:6</availability>
@@ -4374,17 +4382,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:3+,CLAN:6,IS:3+,NIOPS:8,BAN:8,Periphery:3+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4410,6 +4422,10 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:1</availability>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -4417,10 +4433,6 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4474,13 +4486,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:3-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:3-,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -4503,11 +4515,11 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4526,11 +4538,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4541,13 +4553,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:3-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -4588,39 +4600,36 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:2+</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-100A'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:2</availability>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
+		<model name='WSP-100A'>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4653,6 +4662,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4661,19 +4673,16 @@
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4689,16 +4698,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,CFM:6,BAN:8,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,FWL:3+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,CFM:7,CGS:7</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,CFM:6,BAN:8,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4736,39 +4745,39 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:2+,CS:8,LA:1+,CLAN:8,FWL:1+,NIOPS:8,FS:1+,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:7,IS:3,BAN:4</availability>
+			<availability>CHH:4,General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4,General:2</availability>
+			<availability>CHH:8,CLAN:7,IS:3,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:2</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:5</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:3+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:3+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -552,13 +552,13 @@
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
 		</model>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,CLAN:2</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -591,17 +591,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -620,9 +620,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -632,21 +632,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:6,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
+		<model name='Mark VII-C'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='Mk.III'>
 			<availability>General:2</availability>
 		</model>
 		<model name='Mark VII'>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mark VII-C'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -657,23 +657,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -681,33 +665,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -732,11 +732,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -771,11 +771,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -783,11 +783,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:3,OA:3,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:3,OA:3,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -799,26 +799,26 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:1+,CLAN:8,BAN:4</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1G-DC'>
 			<availability>IS:2,MERC:0</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:1+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -856,17 +856,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -923,34 +923,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:3,CHH:8,CLAN:5,FS:3,MERC:3,CS:7,CDS:5,LA:3,CNC:5,FWL:3,NIOPS:7,CJF:5,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -979,36 +979,36 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CC:1+,CLAN:6,DC:1+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:2,DC:2</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:1+,CLAN:6,DC:1+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:3,IS:2,FS:4,MERC:2,Periphery:3</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='CNT-1A'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -1043,18 +1043,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1073,16 +1073,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1094,14 +1094,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1110,13 +1110,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1137,41 +1137,41 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1179,14 +1179,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1197,32 +1197,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1230,11 +1230,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1242,20 +1242,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1266,14 +1266,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1313,13 +1313,13 @@
 	</chassis>
 	<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
 		<availability>LA:1</availability>
-		<model name='(Block II)'>
-			<roles>cruiser</roles>
-			<availability>LA:3</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>cruiser</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>cruiser</roles>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Concordat Frigate' unitType='Warship'>
@@ -1331,11 +1331,11 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1350,13 +1350,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6,CLAN:4</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1390,11 +1390,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
@@ -1417,20 +1417,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:2+,CLAN:3,DC:2+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1438,11 +1438,11 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:3+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1454,6 +1454,12 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1461,23 +1467,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:4,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1517,16 +1517,16 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
@@ -1552,12 +1552,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1594,13 +1594,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:3</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1628,18 +1628,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:2,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1659,10 +1659,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1670,6 +1666,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
@@ -1688,10 +1688,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
@@ -1700,43 +1696,47 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1,CIH:5,LA:2,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
-		<model name='FLC-4N'>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1748,30 +1748,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1803,20 +1803,16 @@
 		<model name='C'>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>CC:8,FS:8</availability>
 		</model>
+		<model name='FFL-3PP3'>
+			<availability>BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -1827,57 +1823,58 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:7</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:2,OA:2,Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
-		<model name='FLE-4'>
-			<availability>MOC:8,OA:8,FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1885,17 +1882,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1914,12 +1914,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:1,CHH:8,CW:8,LA:1,CLAN:7,FWL:1,FS:2,MERC:1,CJF:8,DC:1,CGB:8</availability>
-		<model name='(Fury II)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:3</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:4</availability>
@@ -1970,14 +1970,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1985,6 +1977,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1996,17 +1996,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:4,CLAN:2</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:2,FWL:4,BAN:3</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:4,CLAN:2</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -2029,14 +2029,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:2+,LA:2+,CLAN:6,FWL:2+,FS:2+,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -2048,13 +2048,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>FWL:6,NIOPS:0,MERC:6</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>FWL:6,NIOPS:0,MERC:6</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2082,25 +2082,25 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:3,CLAN:2,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:7,BAN:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:3,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2115,21 +2115,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2140,21 +2140,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2162,33 +2170,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2201,18 +2201,18 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:3,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:6,BAN:3</availability>
-		</model>
-		<model name='HCT-212'>
-			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:4+,DC:4+,Periphery:3+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2220,15 +2220,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2243,32 +2243,32 @@
 			<roles>recon</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:8</availability>
 		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>CLAN:6,FWL:2+,BAN:3</availability>
 		</model>
-		<model name='HER-1A'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>:0,FWL:8</availability>
+			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2288,14 +2288,14 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:5,BAN:2</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2332,23 +2332,23 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:4,CLAN:3,CGS:4,CCO:4,BAN:2,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2393,14 +2393,14 @@
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1A'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1A'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -2418,26 +2418,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:5,IS:3,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4,CLAN:2</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4,CLAN:2</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2458,6 +2458,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2467,11 +2472,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2488,48 +2488,48 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FWL:2,FS:8,MERC:3,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:3,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2552,19 +2552,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2602,17 +2602,17 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:7</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
+		<model name='KGC-0000'>
+			<availability>IS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2620,11 +2620,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:4</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2636,22 +2636,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:1,MOC:2,Periphery.CM:2,Periphery.HR:1,Periphery.ME:2,TC:1</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2659,11 +2659,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2703,17 +2703,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8-</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:1,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2746,10 +2746,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2759,24 +2755,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:1+,CS:5,CIH:9,LA:1+,CLAN:8,FWL:1+,NIOPS:5,FS:1+,CJF:8,DC:1+</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:5</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -2795,18 +2795,22 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:2</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
@@ -2815,17 +2819,13 @@
 			<roles>recon</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,CLAN:2-,FS:7,BAN:5</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:2</availability>
+			<availability>LA:4,General:8,CLAN:2-,FS:7,BAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola II Destroyer' unitType='Warship'>
@@ -2837,24 +2837,24 @@
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8,CLAN:4</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2872,35 +2872,35 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CCO:6</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:2,CLAN:4,FWL:2,DC:2</availability>
-		<model name='LNX-8Q'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='LNX-9Q'>
 			<availability>CLAN:8,IS:4+</availability>
+		</model>
+		<model name='LNX-8Q'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2957,23 +2957,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:8,Periphery.Deep:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:6,FS:2+,CGS:7,BAN:6</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:3,CLAN:4,IS:3+,NIOPS:8,MERC:0,BAN:4,TC:3+</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:6,FS:2+,CGS:7,BAN:6</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2991,11 +2991,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3013,36 +3013,36 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CSJ:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -3054,35 +3054,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3090,20 +3087,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3111,8 +3111,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3164,13 +3164,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3180,11 +3176,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3216,13 +3216,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>MOC:6,OA:6,FWL:6,NIOPS:0,MERC:8,FS:6,DC:6,TC:6</availability>
-		</model>
 		<model name='MON-69'>
 			<roles>recon</roles>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>MOC:6,OA:6,FWL:6,NIOPS:0,MERC:8,FS:6,DC:6,TC:6</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
@@ -3231,11 +3231,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -3252,7 +3252,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3261,14 +3261,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3287,13 +3287,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:1</availability>
-		<model name='(Block II)'>
-			<roles>destroyer</roles>
-			<availability>DC:3</availability>
-		</model>
 		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Block II)'>
+			<roles>destroyer</roles>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3381,22 +3381,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3436,13 +3436,13 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3451,23 +3451,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:1+,CS:4,CW:3,CLAN:3,NIOPS:4,BAN:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3493,14 +3493,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3509,15 +3501,23 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:6,CSJ:8,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -3544,9 +3544,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -3555,18 +3567,6 @@
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3655,11 +3655,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -3670,6 +3670,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
@@ -3682,25 +3690,17 @@
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
@@ -3732,13 +3732,13 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:5,BAN:7</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:5,BAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
@@ -3754,9 +3754,6 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
@@ -3765,6 +3762,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
@@ -3799,11 +3799,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:7</availability>
@@ -3844,17 +3844,17 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,Periphery.Deep:8,FS:8,DC:8,Periphery:8</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3885,20 +3885,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:6,BAN:3</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:6,BAN:3</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3907,37 +3907,37 @@
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:6,FS:2+,BAN:4</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:6,FS:2+,BAN:4</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3951,11 +3951,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:2+,CCO:4,CB:4</availability>
-		<model name='SHG-2H'>
-			<availability>General:8,CLAN:6-,BAN:7</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='SHG-2H'>
+			<availability>General:8,CLAN:6-,BAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -3993,28 +3993,28 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:2+,LA:2+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -4087,14 +4087,14 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4110,29 +4110,41 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A10'>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -4153,17 +4165,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:4,CGS:4</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:4,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4191,15 +4203,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -4207,11 +4219,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4225,13 +4237,13 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -4259,12 +4271,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4310,13 +4322,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4325,17 +4337,17 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:1+</availability>
-		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:6,CSR:6,CDS:6,CW:6,CLAN:6,CNC:6,CJF:6,BAN:4,CGB:6</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4359,20 +4371,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -4386,19 +4398,15 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
-		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
@@ -4406,17 +4414,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4491,13 +4503,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -4520,11 +4532,11 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4543,11 +4555,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4558,13 +4570,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:2-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -4605,36 +4617,33 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:1+</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4667,6 +4676,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4675,19 +4687,16 @@
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4703,16 +4712,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:2+,FWL:2+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,CFM:6,CGS:6</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4750,39 +4759,39 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:2+,CS:8,LA:1+,CLAN:8,FWL:1+,NIOPS:8,FS:1+,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:7,IS:2,BAN:4</availability>
+			<availability>CHH:4,General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4,General:1</availability>
+			<availability>CHH:8,CLAN:7,IS:2,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:4</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:2+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:2+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -546,13 +546,13 @@
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
 		</model>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,CLAN:1</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -585,17 +585,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -614,9 +614,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -626,21 +626,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:6,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
+		<model name='Mark VII-C'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='Mk.III'>
 			<availability>General:2</availability>
 		</model>
 		<model name='Mark VII'>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mark VII-C'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -651,23 +651,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -675,33 +659,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -726,11 +726,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -758,11 +758,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -770,35 +770,35 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:3,OA:3,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:3,OA:3,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:1+,CLAN:8,BAN:4</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1G-DC'>
 			<availability>IS:2,MERC:0</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:1+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -836,17 +836,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -897,34 +897,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:2,CHH:8,CLAN:5,FS:2,MERC:2,CS:7,CDS:5,LA:2,CNC:5,FWL:2,NIOPS:7,CJF:5,DC:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -947,36 +947,36 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CC:1+,CLAN:6,DC:1+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:2,DC:2</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:1+,CLAN:6,DC:1+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:3,IS:2,FS:4,MERC:2,Periphery:3</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='CNT-1A'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -1011,18 +1011,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1041,16 +1041,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1062,14 +1062,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:3,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1078,13 +1078,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1105,41 +1105,41 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1147,14 +1147,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1165,32 +1165,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1198,11 +1198,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1210,20 +1210,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1234,14 +1234,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1281,11 +1281,11 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1300,13 +1300,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6,CLAN:3</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,CLAN:5</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6,CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1333,11 +1333,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
@@ -1360,20 +1360,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:2+,CLAN:3,DC:2+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1381,15 +1381,21 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:3+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1397,23 +1403,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:4,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1446,10 +1446,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -1457,18 +1453,22 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1505,13 +1505,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:3</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1532,18 +1532,18 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:2,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1563,10 +1563,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1575,16 +1571,20 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:6,IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1596,10 +1596,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
@@ -1608,43 +1604,47 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1,CIH:5,LA:2,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
-		<model name='FLC-4N'>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1656,30 +1656,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1711,20 +1711,16 @@
 		<model name='C'>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>CC:8,FS:8</availability>
 		</model>
+		<model name='FFL-3PP3'>
+			<availability>BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -1735,57 +1731,58 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:7</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:2,OA:2,Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
-		<model name='FLE-4'>
-			<availability>MOC:8,OA:8,FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1793,17 +1790,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1822,12 +1822,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:1,CHH:8,CW:8,LA:1,CLAN:6,FWL:1,FS:1,MERC:1,CJF:8,DC:1,CGB:8</availability>
-		<model name='(Fury II)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:3</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:4</availability>
@@ -1878,14 +1878,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1893,6 +1885,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1910,17 +1910,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:3,CLAN:2</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:2,FWL:4,BAN:3</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:3,CLAN:2</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -1943,14 +1943,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:1+,LA:1+,CLAN:6,FWL:1+,FS:1+,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -1962,13 +1962,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>FWL:7,NIOPS:0,MERC:7</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>FWL:7,NIOPS:0,MERC:7</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -1996,25 +1996,25 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:3,CLAN:2,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:7,BAN:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:3,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2029,21 +2029,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2054,21 +2054,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2076,33 +2084,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2115,18 +2115,18 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:2,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:6,BAN:3</availability>
-		</model>
-		<model name='HCT-212'>
-			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:4+,DC:4+,Periphery:2+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2134,15 +2134,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2157,32 +2157,32 @@
 			<roles>recon</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:8</availability>
 		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>CLAN:6,FWL:2+,BAN:3</availability>
 		</model>
-		<model name='HER-1A'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>:0,FWL:8</availability>
+			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2202,14 +2202,14 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:5,BAN:2</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2246,23 +2246,23 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:4,CLAN:3,CGS:4,CCO:4,BAN:2,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2310,14 +2310,14 @@
 		<model name='C'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='IMP-1A'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1A'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -2335,26 +2335,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:2,MOC:2,CLAN:5,IS:2,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4,CLAN:2</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4,CLAN:2</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2375,6 +2375,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2384,11 +2389,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2405,48 +2405,48 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FWL:2,FS:8,MERC:3,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:3,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2469,19 +2469,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2519,17 +2519,17 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:7</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
+		<model name='KGC-0000'>
+			<availability>IS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2537,11 +2537,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:5</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2553,22 +2553,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:1,MOC:2,Periphery.CM:2,Periphery.HR:1,Periphery.ME:2,TC:1</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2576,11 +2576,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2620,17 +2620,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8-</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:1,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
@@ -2652,10 +2652,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2665,24 +2661,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:1+,CS:5,CIH:9,LA:1+,CLAN:8,FWL:1+,NIOPS:5,FS:1+,CJF:8,DC:1+</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:5</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -2701,18 +2701,22 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:2</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
@@ -2721,17 +2725,13 @@
 			<roles>recon</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,CLAN:2-,FS:7,BAN:5</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:2</availability>
+			<availability>LA:4,General:8,CLAN:2-,FS:7,BAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola II Destroyer' unitType='Warship'>
@@ -2743,24 +2743,24 @@
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8,CLAN:3</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2778,35 +2778,35 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:2,CCO:6</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:2,CLAN:4,FWL:2,DC:2</availability>
-		<model name='LNX-8Q'>
-			<availability>LA:3</availability>
-		</model>
 		<model name='LNX-9Q'>
 			<availability>CLAN:8,IS:4+</availability>
+		</model>
+		<model name='LNX-8Q'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2856,23 +2856,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:8,Periphery.Deep:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:6,FS:2+,CGS:7,BAN:6</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:3,CLAN:4,IS:2+,NIOPS:8,MERC:0,BAN:4,TC:3+</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:6,FS:2+,CGS:7,BAN:6</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2890,11 +2890,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -2912,36 +2912,36 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CSJ:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -2953,35 +2953,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2989,20 +2986,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3010,8 +3010,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3063,13 +3063,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3079,11 +3075,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3115,13 +3115,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>MOC:5,OA:5,FWL:5,NIOPS:0,MERC:8,FS:5,DC:5,TC:5</availability>
-		</model>
 		<model name='MON-69'>
 			<roles>recon</roles>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>MOC:5,OA:5,FWL:5,NIOPS:0,MERC:8,FS:5,DC:5,TC:5</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
@@ -3130,11 +3130,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -3151,7 +3151,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3160,14 +3160,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3232,11 +3232,11 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,CIR:4</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -3272,22 +3272,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3327,13 +3327,13 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3342,23 +3342,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:1+,CS:4,CW:3,CLAN:3,NIOPS:4,BAN:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3384,14 +3384,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3400,15 +3392,23 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:6,CSJ:8,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -3435,9 +3435,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -3446,18 +3458,6 @@
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3543,11 +3543,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -3558,6 +3558,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
@@ -3570,25 +3578,17 @@
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
@@ -3620,20 +3620,17 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:4,BAN:7</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:4,BAN:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
@@ -3642,6 +3639,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
@@ -3676,11 +3676,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:7</availability>
@@ -3710,17 +3710,17 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,Periphery.Deep:8,FS:8,DC:8,Periphery:8</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3751,20 +3751,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:6,BAN:3</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:6,BAN:3</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3773,37 +3773,37 @@
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:6,FS:2+,BAN:4</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:6,FS:2+,BAN:4</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3817,11 +3817,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:2+,CCO:4,CB:4</availability>
-		<model name='SHG-2H'>
-			<availability>General:8,CLAN:4-,BAN:7</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='SHG-2H'>
+			<availability>General:8,CLAN:4-,BAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -3859,28 +3859,28 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:2+,LA:2+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3946,14 +3946,14 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3969,29 +3969,41 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM Mk I' unitType='Mek'>
+		<availability>IS:1</availability>
+	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A10'>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -4012,17 +4024,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:4,CGS:4</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:4,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4050,15 +4062,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -4066,11 +4078,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4084,13 +4096,13 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -4111,12 +4123,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4162,13 +4174,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4177,17 +4189,17 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:1+</availability>
-		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:6,CSR:6,CDS:6,CW:6,CLAN:6,CNC:6,CJF:6,BAN:4,CGB:6</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4211,20 +4223,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -4238,18 +4250,17 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		<model name='TBT-5S'>
+			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
@@ -4258,20 +4269,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>FWL:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4346,13 +4358,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -4368,11 +4380,11 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4391,11 +4403,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4406,13 +4418,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:2-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -4447,36 +4459,33 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:1+</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4509,6 +4518,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:5</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4517,19 +4529,16 @@
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4545,16 +4554,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:2+,FWL:2+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,CFM:6,CGS:6</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4592,39 +4601,39 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:2+,CS:8,LA:1+,CLAN:8,FWL:1+,NIOPS:8,FS:1+,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:7,IS:2,BAN:4</availability>
+			<availability>CHH:4,General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,CLAN:5,General:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4,General:1</availability>
+			<availability>CHH:8,CLAN:7,IS:2,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:4</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:2+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:2+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -550,13 +550,13 @@
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
 		</model>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,CLAN:1</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -589,17 +589,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -618,9 +618,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,IS:7,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -630,21 +630,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:5,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
+		<model name='Mark VII-C'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='Mk.III'>
 			<availability>General:1</availability>
 		</model>
 		<model name='Mark VII'>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mark VII-C'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -655,23 +655,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -679,33 +663,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -723,11 +723,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -755,11 +755,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:6,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -767,35 +767,35 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:2,OA:2,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2,OA:2,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:1+,CLAN:8,BAN:4</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1G-DC'>
 			<availability>IS:2,MERC:0</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:1+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -833,17 +833,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -894,34 +894,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:2+,CHH:8,CLAN:4,FS:2+,MERC:2+,CS:7,CDS:4,LA:2+,CNC:4,FWL:2+,NIOPS:7,CJF:4,DC:2+</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:6,BAN:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -944,36 +944,36 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CC:1+,CLAN:6,DC:1+</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:2,DC:1</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:1+,CLAN:6,DC:1+</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:3,IS:1,FS:4,MERC:2,Periphery:3</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='CNT-1A'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -992,10 +992,10 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
@@ -1014,18 +1014,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1044,16 +1044,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1065,14 +1065,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1081,13 +1081,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1108,41 +1108,41 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1150,14 +1150,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1168,32 +1168,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1201,11 +1201,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1213,20 +1213,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1237,14 +1237,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1284,11 +1284,11 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1303,13 +1303,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,CLAN:4</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1336,11 +1336,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
@@ -1363,20 +1363,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:1+,CLAN:3,DC:1+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1384,15 +1384,21 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1400,23 +1406,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:3,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1449,10 +1449,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -1460,18 +1456,22 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1508,13 +1508,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:3</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1535,30 +1535,30 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='EGL-R9'>
-			<availability>LA:4,General:2,FS:4</availability>
-		</model>
-		<model name='EGL-R10'>
-			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:8,FS:4</availability>
 		</model>
+		<model name='EGL-R10'>
+			<roles>ground_support</roles>
+			<availability>LA:4,General:2,FS:4</availability>
+		</model>
+		<model name='EGL-R4'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CW:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1578,10 +1578,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1590,16 +1586,20 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:4,IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1611,10 +1611,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
@@ -1623,43 +1619,47 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1,CIH:5,LA:1,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
-		<model name='FLC-4N'>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1671,30 +1671,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1726,20 +1726,16 @@
 		<model name='C'>
 			<availability>CLAN:7,BAN:2</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>CC:8,FS:8</availability>
 		</model>
+		<model name='FFL-3PP3'>
+			<availability>BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -1750,57 +1746,58 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:7</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:1,OA:1,Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
-		<model name='FLE-4'>
-			<availability>MOC:8,OA:8,FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1808,17 +1805,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1837,12 +1837,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CC:1,CHH:8,CW:8,LA:1,CLAN:6,FWL:1,FS:1,MERC:1,CJF:8,DC:1,CGB:8</availability>
-		<model name='(Fury II)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:4</availability>
@@ -1893,14 +1893,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -1908,6 +1900,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -1925,17 +1925,17 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9,DC:1</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:3,CLAN:2</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:2,FWL:3,BAN:3</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:3,CLAN:2</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -1958,14 +1958,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:1+,LA:1+,CLAN:6,FWL:1+,FS:1+,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -1977,13 +1977,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>FWL:7,NIOPS:0,MERC:7</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>FWL:7,NIOPS:0,MERC:7</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2011,25 +2011,25 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:2,CLAN:2,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:7,BAN:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:2,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2044,21 +2044,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2069,21 +2069,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2091,33 +2099,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2130,18 +2130,18 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:5,BAN:3</availability>
-		</model>
-		<model name='HCT-212'>
-			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:4+,DC:4+,Periphery:1+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2149,15 +2149,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2172,32 +2172,32 @@
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:2,CC:1,CS:3,CHH:5,OA:2,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:1,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:1+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:8</availability>
 		</model>
 		<model name='HER-1Sb'>
 			<roles>recon</roles>
 			<availability>CLAN:5,FWL:1+,BAN:3</availability>
 		</model>
-		<model name='HER-1A'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>:0,FWL:8</availability>
+			<availability>CS:8,General:1+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2208,32 +2208,32 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:2,NIOPS:9,IS:1,CFM:10,MERC:1,FS:1,CJF:10,DC:2</availability>
+		<model name='HGN-733'>
+			<availability>CC:6-,:0,LA:6-</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:3,:0,LA:3</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:7,FWL:1+,BAN:4</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:3-,:0,LA:3-</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:6-,:0,LA:6-</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>CC:2+,MOC:1+,CS:8,LA:2+,CLAN:6,FWL:2+,IS:1+,NIOPS:8,FS:2+,MERC:1+,BAN:8,DC:2+</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:3-,:0,LA:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:5,BAN:2</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2270,23 +2270,23 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:4,CLAN:3,CGS:4,CCO:4,BAN:2,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2334,14 +2334,14 @@
 		<model name='C'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='IMP-1A'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1A'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -2359,26 +2359,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CC:1,MOC:1,CLAN:5,IS:1,FWL.OH:4,FS:2,CIR:1,TC:1,CS:6,OA:2,LA:2,CNC:5,FWL:3,NIOPS:6,DC:2</availability>
-		<model name='IRN-SD2'>
-			<availability>General:4,CLAN:2</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:3,CNC:3</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:4,CLAN:2</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2399,6 +2399,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,CIR:4,TC:4,Periphery:2</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2408,11 +2413,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2429,14 +2429,6 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
@@ -2445,36 +2437,44 @@
 			<roles>recon,raider</roles>
 			<availability>General:5,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FWL:2,FS:8,MERC:3,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:3,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2497,19 +2497,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2547,17 +2547,17 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:7</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
+		<model name='KGC-0000'>
+			<availability>IS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2565,11 +2565,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2581,22 +2581,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:1,MOC:2,Periphery.CM:2,Periphery.HR:1,Periphery.ME:2,TC:1</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2604,11 +2604,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2648,17 +2648,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8-</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:1,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
@@ -2680,10 +2680,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2693,24 +2689,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:1+,CS:5,CIH:9,LA:1+,CLAN:8,FWL:1+,NIOPS:5,FS:1+,CJF:8,DC:1+</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:3,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -2729,18 +2729,22 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:2</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
@@ -2749,39 +2753,35 @@
 			<roles>recon</roles>
 			<availability>FS:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,CLAN:1-,FS:7,BAN:5</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:2</availability>
+			<availability>LA:4,General:8,CLAN:1-,FS:7,BAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8,CLAN:2</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -2799,35 +2799,35 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:3,CCO:8</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:1,CLAN:4,FWL:1,DC:1</availability>
-		<model name='LNX-8Q'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='LNX-9Q'>
 			<availability>CLAN:8,IS:3+</availability>
+		</model>
+		<model name='LNX-8Q'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2877,23 +2877,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:8,Periphery.Deep:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:6,FS:1+,CGS:7,BAN:6</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:2,CLAN:4,IS:1+,NIOPS:8,MERC:0,BAN:4,TC:2+</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:6,FS:1+,CGS:7,BAN:6</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2911,11 +2911,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -2933,36 +2933,36 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CSJ:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:2</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -2974,35 +2974,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3010,20 +3007,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3031,8 +3031,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3084,13 +3084,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3100,11 +3096,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3136,13 +3136,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>MOC:4,OA:4,FWL:4,NIOPS:0,MERC:8,FS:4,DC:4,TC:4</availability>
-		</model>
 		<model name='MON-69'>
 			<roles>recon</roles>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>MOC:4,OA:4,FWL:4,NIOPS:0,MERC:8,FS:4,DC:4,TC:4</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
@@ -3151,11 +3151,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -3172,7 +3172,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3181,14 +3181,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3253,15 +3253,15 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,CIR:4</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -3297,22 +3297,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3352,13 +3352,13 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6,DC:4</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6,DC:4</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3367,23 +3367,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:1+,CS:4,CW:3,CLAN:3,NIOPS:4,BAN:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3409,14 +3409,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3425,15 +3417,23 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:6,CSJ:8,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -3457,9 +3457,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -3468,18 +3480,6 @@
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3565,11 +3565,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -3580,6 +3580,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
@@ -3592,25 +3600,17 @@
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
@@ -3642,20 +3642,17 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:4,BAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:4,BAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
 		</model>
@@ -3664,6 +3661,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
@@ -3698,11 +3698,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:7</availability>
@@ -3732,17 +3732,17 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,Periphery.Deep:8,FS:8,DC:8,Periphery:8</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3773,20 +3773,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:5,BAN:3</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:5,BAN:3</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -3795,37 +3795,37 @@
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:6,FS:1+,BAN:4</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:6,FS:1+,BAN:4</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3839,11 +3839,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:2+,CCO:4,CB:4</availability>
-		<model name='SHG-2H'>
-			<availability>General:8,CLAN:2-,BAN:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='SHG-2H'>
+			<availability>General:8,CLAN:2-,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -3881,28 +3881,28 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:1+,LA:1+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3968,14 +3968,14 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3991,29 +3991,38 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A10'>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -4034,17 +4043,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:3,CGS:3</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:3,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4072,15 +4081,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -4088,11 +4097,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4106,13 +4115,13 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8,CLAN:2</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -4133,12 +4142,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4184,13 +4193,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CLAN:3</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4199,17 +4208,17 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:1+</availability>
-		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:6,CSR:6,CDS:6,CW:6,CLAN:6,CNC:6,CJF:6,BAN:4,CGB:6</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4233,20 +4242,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -4260,18 +4269,17 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,FWL:4,MERC:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
@@ -4280,20 +4288,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,FWL:4,MERC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4368,13 +4377,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -4390,11 +4399,11 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4413,11 +4422,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4428,13 +4437,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:2-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -4469,36 +4478,33 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:1+</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:2</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4531,6 +4537,9 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:4</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4539,19 +4548,16 @@
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4560,11 +4566,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:8,CLAN:4-</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -4576,16 +4582,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:1+,FWL:1+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:5,CFM:6,CGS:6</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4623,39 +4629,39 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:2+,CS:8,LA:1+,CLAN:8,FWL:1+,NIOPS:8,FS:1+,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:7,IS:1,BAN:4</availability>
+			<availability>CHH:4,General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,CLAN:4,General:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4,General:1</availability>
+			<availability>CHH:8,CLAN:7,IS:1,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:4</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:1+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:1+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -541,13 +541,13 @@
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
 		</model>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -580,17 +580,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -609,9 +609,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -621,21 +621,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:5,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
+		<model name='Mark VII-C'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='Mk.III'>
 			<availability>General:1</availability>
 		</model>
 		<model name='Mark VII'>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mark VII-C'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -646,23 +646,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -670,33 +654,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -721,11 +721,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -733,11 +733,11 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -745,14 +745,14 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
@@ -771,11 +771,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -790,20 +790,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,CW:3,CLAN:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -813,7 +813,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,CLAN:3</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -821,62 +829,54 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>MOC:2,OA:2,FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2,OA:2,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CBS:5,CSV:6,CGS:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:4</availability>
+		<model name='BLR-1Gd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1G-DC'>
 			<availability>IS:2,MERC:0</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gd'>
-			<availability>FS:1+</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -917,11 +917,11 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -932,17 +932,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1000,34 +1000,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:1+,CHH:8,CLAN:4,FS:1+,MERC:1+,CS:7,CDS:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:4,DC:1+</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:6,BAN:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -1057,48 +1057,48 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:5,CLAN:2,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FWL:2,DC:1</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:3,IS:1,FS:4,MERC:2,Periphery:3</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:4</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
@@ -1113,10 +1113,10 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
@@ -1135,18 +1135,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1165,16 +1165,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1186,14 +1186,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1,CLAN:6,FS:1,MERC:1,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:1,CLAN:6,FS:1,MERC:1,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1202,13 +1202,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1229,20 +1229,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -1253,23 +1253,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1277,14 +1277,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1295,32 +1295,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1328,11 +1328,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1340,20 +1340,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1364,14 +1364,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:2,CS:3-,OA:2,LA:4,CLAN:1-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
+		<model name='CLNT-2-3T'>
+			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1411,11 +1411,11 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1430,13 +1430,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:1,CS:6,LA:1,CLAN:2,FWL:1,IS:1,NIOPS:6,FS:1,BAN:3,DC:1,TC:1</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1467,11 +1467,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
@@ -1494,20 +1494,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:1+,CLAN:3,DC:1+</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1515,27 +1515,33 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:4,CSV:6</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1543,23 +1549,17 @@
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,CLAN:3,IS:3,FS:5,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1592,10 +1592,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -1603,25 +1599,29 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CHH:4,CCC:6,CIH:3,CDS:3,CLAN:3,CCO:3,CJF:3,BAN:2,CGB:9,CB:6</availability>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -1629,12 +1629,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1668,13 +1668,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:2</availability>
-		<model name='(Command)'>
-			<roles>troop_carrier</roles>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Command)'>
+			<roles>troop_carrier</roles>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1695,25 +1695,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='EGL-R9'>
-			<availability>LA:4,General:2,FS:4</availability>
-		</model>
-		<model name='EGL-R10'>
-			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:8,FS:4</availability>
 		</model>
+		<model name='EGL-R10'>
+			<roles>ground_support</roles>
+			<availability>LA:4,General:2,FS:4</availability>
+		</model>
+		<model name='EGL-R4'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:3,CLAN:2</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -1725,8 +1724,9 @@
 			<roles>marine</roles>
 			<availability>CSR:3,CLAN:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:3,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1746,10 +1746,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1758,6 +1754,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CIH:3+,CGS:3+</availability>
@@ -1765,12 +1765,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -1780,13 +1780,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1798,10 +1798,6 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
@@ -1810,43 +1806,47 @@
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:4,BAN:3</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1,CIH:5,LA:1,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
-		<model name='FLC-4N'>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1858,30 +1858,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1913,20 +1913,16 @@
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3A'>
 			<roles>spotter</roles>
 			<availability>CC:8,FS:8</availability>
 		</model>
+		<model name='FFL-3PP3'>
+			<availability>BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -1937,57 +1933,58 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:1,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:1,OA:1,Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
-		<model name='FLE-4'>
-			<availability>MOC:8,OA:8,FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MOC:3,OA:3,FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -1995,17 +1992,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2024,12 +2024,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CHH:7,CW:7,CLAN:5,CJF:7,CGB:7</availability>
-		<model name='(Fury II)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:4</availability>
@@ -2066,12 +2066,12 @@
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='GAL-200'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -2083,14 +2083,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,TC:3,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -2098,6 +2090,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -2109,26 +2109,26 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:7,CLAN:5</availability>
-		<model name='2'>
-			<availability>CSV:4,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:4,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>MOC:1,CS:9,CDS:7,Periphery.MW:1,CLAN:7,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:2,CLAN:2</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:2,FWL:3,BAN:3</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:2,CLAN:2</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -2151,14 +2151,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:5,CLAN:3,IS:9,Periphery.Deep:6,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -2176,13 +2176,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>FWL:8,NIOPS:0,MERC:8</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4,Periphery:2</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>FWL:8,NIOPS:0,MERC:8</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2210,25 +2210,25 @@
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:1,CLAN:2,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:7,BAN:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:1,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2243,21 +2243,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2268,21 +2268,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2290,33 +2298,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2329,18 +2329,18 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:5,BAN:3</availability>
-		</model>
-		<model name='HCT-212'>
-			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:4+,DC:4+,Periphery:1+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2348,15 +2348,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2371,44 +2371,44 @@
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:1,CC:1,CS:3,CHH:5,OA:1,CLAN:4,FWL:3,NIOPS:3,CGB:5,DC:1,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
-		</model>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:1+,BAN:3</availability>
 		</model>
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:1+,BAN:3</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:6,Periphery.CM:5,IS:3-,Periphery.Deep:5,MERC:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:2,Periphery:1</availability>
 		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:2,Periphery:1</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2419,32 +2419,32 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:1,NIOPS:9,IS:1,CFM:10,FS:1,CJF:10,DC:2</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:4,:0,LA:4</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:7,FWL:1+,BAN:4</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:4,:0,LA:4</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,FWL:1+,FS:1+,BAN:8</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:4,:0,LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:1,MOC:1,CHH:4,OA:1,LA:1,CLAN:3,FWL:1,FS:1,CGS:5,DC:1,TC:2</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:5,BAN:2</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2481,26 +2481,26 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4H'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:4,CLAN:3,CGS:4,CCO:4,BAN:2,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2548,13 +2548,13 @@
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='IMP-1A'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1A'>
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
@@ -2573,26 +2573,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>MOC:1,CC:1,CLAN:5,IS:1,FWL.OH:3,FS:1,TC:1,CS:6,OA:1,LA:1,CNC:5,FWL:2,NIOPS:6,DC:1</availability>
-		<model name='IRN-SD2'>
-			<availability>General:3,CLAN:2</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:3,CNC:3</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:3,CLAN:2</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2600,13 +2600,13 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CIH:3,CLAN:4</availability>
-		<model name='(Original)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
@@ -2617,6 +2617,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,CIR:4,TC:4,Periphery:2</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2626,11 +2631,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2647,14 +2647,6 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
@@ -2663,36 +2655,44 @@
 			<roles>recon,raider</roles>
 			<availability>General:5,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FWL:2,FS:8,MERC:3,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:8,FS:3,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>IS:2,FS:5,MERC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2715,19 +2715,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2771,32 +2771,32 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:8</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
+		<model name='KGC-0000'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:5</availability>
-		<model name='C'>
-			<availability>General:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2807,18 +2807,15 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -2827,6 +2824,9 @@
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2838,22 +2838,22 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>CC:1,MOC:2,Periphery.CM:2,Periphery.HR:1,Periphery.ME:2,TC:1</availability>
-		<model name='KRV-2'>
-			<availability>Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2861,11 +2861,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2905,20 +2905,20 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:2,CC:2,CIH:6,CLAN:5,IS:2,CFM:6,MERC:2,CIR:2,CGS:6,BAN:6,TC:2,CS:6,OA:2,LA:2,NIOPS:6,DC:4</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8-</availability>
-		</model>
 		<model name='LNC25-03'>
 			<availability>IS:4-,DC:6-</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -2947,10 +2947,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -2960,24 +2956,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:1+,CS:5,CIH:9,LA:1+,CLAN:8,FWL:1+,NIOPS:5,FS:1+,CJF:7,DC:1+</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:2,CC:8,CLAN:3,IS:2,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -2996,18 +2996,22 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:2-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8,TC:2</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
@@ -3016,39 +3020,35 @@
 			<roles>recon</roles>
 			<availability>FS:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,CLAN:1-,FS:7,BAN:5</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8,TC:2</availability>
+			<availability>LA:4,General:8,CLAN:1-,FS:7,BAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -3066,35 +3066,35 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:3,CCO:8</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:1,CLAN:4,FWL:1,DC:1</availability>
-		<model name='LNX-8Q'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='LNX-9Q'>
 			<availability>CLAN:8,IS:2+</availability>
+		</model>
+		<model name='LNX-8Q'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -3144,23 +3144,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,IS:8,Periphery.Deep:8,Periphery:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:6,FS:1+,CGS:7,BAN:6</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:1,CLAN:4,NIOPS:8,MERC:0,BAN:4,TC:1+</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:6,FS:1+,CGS:7,BAN:6</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3178,11 +3178,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3200,36 +3200,36 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -3241,35 +3241,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3277,20 +3274,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3298,8 +3298,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3351,13 +3351,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3367,11 +3363,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3403,13 +3403,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>MOC:2,OA:2,FWL:2,NIOPS:0,MERC:8,FS:2,DC:2,TC:2</availability>
-		</model>
 		<model name='MON-69'>
 			<roles>recon</roles>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>MOC:2,OA:2,FWL:2,NIOPS:0,MERC:8,FS:2,DC:2,TC:2</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
@@ -3418,11 +3418,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:1</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -3439,7 +3439,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3448,14 +3448,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3526,15 +3526,15 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,CIR:4</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -3570,22 +3570,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:3-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3601,11 +3601,11 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,FWL:7,NIOPS:6,Periphery.Deep:4,FS:7,MERC:7,Periphery:4</availability>
-		<model name='OTL-4D'>
-			<availability>CLAN:8,IS:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>CLAN:8,IS:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -3628,13 +3628,13 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6,DC:4</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6,DC:4</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3643,23 +3643,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:1+,CS:4,CW:3,CLAN:3,NIOPS:4,BAN:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3685,14 +3685,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3701,15 +3693,23 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:6,CSJ:8,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -3730,9 +3730,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:2,IS:9,FWL:9,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CLAN:3,BAN:4</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -3741,18 +3753,6 @@
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3781,13 +3781,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -3799,10 +3799,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
@@ -3810,6 +3806,10 @@
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='(Support)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
@@ -3846,11 +3846,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -3861,6 +3861,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
@@ -3873,25 +3881,17 @@
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
@@ -3923,20 +3923,17 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:5,CSR:4,CLAN:4,NIOPS:5,CJF:3</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:3,BAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:3,BAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:1,CS:4,OA:2,LA:1,CLAN:3,FWL:1,IS:1,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
 		</model>
@@ -3945,6 +3942,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
@@ -3979,11 +3979,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:7</availability>
@@ -4020,17 +4020,17 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,LA:9,FWL:9,IS:9,Periphery.Deep:9,FS:9,DC:9,Periphery:9</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -4061,20 +4061,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:4,BAN:3</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:4,BAN:3</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -4083,37 +4083,37 @@
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:5,FS:1+,BAN:4</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:5,FS:1+,BAN:4</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4133,11 +4133,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:1+,CCO:4,CB:4</availability>
-		<model name='SHG-2H'>
-			<availability>General:8,CLAN:1-,BAN:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='SHG-2H'>
+			<availability>General:8,CLAN:1-,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -4175,28 +4175,28 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:1+,LA:1+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1G'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SL-1H'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='SL-1G'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Soarece Superheavy MBT' unitType='Tank'>
@@ -4227,13 +4227,13 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>FS.CMM:3</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4272,17 +4272,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4298,29 +4298,38 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Stinger LAM' unitType='Mek'>
+		<availability>IS:1</availability>
+		<model name='STG-A10'>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -4341,17 +4350,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:3,CGS:3</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:3,CGS:3</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>FS:3</availability>
@@ -4386,15 +4395,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -4402,11 +4411,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4420,23 +4429,23 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -4448,13 +4457,13 @@
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CC:1+,CS:3,LA:1+,CLAN:5,FWL:1+,NIOPS:3,FS:1+,MERC:1+,BAN:5,DC:1+</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,General:6,NIOPS:8,BAN:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,General:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
@@ -4468,12 +4477,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4519,13 +4528,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CLAN:3</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4534,8 +4543,8 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:8,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:8,Periphery:6,TC:6,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5Sd'>
+			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -4543,11 +4552,11 @@
 		<model name='TDR-5SS'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='TDR-5Sd'>
-			<availability>FS:1+</availability>
-		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:5,CSR:5,CDS:5,CW:5,CLAN:5,CNC:5,CJF:5,BAN:4,CGB:5</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4575,20 +4584,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -4602,27 +4611,26 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:6,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:5,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-9'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
@@ -4631,20 +4639,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4670,26 +4679,26 @@
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CSR:6,CJF:6</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4743,13 +4752,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:2,CS:2,IS:1,FS:2</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:2,CS:2,IS:1,FS:2</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:2,CS:2,IS:1,FS:2</availability>
 		</model>
 	</chassis>
@@ -4765,11 +4774,11 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4788,11 +4797,11 @@
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Star League)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4803,13 +4812,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:1-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -4844,36 +4853,33 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:1,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:1+</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:1,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
 		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:3</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:4</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -4899,17 +4905,20 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CLAN:1,CSJ:2,CJF:2</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:6,IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:6,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:1-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+		<model name='WTH-0'>
+			<availability>TC:2</availability>
+		</model>
 		<model name='WTH-1'>
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -4918,19 +4927,16 @@
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -4939,11 +4945,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:8,CLAN:4-</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -4955,16 +4961,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:6,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
-		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:1+,FWL:1+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:5,CFM:6,CGS:6</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5002,39 +5008,39 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:2+,CS:8,LA:1+,CLAN:8,FWL:1+,NIOPS:8,FS:1+,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:7,IS:1,BAN:4</availability>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,CLAN:4,General:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:4</availability>
+			<availability>CHH:8,CLAN:7,IS:1,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:4</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-5T'>
+		<model name='ZEU-5S'>
 			<availability>LA:1+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='ZEU-5S'>
+		<model name='ZEU-5T'>
 			<availability>LA:1+</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -539,13 +539,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -578,17 +578,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:2,BAN:3</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -607,9 +607,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -619,21 +619,21 @@
 			<roles>fire_support</roles>
 			<availability>HL:6,LA:7,CLAN:2,IS:8,Periphery.Deep:7,BAN:4,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
+		<model name='Mark VII-C'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='Mk.III'>
 			<availability>General:1</availability>
 		</model>
 		<model name='Mark VII'>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mark VII-C'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -644,23 +644,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -668,33 +652,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -719,11 +719,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -731,11 +731,11 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -743,14 +743,14 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
@@ -769,11 +769,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:5,CLAN:2-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>CS:2,IS:2,FWL:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2,CIR:2</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>CS:2,IS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -788,20 +788,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CW:4,CLAN:4</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -811,7 +811,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:4</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -819,30 +827,28 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,CC:4-,HL:8-,IS:7-,Periphery.Deep:9-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>FWL:4</availability>
-		</model>
 		<model name='BNC-3E'>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -850,47 +856,41 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CBS:5,CSV:6,CGS:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:4,CLAN:3,IS:5,FS:5,Periphery:4,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:3</availability>
+		<model name='BLR-2C'>
+			<availability>CS:1</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='BLR-2C'>
-			<availability>CS:1</availability>
+		<model name='BLR-1G'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1G-DC'>
 			<availability>IS:2,MERC:0</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:3</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -931,11 +931,11 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -946,17 +946,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,FS:1,MERC:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:2,CNC:9,FWL:4,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1027,34 +1027,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:8,FWL:8,DC:9</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CC:1+,CHH:7,CLAN:2,FS:1+,MERC:1+,CS:7,CDS:2,LA:1+,CNC:2,FWL:1+,NIOPS:7,CJF:2,DC:1+</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -1084,48 +1084,48 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:5,CLAN:1,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>HL:1,LA:3,FS:4,MERC:2,Periphery:3</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:4</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
@@ -1140,10 +1140,10 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
@@ -1162,18 +1162,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4,CLAN:1,BAN:2,CGB:1</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:1+,CS:8,CHH:5,CLAN:3,NIOPS:8,BAN:6,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4,CLAN:1,BAN:2,CGB:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1192,16 +1192,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1213,14 +1213,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:2,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1229,13 +1229,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1256,20 +1256,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -1280,23 +1280,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1304,14 +1304,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1328,32 +1328,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1361,11 +1361,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1373,20 +1373,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1397,14 +1397,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:2,IS:4,FS:6,MERC:4,TC:2,Periphery:2,CS:3-,OA:2,LA:4,FWL:4,NIOPS:3-,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
+		<model name='CLNT-2-3T'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1444,11 +1444,11 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1463,13 +1463,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:2,NIOPS:6,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1500,11 +1500,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
@@ -1527,20 +1527,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-27sl'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1548,27 +1548,33 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:4,CSV:6</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1576,23 +1582,17 @@
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,CLAN:1,Periphery.Deep:7,BAN:5,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,CLAN:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1632,10 +1632,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -1643,25 +1639,29 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CHH:4,CCC:6,CIH:3,CDS:3,CLAN:3,CCO:3,CJF:3,BAN:2,CGB:9,CB:6</availability>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -1669,12 +1669,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1721,20 +1721,20 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CFM:7</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1746,25 +1746,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:3,General:1,FS:3</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:1,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:3,CLAN:2</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -1776,8 +1775,9 @@
 			<roles>marine</roles>
 			<availability>CSR:3,CLAN:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:3,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1797,10 +1797,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1809,6 +1805,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CIH:3+,CGS:3+</availability>
@@ -1816,12 +1816,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -1831,13 +1831,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1849,51 +1849,51 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:4,NIOPS:5</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:4,NIOPS:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:4,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:3,BAN:2</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CIH:4,CLAN:2,CGS:4</availability>
-		<model name='FLC-4N'>
-			<availability>BAN:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>BAN:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1905,20 +1905,20 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CW:6</availability>
-		<model name='D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:5</availability>
+		<model name='C'>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
@@ -1930,30 +1930,30 @@
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:1,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -1991,66 +1991,63 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,LA:1+,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>Periphery.MW:2,Periphery.ME:2,FWL:5</availability>
-		<model name='FLE-4'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -2058,17 +2055,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2087,12 +2087,12 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CHH:6,CW:6,CLAN:4,CJF:6,CGB:6</availability>
-		<model name='(Fury II)'>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>apc</roles>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='(Fury II)'>
+			<availability>General:1</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:7,BAN:4</availability>
@@ -2126,12 +2126,12 @@
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,HL:2,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='GAL-200'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -2143,14 +2143,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,HL:1,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,TC:3,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -2158,6 +2150,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -2169,26 +2169,26 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:7,CLAN:5</availability>
-		<model name='2'>
-			<availability>CSV:4,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:4,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>MOC:1,CS:9,CDS:6,Periphery.MW:1,CLAN:6,Periphery.ME:1,CNC:6,FWL:1,NIOPS:9</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:3,Periphery:6</availability>
+		<model name='GTHA-100'>
+			<availability>General:1,CLAN:1</availability>
 		</model>
 		<model name='GTHA-300'>
 			<availability>CLAN:1,FWL:2,BAN:2</availability>
 		</model>
-		<model name='GTHA-100'>
-			<availability>General:1,CLAN:1</availability>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:3,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -2211,14 +2211,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:5,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:5,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:5,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2242,13 +2242,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CS:7,CHH:7,CSR:7,CLAN:5,IS:5,FWL:5,NIOPS:7,FS:4,MERC:5,DC:5,Periphery:3</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4,Periphery:2</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2264,25 +2264,25 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:1,CLAN:1,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:8,CLAN:7,BAN:4</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:2,CNC:2</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:1,CLAN:1,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,HL:2,Periphery.Deep:4,MERC:4,Periphery:4,FWL.pm:8,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,FWL:4,MH:5,DC:4</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2297,21 +2297,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2322,21 +2322,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2344,33 +2352,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2383,18 +2383,18 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:1,NIOPS:4,BAN:2</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:4+,DC:4+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:1,NIOPS:4,BAN:2</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2402,15 +2402,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2421,44 +2421,44 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL:10,MH:4,MERC:4,DC:4</availability>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:5,CLAN:3,FWL:3,NIOPS:3,CGB:5,CB:5</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
-		</model>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:2,Periphery:1</availability>
 		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:2,Periphery:1</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2469,32 +2469,32 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:8,NIOPS:9,CFM:9,CJF:9,DC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,DC:8</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:4,:0,LA:4</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:4,:0,LA:4</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,DC:8</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:4,:0,LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:1,MOC:1,CHH:4,OA:1,LA:1,CLAN:3,FWL:1,FS:1,CGS:4,DC:1,TC:2</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2531,29 +2531,29 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,CLAN:1-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='HBK-4N'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4H'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
-		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:4,CLAN:3,CGS:4,CCO:4,BAN:2,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
@@ -2597,13 +2597,13 @@
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='IMP-1A'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1A'>
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
@@ -2622,26 +2622,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,HL:6,CLAN:9,IS:7,Periphery.Deep:7,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:4</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:4</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:4,CNC:4,FWL:1,NIOPS:6,FWL.OH:2</availability>
-		<model name='IRN-SD2'>
-			<availability>General:3,CLAN:1</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:2,CNC:2</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:3,CLAN:1</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2649,13 +2649,13 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CIH:3,CLAN:4</availability>
-		<model name='(Original)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
@@ -2666,6 +2666,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,CIR:4,TC:4,Periphery:2</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2675,11 +2680,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2696,14 +2696,6 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,HL:3,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
@@ -2712,36 +2704,44 @@
 			<roles>recon,raider</roles>
 			<availability>HL:6,General:5,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FS:8,MERC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2764,19 +2764,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2820,32 +2820,32 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:5,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:6,CGB:6,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:8</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:2</availability>
+		<model name='KGC-0000'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:5</availability>
-		<model name='C'>
-			<availability>General:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2856,18 +2856,15 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -2877,25 +2874,28 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Korvin Tank' unitType='Tank'>
 		<availability>MOC:1,Periphery.CM:1,Periphery.ME:1</availability>
-		<model name='KRV-2'>
-			<availability>HL:3,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='KRV-3'>
 			<availability>CC:8,HL:4,Periphery.Deep:5,Periphery:6</availability>
+		</model>
+		<model name='KRV-2'>
+			<availability>HL:3,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
@@ -2903,11 +2903,11 @@
 		<model name='KSC-3L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='KSC-4I'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='KSC-4I'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>CC:6+</availability>
@@ -2915,17 +2915,9 @@
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CW:4,CSJ:7,CCO:4</availability>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -2934,6 +2926,14 @@
 		<model name='D'>
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2963,20 +2963,20 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:1,CC:1,CIH:6,CLAN:5,IS:1,CFM:6,CIR:1,MERC:1,CGS:6,BAN:6,TC:1,CS:6,OA:1,LA:1,NIOPS:6,DC:3</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8-</availability>
-		</model>
 		<model name='LNC25-03'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3005,10 +3005,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -3018,24 +3014,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CC:1+,CS:5,CIH:8,LA:1+,CLAN:7,FWL:1+,NIOPS:5,FS:1+,CJF:7,DC:1+</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:2,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:2,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:2,CC:8,CS:5-,OA:2,LA:3,CLAN:3,IS:1,NIOPS:5-,FS:3,TC:2,Periphery:2,DC:3</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3051,33 +3051,33 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:2-,IS:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7,BAN:4</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8</availability>
+			<availability>LA:4,General:8,FS:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
@@ -3085,33 +3085,33 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:5,CLAN:2,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6,Periphery:4</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -3129,25 +3129,25 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:3,CCO:8</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -3176,14 +3176,14 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
@@ -3210,14 +3210,14 @@
 		<model name='A'>
 			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -3240,23 +3240,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,CLAN:5,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:5</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,HL:6,IS:8,Periphery.Deep:7,Periphery:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:5,CGS:6,BAN:5</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:3,NIOPS:8,MERC:0,BAN:4</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:5,CGS:6,BAN:5</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3274,11 +3274,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:1,LA:1-,Periphery.MW:1,IS:1-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='II-A'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3296,36 +3296,36 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -3337,35 +3337,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3373,20 +3370,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3394,8 +3394,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3447,13 +3447,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3463,11 +3459,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3516,11 +3516,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:1</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -3537,7 +3537,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3546,14 +3546,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3576,6 +3576,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
@@ -3583,14 +3591,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3647,15 +3647,15 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,PIR:3,FWL:5,CIR:4</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -3687,22 +3687,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,HL:2,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:4,TC:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,CLAN:2,IS:8,Periphery.Deep:7,MERC:8,BAN:4,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3718,11 +3718,11 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:5,FWL:7,NIOPS:6,FS:7,MERC:7,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:6,CLAN:8,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:6,CLAN:8,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -3745,13 +3745,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3760,23 +3760,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:1+,CS:4,CW:2,CLAN:2,NIOPS:4,BAN:1</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:6,LA:6,TC:6</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,CLAN:8,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:6,LA:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3802,14 +3802,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:6,IS:8,Periphery.Deep:7,FS:8,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3818,15 +3810,23 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:6,CSJ:8,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -3847,9 +3847,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:9,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CLAN:2,BAN:3</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -3858,18 +3870,6 @@
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3898,13 +3898,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -3922,13 +3922,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Support)'>
+			<roles>apc</roles>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
@@ -3965,11 +3965,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:1</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:2,General:3+,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:2,CNC:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:2,General:3+,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -3980,6 +3980,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:4,CW:4,General:8,CLAN:4,CNC:4</availability>
@@ -3992,25 +4000,17 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
@@ -4042,20 +4042,17 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:5,CSR:4,CLAN:4,NIOPS:5,CJF:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:2,BAN:5</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:2,BAN:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,OA:1,CLAN:3,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:2,NIOPS:8</availability>
 		</model>
@@ -4064,6 +4061,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:1,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
@@ -4079,17 +4079,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:8,CDS:8,CBS:7,CSV:5,CLAN:6,CNC:6,CSJ:7,CJF:8</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4116,11 +4116,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:2</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:4,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:2</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:6</availability>
@@ -4181,17 +4181,17 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:7,LA:9,FWL:9,IS:9,Periphery.Deep:8,FS:9,DC:9,Periphery:9</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -4234,20 +4234,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:4,CLAN:5,CFM:6,CGS:4,CS:4,CDS:4,CW:4,LA:3-,CBS:4,NIOPS:4,CJF:6,CGB:6,DC:1</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:3,BAN:2</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
+		<model name='STN-3L'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:3,BAN:2</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -4256,37 +4256,37 @@
 			<roles>interceptor</roles>
 			<availability>HL:6,LA:8,IS:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5,CGB:2</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:5,BAN:4</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:5,BAN:4</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4306,11 +4306,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:4,CIH:4,CBS:3,CLAN:3,FWL:1+,CCO:4,CB:3</availability>
-		<model name='SHG-2H'>
-			<availability>General:8,CLAN:1-,BAN:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='SHG-2H'>
+			<availability>General:8,CLAN:1-,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -4337,13 +4337,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -4352,17 +4352,17 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
@@ -4407,13 +4407,13 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:2</availability>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>FS.CMM:3</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4452,17 +4452,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3F'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:2,OA:2,IS:2,Periphery:1,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4479,37 +4479,37 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,HL:4,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:2,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:2,Periphery:4</availability>
+			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:6,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:6,IS:8,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -4530,17 +4530,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,OA:2,LA:2,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CLAN:2,CGS:2</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CLAN:2,CGS:2</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>FS:3</availability>
@@ -4575,15 +4575,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -4591,11 +4591,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4606,23 +4606,23 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -4634,13 +4634,13 @@
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,General:4,NIOPS:8,BAN:3</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,General:4,NIOPS:8,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
@@ -4654,12 +4654,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4705,13 +4705,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4720,9 +4720,6 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,HL:4,CLAN:4,IS:8,Periphery.Deep:5,FS:7,MERC:8,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,MH:6,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:8,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
@@ -4731,6 +4728,9 @@
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:4,CJF:4,BAN:3,CGB:4</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4758,20 +4758,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:6,CLAN:5,FWL:1,NIOPS:9</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,IS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:2</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:6,BAN:4</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -4792,11 +4792,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:5,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
@@ -4811,9 +4811,8 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
@@ -4822,20 +4821,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:4,CLAN:4,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4854,35 +4854,35 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:7,CLAN:5</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CSR:6,CJF:6</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4933,29 +4933,29 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:5,General:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
@@ -4967,13 +4967,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:2,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:1,CS:1,FS:1</availability>
 		</model>
 	</chassis>
@@ -4989,11 +4989,11 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>CC:2</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
@@ -5001,14 +5001,14 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -5036,13 +5036,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -5064,20 +5064,20 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:3</availability>
 		</model>
-		<model name='12'>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
 			<availability>CSJ:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='11'>
+		<model name='12'>
 			<availability>CSJ:3</availability>
 		</model>
 	</chassis>
@@ -5086,33 +5086,30 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,CLAN:1,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:3</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,CLAN:1,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -5138,13 +5135,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CLAN:1,CSJ:2,CJF:2</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:6,IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -5160,13 +5157,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:7,IS:7,Periphery.Deep:5,FWL:10,NIOPS:5-,FS:8,Periphery:4,TC:5,DC:7</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -5175,11 +5172,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:8,CLAN:4-</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -5191,13 +5188,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:5,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:3,DC:5,TC:3</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:4,NIOPS:8,CFM:5,BAN:6</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,CFM:5,CGS:5</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:4,NIOPS:8,CFM:5,BAN:6</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5226,28 +5223,28 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CC:1+,CS:8,CLAN:7,NIOPS:8</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:8,CLAN:7,BAN:4</availability>
+			<availability>CHH:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,CLAN:2,General:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:3</availability>
+			<availability>CHH:8,CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:3</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -553,13 +553,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:2,CCC:2,CIH:2,CSR:6,CDS:2,CBS:2,CSV:2,CNC:4,CLAN:2,CGS:2,CJF:5,CB:2</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -592,17 +592,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,CHH:2,CSR:2,CLAN:1,CCO:2,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-1G'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='ANH-1G'>
-			<availability>BAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -621,9 +621,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:3</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -633,18 +633,18 @@
 			<roles>fire_support</roles>
 			<availability>HL:6,LA:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:3,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -655,23 +655,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -679,33 +663,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -730,11 +730,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:3</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -742,11 +742,11 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -754,14 +754,14 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
@@ -780,14 +780,14 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:6,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:3</availability>
+		</model>
 		<model name='AWS-8R'>
 			<availability>CS:2,IS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:3</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -802,20 +802,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CW:4,CLAN:4</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -825,7 +825,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:4</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -833,33 +841,31 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:6-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:3</availability>
 		</model>
 		<model name='BNC-3E'>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:4</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -867,47 +873,41 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:6,CSR:2,CDS:2,CBS:6,CSV:8,CNC:2,CGS:6,CCO:2,CB:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:3,CLAN:2,IS:5,FS:5,Periphery:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:3</availability>
+		<model name='BLR-2C'>
+			<availability>CS:1</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='BLR-2C'>
-			<availability>CS:1</availability>
+		<model name='BLR-1G'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1G-DC'>
 			<availability>IS:2,MERC:0</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:3</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -943,14 +943,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,General:8</availability>
@@ -958,11 +958,11 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:6,CS:6-,LA:7,PIR:6,FS:9,MERC:6,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -977,11 +977,11 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -992,17 +992,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:6,NIOPS:4,CGS:7,BAN:3</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:6,NIOPS:4,CGS:7,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1048,13 +1048,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CLAN:3,CGS:3</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -1093,34 +1093,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:7,FWL:7,DC:8</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CS:7,CHH:6,CDS:1,CLAN:1,CNC:1,NIOPS:7,CJF:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:2,BAN:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -1143,13 +1143,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CHH:1,CCC:1,CIH:1,CSR:1,CDS:5,CW:1,CSV:1,CNC:6,CFM:1,CGS:1,CCO:1,CGB:1</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CDS:6,CNC:6</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CDS:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1161,48 +1161,48 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:5</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
+			<availability>DC:2</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>HL:1,LA:3,FS:4,MERC:2,Periphery:3</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:4</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
@@ -1217,11 +1217,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -1239,18 +1239,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:3,BAN:1</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4,CLAN:1,BAN:1,CGB:1</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CS:8,CHH:5,CLAN:2,NIOPS:8,BAN:5,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4,CLAN:1,BAN:1,CGB:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1269,6 +1269,10 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
@@ -1276,35 +1280,31 @@
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,CLAN:2,NIOPS:6</availability>
-		<model name='(BAP)'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:1,FWL:4,MERC:3,FS:3,CIR:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:6,CGS:6,BAN:3</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1313,13 +1313,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1340,20 +1340,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -1364,23 +1364,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1388,14 +1388,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1412,32 +1412,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1445,11 +1445,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1457,20 +1457,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1481,14 +1481,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:5,MOC:1,IS:4,FS:5,MERC:4,TC:1,Periphery:1,CS:3-,OA:1,LA:4,FWL:4,NIOPS:3-,MH:1,DC:4</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
+		<model name='CLNT-2-3T'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:8,Periphery:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:8,Periphery:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1528,11 +1528,11 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1547,13 +1547,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:2,NIOPS:6,BAN:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1584,11 +1584,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
@@ -1611,17 +1611,17 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:4,IS:2,CFM:3,MERC:2,CGS:5,Periphery:2,CS:5,CDS:5,CW:5,CBS:5,NIOPS:5,FWL:2,CJF:3,CGB:3,DC:2</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:6,CGS:7,BAN:3</availability>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-27b'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1629,27 +1629,33 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CSV:8,CSJ:5,CCO:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1657,23 +1663,17 @@
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:6,CGS:7,BAN:3</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1713,10 +1713,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -1724,25 +1720,29 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:6,CCC:6,CIH:5,CDS:5,CLAN:5,CCO:4,CJF:4,BAN:4,CGB:9,CB:6</availability>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -1750,12 +1750,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1795,20 +1795,20 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:4,CIH:4,CDS:4,CSV:3,CLAN:4,CFM:5,CSJ:3,CJF:4,CGB:3,CB:4</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1820,25 +1820,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:7,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:3,FS:3</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
+		<model name='EGL-R4'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -1850,8 +1849,9 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1871,10 +1871,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -1883,6 +1879,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CIH:3+,CGS:3+</availability>
@@ -1890,12 +1890,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -1905,13 +1905,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CIH:1,CSR:1,CDS:3,CSV:1,CLAN:1,CSJ:3,CGS:1,CCO:1,CGB:3,CB:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1923,51 +1923,51 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6,CGS:7,BAN:3</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:4,NIOPS:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6,CGS:7,BAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:4,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:3</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:2,BAN:1</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>CIH:3,CLAN:1,CGS:3</availability>
-		<model name='FLC-4N'>
-			<availability>BAN:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>BAN:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1979,63 +1979,63 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CIH:7,CDS:5,CW:8,CSV:2,CNC:4,CLAN:2,CSJ:4,CJF:6,CGB:2</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:4,LA:3,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:3,FS:9</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:2,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:2,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:1,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -2067,66 +2067,63 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-7K'>
-			<availability>:0,LA:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>Periphery.MW:1,Periphery.ME:1,FWL:4</availability>
-		<model name='FLE-4'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -2134,17 +2131,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2194,11 +2194,11 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:7,CW:7,CLAN:6</availability>
-		<model name='2'>
-			<availability>CW:6,CCO:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:6,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -2209,12 +2209,12 @@
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:4,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:2,LA:2,DC:3,Periphery:2</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='GAL-200'>
+			<availability>MOC:2,LA:2,DC:3,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -2226,14 +2226,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,HL:1,LA:2,FS.CH:7,FS:6,MERC:2,CIR:4,Periphery:3,TC:3,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -2241,6 +2233,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -2252,23 +2252,23 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:4</availability>
-		<model name='2'>
-			<availability>CSV:6,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:6,CLAN:6,CNC:6,NIOPS:9</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:6,BAN:3</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:1,BAN:1</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-300'>
-			<availability>CLAN:1,BAN:1</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -2294,14 +2294,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:4,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:3,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2325,13 +2325,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:4,CS:7,CHH:6,CSR:6,CLAN:4,IS:4,FWL:4,NIOPS:7,FS:3,MERC:4,DC:4,Periphery:3</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:3,Periphery.ME:3,FWL:3,NIOPS:0,MERC:3,Periphery:1</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2347,14 +2347,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,General:1,CLAN:1,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:7,CLAN:6,BAN:3</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:1,CNC:1</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:7,CLAN:6,BAN:3</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,General:1,CLAN:1,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -2366,13 +2366,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:6,MH:6,DC:5</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2387,21 +2387,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2412,21 +2412,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2434,49 +2442,41 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:6</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,CLAN:1,NIOPS:4,BAN:1</availability>
+		</model>
 		<model name='HCT-213C'>
 			<availability>CLAN:2,BAN:1</availability>
-		</model>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:1+,DC:1+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,CLAN:1,NIOPS:4,BAN:1</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2484,15 +2484,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2503,47 +2503,47 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL:10,MH:4,MERC:4,DC:4</availability>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:4,CLAN:2,FWL:2,NIOPS:3,CGB:4,CB:4</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
-		</model>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>CLAN:2,BAN:1</availability>
 		</model>
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>CLAN:2,BAN:1</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:2</availability>
+		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2554,29 +2554,29 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:8,NIOPS:9,CFM:9,CJF:9,DC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,DC:8</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:3,:0,LA:3</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:3,:0,LA:3</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,DC:8</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:3,:0,LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,CLAN:3,CGS:4,TC:1</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:3,BAN:1</availability>
-		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:8,CLAN:2,BAN:2</availability>
+		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2617,36 +2617,36 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='HBK-4N'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4H'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
-		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>CDS:4,CLAN:3,CGS:5,CCO:4,BAN:3,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>CC:6,MOC:4,HL:3,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:5,OA:5,LA:7,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:8</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -2656,9 +2656,9 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2695,13 +2695,13 @@
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='IMP-1A'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='IMP-1C'>
 			<availability>CHH:3,CLAN:1</availability>
 		</model>
 		<model name='IMP-1B'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='IMP-1A'>
 			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
@@ -2720,26 +2720,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,HL:6,CLAN:9,IS:7,Periphery.Deep:7,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:3</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:3</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:3,CNC:3,NIOPS:6,FWL.OH:1</availability>
-		<model name='IRN-SD2'>
-			<availability>General:2,CLAN:1</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:1,CNC:1</availability>
+		</model>
+		<model name='IRN-SD2'>
+			<availability>General:2,CLAN:1</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:7,CLAN:6,BAN:3</availability>
@@ -2747,13 +2747,13 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CIH:3,CLAN:4</availability>
-		<model name='(Original)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
@@ -2764,6 +2764,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:2,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2773,11 +2778,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2794,17 +2794,6 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:4,FWL:3,NIOPS:4-,DC:6</availability>
-		<model name='(Cell)'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
@@ -2813,36 +2802,47 @@
 			<roles>recon,raider</roles>
 			<availability>HL:6,General:5,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>DC:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FS:8,MERC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -2865,19 +2865,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -2921,32 +2921,32 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2+,CS:6,LA:2+,CLAN:5,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:6,CGB:6,DC:2+</availability>
+		<model name='KGC-010'>
+			<availability>CLAN:1</availability>
+		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:6,CGS:7,BAN:3</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:8</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:1</availability>
+		<model name='KGC-0000'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2957,18 +2957,15 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:6,CGS:7,BAN:3</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:5,CGB:9</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -2978,31 +2975,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CIH:5,CSR:5,CSV:5,CLAN:5,CCO:5,CGS:5,BAN:5,CSA:5,CDS:5,CW:5,CBS:5,CSJ:9,CJF:4,CB:5</availability>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -3011,6 +3003,14 @@
 		<model name='D'>
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3040,17 +3040,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:6,CLAN:5,NIOPS:6,CFM:6,CGS:6,BAN:7,DC:2</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3079,10 +3079,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -3092,24 +3088,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:5,CIH:8,CLAN:7,NIOPS:5,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:1,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:1,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:6,CC:7,CS:5-,OA:6,LA:4,CLAN:2,NIOPS:5-,FS:4,TC:3,Periphery:2,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:2</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3125,33 +3125,33 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:5,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:2-,IS:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7,BAN:2</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8</availability>
+			<availability>LA:4,General:8,FS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
@@ -3159,33 +3159,33 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:2,CHH:3,CSR:4,CIH:3,CSV:3,CLAN:2,CFM:3,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:1,CSJ:3,CGB:3,CB:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6,Periphery:5</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -3209,25 +3209,25 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:2-,CCO:7,BAN:3</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -3256,14 +3256,14 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
@@ -3296,14 +3296,14 @@
 		<model name='A'>
 			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -3326,23 +3326,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,CLAN:4,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:4</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,HL:6,IS:8,Periphery.Deep:7,Periphery:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:4,CGS:5,BAN:4</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:2,NIOPS:8,MERC:0,BAN:3</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:4,CGS:5,BAN:4</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3360,11 +3360,11 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:7</availability>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:9</availability>
@@ -3388,18 +3388,22 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
@@ -3408,20 +3412,16 @@
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -3433,35 +3433,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3469,20 +3466,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3490,8 +3490,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3543,13 +3543,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3559,11 +3555,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3612,11 +3612,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:1</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -3633,7 +3633,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3642,14 +3642,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3672,6 +3672,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
@@ -3680,25 +3688,17 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
 		<availability>LA:3,FS:4,DC:4</availability>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -3749,15 +3749,15 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,LA:3,PIR:4,Periphery.ME:4,FWL:8,MH:4,CIR:4,FS:3</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -3789,22 +3789,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:3,CS:4,HL:1,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:3</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -3820,11 +3820,11 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:5,FWL:7,NIOPS:6,FS:7,MERC:7,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:6,CLAN:8,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:6,CLAN:8,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -3847,13 +3847,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3862,23 +3862,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CS:4,CW:1,CLAN:1,NIOPS:4,BAN:1</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:4,LA:4,TC:4</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,CLAN:8,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:4,LA:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3904,14 +3904,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:6,IS:9,Periphery.Deep:7,FS:9,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -3920,15 +3912,23 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:5,CSJ:8,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -3943,18 +3943,30 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:1,FWL:3</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CLAN:1,BAN:2</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:6</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -3964,26 +3976,14 @@
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:2</availability>
 		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,LA:5,FWL:4,MH:4,DC:5</availability>
-		<model name='(Missile)'>
-			<availability>MOC:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
+		</model>
+		<model name='(Missile)'>
+			<availability>MOC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -4012,13 +4012,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:2,CCC:3,CIH:2,CSR:5,CSV:3,CLAN:1,CFM:2,CGS:4,CCO:3,CSA:2,CS:1,CDS:5,CW:2,NIOPS:1,CSJ:2</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4036,21 +4036,21 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4083,11 +4083,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,CLAN:1,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:3,CSR:3,CBS:3,CLAN:1,CNC:1</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,CLAN:1,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:8</availability>
@@ -4098,6 +4098,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6,BAN:3</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:4,CW:4,General:8,CLAN:2,CNC:4</availability>
@@ -4110,34 +4118,26 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:8,CLAN:8,CNC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:4,CNC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:8,CLAN:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -4156,20 +4156,17 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:4,CSR:3,CLAN:3,NIOPS:5,CJF:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,CLAN:1,BAN:4</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,CLAN:1,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:3,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:3</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:1,NIOPS:8</availability>
 		</model>
@@ -4178,6 +4175,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:1,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
@@ -4193,17 +4193,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:8,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:6</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4230,11 +4230,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8,CLAN:1</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8,CLAN:1</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:6</availability>
@@ -4242,11 +4242,11 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -4292,26 +4292,26 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FWL:9,IS:10,Periphery.Deep:9,FS:9,DC:9,Periphery:10</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -4335,9 +4335,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CJF:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -4346,6 +4343,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -4369,20 +4369,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:4,CLAN:5,CFM:6,CGS:4,CS:4,CDS:4,CW:4,CBS:4,LA:2-,NIOPS:4,CJF:6,CGB:6,DC:1</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3Lb'>
-			<availability>CLAN:2,BAN:1</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
+		<model name='STN-3L'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='STN-3Lb'>
+			<availability>CLAN:2,BAN:1</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -4391,37 +4391,37 @@
 			<roles>interceptor</roles>
 			<availability>HL:6,LA:8,IS:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5,CGB:2</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:5,BAN:3</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:5,BAN:3</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4441,11 +4441,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:4,CIH:4,CBS:2,CLAN:2,CCO:4,CB:2</availability>
-		<model name='SHG-2H'>
-			<availability>CLAN:1-,BAN:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='SHG-2H'>
+			<availability>CLAN:1-,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -4472,13 +4472,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -4487,17 +4487,17 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
@@ -4536,13 +4536,13 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:4</availability>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>FS.CMM:3</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4584,17 +4584,17 @@
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:3</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4604,49 +4604,49 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:8,Periphery:6,DC:6,CGB:1-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:1,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:1,Periphery:4</availability>
+			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:3,FS:2,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:5,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
 		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:5,IS:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -4670,17 +4670,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CGS:2</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CGS:2</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,FS:3,TC:2,Periphery:1</availability>
@@ -4688,17 +4688,17 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4730,15 +4730,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -4746,11 +4746,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4761,26 +4761,23 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -4789,16 +4786,19 @@
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
 		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,General:2,NIOPS:8,BAN:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,General:2,NIOPS:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
@@ -4812,12 +4812,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4863,13 +4863,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CLAN:1</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4878,9 +4878,6 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:3,CLAN:4,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:5,TC:5,CS:5-,LA:8,NIOPS:5-,MH:5,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:6,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
@@ -4889,6 +4886,9 @@
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:4,CJF:4,BAN:2,CGB:4</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4916,20 +4916,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:5,NIOPS:9</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,NIOPS:4</availability>
-		</model>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:1</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:5,BAN:3</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -4950,11 +4950,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:5,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
@@ -4969,9 +4969,8 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
@@ -4980,20 +4979,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:1,MOC:1,CS:7,OA:3,CSR:2,CLAN:2,NIOPS:7,FS:1,MERC:1,DC:1,TC:1</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:6,BAN:3</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5012,35 +5012,35 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:8,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:3,CIH:3,CSR:7,CSV:2,CLAN:4,CCO:3,CDS:2,CW:3,CBS:5,CNC:2,CSJ:3,CJF:7,CGB:3</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -5077,43 +5077,43 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:2,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
 		</model>
+		<model name='VLK-QF'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:3</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>HL:8,IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:4,General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:5,General:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
@@ -5125,13 +5125,13 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
 			<availability>CC:1,CS:1,FS:1</availability>
 		</model>
 	</chassis>
@@ -5151,11 +5151,11 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>CC:1</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
@@ -5163,23 +5163,23 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8,CJF:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -5207,13 +5207,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
@@ -5221,14 +5221,14 @@
 		<model name='B'>
 			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -5246,20 +5246,20 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:4</availability>
 		</model>
-		<model name='12'>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
 			<availability>CSJ:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='11'>
+		<model name='12'>
 			<availability>CSJ:4</availability>
 		</model>
 	</chassis>
@@ -5268,17 +5268,17 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:3</availability>
@@ -5297,16 +5297,13 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
@@ -5332,13 +5329,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CLAN:1,CSJ:2,CJF:2</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:3,IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:3,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -5354,13 +5351,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10,MH:6</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10,MH:6</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -5369,11 +5366,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:6,CLAN:4-,BAN:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -5385,13 +5382,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:5,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:2,DC:5,TC:3</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:3,NIOPS:8,CFM:5,BAN:5</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:3,CFM:4,CGS:4</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:3,NIOPS:8,CFM:5,BAN:5</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5427,28 +5424,28 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:8,CLAN:7,NIOPS:8</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:7,CLAN:6,BAN:3</availability>
+			<availability>CHH:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,CLAN:1,General:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:2</availability>
+			<availability>CHH:7,CLAN:6,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,General:8,CLAN:3,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:2</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,General:8,CLAN:3,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/3000.xml
+++ b/megamek/data/forcegenerator/3000.xml
@@ -575,13 +575,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:2,CCC:2,CIH:2,CSR:6,CDS:1,CBS:1,CSV:1,CNC:4,CLAN:1,CGS:2,CJF:5,CB:1</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -608,14 +608,14 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:5,CHH:2,CSR:2,CLAN:1,CCO:2,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.WD:8,CLAN:2-,MERC:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -634,13 +634,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8</availability>
+			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -650,18 +646,22 @@
 			<roles>fire_support</roles>
 			<availability>HL:6,LA:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -672,23 +672,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -696,33 +680,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -753,11 +753,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -765,11 +765,11 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -777,14 +777,14 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
@@ -803,14 +803,14 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
+		</model>
 		<model name='AWS-8R'>
 			<availability>CS:1,IS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -825,20 +825,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CW:3,CLAN:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -848,15 +848,11 @@
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -864,7 +860,11 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -875,7 +875,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:3</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -883,29 +891,13 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:7</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
@@ -918,33 +910,47 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:5-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='BNC-3E'>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -952,47 +958,41 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:4,CLAN:2,IS:5,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
+		<model name='BLR-2C'>
+			<availability>CS:1</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='BLR-2C'>
-			<availability>CS:1</availability>
+		<model name='BLR-1G'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1G-DC'>
 			<availability>IS:2,MERC:0</availability>
 		</model>
-		<model name='BLR-1G'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1028,14 +1028,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='4'>
 			<availability>General:3</availability>
 		</model>
 		<model name='5'>
 			<availability>General:3</availability>
+		</model>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,General:8</availability>
@@ -1043,15 +1043,15 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:6,CS:6-,LA:7,PIR:6,FS:9,MERC:6,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1066,11 +1066,11 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -1081,17 +1081,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:3,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1143,13 +1143,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CLAN:1,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -1174,11 +1174,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -1197,34 +1197,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CS:7,CHH:5,NIOPS:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -1247,13 +1247,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:3,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1265,48 +1265,48 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:1</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,HL:6,CLAN:4,IS:6,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,OA:3</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
+			<availability>DC:1</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,HL:6,CLAN:4,IS:6,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
@@ -1327,11 +1327,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -1349,18 +1349,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CS:8,CHH:4,CLAN:1,NIOPS:8,BAN:4,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1372,22 +1372,26 @@
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:5-,LA:4-,FWL:2-,MERC:2-,DC:7-</availability>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
+		</model>
 		<model name='CGR-1A1'>
 			<roles>recon</roles>
 			<availability>CC:6-,LA:6-,FWL:6-,DC:6-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MERC:2</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
-		</model>
 		<model name='CGR-1L'>
 			<availability>CC:8</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
@@ -1395,35 +1399,31 @@
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6</availability>
-		<model name='(BAP)'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:5,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1432,13 +1432,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1465,20 +1465,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -1495,23 +1495,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1519,14 +1519,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1543,32 +1543,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1576,11 +1576,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1588,20 +1588,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -1619,14 +1619,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FWL:3,IS:3,NIOPS:3-,FS:4,MERC:3,DC:3</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
+		<model name='CLNT-2-3T'>
+			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1653,16 +1653,16 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>Periphery.R:4,MERC.KH:8,HL:3,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CIR:4,MERC:4,Periphery:3,TC:6</availability>
+		<model name='COM-1C'>
+			<roles>recon</roles>
+			<availability>LA:2</availability>
+		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
 		</model>
 		<model name='COM-1B'>
-			<roles>recon</roles>
-			<availability>LA:2</availability>
-		</model>
-		<model name='COM-1C'>
 			<roles>recon</roles>
 			<availability>LA:2</availability>
 		</model>
@@ -1674,17 +1674,17 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Fission)'>
-			<availability>CC:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
 		</model>
+		<model name='(Fission)'>
+			<availability>CC:1</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1699,13 +1699,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:1,NIOPS:6,BAN:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1736,17 +1736,17 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='CSR-V20'>
-			<availability>LA:2,FS.AH:5,Periphery:2</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:2,FS.AH:5,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1766,17 +1766,17 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-27b'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1784,27 +1784,33 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CSV:8,CSJ:5,CCO:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9</availability>
@@ -1812,23 +1818,17 @@
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1854,14 +1854,14 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CW:4,CSJ:8</availability>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:5,CSV:4,CNC:4,General:5,CJF:6,CGB:5</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -1880,10 +1880,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -1891,25 +1887,29 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:8,CCC:6,CIH:6,CDS:5,CLAN:5,CCO:4,CJF:4,BAN:5,CGB:9,CB:6</availability>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -1917,12 +1917,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1978,20 +1978,20 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:6,CIH:6,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:5,CB:6</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2003,25 +2003,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R4'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
+		<model name='EGL-R4'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -2033,8 +2032,9 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2051,10 +2051,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -2063,6 +2059,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:2+,CIH:3+,CGS:3+,CB:2+</availability>
@@ -2070,12 +2070,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -2085,13 +2085,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CIH:1,CSR:1,CDS:2,CSV:1,CLAN:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2103,39 +2103,39 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:3,NIOPS:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:3,NIOPS:4,FWL:2</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
-		</model>
-		<model name='EXT-4A'>
-			<availability>FWL:8</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4A'>
+			<availability>FWL:8</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -2146,17 +2146,17 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>MERC.WD:3,CIH:2,CGS:2</availability>
-		<model name='FLC-4N'>
-			<availability>MERC.WD:8,BAN:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>MERC.WD:8,BAN:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2168,63 +2168,63 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:7,CDS:5,CW:8,CSV:3,CNC:4,CLAN:3,CSJ:4,CJF:6,CGB:3</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:4,LA:3,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:3,FS:9</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:2,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:2,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:1,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -2238,75 +2238,72 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>MERC.WD:4,CIH:6,CLAN:4,BAN:3,CB:5</availability>
-		<model name='FFL-4A'>
-			<availability>:0,MERC.WD:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='FFL-4A'>
+			<availability>:0,MERC.WD:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:8,LA:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:8,LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MERC.WD:4,Periphery.MW:1,Periphery.ME:1,FWL:3</availability>
-		<model name='FLE-4'>
-			<availability>MERC.WD:8,FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MERC.WD:3,FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>MERC.WD:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -2314,17 +2311,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2370,21 +2370,21 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:6,CW:6,CLAN:5</availability>
-		<model name='2'>
-			<availability>CW:6,CCO:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:6,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:3,LA:3,DC:3,Periphery:3</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='GAL-200'>
+			<availability>MOC:3,LA:3,DC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -2396,32 +2396,24 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CGB:8</availability>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,OA:3,HL:1,LA:2,FS.CH:7,FS:6,MERC:1,CIR:4,Periphery:3,TC:3,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -2429,6 +2421,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -2440,20 +2440,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:3</availability>
-		<model name='2'>
-			<availability>CSV:6,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:5,NIOPS:9</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:5,FWL:5,MH:5,MERC:5</availability>
@@ -2488,14 +2488,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:3,HL:4,CLAN:2,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2522,13 +2522,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CS:7,CHH:5,CSR:5,CLAN:2,IS:3,FWL:3,NIOPS:7,FS:2,MERC:3,DC:3,Periphery:2</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2,Periphery:1</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2544,14 +2544,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:7,CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:7,CLAN:5,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -2563,13 +2563,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2584,21 +2584,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2609,21 +2609,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2631,46 +2639,38 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,NIOPS:6</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,NIOPS:4</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2678,15 +2678,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:5,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2701,21 +2701,17 @@
 			<roles>recon</roles>
 			<availability>FWL:4:3025</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:4,CLAN:1,FWL:1,NIOPS:3,CGB:4,CB:3</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2724,26 +2720,30 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
+		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2754,35 +2754,35 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:1,CLAN:7,NIOPS:9,CFM:8,CJF:8,DC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,DC:8</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:2,:0,LA:2</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:2,:0,LA:2</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,DC:8</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:2,:0,LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,MERC.WD:4,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:2,BAN:1</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:1</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:1</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:2,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2823,39 +2823,39 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:2,MERC:2,DC:2,Periphery:2</availability>
 		</model>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:3,IS:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:8</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -2865,9 +2865,9 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -2923,16 +2923,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,HL:6,CLAN:9,IS:7,Periphery.Deep:7,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:2</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6,CLAN:2</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2960,6 +2960,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:2,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -2969,11 +2974,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2990,17 +2990,6 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:3,NIOPS:4-,DC:6</availability>
-		<model name='(Cell)'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
@@ -3009,13 +2998,24 @@
 			<roles>recon,raider</roles>
 			<availability>HL:6,General:5,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>DC:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3024,36 +3024,36 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,FS:8,MERC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -3076,19 +3076,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -3119,18 +3119,18 @@
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:6,CW:5,CLAN:5</availability>
-		<model name='(Standard)'>
-			<roles>specops</roles>
-			<availability>MERC.WD:6</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SL)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<roles>specops</roles>
+			<availability>MERC.WD:6</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
+		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 	</chassis>
@@ -3146,26 +3146,26 @@
 		<model name='KGC-000b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='KGC-0000'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -3176,18 +3176,15 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -3197,16 +3194,19 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
@@ -3217,17 +3217,9 @@
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:6,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:6</availability>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -3236,6 +3228,14 @@
 		<model name='D'>
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3265,17 +3265,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,CLAN:4,NIOPS:6,CFM:5,CGS:5,BAN:7,DC:1</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,DC:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3311,10 +3311,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -3324,24 +3320,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:5,CIH:7,CLAN:6,NIOPS:5,CJF:5</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,CLAN:1,IS:3,FS:5,TC:5,Periphery:4,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3357,37 +3357,37 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:5,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:1-,IS:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
-		<model name='LCT-1Vb'>
-			<roles>recon</roles>
-			<availability>CLAN:7,BAN:2</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='LCT-1V'>
+		<model name='LCT-1S'>
 			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7</availability>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LCT-1Vb'>
+			<roles>recon</roles>
+			<availability>CLAN:7,BAN:2</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8</availability>
+			<availability>LA:4,General:8,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
@@ -3395,33 +3395,33 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CLAN:1,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:5,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6,Periphery:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -3445,25 +3445,25 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:2-,CCO:5-,BAN:2</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -3492,14 +3492,14 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
@@ -3532,14 +3532,14 @@
 		<model name='A'>
 			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -3571,23 +3571,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,CLAN:3,IS:3,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,HL:6,IS:8,Periphery.Deep:7,Periphery:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:3,CGS:4,BAN:3</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:3,CGS:4,BAN:3</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3615,11 +3615,11 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,CSA:3,CDS:3,CW:3,CBS:2,CNC:3,CSJ:8,CJF:3,CGB:3,CB:3</availability>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:9</availability>
@@ -3647,18 +3647,22 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
@@ -3667,20 +3671,16 @@
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -3707,35 +3707,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3743,20 +3740,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3764,8 +3764,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3819,13 +3819,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -3835,11 +3831,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -3888,11 +3888,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:1</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -3909,7 +3909,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -3918,14 +3918,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -3948,6 +3948,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
@@ -3956,25 +3964,17 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
 		<availability>LA:4,FS:4,DC:4</availability>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -4025,15 +4025,15 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,LA:4,PIR:4,Periphery.ME:4,FWL:9,MH:4,CIR:4,FS:4</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -4065,22 +4065,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:4,MOC:3,CS:4,HL:1,LA:5,CLAN:2-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -4096,11 +4096,11 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:6,NIOPS:6,FS:6,MERC:6,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -4123,13 +4123,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:4,MERC.KH:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:4,MERC.KH:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -4138,23 +4138,23 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CS:4,NIOPS:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
-		<model name='PNT-8Z'>
-			<availability>CC:2,LA:2,TC:2</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
+		</model>
+		<model name='PNT-8Z'>
+			<availability>CC:2,LA:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4166,16 +4166,16 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -4187,14 +4187,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:7,HL:5,IS:9,Periphery.Deep:7,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -4203,15 +4195,23 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:4,CSJ:7,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
@@ -4232,18 +4232,30 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>BAN:1</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -4253,28 +4265,16 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
@@ -4304,13 +4304,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4334,41 +4334,41 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSA:9,CSR:6,CDS:6,CW:5,CBS:5,CNC:5,CLAN:5,CFM:6,CSJ:7,CCO:6,CJF:4,CGB:5</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4404,11 +4404,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:8</availability>
@@ -4419,6 +4419,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
@@ -4431,34 +4439,26 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+		<model name='F-100'>
+			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:7,CLAN:7,CNC:7</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:7,CLAN:7,CNC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -4481,20 +4481,17 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:4,CSR:2,CLAN:2,NIOPS:5,CJF:1</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
@@ -4503,6 +4500,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
@@ -4518,17 +4518,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4555,11 +4555,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:5</availability>
@@ -4567,11 +4567,11 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -4617,26 +4617,26 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FWL:9,IS:10,Periphery.Deep:9,FS:9,DC:9,Periphery:10</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -4660,9 +4660,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -4671,6 +4668,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -4694,17 +4694,17 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='STN-3KA'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='STN-3K'>
 			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -4713,52 +4713,52 @@
 			<roles>interceptor</roles>
 			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:4,CSR:4,CDS:4,CW:4,CSV:4,CNC:6,CFM:4,CSJ:5,CB:4</availability>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
+			<availability>CSR:3,General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4778,11 +4778,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -4809,13 +4809,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -4824,27 +4824,27 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:4</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -4876,10 +4876,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:5,TC:8</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:4,DC:8</availability>
@@ -4887,6 +4883,10 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>FS.CMM:3</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:5,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4922,17 +4922,17 @@
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4942,49 +4942,49 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:9,Periphery:6,DC:6,CGB:1-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
 		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -5022,17 +5022,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:5,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CGS:1</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,LA:3,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,LA:3,FS.DMM:8</availability>
+		<model name='STU-K5b2'>
+			<availability>CGS:1</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,FS:3,TC:2,Periphery:1</availability>
@@ -5047,17 +5047,17 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:5,CGB:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -5089,15 +5089,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -5105,11 +5105,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -5120,26 +5120,23 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -5148,16 +5145,19 @@
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
 		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,NIOPS:8,BAN:1</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,NIOPS:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
@@ -5171,12 +5171,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -5233,9 +5233,6 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:2,CLAN:3,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:5,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
@@ -5244,6 +5241,9 @@
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -5271,16 +5271,16 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,NIOPS:4</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -5301,11 +5301,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:5,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
@@ -5320,9 +5320,8 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
@@ -5331,20 +5330,21 @@
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5370,50 +5370,50 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:4,CJF:4,CGB:4</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:3,CLAN:4,CCO:3,CDS:4,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -5450,43 +5450,43 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:2,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
 		</model>
+		<model name='VLK-QF'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>HL:8,IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:4,General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:5,General:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
@@ -5498,6 +5498,9 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
@@ -5506,9 +5509,6 @@
 		</model>
 		<model name='VTR-9S'>
 			<availability>LA:4,CIR:4</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -5524,11 +5524,11 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
@@ -5536,26 +5536,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:7,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -5571,11 +5571,11 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,LA:5,FWL:4,IS:1,FS:4,DC:5</availability>
-		<model name='VNL-K100'>
-			<availability>FS:3</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>FS:3</availability>
 		</model>
 		<model name='VNL-K70'>
 			<availability>DC:3</availability>
@@ -5589,13 +5589,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
@@ -5603,14 +5603,14 @@
 		<model name='B'>
 			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -5628,20 +5628,20 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:5</availability>
 		</model>
-		<model name='12'>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
 			<availability>CSJ:5</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='11'>
+		<model name='12'>
 			<availability>CSJ:5</availability>
 		</model>
 	</chassis>
@@ -5650,17 +5650,17 @@
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2</availability>
@@ -5679,29 +5679,22 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
+		<availability>IS:1</availability>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:2,Periphery:6</availability>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
@@ -5709,6 +5702,10 @@
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
@@ -5721,13 +5718,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CSJ:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -5743,13 +5740,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -5758,11 +5755,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:4-,CLAN:3-,BAN:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -5774,13 +5771,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:4,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,FS:5,MERC:4,Periphery:1,DC:5,TC:2</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:2,NIOPS:8,CFM:4,BAN:4</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:2,CFM:3,CGS:3</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:2,NIOPS:8,CFM:4,BAN:4</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5816,28 +5813,28 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:7,CLAN:5,BAN:2</availability>
+			<availability>CHH:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:1</availability>
+			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,CLAN:2,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:1</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -616,13 +616,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:2,CCC:2,CIH:2,CSR:6,CDS:1,CBS:1,CSV:1,CNC:4,CGS:2,CJF:5,CB:1</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -649,9 +649,6 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:5,CHH:2,CSR:2,CLAN:1,CCO:2,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.WD:6,CLAN:2-,MERC:8</availability>
 		</model>
@@ -660,6 +657,9 @@
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -678,13 +678,9 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8</availability>
+			<availability>FRR:4,DC:8</availability>
 		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
@@ -694,18 +690,22 @@
 			<roles>fire_support</roles>
 			<availability>HL:6,LA:6,FRR:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>FRR:4,DC:8</availability>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -716,23 +716,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -740,33 +724,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -800,11 +800,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -812,11 +812,11 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -824,14 +824,14 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -843,14 +843,14 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
+		</model>
 		<model name='AWS-8R'>
 			<availability>CS:1,IS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -874,20 +874,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CW:3,CLAN:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -897,15 +897,11 @@
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -913,7 +909,11 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -924,7 +924,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:3</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -932,29 +940,13 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:7</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
@@ -967,36 +959,50 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:7-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
-		</model>
-		<model name='BNC-3E'>
-			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>LA:3</availability>
 		</model>
+		<model name='BNC-3E'>
+			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -1004,50 +1010,44 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:4,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1</availability>
 		</model>
 		<model name='BLR-1S'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1083,14 +1083,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='4'>
 			<availability>General:3</availability>
 		</model>
 		<model name='5'>
 			<availability>General:3</availability>
+		</model>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,General:8</availability>
@@ -1098,15 +1098,15 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:6,CS:6-,LA:7,FRR:7,PIR:6,SIC:7,FS:9,MERC:6,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1121,11 +1121,11 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -1136,17 +1136,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,MERC:1,FS:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1162,13 +1162,13 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:4,CC:5-,OA:4,HL:2,IS:2,SIC:5,MERC:4,FS:6,Periphery:4,TC:4</availability>
-		<model name='BJ-1DC'>
+		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='BJ-1DB'>
+		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 	</chassis>
@@ -1211,13 +1211,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CLAN:1,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -1242,11 +1242,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -1265,34 +1265,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CS:7,CHH:5,NIOPS:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -1315,13 +1315,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1333,8 +1333,8 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:3,SIC:2</availability>
-		<model name='CTF-2X'>
-			<availability>CC:1</availability>
+		<model name='CTF-1X'>
+			<availability>General:8,Periphery:8</availability>
 		</model>
 		<model name='CTF-0X'>
 			<availability>CC:1</availability>
@@ -1342,54 +1342,54 @@
 		<model name='CTF-4X'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>General:8,Periphery:8</availability>
+		<model name='CTF-2X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:4:3033</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,HL:6,CLAN:4,IS:4,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
-		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,OA:3,SIC:3</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
+			<availability>FRR:3,DC:4:3033</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,HL:6,CLAN:4,IS:4,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,SIC:2,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
@@ -1410,11 +1410,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -1432,18 +1432,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CS:8,CHH:4,CLAN:1,NIOPS:8,BAN:4,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1455,6 +1455,9 @@
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:5-,LA:4-,FRR:7-,FWL:3-,SIC:5-,MERC:3-,DC:7-</availability>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
+		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:2+,DC:2+</availability>
 		</model>
@@ -1462,18 +1465,19 @@
 			<roles>recon</roles>
 			<availability>CC:5-,LA:5-,FRR:5-,FWL:5-,DC:5-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
-		</model>
 		<model name='CGR-1L'>
 			<availability>CC:8,SIC:6,Periphery:3</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,SIC:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
@@ -1481,35 +1485,31 @@
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6</availability>
-		<model name='(BAP)'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:3,CIR:2,Periphery:2,TC:2,OA:2,LA:7,FWL:4,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1518,13 +1518,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2,SIC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2,SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1551,20 +1551,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -1581,23 +1581,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1605,14 +1605,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1629,32 +1629,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1662,11 +1662,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1674,20 +1674,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -1705,14 +1705,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:3-,SIC:4,FS:4,MERC:3,DC:3</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
+		<model name='CLNT-2-3T'>
+			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1745,6 +1745,14 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:3,FRR:3,CIR:4,MERC:4,FS:3,Periphery:3,TC:6,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+		<model name='COM-1C'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
+		<model name='COM-3A'>
+			<roles>recon</roles>
+			<availability>LA:6,MERC:3</availability>
+		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
@@ -1754,14 +1762,6 @@
 			<roles>recon</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='COM-1C'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:6,MERC:3</availability>
-		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
@@ -1770,14 +1770,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8</availability>
@@ -1792,13 +1792,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:1,NIOPS:6,BAN:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1829,17 +1829,17 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,CIR:2,Periphery:2,TC:2,OA:3,LA:4,FWL:2,DC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='CSR-V20'>
-			<availability>LA:2,FS.AH:5,Periphery:2</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:2,FS.AH:5,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1859,17 +1859,17 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8,DC:6+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-27b'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8,DC:6+</availability>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1877,11 +1877,11 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -1892,18 +1892,24 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CSV:8,CSJ:5,CCO:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:5,DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9,SIC:8</availability>
@@ -1911,23 +1917,17 @@
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:5,DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1953,14 +1953,14 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CW:6,CBS:2,CNC:3,CLAN:3,CSJ:8,CJF:4,BAN:2,CGB:3,CB:3</availability>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:5,CSV:4,CNC:4,General:5,CJF:6,CGB:5</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -1979,10 +1979,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -1990,25 +1986,29 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:8,CCC:6,CIH:6,CDS:6,CLAN:5,CCO:4,CJF:4,BAN:5,CGB:9,CB:6</availability>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -2016,12 +2016,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -2083,29 +2083,29 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:6,CIH:7,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:9,CB:7</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,FRR:4</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CC:8,General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2117,25 +2117,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:3,FS:3</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
+		<model name='EGL-R4'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -2147,8 +2146,9 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2165,10 +2165,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -2177,6 +2173,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:2+,CIH:3+,CGS:3+,CB:2+</availability>
@@ -2184,12 +2184,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -2199,13 +2199,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CIH:1,CDS:2,CSV:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2217,39 +2217,39 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:3,NIOPS:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:3,FWL:2,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
-		</model>
-		<model name='EXT-4A'>
-			<availability>FWL:8</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4A'>
+			<availability>FWL:8</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -2260,17 +2260,17 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>DC.GHO:4,MERC.WD:3,CIH:1,CGS:2</availability>
-		<model name='FLC-4N'>
-			<availability>MERC.WD:8,BAN:8,DC:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>MERC.WD:8,BAN:8,DC:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2282,63 +2282,63 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CIH:7,CDS:5,CW:8,CSV:4,CNC:4,CLAN:3,CSJ:4,CJF:6,CGB:4</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:4,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:6,SIC:5,FS:9</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:2,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:2,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:1,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
+		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sniper)'>
+		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -2352,75 +2352,72 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>MERC.WD:4,CIH:6,CLAN:4,BAN:3,CB:5</availability>
-		<model name='FFL-4A'>
-			<availability>:0,MERC.WD:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='FFL-4A'>
+			<availability>:0,MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:8,LA:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:8,LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MERC.WD:2,Periphery.MW:1,Periphery.ME:1,FWL:3</availability>
-		<model name='FLE-4'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MERC.WD:3,FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -2428,17 +2425,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2484,21 +2484,21 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:6,CW:6,CLAN:5</availability>
-		<model name='2'>
-			<availability>CW:6,CCO:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:6,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,HL:2,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:6,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:3,LA:3,FRR:3,DC:3,Periphery:3</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='GAL-200'>
+			<availability>MOC:3,LA:3,FRR:3,DC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -2510,32 +2510,24 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CDS:4,CSR:3,CNC:3,CLAN:3,CSJ:3,CJF:3,BAN:2,CGB:8,CB:3</availability>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:4,TC:3,Periphery:3,OA:3,LA:3,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FS:5</availability>
@@ -2543,6 +2535,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,FRR:2,NIOPS:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -2554,20 +2554,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:3</availability>
-		<model name='2'>
-			<availability>CSV:6,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:6,NIOPS:9</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -2602,14 +2602,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6,FRR:4,MERC:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2636,13 +2636,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CS:7,CHH:5,CSR:5,CLAN:2,IS:3,FWL:3,NIOPS:7,FS:2,MERC:3,DC:3,Periphery:2</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2,Periphery:1</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2658,35 +2658,35 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:7,CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:7,CLAN:5,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:6</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -2698,13 +2698,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2716,12 +2716,12 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>LA:4,FS:1,DC:1</availability>
-		<model name='HCT-3NH'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>LA:8,Periphery.Deep:6,MERC:8,FS:8,Periphery:8</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2733,21 +2733,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2758,21 +2758,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2780,46 +2788,38 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,NIOPS:6</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,NIOPS:4</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -2827,15 +2827,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:5,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2850,21 +2850,17 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:4,CLAN:1,FWL:1,NIOPS:3,CGB:4,CB:3</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2873,26 +2869,30 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,MERC:5,Periphery:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
+		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -2911,35 +2911,35 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:1,CLAN:7,NIOPS:9,CFM:8,SIC:1,CJF:8,DC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:2,:0,LA:2,SIC:2</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8,DC:4+</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,MERC.WD:2,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:2,BAN:1</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:1</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:1</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:2,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2980,39 +2980,39 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:8,CLAN:4</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:8,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:3,FRR:5,IS:5,SIC:6,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:8</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -3022,9 +3022,9 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
@@ -3080,16 +3080,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:6,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:2</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6,CLAN:2</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -3117,6 +3117,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:2,SIC:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -3126,11 +3131,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -3147,14 +3147,6 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:5,MOC:5,CC:3,HL:3,FRR:5,FS.AH:5,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
@@ -3163,13 +3155,21 @@
 			<roles>recon,raider</roles>
 			<availability>HL:6,General:5,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3178,36 +3178,36 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,SIC:6,FS:8,MERC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FRR:8,SIC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FRR:8,SIC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
@@ -3245,19 +3245,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -3294,6 +3294,13 @@
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:6,CW:5,CLAN:5</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6</availability>
@@ -3301,19 +3308,12 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Scout)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
+		<model name='(Scout)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -3328,26 +3328,26 @@
 		<model name='KGC-000b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='KGC-0000'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -3358,18 +3358,15 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6</availability>
-		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -3379,16 +3376,19 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
@@ -3399,17 +3399,9 @@
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -3418,6 +3410,14 @@
 		<model name='D'>
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3447,17 +3447,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:1,CLAN:4,NIOPS:6,CFM:5,CGS:5,BAN:7,DC:1</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,FRR:8,DC:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,FRR:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3493,10 +3493,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -3506,24 +3502,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:5,CIH:7,CLAN:6,NIOPS:5,CJF:5</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:3,SIC:6,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3539,18 +3539,26 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:5,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:1-,IS:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2</availability>
@@ -3559,21 +3567,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
-			<roles>recon</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8</availability>
+			<availability>LA:4,General:8,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
@@ -3581,33 +3581,33 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6,Periphery:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -3631,25 +3631,25 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:1-,CCO:4-,BAN:2</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -3678,14 +3678,14 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
@@ -3718,14 +3718,14 @@
 		<model name='A'>
 			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -3757,23 +3757,23 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,HL:6,IS:8,Periphery.Deep:7,Periphery:8,TC:8</availability>
 		</model>
 		<model name='MAD-3L'>
 			<availability>CC:3,SIC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:3,CGS:4,BAN:3</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:3,CGS:4,BAN:3</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
@@ -3794,11 +3794,11 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:4,CB:3</availability>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:9</availability>
@@ -3826,18 +3826,22 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
@@ -3846,20 +3850,16 @@
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -3886,35 +3886,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3922,20 +3919,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3943,8 +3943,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3998,13 +3998,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -4014,11 +4010,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -4054,13 +4054,13 @@
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='MON-68'>
 			<roles>recon</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -4071,11 +4071,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:1</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -4092,7 +4092,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -4101,14 +4101,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -4131,6 +4131,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
@@ -4139,25 +4147,17 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
 		<availability>LA:5,FS:6,DC:4</availability>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -4208,15 +4208,15 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,LA:5,PIR:4,Periphery.ME:4,FWL:9,MH:4,SIC:5,FS:5,CIR:4</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,SIC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -4248,22 +4248,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:4,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -4279,11 +4279,11 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:6,NIOPS:6,FS:6,MERC:6,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -4306,13 +4306,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,FS:3,MERC:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,FS:3,MERC:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -4321,13 +4321,13 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CS:4,NIOPS:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
@@ -4346,16 +4346,16 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:6,FS:8,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -4373,14 +4373,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:7,CC:9,HL:5,FRR:8,IS:9,Periphery.Deep:7,SIC:9,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -4389,27 +4381,35 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:4,CSJ:7,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:8-,LA:3-,FRR:5-,FWL:5-,IS:5-,SIC:8-,FS:5-,MERC:6-,DC:6-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:6</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -4424,18 +4424,30 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>BAN:1</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:6,DC:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -4445,28 +4457,16 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:1</availability>
 		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:6,DC:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
@@ -4508,13 +4508,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4538,41 +4538,41 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:7,CFM:8,CCO:7,BAN:3,CSA:9,CDS:7,CW:7,CBS:7,CNC:7,CSJ:7,CJF:5,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4608,11 +4608,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:8</availability>
@@ -4630,6 +4630,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
@@ -4642,34 +4650,26 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+		<model name='F-100'>
+			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:6,CLAN:6,CNC:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:6,CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -4681,10 +4681,6 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:9-,CCC:1,HL:3,CSV:1,FRR:8-,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:8-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:3</availability>
-		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:2</availability>
@@ -4693,23 +4689,24 @@
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>HL:6,CLAN:1-,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:4,CSR:2,CLAN:2,NIOPS:5,CJF:1</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
@@ -4718,6 +4715,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
@@ -4739,17 +4739,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4776,11 +4776,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:5</availability>
@@ -4788,11 +4788,11 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:8,DC.AL:10,FRR:9,IS:7,SIC:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,LA:6,FWL:7,DC:9</availability>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -4848,26 +4848,26 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,FRR:10,IS:6,Periphery.Deep:4,SIC:8,MERC:6,Periphery.OS:6,FS:7,CIR:6,Periphery:6,TC:6,OA:6,LA:6,FWL:6,DC:9</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FRR:10,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -4891,9 +4891,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -4902,6 +4899,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -4925,17 +4925,17 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='STN-3KA'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='STN-3K'>
 			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -4944,52 +4944,52 @@
 			<roles>interceptor</roles>
 			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:7,CFM:5,CSJ:6,CB:5</availability>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
+			<availability>CSR:3,General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 		<model name='SHD-2K'>
 			<availability>FRR:8,DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -5009,11 +5009,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -5040,13 +5040,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -5055,27 +5055,27 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
-		<model name='SL-15A'>
-			<availability>OA:4,FRR:4,DC:4</availability>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:4,FRR:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:5</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -5107,10 +5107,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:3,TC:8</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:4,FRR:8,DC:8</availability>
@@ -5118,6 +5114,10 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>LA:8,FS.CMM:3</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:3,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -5153,17 +5153,17 @@
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5173,49 +5173,49 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
 		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -5253,17 +5253,17 @@
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
-		<model name='STU-K5b2'>
-			<availability>CGS:1</availability>
-		</model>
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
+		<model name='STU-K5b2'>
+			<availability>CGS:1</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:3,FS:3,TC:2,Periphery:1</availability>
@@ -5281,17 +5281,17 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -5323,15 +5323,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -5339,11 +5339,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -5354,26 +5354,23 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -5382,16 +5379,19 @@
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
 		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,NIOPS:8,BAN:1</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,NIOPS:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
@@ -5405,12 +5405,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -5467,9 +5467,6 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:2,CLAN:3,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
-		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:5,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
@@ -5478,6 +5475,9 @@
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -5508,16 +5508,16 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,NIOPS:4</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -5538,11 +5538,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:8,MERC:3,TC:2</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:5,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
@@ -5557,35 +5557,35 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-7K'>
 			<roles>fire_support</roles>
 			<availability>FRR:2,DC:4</availability>
 		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5611,50 +5611,50 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -5691,43 +5691,43 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:3,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
 		</model>
+		<model name='VLK-QF'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>HL:8,IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:4,General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:5,General:8,SIC:5</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
@@ -5739,6 +5739,9 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
@@ -5747,9 +5750,6 @@
 		</model>
 		<model name='VTR-9S'>
 			<availability>LA:4,CIR:4</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -5768,14 +5768,14 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>FRR:8</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
 		<model name='VND-1SIC'>
 			<availability>SIC:2</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
@@ -5783,26 +5783,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:7,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -5818,11 +5818,11 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,LA:5,FRR:5,FWL:4,IS:1,FS:4,DC:5</availability>
-		<model name='VNL-K100'>
-			<availability>LA:1,FS:3</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:3,DC:3</availability>
@@ -5836,13 +5836,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
@@ -5850,14 +5850,14 @@
 		<model name='B'>
 			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -5875,21 +5875,21 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='12'>
-			<availability>CSJ:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
+			<availability>CSJ:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='11'>
-			<availability>CSJ:6</availability>
+		<model name='12'>
+			<availability>CSJ:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
@@ -5897,17 +5897,17 @@
 		<model name='WHM-6L'>
 			<availability>CC:4,SIC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:4,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2</availability>
@@ -5926,29 +5926,25 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:2</availability>
+		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:2,Periphery:6</availability>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:4,DC:4</availability>
@@ -5956,6 +5952,10 @@
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
@@ -5968,13 +5968,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CSJ:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -5990,13 +5990,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -6005,11 +6005,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:2-,CLAN:2-,BAN:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -6021,13 +6021,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:4,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,MERC:4,FS:5,Periphery:1,DC:5,TC:2</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>CS:8,CLAN:1,NIOPS:8,CFM:4,BAN:4</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:2,CFM:3,CGS:3</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>CS:8,CLAN:1,NIOPS:8,CFM:4,BAN:4</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -6063,28 +6063,28 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:7,CLAN:5,BAN:2</availability>
+			<availability>CHH:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:1</availability>
+			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,CLAN:2,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:1</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -665,13 +665,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:2,CS:4,CCC:2,CIH:2,CSR:6,CDS:1,CBS:1,CSV:1,CNC:4,CGS:2,CJF:5,CB:1</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -698,20 +698,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:5,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:6,MERC.WD:2,CLAN:2-,MERC:6</availability>
 		</model>
 		<model name='ANH-1E'>
 			<availability>MERC.WD:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.WD:4+</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:3</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -730,6 +730,22 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+		<model name='ARC-2K'>
+			<roles>fire_support</roles>
+			<availability>FRR:4,DC:8</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='ARC-4M'>
+			<roles>fire_support</roles>
+			<availability>FWL:4+</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:6,LA:6,FRR:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
+		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -738,30 +754,14 @@
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:6,LA:6,FRR:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
-		</model>
-		<model name='ARC-4M'>
-			<roles>fire_support</roles>
-			<availability>FWL:4+</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -772,23 +772,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -796,33 +780,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -856,11 +856,11 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -868,11 +868,11 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -880,14 +880,14 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -903,14 +903,14 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
+		</model>
 		<model name='AWS-8R'>
 			<availability>CS:1,IS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -940,20 +940,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CW:3,CLAN:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -963,15 +963,11 @@
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -979,7 +975,11 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -990,7 +990,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:3</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -998,29 +1006,13 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:7</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
@@ -1033,39 +1025,53 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:6-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
-		<model name='BNC-3MC'>
-			<availability>MOC:9</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		<model name='BNC-3MC'>
+			<availability>MOC:9</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
 		</model>
+		<model name='BNC-3E'>
+			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -1073,53 +1079,47 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1</availability>
 		</model>
 		<model name='BLR-1S'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-3M'>
 			<availability>FWL:4+</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1155,14 +1155,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='4'>
 			<availability>General:3</availability>
 		</model>
 		<model name='5'>
 			<availability>General:3</availability>
+		</model>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,General:8</availability>
@@ -1170,15 +1170,15 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:6,CS:6-,LA:7,FRR:7,PIR:6,SIC:7,FS:10,MERC:6,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1193,11 +1193,11 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -1208,17 +1208,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,FS:1,MERC:1,CGS:9,DC.GHO:3,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>DC.GHO:4,CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:6</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>DC.GHO:4,CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1234,17 +1234,17 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:4,CC:5-,OA:4,HL:2,IS:2,SIC:5,MERC:4,FS:6,Periphery:4,TC:4</availability>
-		<model name='BJ-1DC'>
+		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='BJ-1DC'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='BJ-3'>
 			<availability>SIC:2+,FS:2+</availability>
-		</model>
-		<model name='BJ-1DB'>
-			<availability>FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
@@ -1286,13 +1286,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CLAN:1,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -1317,11 +1317,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -1340,34 +1340,34 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:8,CC:9,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,TC:8,Periphery:7,LA:6,FWL:6,DC:8</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CS:7,CHH:5,NIOPS:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -1390,13 +1390,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1408,51 +1408,54 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:7,SIC:5,FS:5</availability>
-		<model name='CTF-2X'>
-			<availability>CC:4,SIC:2,FS:1,MERC:1</availability>
+		<model name='CTF-1X'>
+			<availability>General:8,Periphery:8</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>General:8,Periphery:8</availability>
+		<model name='CTF-2X'>
+			<availability>CC:4,SIC:2,FS:1,MERC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:2,TC:2,Periphery:2,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:6</availability>
-		<model name='CPLT-K2'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>FRR:3,DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,HL:6,CLAN:4,IS:3,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
+			<availability>DC:6+</availability>
 		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,OA:3,SIC:3</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='CPLT-K3'>
-			<roles>fire_support</roles>
-			<availability>DC:6+</availability>
+			<availability>FRR:3,DC:6</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,SIC:4</availability>
 		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,HL:6,CLAN:4,IS:3,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:4</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<availability>General:5</availability>
@@ -1461,31 +1464,28 @@
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:6,Periphery.HR:6,FS:6,MERC:6,Periphery.OS:6,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,SIC:3,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,LA:8,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
@@ -1506,11 +1506,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -1528,18 +1528,18 @@
 		<model name='CHP-1Nb'>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CS:4</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>DC.GHO:8,CS:8,CHH:4,CLAN:1,NIOPS:8,MERC.SI:8,BAN:4,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1551,6 +1551,9 @@
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:5-,LA:4-,FRR:7-,FWL:3-,SIC:5-,MERC:3-,DC:7-</availability>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
+		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:3+,DC:3+</availability>
 		</model>
@@ -1558,18 +1561,19 @@
 			<roles>recon</roles>
 			<availability>CC:5-,LA:5-,FRR:5-,FWL:5-,DC:5-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
-		</model>
 		<model name='CGR-1L'>
 			<availability>CC:8,HL:2,SIC:6,Periphery:4</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,SIC:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5</availability>
 		</model>
@@ -1577,35 +1581,31 @@
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6</availability>
-		<model name='(BAP)'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:5,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -1614,13 +1614,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2,SIC:2</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2,SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -1647,20 +1647,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -1677,23 +1677,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -1701,14 +1701,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -1725,32 +1725,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1758,11 +1758,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -1770,20 +1770,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -1801,14 +1801,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:3-,SIC:4,FS:4,MERC:3,DC:3</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,SIC:3,FS:3</availability>
+		<model name='CLNT-2-3T'>
+			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,SIC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,SIC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -1848,6 +1848,10 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:3,FRR:4,CIR:4,MERC:4,FS:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+		<model name='COM-3A'>
+			<roles>recon</roles>
+			<availability>LA:6,MERC:3</availability>
+		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
@@ -1857,10 +1861,6 @@
 			<roles>recon</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:6,MERC:3</availability>
-		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
@@ -1869,14 +1869,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:5</availability>
@@ -1898,13 +1898,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:3,NIOPS:6,BAN:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1935,17 +1935,17 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:6,FWL:2,DC:2</availability>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='CSR-V20'>
-			<availability>LA:2,FS.AH:5,Periphery:2</availability>
-		</model>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:2,FS.AH:5,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1965,17 +1965,17 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8,DC:8+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-27b'>
 			<roles>raider</roles>
-			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8,DC:8+</availability>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -1983,11 +1983,11 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -1998,18 +1998,24 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CSV:8,CSJ:5,CCO:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:5,DC:5</availability>
+		</model>
 		<model name='CRD-3L'>
 			<roles>raider</roles>
 			<availability>CC:9,SIC:8</availability>
@@ -2017,29 +2023,23 @@
 		<model name='CRD-3R'>
 			<availability>HL:5,General:7,Periphery.Deep:7,BAN:3,Periphery:7</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:5,DC:5</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:1+,CS:1+,LA:1+,FWL:1+,IS:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -2071,14 +2071,14 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CW:6,CBS:3,CNC:3,CLAN:3,CSJ:8,CJF:5,BAN:2,CGB:3,CB:3</availability>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:5,CSV:4,CNC:4,General:5,CJF:6,CGB:5</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2097,10 +2097,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -2108,25 +2104,29 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:8,CCC:6,CIH:6,CDS:6,CLAN:5,CCO:4,CJF:4,BAN:5,CGB:9,CB:6</availability>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -2134,12 +2134,12 @@
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -2164,11 +2164,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
-		<model name='DV-6M'>
-			<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='DV-7D'>
 			<availability>FS:4+</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -2179,11 +2179,11 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>LA:1+,FS:1+</availability>
-		<model name='DVS-2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>LA:8,FS:8,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
@@ -2210,32 +2210,32 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:6,CIH:7,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:9,CB:7</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:1,LA:7,FRR:4,FWL:3,IS:3,SIC:2,FS:6,MERC:3,CC.CHG:4,DC:3,Periphery:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8</availability>
+		<model name='(ERLL)'>
+			<availability>LA:1+,FS:1+</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:8,General:4</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:1+,FS:1+</availability>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2247,25 +2247,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:3,FS:3</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
+		<model name='EGL-R4'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -2277,8 +2276,9 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2295,10 +2295,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -2307,6 +2303,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:2+,CIH:3+,CGS:3+,CB:2+</availability>
@@ -2314,12 +2314,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -2329,13 +2329,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2347,39 +2347,39 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:3,NIOPS:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:3,FWL:2,NIOPS:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2,DC:8</availability>
-		</model>
-		<model name='EXT-4A'>
-			<availability>FWL:8</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4A'>
+			<availability>FWL:8</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -2390,17 +2390,17 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>DC.GHO:4,MERC.WD:3,CGS:1</availability>
-		<model name='FLC-4N'>
-			<availability>MERC.WD:8,BAN:8,DC:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>MERC.WD:8,BAN:8,DC:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2412,71 +2412,71 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CNC:4,CLAN:4,CSJ:4,CJF:6,CGB:5</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:1,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:3,IS:2</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:3,IS:2</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:3</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(AC5)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
@@ -2493,75 +2493,72 @@
 		<model name='FFL-4B'>
 			<availability>MERC.WD:3+</availability>
 		</model>
-		<model name='FFL-4A'>
-			<availability>:0,MERC.WD:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='FFL-4A'>
+			<availability>:0,MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
-		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:8,LA:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:8,LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MERC.WD:1,Periphery.MW:1,Periphery.ME:1,FWL:2</availability>
-		<model name='FLE-4'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MERC.WD:3,FWL:3</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -2569,17 +2566,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2625,25 +2625,25 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:6,CW:6,CLAN:5</availability>
-		<model name='2'>
-			<availability>CW:6,CCO:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:6,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:5,HL:3,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:5,FS:8,CIR:6,Periphery:5,TC:6,CS:6,OA:8,LA:7,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>FWL:3</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:3,LA:3,FRR:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:8</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -2655,20 +2655,20 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CDS:5,CSR:4,CNC:4,CLAN:5,CSJ:6,CJF:5,BAN:3,CGB:8,CB:5</availability>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,CW:7,CNC:7,General:4,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
@@ -2679,14 +2679,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:3,TC:3,Periphery:3,OA:3,LA:4,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,SIC:4,FS:5</availability>
@@ -2694,6 +2686,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,FRR:2,NIOPS:2,SIC:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -2709,20 +2709,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:3</availability>
-		<model name='2'>
-			<availability>CSV:6,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:8,NIOPS:9</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -2760,14 +2760,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+		<model name='GRF-1N'>
+			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
+		</model>
 		<model name='GRF-1S'>
 			<availability>LA:6,FRR:4,MERC:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2794,13 +2794,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CHH:5,CSR:5,CLAN:1,IS:3,FS:2,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:3,NIOPS:7,DC:3</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2,Periphery:1</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -2823,35 +2823,35 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:7,CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:7,CLAN:5,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CSV:5,CNC:5,CSJ:6,CJF:4</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -2863,13 +2863,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:2,FRR:6,Periphery.Deep:4,MERC:6,Periphery:4,FWL.pm:8,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -2881,11 +2881,11 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='HTM-26T'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='HTM-27T'>
 			<availability>DC:3+</availability>
+		</model>
+		<model name='HTM-26T'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -2908,12 +2908,12 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>LA:4,FS:3,DC:2</availability>
-		<model name='HCT-3NH'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>LA:8,Periphery.Deep:6,MERC:8,FS:8,Periphery:8</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2925,21 +2925,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2950,21 +2950,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2972,46 +2980,38 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,NIOPS:6</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,DC:4+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:4,NIOPS:4</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -3019,15 +3019,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:5,FS:4</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -3042,21 +3042,17 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:4,CLAN:1,FWL:3,NIOPS:3,CGB:4,CB:2</availability>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:3+</availability>
@@ -3069,26 +3065,30 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
 		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,SIC:8,MERC:5,Periphery:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
+		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -3107,35 +3107,35 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:1,CLAN:7,NIOPS:9,CFM:8,SIC:1,CJF:8,DC:3</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8,DC:3+</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,MERC.WD:1,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:2,BAN:1</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:1</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:1</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:2,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -3176,42 +3176,42 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4P'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='HBK-5M'>
 			<availability>FWL:3+</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:8</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -3221,22 +3221,22 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:6,CS:4,CIH:7,CSV:7,CLAN:6,NIOPS:4</availability>
-		<model name='HSR-200-D'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8</availability>
+		<model name='HSR-300-D'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='HSR-350-D'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='HSR-300-D'>
-			<availability>DC:8</availability>
+		<model name='HSR-200-D'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:3,BAN:1</availability>
@@ -3285,16 +3285,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:6,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:2</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6,CLAN:2</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -3322,6 +3322,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:2,SIC:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -3331,11 +3336,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -3352,14 +3352,6 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
@@ -3368,13 +3360,21 @@
 			<roles>recon,raider</roles>
 			<availability>HL:6,General:5,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3383,36 +3383,36 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,NIOPS:3,SIC:6,MERC:3,FS:8</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FRR:8,SIC:8,FS:8</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FRR:8,SIC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
-		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
@@ -3432,14 +3432,14 @@
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:4,CGS:4,CCO:5,CB:6</availability>
+		<model name='2'>
+			<availability>CCC:5,CSV:5,CNC:5</availability>
+		</model>
 		<model name='3'>
 			<availability>CCC:4,CSV:4,CNC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,CLAN:8,CNC:8</availability>
-		</model>
-		<model name='2'>
-			<availability>CCC:5,CSV:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -3466,19 +3466,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -3521,6 +3521,13 @@
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:6,CW:5,CLAN:5</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -3528,22 +3535,15 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(SL)'>
+			<availability>IS:2</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>MERC.WD:2</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SL)'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
-		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -3558,26 +3558,26 @@
 		<model name='KGC-000b'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='KGC-0000'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -3588,21 +3588,18 @@
 		<model name='KTO-19'>
 			<availability>DC.GHO:8,CS:8,DC.SL:4,CLAN:6,NIOPS:8,MERC.SI:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 		<model name='KTO-20'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		<model name='KTO-18'>
+			<availability>:0,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -3612,16 +3609,19 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
@@ -3632,17 +3632,9 @@
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -3651,6 +3643,14 @@
 		<model name='D'>
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3680,17 +3680,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:1,CLAN:4,NIOPS:6,CFM:5,CGS:5,BAN:7,DC:1</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,FRR:8,DC:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:6</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:6</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,FRR:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3726,10 +3726,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -3739,24 +3735,28 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:5,CIH:7,CLAN:6,NIOPS:5,CJF:5</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:4,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3772,18 +3772,26 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,CLAN:5,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:1-,IS:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2,SIC:2</availability>
@@ -3792,21 +3800,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
-			<roles>recon</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:7,FS:7</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:8</availability>
+			<availability>LA:4,General:7,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
@@ -3814,33 +3814,33 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CS:6,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6,Periphery:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -3864,25 +3864,25 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>CLAN:1-,CCO:2-,BAN:2</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -3911,14 +3911,14 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
@@ -3951,14 +3951,14 @@
 		<model name='A'>
 			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -3990,9 +3990,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-5D'>
 			<availability>LA:3+,FRR:3+,FS:3+,DC:4+</availability>
 		</model>
@@ -4002,14 +3999,17 @@
 		<model name='MAD-3L'>
 			<availability>CC:3,SIC:3</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:3,CGS:4,BAN:3</availability>
-		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:3,CGS:4,BAN:3</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
@@ -4030,11 +4030,11 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:5,CB:4</availability>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:9</availability>
@@ -4072,18 +4072,22 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
@@ -4092,20 +4096,16 @@
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -4132,35 +4132,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -4168,20 +4165,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -4189,8 +4189,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -4254,13 +4254,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -4270,11 +4266,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -4310,13 +4310,13 @@
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='MON-68'>
 			<roles>recon</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -4327,11 +4327,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:1</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -4348,7 +4348,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -4357,14 +4357,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -4387,6 +4387,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
@@ -4395,25 +4403,17 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
 		<availability>LA:6,FS:8,DC:6</availability>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -4451,15 +4451,15 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CNC:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -4481,15 +4481,15 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,LA:6,PIR:4,Periphery.ME:4,FWL:9,MH:4,SIC:6,FS:7,CIR:4</availability>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,SIC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -4521,22 +4521,22 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -4556,11 +4556,11 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:6,NIOPS:6,FS:6,MERC:6,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -4583,13 +4583,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,SIC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -4598,13 +4598,13 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CS:4,NIOPS:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
@@ -4623,16 +4623,16 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:7,FS:9,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -4650,14 +4650,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:6,CC:8,HL:4,FRR:8,IS:8,Periphery.Deep:6,SIC:8,FS:8,CIR:6,Periphery:6,TC:6,OA:6,LA:8,FWL:8,DC:8</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -4666,27 +4658,35 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:4,CSJ:7,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:6-,LA:2-,FRR:5-,FWL:3-,IS:3-,SIC:6-,FS:3-,MERC:4-,DC:4-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:4</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -4707,18 +4707,42 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+		<model name='PXH-3S'>
+			<roles>recon</roles>
+			<availability>LA:4+</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:4+,MERC:3+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:7,BAN:6,Periphery:7</availability>
+		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>BAN:1</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:6,DC:6</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:4+</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
@@ -4728,40 +4752,16 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:1</availability>
 		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:6,DC:6</availability>
-		</model>
-		<model name='PXH-3S'>
-			<roles>recon</roles>
-			<availability>LA:4+</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:4+</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:7,BAN:6,Periphery:7</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:4+,MERC:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:4,DC:5</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
@@ -4803,13 +4803,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4833,41 +4833,41 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:5,CSA:9,CDS:8,CW:8,CBS:7,CNC:8,CSJ:7,CJF:6,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4903,11 +4903,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,NIOPS:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,NIOPS:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:8</availability>
@@ -4918,27 +4918,35 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:5,SIC:3,FS:3</availability>
-		<model name='RVN-4X'>
-			<availability>CC:2</availability>
-		</model>
-		<model name='RVN-1X'>
-			<roles>recon,ew_support</roles>
-			<availability>CC:5,SIC:3,FS:3</availability>
+		<model name='RVN-2X'>
+			<availability>FS:1</availability>
 		</model>
 		<model name='RVN-3L'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
+		<model name='RVN-1X'>
+			<roles>recon,ew_support</roles>
+			<availability>CC:5,SIC:3,FS:3</availability>
+		</model>
+		<model name='RVN-4X'>
+			<availability>CC:2</availability>
+		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:1</availability>
 		</model>
-		<model name='RVN-2X'>
-			<availability>FS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
@@ -4951,34 +4959,26 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+		<model name='F-100'>
+			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
+		</model>
 		<model name='F-100b'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:4</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:6,CLAN:6,CNC:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:6,CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -4990,10 +4990,6 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:8-,CCC:1,HL:3,FRR:8-,CSV:1,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:7-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:3</availability>
-		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:2</availability>
@@ -5002,23 +4998,24 @@
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>HL:6,CLAN:1-,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:4,CSR:2,CLAN:2,NIOPS:5,CJF:1</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
@@ -5027,6 +5024,9 @@
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
@@ -5048,17 +5048,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -5085,11 +5085,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:5</availability>
@@ -5097,36 +5097,36 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:4,CJF:4</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>DC:3</availability>
-		<model name='S-4X'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='S-3'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='S-4X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,DC.AL:10,FRR:9,IS:7,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,LA:8,FWL:8,DC:9</availability>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -5182,26 +5182,26 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,OA:8,LA:8,FWL:6,DC:9</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FRR:10,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -5225,9 +5225,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -5236,6 +5233,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -5259,20 +5259,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:8</availability>
 		</model>
 		<model name='STN-3KB'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='STN-3KA'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -5281,55 +5281,55 @@
 			<roles>interceptor</roles>
 			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:8,CFM:5,CSJ:6,CB:5</availability>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
+			<availability>CSR:3,General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:8,DC:9</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:10</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
-		</model>
 		<model name='SHD-2Hb'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>FWL:5+</availability>
+		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:8,DC:9</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FS:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -5352,14 +5352,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -5386,13 +5386,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:5,NIOPS:3,DC:8</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -5401,8 +5401,8 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
-		<model name='SL-15A'>
-			<availability>OA:3,FRR:3,DC:3</availability>
+		<model name='SL-15'>
+			<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>DC:4+</availability>
@@ -5410,21 +5410,21 @@
 		<model name='SL-15B'>
 			<availability>FRR:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>FRR:3,DC:3</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:3,FRR:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -5456,10 +5456,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:2,TC:8</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:4,FRR:8,DC:8</availability>
@@ -5467,6 +5463,10 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>LA:8,FS.CMM:3</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:2,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -5502,17 +5502,17 @@
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5534,49 +5534,49 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STG-3G'>
+		<model name='STG-3R'>
 			<roles>recon</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+		<model name='F-90'>
+			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:8</availability>
 		</model>
-		<model name='F-90'>
-			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -5617,11 +5617,11 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
+		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:3,FS:3,TC:2,Periphery:1</availability>
@@ -5639,17 +5639,17 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -5681,15 +5681,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -5697,11 +5697,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -5712,26 +5712,23 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -5740,38 +5737,41 @@
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
 		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,NIOPS:8,BAN:1</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,NIOPS:8,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>DC.GHO:3,CSA:1,CS:6,CDS:2,CLAN:3,NIOPS:6,CCO:1,CJF:2,CGB:2</availability>
+		<model name='THE-N'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -5828,23 +5828,23 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:2,CLAN:3,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-9SE'>
-			<availability>MERC.ELH:3+</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-7M'>
+			<availability>FWL:3+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:5,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>FWL:3+</availability>
+		<model name='TDR-9SE'>
+			<availability>MERC.ELH:3+</availability>
 		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:8</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -5875,16 +5875,16 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:4,NIOPS:4</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -5905,11 +5905,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:2</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:5,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
@@ -5924,39 +5924,39 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>FWL:3+</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-7K'>
 			<roles>fire_support</roles>
 			<availability>FRR:2,DC:4</availability>
 		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>FWL:3+</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
-		</model>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5989,50 +5989,50 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CDS:2,CW:2,CSV:1,CNC:1,General:2,CSJ:2,CJF:2,CGB:2,CB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -6069,43 +6069,43 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:6,FS:8,MERC:8,TC:8</availability>
 		</model>
+		<model name='VLK-QF'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>HL:8,IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:4,General:5,SIC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:5,General:8,SIC:5</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
@@ -6117,6 +6117,9 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:5</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
+		</model>
 		<model name='VTR-9B'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
@@ -6125,9 +6128,6 @@
 		</model>
 		<model name='VTR-9S'>
 			<availability>LA:4,CIR:4</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -6146,14 +6146,14 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>FRR:8</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1,SIC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
 		<model name='VND-1SIC'>
 			<availability>SIC:2</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1,SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
@@ -6161,26 +6161,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:7,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -6196,11 +6196,11 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:5,FRR:5,FWL:4,IS:1,FS:4,DC:5</availability>
-		<model name='VNL-K100'>
-			<availability>LA:1,FS:3</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:3,DC:3</availability>
@@ -6214,13 +6214,13 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
@@ -6228,14 +6228,14 @@
 		<model name='B'>
 			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -6253,21 +6253,21 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='12'>
-			<availability>CSJ:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
+			<availability>CSJ:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='11'>
-			<availability>CSJ:6</availability>
+		<model name='12'>
+			<availability>CSJ:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
@@ -6275,23 +6275,23 @@
 		<model name='WHM-6L'>
 			<availability>CC:4,SIC:4</availability>
 		</model>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:4,FS.DMM:2,FS:1,DC:4</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='WHM-7M'>
-			<availability>FWL:4+</availability>
+		<model name='WHM-7A'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>FWL:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -6307,32 +6307,28 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:2,Periphery:6</availability>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:4,DC:4</availability>
@@ -6340,6 +6336,10 @@
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
@@ -6352,13 +6352,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CSJ:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -6386,13 +6386,13 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -6401,11 +6401,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:1-,CLAN:1-,BAN:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -6417,13 +6417,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,CLAN:3,IS:4,CFM:4,MERC:4,FS:5,Periphery:1,TC:2,CS:6,DC.GHO:6,NIOPS:6,DC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:8,CS:8,NIOPS:8,CFM:4,BAN:4</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:2,CFM:3,CGS:3</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:8,CS:8,NIOPS:8,CFM:4,BAN:4</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -6459,43 +6459,43 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>DC.GHO:4,CS:8,CLAN:6,NIOPS:8</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
+		<model name='(SRM2)'>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:7,CLAN:5,BAN:2</availability>
+			<availability>CHH:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(SRM2)'>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:1</availability>
+			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:8,CLAN:2,NIOPS:8</availability>
-		</model>
 		<model name='ZRO-116b'>
 			<availability>CSR:1</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:8,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:4,LA:10,FRR:4,FS:6-,MERC:5</availability>
-		<model name='ZEU-9S'>
-			<availability>LA:4+</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:4,FS:6</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:6,Periphery.Deep:6,FS:8,Periphery:8</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:1+</availability>
 		</model>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:6,Periphery.Deep:6,FS:8,Periphery:8</availability>
+		<model name='ZEU-9S'>
+			<availability>LA:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>

--- a/megamek/data/forcegenerator/3050.xml
+++ b/megamek/data/forcegenerator/3050.xml
@@ -852,13 +852,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CCC:2,CIH:2,CSR:4,CSV:1,CGS:2,CSA:2,CS:4,MERC.WD:1,CDS:1,CBS:1,CNC:5,CJF:6,CB:1</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -885,20 +885,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:3,CLAN:2-,MERC:5</availability>
 		</model>
 		<model name='ANH-1E'>
 			<availability>MERC.WD:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:4+,MERC.WD:6+</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:3</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -924,54 +924,54 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,WOB:4-,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:4+,LA:2+,MERC:2+</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:6</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CW:2</availability>
+			<availability>FRR:4,DC:8</availability>
 		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:4+,FS:3+</availability>
 		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-2S'>
 			<roles>fire_support</roles>
-			<availability>FRR:4+</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:4,LA:6,FRR:6,IS:6,Periphery.Deep:6,BAN:2,DC:6,Periphery:6</availability>
+			<availability>LA:8</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:4+,FWL:6+,WOB:4</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2R'>
 			<roles>fire_support</roles>
-			<availability>FRR:4,DC:8</availability>
+			<availability>HL:4,LA:6,FRR:6,IS:6,Periphery.Deep:6,BAN:2,DC:6,Periphery:6</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:4+</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:4+,LA:2+,MERC:2+</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CW:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -982,23 +982,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1006,33 +990,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1040,12 +1040,12 @@
 		<model name='ASN-101'>
 			<availability>FS.CMM:2</availability>
 		</model>
+		<model name='ASN-21'>
+			<availability>General:4</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:4</availability>
-		</model>
-		<model name='ASN-21'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1070,42 +1070,42 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:4,CLAN:2,IS:3,WOB:4-,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:4,NIOPS:4-,DC:6</availability>
-		<model name='AS7-K'>
-			<availability>CS:2+,DC:4+</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,DC:2</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:3+,DC:3+</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>DC:1+</availability>
+		<model name='AS7-S'>
+			<availability>LA:5+,FS:4,MERC:3+</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:3+,DC:3+</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>DC:2+</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>LA:5+,FS:4,MERC:3+</availability>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>DC:1+</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>CS:2+,DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -1113,14 +1113,14 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -1136,23 +1136,23 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,WOB:8,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>LA:3,FWL:3,FS:3</availability>
+		</model>
+		<model name='AWS-9M'>
+			<availability>FWL:5+,IS:4+</availability>
+		</model>
 		<model name='AWS-8R'>
 			<availability>IS:2,FWL:4</availability>
 		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
-		</model>
-		<model name='AWS-9M'>
-			<availability>FWL:5+,IS:4+</availability>
-		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:3,FWL:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1166,12 +1166,12 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5+,FS:3+</availability>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
+		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:6,FS:4</availability>
-		</model>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
@@ -1183,20 +1183,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CW:2,CLAN:2</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -1206,15 +1206,11 @@
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5,MERC:4</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1222,7 +1218,11 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1239,7 +1239,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CLAN:2</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1247,29 +1255,13 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:6</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
@@ -1282,42 +1274,56 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:2-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
-		<model name='BNC-3MC'>
-			<availability>MOC:9</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
-		</model>
-		<model name='BNC-3E'>
-			<availability>HL:4,General:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='BNC-3S'>
-			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:6+</availability>
 		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:9</availability>
+		</model>
+		<model name='BNC-3S'>
+			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>HL:4,General:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -1325,23 +1331,17 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -1360,26 +1360,14 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
 		</model>
 		<model name='BLR-1S'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:4+,FS:3+</availability>
@@ -1389,6 +1377,18 @@
 		</model>
 		<model name='BLR-3M'>
 			<availability>CS:4+,CC:3+,FWL:5+,WOB:4+,SIC:3+,MERC:3+</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1424,14 +1424,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:2,CSJ:5,CGS:3</availability>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='4'>
 			<availability>General:2</availability>
 		</model>
 		<model name='5'>
 			<availability>General:2</availability>
+		</model>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,General:8</availability>
@@ -1439,15 +1439,15 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:6,HL:1,FRR:7,IS:4,WOB:6-,SIC:7,MERC:6,FS:10,Periphery:3,CS:6-,OA:5,LA:7,PIR:6,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1462,30 +1462,33 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CCO:5</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:1,CW:2,CSV:2,CNC:1,CLAN:1,General:2,CSJ:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CCO:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,FRR:2,CLAN:8,CFM:7,FS:1,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:5,CLAN:5,FWL:4+,NIOPS:5,WOB:5,CGS:6,BAN:2</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
+		</model>
+		<model name='BL-7-KNT'>
+			<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>CS:5+,WOB:5+</availability>
@@ -1493,32 +1496,29 @@
 		<model name='BL-6-KNT'>
 			<availability>DC.GHO:4,CS:6,FRR:3+,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:3+</availability>
 		</model>
-		<model name='BL-7-KNT'>
-			<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:5,CLAN:5,FWL:4+,NIOPS:5,WOB:5,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CJF:4</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1534,20 +1534,20 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:2,IS:2,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-1DC'>
+		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:1+,SIC:3+,FS:2+</availability>
-		</model>
-		<model name='BJ-1DB'>
+		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CS:3+,WOB:3+,SIC:3+,FS:3+</availability>
+		</model>
+		<model name='BJ-3'>
+			<availability>CC:1+,SIC:3+,FS:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
@@ -1596,13 +1596,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -1627,11 +1627,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -1650,25 +1650,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:8,CC:9,HL:4,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:6,TC:8,Periphery:6,LA:6,FWL:6,DC:8</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1712,13 +1712,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1730,62 +1730,65 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,LA:3,SIC:5,FS:5,MERC:2</availability>
-		<model name='CTF-2X'>
-			<availability>CC:6,SIC:2,FS:1,MERC:1</availability>
-		</model>
 		<model name='CTF-3D'>
 			<availability>LA:3+,FS:3+</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:5+</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FS:3</availability>
 		</model>
 		<model name='CTF-1X'>
 			<availability>General:8,Periphery:8</availability>
 		</model>
+		<model name='CTF-4X'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:6,SIC:2,FS:1,MERC:1</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:5+</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,FS:1,CIR:2,TC:2,Periphery:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
-		<model name='CPLT-K2'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>FRR:3,DC:6</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:6,HL:4,CLAN:4,IS:2,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+			<availability>DC:6+</availability>
 		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,DC:6</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:4,SIC:4</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4+,CS:2,WOB:2</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='CPLT-K3'>
-			<roles>fire_support</roles>
-			<availability>DC:6+</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:4,SIC:4</availability>
+			<availability>CC:6,HL:4,CLAN:4,IS:2,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<availability>General:5</availability>
@@ -1794,20 +1797,17 @@
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:4,FS:6,MERC:4</availability>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -1826,38 +1826,38 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:5,Periphery.HR:5,FS:5,MERC:5,Periphery.OS:5,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:3,IS:2,FS:4,MERC:4,Periphery:2</availability>
+		<model name='CN10-B'>
+			<availability>LA:2+,FS:3+</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,LA:6,FRR:6,General:6,FWL:6,Periphery.Deep:7,FS:6,MERC:6,Periphery:8</availability>
 		</model>
+		<model name='CN9-D3'>
+			<availability>FS:2+</availability>
+		</model>
 		<model name='CN9-D'>
 			<availability>SIC:2+,FS:6+</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:3,IS:2,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>IS:2,FS:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='CN9-D3'>
-			<availability>FS:2+</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:2+,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -1880,11 +1880,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -1899,21 +1899,21 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:4,CHH:3,CLAN:2,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:5,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-3N'>
-			<availability>CS:4,WOB:5</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:3+,CS:4,LA:3+,IS:3+,MERC:3+</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:3,WOB:8,SIC:3,FS:3,MERC:3,BAN:4,DC.GHO:6,CS:8,LA:3,NIOPS:8,MERC.SI:8,DC:3,CGB:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:3+,CS:4,LA:3+,IS:3+,MERC:3+</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>CS:4,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1928,8 +1928,8 @@
 		<model name='CGR-3K'>
 			<availability>CC:2,FRR:3,MERC:2,DC:4</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:3</availability>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:5,DC:5</availability>
@@ -1938,39 +1938,39 @@
 			<roles>recon</roles>
 			<availability>CC:5-,MOC:5-,OA:4-,HL:3-,LA:5-,FRR:5-,FWL:5-,DC:5-,Periphery:5-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
-		</model>
 		<model name='CGR-1L'>
 			<availability>CC:6,HL:2,SIC:6,Periphery:4</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:3</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,SIC:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,WOB:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:7,HL:5,General:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
+		</model>
 		<model name='F-12-S'>
 			<availability>FWL:5,WOB:5</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>FWL:4+</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:7,HL:5,General:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
-		</model>
 		<model name='F-11'>
 			<availability>FWL:5+</availability>
-		</model>
-		<model name='F-14-S'>
-			<availability>FWL:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6,WOB:6</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -1978,24 +1978,24 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:4+,FRR:2+,CLAN:6,WOB:6,SIC:2+,FS:2+,MERC:2+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:4+,FRR:2+,CLAN:6,WOB:6,SIC:2+,FS:2+,MERC:2+,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -2004,6 +2004,10 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='CDA-3C'>
+			<roles>training</roles>
+			<availability>IS:2</availability>
+		</model>
 		<model name='CDA-3M'>
 			<roles>recon</roles>
 			<availability>FWL:6+,IS:2+,MERC:5+</availability>
@@ -2011,10 +2015,6 @@
 		<model name='CDA-2B'>
 			<roles>anti_infantry</roles>
 			<availability>CC:1,SIC:1</availability>
-		</model>
-		<model name='CDA-3C'>
-			<roles>training</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -2041,20 +2041,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -2071,23 +2071,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -2095,14 +2095,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -2119,32 +2119,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -2152,11 +2152,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -2164,20 +2164,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -2202,17 +2202,17 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:3-,WOB:3-,SIC:4,FS:4,MERC:3,DC:3</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,SIC:3,FS:3</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:3+,CS:3</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,SIC:1,FS:1</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,SIC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -2252,22 +2252,22 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:3,FRR:4,FS:5,CIR:4,MERC:5,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>LA:6+,FRR:3+</availability>
+			<availability>LA:5,FS:1,MERC:3</availability>
 		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
 		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>LA:6+,FRR:3+</availability>
+		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
 			<availability>LA:2</availability>
-		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:5,FS:1,MERC:3</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -2277,14 +2277,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,HL:1,FRR:3,IS:3,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:5</availability>
@@ -2306,13 +2306,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -2356,20 +2356,20 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+		<model name='CSR-V12'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
+		</model>
 		<model name='CSR-V14'>
 			<availability>LA:4+,FRR:3+,FS:4+,MERC:3+</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='CSR-V20'>
-			<availability>LA:2,FS.AH:5,Periphery:2</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
-		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:2,FS.AH:5,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -2389,20 +2389,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,WOB:5,MERC:1,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:4</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
+			<availability>DC.GHO:8,CS:6,CLAN:6,NIOPS:6,WOB:6,BAN:8,DC:8+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
 		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
 		<model name='CRB-C'>
 			<availability>DC:4+</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:8,CS:6,CLAN:6,NIOPS:6,WOB:6,BAN:8,DC:8+</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -2410,11 +2410,11 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -2425,36 +2425,23 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CSV:8,CSJ:5,CCO:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:6-,Periphery:5</availability>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9,SIC:8</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:3,Periphery:6</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>FWL:4+,WOB:4</availability>
+		<model name='CRD-3D'>
+			<availability>FS:5</availability>
 		</model>
 		<model name='CRD-3K'>
 			<availability>FRR:5,DC:5</availability>
-		</model>
-		<model name='CRD-4K'>
-			<availability>LA:3+,FRR:4+,MERC:3+,FS:3+,DC:4+</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:4</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:4+,FS:3+,MERC:3+</availability>
@@ -2462,11 +2449,24 @@
 		<model name='CRD-4L'>
 			<availability>CC:4+</availability>
 		</model>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9,SIC:8</availability>
+		</model>
+		<model name='CRD-3R'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:3,Periphery:6</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>MERC:4</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>LA:3+,FRR:4+,MERC:3+,FS:3+,DC:4+</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FS:5</availability>
+		<model name='CRD-5M'>
+			<availability>FWL:4+,WOB:4</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FS:4+</availability>
@@ -2474,17 +2474,17 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:1+,CS:1,LA:1+,FWL:1+,IS:1+,WOB:1,FS:1+,DC:2+</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -2526,12 +2526,11 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:2,CDS:5,CW:6,CBS:3,CNC:4,CLAN:4,CSJ:8,CJF:5,BAN:2,CGB:4,CB:4</availability>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<availability>MERC.WD:5</availability>
@@ -2542,8 +2541,9 @@
 		<model name='C'>
 			<availability>CCO:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2574,18 +2574,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(ECM)'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(BAP)'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -2593,41 +2581,53 @@
 		<model name='(SRM-2)'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(ECM)'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:8,CCC:6,MERC.WD:3,CIH:6,CDS:6,CLAN:5,CCO:4,CJF:4,BAN:5,CGB:9,CB:6</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,WOB:6-,SIC:8,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>CC:3+,CS:3,LA:3+,FRR:3+,FWL:3+,IS:2+,WOB:3,SIC:3+,FS:3+,DC:3+</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -2652,11 +2652,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:7,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
-		<model name='DV-6M'>
-			<availability>HL:6,CLAN:4,IS:7-,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='DV-7D'>
 			<availability>FS:5+</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>HL:6,CLAN:4,IS:7-,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -2667,11 +2667,11 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>LA:1+,FS:2+,TC:2</availability>
-		<model name='DVS-2'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>LA:6,FS:6,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
@@ -2698,35 +2698,35 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:3,CHH:6,CIH:7,CDS:5,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:5,CGB:9,CB:7</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='E'>
-			<availability>CCO:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:1,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8</availability>
+		<model name='(ERLL)'>
+			<availability>LA:1+,FS:1+</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:8,General:4</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:1+,FS:1+</availability>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8</availability>
 		</model>
 		<model name='(Streak)'>
 			<availability>LA:6+</availability>
@@ -2741,25 +2741,27 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:3,FS:3</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:2,General:8,FS:2</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:2,General:8,FS:2</availability>
+		<model name='EGL-R4'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,MERC.WD:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -2771,11 +2773,9 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2786,19 +2786,15 @@
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>LA:5,MH:2,SIC:3,FS:9,MERC:5,TC:2,DC:3</availability>
-		<model name='ENF-5D'>
-			<availability>LA:2+,FS:4+</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>LA:6,General:8,FS:8,TC:8</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>LA:2+,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -2807,6 +2803,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:3+,CIH:3+,CGS:3+,CB:2+</availability>
@@ -2814,12 +2814,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -2829,13 +2829,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2847,36 +2847,36 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:2,NIOPS:8,WOB:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3,WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:2,FWL:1,NIOPS:4,WOB:4</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4A'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -2887,8 +2887,8 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>DC.GHO:3,MERC.WD:2</availability>
-		<model name='FLC-4N'>
-			<availability>MERC.WD:6,BAN:8,DC:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
@@ -2896,11 +2896,11 @@
 		<model name='FLC-4P'>
 			<availability>MERC.WD:4+</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>MERC.WD:6,BAN:8,DC:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2912,63 +2912,71 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:4,CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CNC:4,CLAN:4,CSJ:4,CJF:6,CGB:5</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:1,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:4,IS:3</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:4,IS:3</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(Light Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(AC20)'>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2976,26 +2984,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC2)'>
+		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CJF:3</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
@@ -3004,6 +2999,11 @@
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -3034,79 +3034,79 @@
 		<model name='FFL-4B'>
 			<availability>MERC.WD:4+</availability>
 		</model>
-		<model name='FFL-4A'>
-			<availability>:0,MERC.WD:3-</availability>
+		<model name='FFL-4C'>
+			<availability>CS:5,WOB:5</availability>
 		</model>
 		<model name='C'>
 			<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
 		</model>
-		<model name='FFL-4C'>
-			<availability>CS:5,WOB:5</availability>
+		<model name='FFL-4A'>
+			<availability>:0,MERC.WD:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
+		<model name='FS9-S1'>
 			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
+			<availability>LA:3+,FS:2+</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:2+,CS:2+,MOC:2+,LA:3+,FRR:2+,General:2+,FS:2+,TC:2+</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='FS9-S'>
+		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
-			<availability>CC:2+,CS:2+,MOC:2+,LA:3+,FRR:2+,General:2+,FS:2+,TC:2+</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:3+,FS:2+</availability>
+			<availability>LA:1,LA.SR:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:6,LA:6</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:6,LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,MERC.WD:3,Periphery.MW:4,Periphery.ME:4,FWL:2,CIR:4,Periphery:4,TC:4</availability>
-		<model name='FLE-4'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MERC.WD:2,FWL:2</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:5+</availability>
@@ -3114,9 +3114,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -3124,17 +3121,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -3183,25 +3183,25 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:5,CW:5,CLAN:4</availability>
-		<model name='2'>
-			<availability>CW:6,CCO:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:6,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:4,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>CS:3,MOC:3,LA:3,FRR:3,FWL:5,FS:3,MERC:3,CIR:3</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:8</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>CS:3,MOC:3,LA:3,FRR:3,FWL:5,FS:3,MERC:3,CIR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -3213,20 +3213,20 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,MERC.WD:2,CDS:5,CSR:4,CNC:5,CLAN:5,CSJ:7,CJF:6,BAN:3,CGB:8,CB:6</availability>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,CW:7,CNC:7,General:4,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
@@ -3244,14 +3244,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,WOB:2,SIC:1,MERC:1,FS:6,CIR:3,Periphery:3,TC:3,CS:3-,OA:2,LA:4,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,SIC:4,FS:5</availability>
@@ -3259,6 +3251,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,FRR:2,NIOPS:2,WOB:2,SIC:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -3274,20 +3274,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:2</availability>
-		<model name='2'>
-			<availability>CSV:6,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,Periphery.MW:3,PIR:3,CLAN:5,Periphery.ME:3,CNC:5,FWL:8,NIOPS:9,WOB:9,MERC:4</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:3,HL:2,CNC:3,FWL:4,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:4,BAN:1,Periphery:4</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -3301,11 +3301,11 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='DRG-1G'>
-			<availability>FRR:8,DC:8</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:3+,DC:4+</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='DRG-C'>
 			<availability>FRR:4+,DC:4+</availability>
@@ -3316,9 +3316,6 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>CS:2,IS:2+,WOB:2</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
@@ -3327,6 +3324,9 @@
 		</model>
 		<model name='GHR-C'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>CS:2,IS:2+,WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -3338,14 +3338,14 @@
 	</chassis>
 	<chassis name='Gray Death Standard Suit' unitType='BattleArmor'>
 		<availability>MERC.GDL:4</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -3359,20 +3359,20 @@
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CDS:5</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
@@ -3386,20 +3386,20 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,WOB:4,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
-		<model name='GRF-1S'>
-			<availability>LA:6,FRR:4,MERC:4</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>LA:4+,FWL:4+</availability>
+		<model name='GRF-1N'>
+			<availability>HL:5,General:7,Periphery.Deep:7,BAN:2,Periphery:7</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>LA:4+,FRR:4+,FS:4+,MERC:4+,DC:4+</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:5,General:7,Periphery.Deep:7,BAN:2,Periphery:7</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6,FRR:4,MERC:4</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>LA:4+,FWL:4+</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
@@ -3432,13 +3432,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,NIOPS:0,MERC:7,Periphery:7</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,NIOPS:0,MERC:7,Periphery:7</availability>
 		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
@@ -3486,35 +3486,35 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7,WOB:7,DC:2</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:6,CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:6,CLAN:5,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:4,CSV:5,CNC:5,CLAN:2,CSJ:6,CJF:4,CCO:2,CGB:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -3526,13 +3526,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -3544,24 +3544,24 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:4,DC:8</availability>
-		<model name='HTM-26T'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='HTM-27T'>
 			<availability>FRR:4+,DC:3+</availability>
+		</model>
+		<model name='HTM-26T'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>FRR:3,DC:4</availability>
+		<model name='HTM-27U'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6+</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4+</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaze' unitType='Mek'>
@@ -3584,15 +3584,15 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:3,LA:6,FRR:3,FS:4,MERC:3,DC:4</availability>
-		<model name='HCT-3NH'>
-			<availability>DC:5</availability>
+		<model name='HCT-3F'>
+			<roles>urban</roles>
+			<availability>LA:6,Periphery.Deep:4,MERC:6,FS:6,Periphery:6</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>LA:4+,FRR:2+,FS:4+</availability>
 		</model>
-		<model name='HCT-3F'>
-			<roles>urban</roles>
-			<availability>LA:6,Periphery.Deep:4,MERC:6,FS:6,Periphery:6</availability>
+		<model name='HCT-3NH'>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -3604,21 +3604,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -3629,21 +3629,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -3652,45 +3660,37 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8,WOB:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8,WOB:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:2,NIOPS:6,WOB:6,FS:2,DC:3</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:5,NIOPS:5,WOB:5</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,DC:6+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:5,NIOPS:5,WOB:5</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -3698,15 +3698,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:4,FS:3</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -3734,10 +3734,6 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
@@ -3746,17 +3742,13 @@
 			<roles>recon</roles>
 			<availability>FWL:4+</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:3,FWL:4,NIOPS:3,WOB:3,CGB:3,CB:2</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:2+</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:4+,WOB:4+</availability>
@@ -3765,34 +3757,42 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:2</availability>
 		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:3+,WOB:3</availability>
-		</model>
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:4</availability>
 		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:2+</availability>
+		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:3+,WOB:3</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:4-,CDS:2,Periphery.CM:7,CNC:2,IS:4-,Periphery.Deep:6,WOB:4-,SIC:8,MERC:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
+		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -3811,20 +3811,20 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:3,CLAN:7,NIOPS:9,CFM:8,WOB:9,SIC:1,CJF:8,DC:2</availability>
+		<model name='HGN-733'>
+			<availability>CC:6,:0,LA:6,SIC:6,DC:6</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:6,:0,LA:6,SIC:6,DC:6</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>DC.GHO:8,CS:6,CLAN:6,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -3835,37 +3835,37 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:1,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:3</availability>
 		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:8,CLAN:2</availability>
+		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
-		<model name='HNT-161'>
-			<availability>MERC.WD:6-</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:3</availability>
 		</model>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:8</availability>
+		<model name='HNT-161'>
+			<availability>MERC.WD:6-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:4+,MERC:4+</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -3895,46 +3895,42 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,WOB:5-,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
-		</model>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4P'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='HBK-5M'>
 			<availability>CS:3+,CC:2+,FRR:2+,FWL:4+,WOB:3+,MERC:3+</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>LA:7+,FS:3+</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -3944,28 +3940,32 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>LA:7+,FS:3+</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:6,CS:4,CIH:7,CSV:7,CLAN:6,NIOPS:4,WOB:4,DC:2</availability>
-		<model name='HSR-200-D'>
-			<roles>recon</roles>
-			<availability>CS:8,General:4,CLAN:6,NIOPS:8,MERC.SI:8,WOB:6,BAN:8</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:4</availability>
+		<model name='HSR-400-D'>
+			<availability>CS:4,LA:4,WOB:4,MERC:4</availability>
 		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:8</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='HSR-200-D'>
+			<roles>recon</roles>
+			<availability>CS:8,General:4,CLAN:6,NIOPS:8,MERC.SI:8,WOB:6,BAN:8</availability>
+		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:4,LA:4,WOB:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -3976,29 +3976,29 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,WOB:8,FS:8,DC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Level I) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [MG]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
 		<model name='(Level I) [SRM]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Level I) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -4048,16 +4048,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:6,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6,CLAN:1</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:1</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6,CLAN:1</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -4085,6 +4085,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:3,SIC:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -4094,11 +4099,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -4115,9 +4115,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,WOB:3-,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:3-,OA:5,LA:6,FWL:3,NIOPS:3-,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:6,General:4,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -4127,17 +4131,13 @@
 			<roles>recon,raider</roles>
 			<availability>DC:6,TC:3</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:6,General:4,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
@@ -4148,10 +4148,10 @@
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>CS:2-,NIOPS:2-,WOB:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -4160,47 +4160,47 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,LA:4,FRR:5,IS:2,FWL:3,NIOPS:3,WOB:3,SIC:6,MERC:3,FS:8,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:8,FRR:8,IS:8,SIC:8,FS:8</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>OA:4+,LA:4+,FRR:4+,FS:4+,MERC:4+,DC:4+</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:8,FRR:8,IS:8,SIC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10P'>
+		<model name='JVN-10N'>
 			<roles>recon</roles>
-			<availability>FS:4+</availability>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:2,FS:6,MERC:2,TC:2,Periphery:2</availability>
 		</model>
-		<model name='JVN-10N'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+			<availability>FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
@@ -4220,14 +4220,14 @@
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:5,CGS:4,CCO:5,CB:6</availability>
+		<model name='2'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,CLAN:8,CNC:8</availability>
-		</model>
-		<model name='2'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -4258,19 +4258,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -4313,6 +4313,13 @@
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>CS:3,MERC.WD:5,CW:5,LA:3,FRR:3,CLAN:5,FS:4,DC:2</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -4320,18 +4327,11 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
-		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -4343,32 +4343,32 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:1,CLAN:4,IS:1,WOB:6,FS:3,MERC:1,CGS:5,DC.GHO:5,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
-		<model name='KGC-001'>
-			<availability>CS:4+,LA:3+,IS:3+,WOB:4</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:8</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,FRR:4+,CLAN:6,NIOPS:8,WOB:8,BAN:8,CB:5,DC:4+</availability>
 		</model>
+		<model name='KGC-001'>
+			<availability>CS:4+,LA:3+,IS:3+,WOB:4</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -4376,27 +4376,24 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:6,MERC:3,DC:5</availability>
-		<model name='KTO-C'>
-			<availability>DC:4+</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:8,CS:8,DC.SL:4,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:4+,MERC:4+,BAN:7</availability>
-		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6,MERC:6,DC:4</availability>
-		</model>
-		<model name='KTO-20'>
-			<availability>CS:4,WOB:4,MERC:4,DC:8</availability>
 		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
+		<model name='KTO-20'>
+			<availability>CS:4,WOB:4,MERC:4,DC:8</availability>
+		</model>
+		<model name='KTO-C'>
+			<availability>DC:4+</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6,MERC:6,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -4406,51 +4403,46 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:5,CCC:3,CIH:5,CLAN:3,CGS:4,CCO:3,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='5'>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
 		<availability>DC:4</availability>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:6,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:4,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -4460,9 +4452,17 @@
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CCO:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -4470,11 +4470,11 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='3'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='2'>
+		<model name='3'>
+			<roles>fire_support</roles>
 			<availability>CJF:4</availability>
 		</model>
 	</chassis>
@@ -4499,17 +4499,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:3,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:4</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,FRR:6,DC:6</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,FRR:3+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:3+</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,FRR:3+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:3+</availability>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,FRR:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -4545,10 +4545,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -4558,39 +4554,43 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CIH:7,CLAN:6,WOB:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSR:5,CW:5,CCO:4</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:4,General:5,CGB:5</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CGB:8</availability>
 		</model>
 		<model name='A'>
 			<availability>CW:7,General:7,CGB:7</availability>
 		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:4,General:5,CGB:5</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:3,CJF:2,CGB:3,CB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:5,General:5,CGB:5</availability>
@@ -4598,13 +4598,13 @@
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CS:6,CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,WOB:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -4613,18 +4613,30 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,CLAN:5,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:1-,IS:9,NIOPS:6-,Periphery.Deep:5,WOB:6-,Periphery:6</availability>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FS:4+,MERC:2+</availability>
+		</model>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:7,MERC:4</availability>
+		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2,SIC:2</availability>
@@ -4633,73 +4645,61 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
-			<roles>recon</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:3,General:6,FS:6</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
-		<model name='LCT-3S'>
-			<roles>recon</roles>
-			<availability>LA:4+,FRR:2+,MERC:2+</availability>
 		</model>
 		<model name='LCT-3M'>
 			<roles>recon</roles>
 			<availability>MOC:2+,FWL:4+,IS:2+,MERC:3+</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:7,MERC:4</availability>
+			<availability>LA:3,General:6,FS:6</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-3S'>
 			<roles>recon</roles>
-			<availability>FS:4+,MERC:2+</availability>
+			<availability>LA:4+,FRR:2+,MERC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CDS:7,CW:6,CBS:7,CSV:6,CLAN:6,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CCO:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
 		</model>
+		<model name='C'>
+			<availability>CCO:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CS:6,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,WOB:4,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:6,OA:6,General:6,TC:6,Periphery:6</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -4713,14 +4713,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
-		<model name='LCF-R16'>
-			<availability>LA:4+,FS:3+</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:4+,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -4729,25 +4729,25 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -4776,13 +4776,12 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:1,CW:2,CSV:3,CNC:1,CLAN:1,General:1,CSJ:3,CJF:2,CGB:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
@@ -4790,8 +4789,9 @@
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:1,CW:2,CSV:3,CNC:1,CLAN:1,General:1,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
@@ -4824,14 +4824,14 @@
 		<model name='A'>
 			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -4860,26 +4860,17 @@
 		<model name='MAD-5A'>
 			<availability>MERC.WD:4+</availability>
 		</model>
-		<model name='MAD-4A'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='MAD-5C'>
 			<availability>MERC.WD:1</availability>
+		</model>
+		<model name='MAD-4A'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:2</availability>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='MAD-5D'>
 			<availability>LA:4+,FRR:4+,WOB:2+,FS:4+,MERC:2+,DC:5+</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>CS:2+,FWL:3+,IS:2+,WOB:2+</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:1+,FS:1+,DC:1+</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,HL:6,IS:6,Periphery.Deep:7,WOB:4-,Periphery:8,TC:8</availability>
@@ -4887,14 +4878,23 @@
 		<model name='MAD-3L'>
 			<availability>CC:2,SIC:2</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:2,CGS:3,BAN:2</availability>
+		<model name='MAD-5M'>
+			<availability>CS:2+,FWL:3+,IS:2+,WOB:2+</availability>
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:6,CLAN:1,NIOPS:6,WOB:6,MERC:0,BAN:2</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>MOC:4,Periphery.ME:4,FWL:5,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:2,CGS:3,BAN:2</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='MAD-5S'>
 			<availability>LA:3+,FS:3+</availability>
@@ -4918,23 +4918,23 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CSA:4,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:5,CB:4</availability>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CCO:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CCO:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -4966,52 +4966,52 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:3,FRR:7,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
-		<model name='(SRM2)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM2)'>
 			<roles>apc</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>LA:4,IS:2,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>LA:5,FS:5,DC:6</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:5,FS:5,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -5038,35 +5038,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -5074,20 +5071,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -5095,8 +5095,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -5148,11 +5148,11 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,HL:2,MERC:6,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>OA:4+</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -5177,13 +5177,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:3+,MERC:1+,DC:3+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -5193,11 +5189,15 @@
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -5240,13 +5240,13 @@
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-68'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -5257,11 +5257,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -5278,7 +5278,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -5287,14 +5287,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -5317,6 +5317,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
@@ -5325,25 +5333,17 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
 		<availability>LA:8,FS:8,DC:8</availability>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
@@ -5354,19 +5354,19 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CJF:2</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -5405,15 +5405,15 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CNC:6</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -5435,8 +5435,8 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,FRR:3,IS:3,SIC:7,MERC:3,FS:7,CIR:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:3</availability>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
@@ -5445,8 +5445,8 @@
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>IS:4</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -5457,8 +5457,8 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:5-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='ON1-MA'>
-			<availability>FWL:2+</availability>
+		<model name='ON1-M'>
+			<availability>CS:3+,FWL:4+,WOB:3+</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:3,MH:3,TC:3</availability>
@@ -5466,11 +5466,11 @@
 		<model name='ON1-V-DC'>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>FWL:2+</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>HL:5,General:7,CLAN:7,Periphery.Deep:7,Periphery:7</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>CS:3+,FWL:4+,WOB:3+</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
@@ -5484,25 +5484,25 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,WOB:4,SIC:3,Periphery:3,TC:3,CS:4,LA:4,NIOPS:4,DC:6</availability>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		<model name='OSR-2L'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
-		</model>
-		<model name='OSR-2Cb'>
-			<roles>urban</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>CS:4+,IS:1+</availability>
 		</model>
 		<model name='OSR-2M'>
 			<availability>FWL:6</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='OSR-2Cb'>
+			<roles>urban</roles>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -5522,14 +5522,14 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:5,NIOPS:6,WOB:6,FS:5,MERC:5,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
-		</model>
 		<model name='OTL-5M'>
 			<availability>FWL:4+,WOB:3+</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -5552,13 +5552,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:3,MERC.KH:3,HL:2,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:4,PIR:3,General:3,FWL:3,DC:3</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,SIC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:3,MERC.KH:3,HL:2,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:4,PIR:3,General:3,FWL:3,DC:3</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -5567,21 +5567,17 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:2,CS:4,NIOPS:4,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:1,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,FWL:2,NIOPS:2,DC:10</availability>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>DC:4+</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
@@ -5589,6 +5585,10 @@
 		<model name='PNT-C'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4+,FRR:4+,FS.DMM:4+,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -5600,16 +5600,16 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:9,CIR:6,Periphery:9,TC:9,CS:6-,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -5627,14 +5627,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:6,Periphery.Deep:8,WOB:5-,SIC:7,FS:7,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:7,FWL:6,DC:7</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -5643,37 +5635,45 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:3,CSJ:6,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:4-,LA:2-,FRR:3-,FWL:2-,IS:2-,SIC:3-,FS:2-,MERC:3-,DC:3-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CW:6</availability>
+		<model name='D'>
+			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -5705,15 +5705,39 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,WOB:7,Periphery:4,CGB:2</availability>
+		<model name='PXH-3S'>
+			<roles>recon</roles>
+			<availability>LA:6+,MERC:3+</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:5+,MERC:4+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:6,BAN:6,Periphery:6</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:5,DC:5</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:6+,IS:2+</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:5,MERC:4</availability>
@@ -5722,44 +5746,20 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:1</availability>
 		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:5,DC:5</availability>
-		</model>
 		<model name='PXH-3K'>
 			<roles>recon</roles>
 			<availability>FRR:5+,DC:5+</availability>
 		</model>
-		<model name='PXH-3S'>
-			<roles>recon</roles>
-			<availability>LA:6+,MERC:3+</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:6+,IS:2+</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:6,BAN:6,Periphery:6</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:5+,MERC:4+</availability>
-		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,WOB:6-,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:5,DC:5</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
@@ -5807,33 +5807,33 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CW:7,CGS:5,CCO:5</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:9,CGB:9</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CDS:9,CW:7,General:7,CGB:7,CB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:6,CDS:9,CW:7,General:7,CGB:7,CB:7</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -5857,10 +5857,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
@@ -5869,33 +5865,37 @@
 			<roles>support</roles>
 			<availability>General:2+</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8,General:4</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CSA:9,MERC.WD:2,CDS:9,CW:8,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -5915,14 +5915,11 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
-		<model name='QKD-5K'>
-			<availability>DC:2+</availability>
-		</model>
 		<model name='QKD-5A'>
 			<availability>General:3,MERC:4,DC:4,Periphery:4</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>DC:2+</availability>
+		<model name='QKD-5M'>
+			<availability>FWL:4+</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:6,OA:6,HL:4,Periphery.Deep:6,FWL:6,IS:6,Periphery:6,DC:6,TC:6</availability>
@@ -5930,8 +5927,11 @@
 		<model name='QKD-4H'>
 			<availability>General:3</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>FWL:4+</availability>
+		<model name='QKD-C'>
+			<availability>DC:2+</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
@@ -5946,11 +5946,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:4+,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2,CNC:1</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:4+,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:8</availability>
@@ -5961,28 +5961,39 @@
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>DC:2+</availability>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OC'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:7,SIC:3,FS:4</availability>
+		<model name='RVN-2X'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:4</availability>
+		</model>
+		<model name='RVN-1X'>
+			<roles>recon,ew_support</roles>
+			<availability>CC:5,SIC:3,FS:3</availability>
+		</model>
 		<model name='RVN-4X'>
 			<availability>CC:8</availability>
 		</model>
@@ -5990,24 +6001,21 @@
 			<roles>fire_support</roles>
 			<availability>FWL:3,MERC:3</availability>
 		</model>
-		<model name='RVN-1X'>
-			<roles>recon,ew_support</roles>
-			<availability>CC:5,SIC:3,FS:3</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:4</availability>
-		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='RVN-2X'>
-			<availability>FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:9,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CNC:3</availability>
@@ -6020,19 +6028,11 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:3,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
-		<model name='F-700a'>
-			<availability>CC:3+,FWL:3+,WOB:3+,MERC:3+</availability>
+		<model name='F-100'>
+			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>FRR:8,DC:8</availability>
@@ -6043,17 +6043,17 @@
 		<model name='F-700'>
 			<availability>CC:4+,FWL:4+,WOB:8,MERC:4+</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
+		<model name='F-700a'>
+			<availability>CC:3+,FWL:3+,WOB:3+,MERC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:4,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:6,CLAN:6,CNC:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:6,CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -6065,20 +6065,12 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:7-,CS:6-,HL:3,FRR:8-,IS:8-,Periphery.Deep:5,FWL:8-,NIOPS:6-,WOB:6-,SIC:7-,FS:9-,Periphery:5</availability>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:3</availability>
+		<model name='RFL-5D'>
+			<availability>LA:4+,FS:4+,MERC:3+</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:1,Periphery:8</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>LA:4+,FS:4+,MERC:3+</availability>
 		</model>
 		<model name='RFL-5M'>
 			<availability>FWL:3+</availability>
@@ -6086,23 +6078,28 @@
 		<model name='C'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:1,Periphery:8</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:4,CSR:2,CLAN:2,NIOPS:5,WOB:5,CJF:1</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8,WOB:6</availability>
 		</model>
@@ -6112,17 +6109,20 @@
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6,WOB:4</availability>
 		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>LA:8,FRR:5,FS:7,MERC:3,TC:2</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,TC:0</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -6135,20 +6135,20 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,MERC.WD:6,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
+		</model>
 		<model name='E'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -6179,11 +6179,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,HL:1-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:5</availability>
@@ -6191,42 +6191,42 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CJF:6</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CSJ:5,DC:5</availability>
-		<model name='S-4X'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:8</availability>
 		</model>
+		<model name='S-4X'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:2,DC:9</availability>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -6293,30 +6293,30 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,WOB:5-,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,CS:5-,OA:8,LA:8,FWL:6,DC:9</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:4+</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,HL:7,LA:8,FRR:10,FWL:8,IS:9,Periphery.Deep:8,SIC:8,FS:8,DC:8,Periphery:9</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -6343,9 +6343,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CHH:3,CIH:3,CFM:3,CSJ:3,CJF:7,CGS:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -6354,6 +6351,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -6377,20 +6377,20 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,WOB:4,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:2,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:6,DC:6</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:3</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:8,DC:1+</availability>
 		</model>
 		<model name='STN-3KB'>
 			<availability>LA:3</availability>
+		</model>
+		<model name='STN-3KA'>
+			<availability>LA:3</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
@@ -6403,61 +6403,61 @@
 			<roles>interceptor</roles>
 			<availability>LA:5+,FRR:3+,FS:5+,MERC:3+</availability>
 		</model>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:8,CFM:5,CSJ:6,CJF:2,CB:5</availability>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
+			<availability>CSR:3,General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:6,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,WOB:6-,BAN:2,Periphery:5,CGB:1</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:7,MERC:4,DC:8</availability>
-		</model>
-		<model name='SHD-2D2'>
-			<availability>LA:3+,FS:4+</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
-		</model>
 		<model name='SHD-2Hb'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:3+,FRR:3+,FWL:6+,IS:3+,MERC:3+,DC:3+</availability>
 		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:7,MERC:4,DC:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>LA:3+,FS:4+</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -6480,14 +6480,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -6514,13 +6514,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,WOB:3-,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:8</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -6529,8 +6529,8 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
-		<model name='SL-15A'>
-			<availability>OA:2,FRR:2,DC:2</availability>
+		<model name='SL-15'>
+			<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>FRR:4+,DC:5+</availability>
@@ -6538,11 +6538,11 @@
 		<model name='SL-15B'>
 			<availability>FRR:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>FRR:2,DC:2</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:2,FRR:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -6559,12 +6559,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -6596,13 +6596,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-6D'>
-			<availability>FS:4+</availability>
-		</model>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:2,TC:8</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:4,FRR:8,DC:8</availability>
@@ -6610,6 +6603,13 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>LA:8,FS.CMM:3</availability>
+		</model>
+		<model name='SPR-6D'>
+			<availability>FS:4+</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:2,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -6642,12 +6642,12 @@
 			<roles>anti_infantry</roles>
 			<availability>FRR:6,DC:6</availability>
 		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:2+,CC:4+,FWL:4+,SIC:4+,FS:4+,MERC:2+,DC:5+</availability>
-		</model>
 		<model name='SDR-5D'>
 			<roles>anti_infantry</roles>
 			<availability>FS:8</availability>
+		</model>
+		<model name='SDR-7M'>
+			<availability>MOC:2+,CC:4+,FWL:4+,SIC:4+,FS:4+,MERC:2+,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
@@ -6659,23 +6659,23 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:6,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-5M'>
-			<availability>CC:2+,MOC:2+,FWL:5+,IS:2+,DC:4+,TC:2+</availability>
-		</model>
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='STK-3F'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STK-5M'>
+			<availability>CC:2+,MOC:2+,FWL:5+,IS:2+,DC:4+,TC:2+</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>LA:4+,FS:3+</availability>
@@ -6707,59 +6707,59 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:4-,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
+		</model>
 		<model name='STG-5M'>
 			<roles>recon</roles>
 			<availability>FWL:4+,WOB:4</availability>
 		</model>
-		<model name='STG-3G'>
-			<roles>recon</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='F-94'>
 			<availability>IS:2+</availability>
-		</model>
-		<model name='F-92'>
-			<availability>FWL:3+,IS:2+</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:7,LA:4,IS:7,FS:7,Periphery:7</availability>
 		</model>
+		<model name='F-92'>
+			<availability>FWL:3+,IS:2+</availability>
+		</model>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -6800,17 +6800,17 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 		</model>
-		<model name='STU-K15'>
-			<availability>OA:2,SIC:2,FS:2,TC:2,Periphery:1</availability>
-		</model>
 		<model name='STU-D6'>
 			<availability>LA:4+,FS:6+,MERC:4+</availability>
+		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:2,SIC:2,FS:2,TC:2,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
@@ -6825,17 +6825,17 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -6867,15 +6867,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -6883,11 +6883,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -6905,29 +6905,26 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,MERC.WD:3,CDS:6,CW:6,CNC:6,CSJ:7,CJF:10,CGB:6,CB:5</availability>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -6936,47 +6933,50 @@
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
 		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
 		<model name='E'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>DC.GHO:3,CSA:1,CS:5,CDS:1,CLAN:2,NIOPS:5,WOB:7,CCO:1,CJF:1,CGB:1,DC:1</availability>
+		<model name='THE-N1'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='THE-N'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -7022,13 +7022,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:2+,LA:4+,FRR:3+,MH:2+,MERC:3+</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:2+,LA:4+,FRR:3+,MH:2+,MERC:3+</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -7037,26 +7037,26 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:2,CLAN:2,IS:8,Periphery.Deep:6,WOB:4-,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-9SE'>
-			<availability>LA:2+,MERC.ELH:5+,MERC:2+,FS:2+</availability>
-		</model>
 		<model name='TDR-9S'>
 			<availability>LA:4+,FS:3+</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:6,MERC:1</availability>
+		<model name='TDR-7M'>
+			<availability>CS:2+,FWL:5+,WOB:2+</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:7,HL:5,LA:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CS:2+,FWL:5+,WOB:2+</availability>
+		<model name='TDR-9SE'>
+			<availability>LA:2+,MERC.ELH:5+,MERC:2+,FS:2+</availability>
 		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:8,MERC:4</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CGB:2</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:6,MERC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -7078,11 +7078,11 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>FRR:8,DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='TKG-150'>
 			<availability>FRR:6,DC:5</availability>
@@ -7090,10 +7090,6 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:3,NIOPS:3,WOB:3</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
@@ -7103,6 +7099,10 @@
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:3,BAN:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -7126,11 +7126,11 @@
 		<model name='TR-13A'>
 			<availability>CC:4+</availability>
 		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:5,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
@@ -7145,27 +7145,27 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:5-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:5,IS:6,NIOPS:2,WOB:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,FWL:2+,NIOPS:6,WOB:6,MERC:2+</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>FWL:4+</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-7K'>
 			<roles>fire_support</roles>
 			<availability>FRR:2,DC:4</availability>
 		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>FWL:4+</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,FWL:2+,NIOPS:6,WOB:6,MERC:2+</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:5,IS:6,NIOPS:2,WOB:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -7200,76 +7200,76 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CGB:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CSJ:2,CJF:5</availability>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CJF:7,CGS:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:7,General:7,CGB:7</availability>
 		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,MERC.WD:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:1,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CGB:2</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
+		<model name='W'>
+			<roles>training</roles>
+			<availability>CW:3</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
+		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CDS:4,CW:3,CSV:3,CNC:3,General:2,CSJ:4,CJF:5,CGB:4,CB:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CCO:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:1,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<roles>training</roles>
-			<availability>CW:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -7310,6 +7310,10 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:5,FS:7,MERC:7,TC:7</availability>
+		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4,FS:4,MERC:4</availability>
@@ -7318,39 +7322,35 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:5+,FS:4+</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:5,FS:7,MERC:7,TC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:6-,HL:8,IS:10,Periphery.Deep:8,WOB:6-,Periphery:10,CGB:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:4,General:5,SIC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:5,General:8,SIC:5</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
@@ -7368,29 +7368,29 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:2,FRR:6,IS:4,Periphery.Deep:4,WOB:5,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:5-,CJF:3,DC:6</availability>
-		<model name='VTR-9B'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='VTR-9K'>
-			<availability>FRR:4+,DC:4+</availability>
-		</model>
-		<model name='VTR-C'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:4,CIR:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-9A'>
 			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
+		<model name='VTR-9K'>
+			<availability>FRR:4+,DC:4+</availability>
+		</model>
 		<model name='VTR-9D'>
 			<availability>LA:4+,SIC:4+,FS:5+</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>DC:3</availability>
+		</model>
+		<model name='VTR-9S'>
+			<availability>LA:4,CIR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -7409,9 +7409,6 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>FRR:8</availability>
 		</model>
-		<model name='VND-1X'>
-			<availability>CC:1,SIC:1</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
@@ -7420,6 +7417,9 @@
 		</model>
 		<model name='VND-1SIC'>
 			<availability>SIC:2</availability>
+		</model>
+		<model name='VND-1X'>
+			<availability>CC:1,SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -7436,26 +7436,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:4,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -7471,11 +7471,11 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:5,FRR:5,IS:1,FWL:4,WOB:6,FS:4,DC:5</availability>
-		<model name='VNL-K100'>
-			<availability>LA:1,FS:3</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:3,DC:3</availability>
@@ -7492,10 +7492,6 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,Periphery:2,TC:2</availability>
@@ -7503,6 +7499,10 @@
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FWL:4+</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:8,FS:4</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -7514,17 +7514,17 @@
 		<model name='B'>
 			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CCO:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CCO:6</availability>
+		<model name='A'>
+			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -7548,21 +7548,21 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='12'>
-			<availability>CSJ:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
+			<availability>CSJ:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='11'>
-			<availability>CSJ:6</availability>
+		<model name='12'>
+			<availability>CSJ:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
@@ -7570,30 +7570,30 @@
 		<model name='WHM-6L'>
 			<availability>CC:4,SIC:3</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:4+</availability>
-		</model>
-		<model name='WHM-6R'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:3,FS.DMM:2,FS:1,DC:4</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:3+,CC:2+,FRR:2+,FWL:6+,WOB:3+,DC:2+,Periphery:2+</availability>
 		</model>
 		<model name='WHM-7S'>
 			<availability>LA:4+,FS:3+,MERC:2+</availability>
 		</model>
-		<model name='C'>
-			<availability>LA:2+,FS:2+,DC:2+</availability>
+		<model name='WHM-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CS:3+,CC:2+,FRR:2+,FWL:6+,WOB:3+,DC:2+,Periphery:2+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:2+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -7609,51 +7609,51 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,WOB:4-,CIR:2,Periphery:6</availability>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:6+</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:4,DC:4</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:6+,FS:4+,MERC:2+</availability>
 		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:3+,MOC:3+,FWL:6+,WOB:6,MH:3+,MERC:3+,DC:3+</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:6+</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
@@ -7666,13 +7666,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CSJ:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -7681,13 +7681,13 @@
 			<roles>fire_support</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-1S'>
-			<roles>fire_support</roles>
-			<availability>FRR:2,DC:2</availability>
-		</model>
 		<model name='WTH-2'>
 			<roles>fire_support</roles>
 			<availability>CS:4,OA:2+,FS:2+,DC:2+,TC:2+</availability>
+		</model>
+		<model name='WTH-1S'>
+			<roles>fire_support</roles>
+			<availability>FRR:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
@@ -7701,11 +7701,11 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,LA:6,FS:7,MERC:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:3,FS:4,MERC:3</availability>
-		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:3,FS:4,MERC:3</availability>
 		</model>
 		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
@@ -7713,25 +7713,25 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,WOB:5-,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>FWL:4+,WOB:4</availability>
-		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>FRR:4+,MERC:3+</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:9</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>FWL:4+,WOB:4</availability>
+		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>LA:3+,FS:4+</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:9</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -7740,11 +7740,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -7756,10 +7756,6 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:4,CLAN:3,IS:4,CFM:4,WOB:6,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:6,NIOPS:6,DC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:8,CS:8,FRR:8,NIOPS:8,WOB:8,CFM:3,FS:4+,MERC:4+,BAN:4,DC:4+</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
@@ -7767,6 +7763,10 @@
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:8,CS:8,FRR:8,NIOPS:8,WOB:8,CFM:3,FS:4+,MERC:4+,BAN:4,DC:4+</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -7802,15 +7802,15 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:8,DC.GHO:4,CLAN:6,NIOPS:8,WOB:7,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:7,CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,WOB:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
@@ -7827,20 +7827,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:4,LA:10,FRR:4,IS:2,FS:7-,MERC:5</availability>
-		<model name='ZEU-9S'>
-			<availability>LA:5+,FS:3+</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:4,FS:8</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:1+</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:2+,FS:2+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>HL:6,General:5,Periphery.Deep:6,FS:6,Periphery:8</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:1+</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>LA:5+,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>

--- a/megamek/data/forcegenerator/3055.xml
+++ b/megamek/data/forcegenerator/3055.xml
@@ -908,13 +908,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CCC:2,CIH:2,CSR:4,CSV:1,CGS:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,CJF:6,CB:1</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -954,20 +954,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:1,CLAN:2-,MERC:4</availability>
 		</model>
 		<model name='ANH-1E'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:4+,MERC.WD:7+,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:3</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -982,21 +982,17 @@
 		<model name='ANV-5M'>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
+		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:3</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:4,LA:3,FWL:8,SIC:4,MERC:4,FS:3,DC:6</availability>
 		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1008,6 +1004,10 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
 		<availability>FWL:4</availability>
@@ -1018,57 +1018,57 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:6,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:6+,LA:3+,MERC:3+</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:5</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CCC:4,CW:3,LA:2+,CSV:4,CFM:4,FS:2+,CGS:4,CWIE:3,DC:2+</availability>
+			<availability>FRR:4,DC:6</availability>
 		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:6+,FS:4+</availability>
 		</model>
-		<model name='(Wolf)'>
-			<availability>CWIE:3</availability>
-		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-2S'>
 			<roles>fire_support</roles>
-			<availability>FRR:6+,MERC:3+,DC:3+</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+			<availability>LA:6</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6+,CC:3+,LA:3+,PIR:2+,FWL:7+,WOB:6,SIC:3+,MERC:3+,FS:3+,DC:3+</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2R'>
 			<roles>fire_support</roles>
-			<availability>FRR:4,DC:6</availability>
+			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:5</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:6+,MERC:3+,DC:3+</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>CWIE:3</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:6+,LA:3+,MERC:3+</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CCC:4,CW:3,LA:2+,CSV:4,CFM:4,FS:2+,CGS:4,CWIE:3,DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -1079,23 +1079,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1103,33 +1087,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1137,12 +1137,12 @@
 		<model name='ASN-101'>
 			<availability>FS.CMM:1</availability>
 		</model>
+		<model name='ASN-21'>
+			<availability>General:3</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MH:3,MERC:3,FS:3</availability>
-		</model>
-		<model name='ASN-21'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1167,42 +1167,42 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:5,CLAN:3,IS:3,WOB:4-,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:4,NIOPS:4-,DC:8</availability>
-		<model name='AS7-K'>
-			<availability>CC:2+,CS:3+,FRR:4+,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,DC:2</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4+,IS:3+,DC:4+</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2+,MERC:2+,DC:2+</availability>
+		<model name='AS7-S'>
+			<availability>LA:5+,FS:4,MERC:3+</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4+,IS:3+,DC:4+</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:3+,MERC:3+,DC:4+</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>LA:5+,FS:4,MERC:3+</availability>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>FRR:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>CC:2+,CS:3+,FRR:4+,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -1210,21 +1210,18 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CS:3+,IS:3+,DC:4+</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
@@ -1236,6 +1233,9 @@
 			<availability>General:7</availability>
 		</model>
 		<model name='AV1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -1252,17 +1252,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>IS:2,FWL:4</availability>
-		</model>
-		<model name='AWS-8V'>
-			<availability>IS:1</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2,CIR:4</availability>
 		</model>
-		<model name='AWS-8Q'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='AWS-9Ma'>
+			<availability>LA:4,FWL:4,FS:4</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>FWL:6+,IS:5+</availability>
@@ -1270,8 +1264,14 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+,TC:2+,Periphery:2+</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:4,FWL:4,FS:4</availability>
+		<model name='AWS-8R'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='AWS-8V'>
+			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1285,12 +1285,12 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5+,FRR:2+,FS:3+,MERC:2+</availability>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
+		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:6,FS:4</availability>
-		</model>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
@@ -1302,20 +1302,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,MERC.WD:2,CW:2,CLAN:2</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -1325,15 +1325,11 @@
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1341,7 +1337,11 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1358,7 +1358,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:3,CHH:4,CLAN:2</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1366,29 +1374,13 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:6</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
@@ -1401,10 +1393,6 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
@@ -1413,34 +1401,52 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
-		<model name='BNC-3MC'>
-			<availability>MOC:9</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='BNC-3E'>
-			<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='BNC-3S'>
-			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:7+,FRR:3+,FS:6+,MERC:3+</availability>
 		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:9</availability>
+		</model>
+		<model name='BNC-3S'>
+			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -1448,17 +1454,11 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -1466,8 +1466,8 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -1486,26 +1486,14 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
 		</model>
 		<model name='BLR-1S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:6+,FS:4+</availability>
@@ -1515,6 +1503,18 @@
 		</model>
 		<model name='BLR-3M'>
 			<availability>CS:5+,CC:4+,PIR:2+,FWL:6+,IS:2+,WOB:5+,MH:2+,SIC:4+,MERC:4+</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1550,14 +1550,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:2,CSJ:5,CGS:3</availability>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='4'>
 			<availability>General:2</availability>
 		</model>
 		<model name='5'>
 			<availability>General:2</availability>
+		</model>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,General:8</availability>
@@ -1565,15 +1565,15 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:6,HL:4,FRR:7,IS:5,WOB:6-,SIC:7,MERC:6,FS:9,Periphery:5,CS:6-,OA:7,LA:7,PIR:6,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1585,11 +1585,11 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:4,FRR:2,FS:2</availability>
-		<model name='BRZ-A3'>
-			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
-		</model>
 		<model name='BRZ-B3'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='BRZ-A3'>
+			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
@@ -1597,54 +1597,57 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>LA:4+,FRR:4+,SIC:2+,FS:2+,DC:5+</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,FRR:3,CLAN:8,CFM:7,FS:1,CWIE:9,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
+		</model>
+		<model name='BL-7-KNT'>
+			<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>CS:6+,WOB:6+</availability>
@@ -1652,32 +1655,29 @@
 		<model name='BL-6-KNT'>
 			<availability>DC.GHO:4,CS:4,OA:2+,FRR:4+,CLAN:6,FWL:3+,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4+</availability>
 		</model>
-		<model name='BL-7-KNT'>
-			<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CIH:4,CSV:4,CJF:5</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1693,44 +1693,44 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:3,IS:2,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-1DC'>
+		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+</availability>
-		</model>
-		<model name='BJ-1DB'>
+		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:3+,CS:3+,LA:3+,WOB:3+,SIC:4,FS:6+,MERC:3+</availability>
 		</model>
+		<model name='BJ-3'>
+			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FWL:2+,IS:2+,WOB:2+,FS:2+,DC:5+</availability>
-		<model name='BJ2-OE'>
-			<availability>General:5,FWL:6</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,DC:1+</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='BJ2-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,DC:1+</availability>
+		</model>
 		<model name='BJ2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-O'>
-			<availability>General:8</availability>
+		<model name='BJ2-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:5,FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
@@ -1779,13 +1779,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -1810,11 +1810,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -1839,25 +1839,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:8,CC:9,HL:5,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:5,CIR:7,MERC:6,Periphery:6,TC:8,LA:5,FWL:5,DC:8</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1904,13 +1904,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1922,70 +1922,73 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,LA:3,SIC:5,FS:5,MERC:3</availability>
-		<model name='CTF-2X'>
-			<availability>CC:6,SIC:2,FS:1,MERC:1</availability>
-		</model>
 		<model name='CTF-3D'>
 			<availability>LA:4+,FS:4+</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:7+</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='CTF-1X'>
 			<availability>General:6,Periphery:6</availability>
 		</model>
+		<model name='CTF-4X'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:6,SIC:2,FS:1,MERC:1</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:7+</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
-		<model name='CPLT-C4C'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>CC:2+,FS:2+,MERC:2+</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:5</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
+			<availability>DC:5+</availability>
 		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
 		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,DC:5</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:3,SIC:3</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='CPLT-K5'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:2+,FS:2+,MERC:2+</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4+,CS:2,WOB:2,FS:3+,DC:3+</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='CPLT-K3'>
-			<roles>fire_support</roles>
-			<availability>DC:5+</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:3,SIC:3</availability>
+			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:4,CCC:4,CSR:4,CDS:4,CW:4,CLAN:2,CSJ:6,CGS:4,CJF:4,CGB:4</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<availability>General:5</availability>
@@ -1994,24 +1997,21 @@
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:4,IS:3,CM:4,FS:6,MERC:4</availability>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -2030,38 +2030,38 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:5,Periphery.HR:5,FS:5,MERC:5,Periphery.OS:5,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
+		<model name='CN10-B'>
+			<availability>LA:4+,IS:3+,FS:5+</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:4,LA:4-,FRR:4-,General:4-,FWL:4-,Periphery.Deep:6,FS:5-,MERC:5-,Periphery:6</availability>
 		</model>
+		<model name='CN9-D3'>
+			<availability>FS:2,MERC:2+</availability>
+		</model>
 		<model name='CN9-D'>
 			<availability>LA:3+,FRR:3+,FWL:3+,SIC:3+,FS:8+,MERC:3+,CIR:3+,Periphery:2+</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>IS:1,FS:3,MERC:3,Periphery:2</availability>
-		</model>
-		<model name='CN9-D3'>
-			<availability>FS:2,MERC:2+</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:4+,IS:3+,FS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -2090,11 +2090,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -2112,6 +2112,10 @@
 			<roles>training</roles>
 			<availability>IS:4,Periphery:2</availability>
 		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:4,IS:3,FS:4</availability>
+		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:3,IS:2,FS:3</availability>
@@ -2120,31 +2124,27 @@
 			<roles>training</roles>
 			<availability>General:4-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:4,IS:3,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CHH:3,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		</model>
 		<model name='CHP-3P'>
 			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-2N'>
-			<availability>IS:6,NIOPS:0</availability>
-		</model>
-		<model name='CHP-3N'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:6,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -2159,8 +2159,8 @@
 		<model name='CGR-3K'>
 			<availability>CC:4,FRR:5,MERC:4,DC:5</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:5,DC:5</availability>
@@ -2169,43 +2169,43 @@
 			<roles>recon</roles>
 			<availability>CC:4-,MOC:4-,OA:4-,HL:2-,LA:4-,FRR:4-,FWL:4-,DC:4-,Periphery:4-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
-		</model>
 		<model name='CGR-1L'>
 			<availability>CC:5,HL:2,SIC:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,SIC:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-12-S'>
-			<availability>FWL:4,WOB:4</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='F-11'>
-			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
+		<model name='F-12-S'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>FWL:7+</availability>
 		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6,WOB:6,DC:2+</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -2213,7 +2213,7 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -2226,17 +2226,17 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -2244,6 +2244,14 @@
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='CDA-3C'>
+			<roles>training</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CDA-3F'>
+			<roles>recon</roles>
+			<availability>FWL:5+,IS:2+,WOB:4+</availability>
 		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
@@ -2256,14 +2264,6 @@
 		<model name='CDA-2B'>
 			<roles>anti_infantry</roles>
 			<availability>CC:1,SIC:1</availability>
-		</model>
-		<model name='CDA-3C'>
-			<roles>training</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='CDA-3F'>
-			<roles>recon</roles>
-			<availability>FWL:5+,IS:2+,WOB:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -2290,20 +2290,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -2320,23 +2320,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -2344,14 +2344,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -2368,32 +2368,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -2401,11 +2401,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -2413,20 +2413,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -2451,14 +2451,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:2-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:2-,WOB:2-,SIC:4,FS:4,MERC:3,DC:3</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,SIC:3,FS:3</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:5+,CS:4,LA:3+,General:4+</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,SIC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -2498,22 +2498,22 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
+			<availability>LA:3,FS:1,MERC:2</availability>
 		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
 		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
+		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
 			<availability>LA:2</availability>
-		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:3,FS:1,MERC:2</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -2523,14 +2523,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:5</availability>
@@ -2538,13 +2538,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,WOB:4,CIR:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:2,DC:4</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Confederate C' unitType='Dropship'>
@@ -2556,13 +2556,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -2606,20 +2606,20 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+		<model name='CSR-V12'>
+			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
+		</model>
 		<model name='CSR-V14'>
 			<availability>LA:5+,FRR:4+,FS:5+,MERC:4+</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='CSR-V20'>
-			<availability>LA:2,FS.AH:4,Periphery:2</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
-		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:2,FS.AH:4,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -2639,20 +2639,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+			<availability>DC.GHO:6,CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
 		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
 		<model name='CRB-C'>
 			<availability>DC:5+</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:6,CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -2660,11 +2660,11 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:7,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:6,FRR:4,CLAN:6,NIOPS:6,WOB:6,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:7,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -2675,36 +2675,23 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CSV:8,CSJ:5,CCO:3,CB:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:5-,Periphery:5</availability>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:8,SIC:7</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
+		<model name='CRD-3D'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='CRD-3K'>
 			<availability>FRR:4,DC:4</availability>
-		</model>
-		<model name='CRD-4K'>
-			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:5</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:6+,FS:4+,MERC:4+</availability>
@@ -2712,11 +2699,24 @@
 		<model name='CRD-4L'>
 			<availability>CC:5+</availability>
 		</model>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:8,SIC:7</availability>
+		</model>
+		<model name='CRD-3R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>MERC:5</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FS:4</availability>
+		<model name='CRD-5M'>
+			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FS:6+</availability>
@@ -2724,20 +2724,20 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>CS:4+,FRR:4+,MERC:4+</availability>
-		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:2+,CS:3,MOC:3+,LA:2+,FWL:3+,IS:2+,WOB:3,FS:4+,DC:4+,TC:3+</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:6,General:6,IS:6,FS:6,MERC:6,DC:6,TC:6</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
+		<model name='CP-10-Q'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>CS:4+,FRR:4+,MERC:4+</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -2777,24 +2777,23 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>FRR:5,DC:6</availability>
-		<model name='DMO-4K'>
-			<availability>FRR:2,DC:4</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:2,DC:3</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:8</availability>
+		<model name='DMO-4K'>
+			<availability>FRR:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:4,CDS:5,CW:6,CBS:4,CNC:4,CLAN:4,CSJ:8,CJF:5,BAN:2,CWIE:6,CGB:5,CB:4</availability>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<availability>MERC.WD:6,General:1,CWIE:3</availability>
@@ -2808,8 +2807,9 @@
 		<model name='H'>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2840,11 +2840,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2856,54 +2859,51 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:8,CCC:6,MERC.WD:5,CIH:6,CDS:6,CLAN:5,CCO:4,CJF:4,BAN:5,CGB:9,CB:6</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7,CB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CWIE:7,CGB:8,CB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CWIE:7,CGB:8,CB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7,CB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,FWL:8,NIOPS:6,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>CC:5+,CS:5,LA:5+,FRR:4+,FWL:5+,IS:4+,WOB:5,SIC:4+,FS:5+,DC:5+,CWIE:4</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:6,CLAN:6</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -2928,11 +2928,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
-		<model name='DV-6M'>
-			<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='DV-7D'>
 			<availability>LA:4+,FS:6+,MERC:4+,TC:4+</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -2943,11 +2943,11 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:2+,LA:3+,FS:3+,MERC:2+,TC:3</availability>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>LA:4,FS:4,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
@@ -2974,35 +2974,35 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:5,CHH:6,CIH:7,CDS:4,CSV:5,CLAN:5,CFM:5,CSJ:5,CJF:4,CGB:9,CB:7</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:7</availability>
+		<model name='(ERLL)'>
+			<availability>LA:1+,FS:1+</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:8,General:4</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:1+,FS:1+</availability>
+		<model name='(Standard)'>
+			<availability>CC:6,General:7</availability>
 		</model>
 		<model name='(Streak)'>
 			<availability>LA:7+,WOB:4,FS:4+</availability>
@@ -3017,25 +3017,30 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:3,FS:3</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:2,General:8,FS:2</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:2,General:8,FS:2</availability>
+		<model name='EGL-R4'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,MERC.WD:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -3047,14 +3052,9 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -3072,19 +3072,15 @@
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>LA:5,MH:2,SIC:3,FS:9,MERC:5,TC:2,DC:3</availability>
-		<model name='ENF-5D'>
-			<availability>LA:4+,FS:6+,MERC:2+,TC:2+</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>LA:4,General:6,FS:6,TC:6</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>LA:4+,FS:6+,MERC:2+,TC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -3093,6 +3089,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:3+,CIH:3+,CGS:3+,CB:2+</availability>
@@ -3100,12 +3100,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -3115,13 +3115,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,WOB:2,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -3130,20 +3130,16 @@
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5,CIR:1+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:2,NIOPS:8,WOB:8</availability>
@@ -3152,28 +3148,32 @@
 			<roles>fire_support</roles>
 			<availability>CS:6,WOB:6,CIR:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3,WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:2,FWL:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4A'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
@@ -3181,12 +3181,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -3197,8 +3197,8 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>DC.GHO:2,MERC.WD:2,DC:2</availability>
-		<model name='FLC-4N'>
-			<availability>MERC.WD:4,BAN:8,DC:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
@@ -3206,11 +3206,11 @@
 		<model name='FLC-4P'>
 			<availability>MERC.WD:6+</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>MERC.WD:4,BAN:8,DC:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -3228,17 +3228,8 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:6,CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CNC:4,CLAN:4,CSJ:4,CJF:6,CWIE:8,CGB:5</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CCO:5</availability>
@@ -3246,87 +3237,91 @@
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4,CWIE:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(Light Gauss)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:6</availability>
 		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC20)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:6</availability>
+			<availability>General:8</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(AC20)'>
 			<roles>field_gun</roles>
-			<availability>IS:6</availability>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(UAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:7</availability>
 		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CFM:2,CJF:4</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
@@ -3335,6 +3330,11 @@
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -3373,50 +3373,44 @@
 		<model name='FFL-4B'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='FFL-4A'>
-			<availability>:0,MERC.WD:2-</availability>
+		<model name='FFL-4C'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
 		</model>
-		<model name='FFL-4C'>
-			<availability>CS:6,WOB:6</availability>
+		<model name='FFL-4A'>
+			<availability>:0,MERC.WD:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
+		<model name='FS9-S1'>
 			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
+			<availability>LA:5+,General:2+,FS:4+</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:3+,CS:3+,MOC:4+,LA:5+,FRR:4+,General:3+,FS:4+,TC:3+</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='FS9-S'>
+		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
-			<availability>CC:3+,CS:3+,MOC:4+,LA:5+,FRR:4+,General:3+,FS:4+,TC:3+</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:5+,General:2+,FS:4+</availability>
+			<availability>LA:1,LA.SR:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:4+,CC:3+,LA:4+,IS:3+,WOB:4+,FS:4+,MERC:3+,DC:6+</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:6</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='FS9-OA'>
 			<availability>General:7</availability>
@@ -3425,53 +3419,59 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,FRR:2,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4,DC:2</availability>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:5,LA:5</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:8,CS:6,LA:2,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='FLS-C'>
 			<availability>DC:4+</availability>
 		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:5,LA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
-		<model name='FLE-4'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MERC.WD:1,FWL:1</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>FWL:2</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:6+,FWL:2+,MERC:2+,Periphery:2+</availability>
@@ -3485,9 +3485,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -3495,17 +3492,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -3554,13 +3554,13 @@
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>FWL:4,WOB:3</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:8,General:8,FWL:8,WOB:8</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>FWL:4,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -3572,69 +3572,69 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:5,CW:5,CLAN:4</availability>
-		<model name='2'>
-			<availability>CW:6,CCO:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:6,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:3,Periphery:2,CS:5,LA:5,FWL:7,DC:3</availability>
-		</model>
-		<model name='GAL-200'>
-			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:6</availability>
 		</model>
+		<model name='GAL-200'>
+			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
+		</model>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:3,Periphery:2,CS:5,LA:5,FWL:7,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:2+,MOC:2+,MERC.WD:6,IS:4+,FWL:2+,MH:4,MERC:6,TC:2+</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='GAL-1GLS'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='GAL-2GLS'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,MERC.WD:3,CDS:5,CSR:3,CNC:5,CLAN:5,CSJ:7,CJF:6,BAN:3,CGB:9,CB:6,CWIE:4</availability>
-		<model name='H'>
-			<availability>CSA:4</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
+		<model name='B'>
+			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:4,CW:6,CNC:6,General:3,CSJ:3,CJF:4,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -3667,14 +3667,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,SIC:4,FS:5</availability>
@@ -3682,6 +3674,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,FRR:2,NIOPS:2,WOB:2,SIC:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -3697,20 +3697,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:5,CLAN:2</availability>
-		<model name='2'>
-			<availability>CSV:6,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -3718,20 +3718,20 @@
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
 		<availability>FWL:3,WOB:4</availability>
-		<model name='GRN-D-01'>
-			<availability>FWL:6,WOB:6</availability>
-		</model>
 		<model name='GRN-D-02'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='GRN-D-01'>
+			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='DRG-1G'>
-			<availability>FRR:6,DC:6</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:4+,DC:6+</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>FRR:6,DC:6</availability>
 		</model>
 		<model name='DRG-C'>
 			<availability>FRR:6+,DC:6+</availability>
@@ -3751,9 +3751,6 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>CS:2,IS:2+,WOB:2,Periphery:2+</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
@@ -3762,6 +3759,9 @@
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:2+,DC:3+</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>CS:2,IS:2+,WOB:2,Periphery:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -3773,14 +3773,14 @@
 	</chassis>
 	<chassis name='Gray Death Standard Suit' unitType='BattleArmor'>
 		<availability>MERC.GDL:6</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -3794,20 +3794,20 @@
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:3,CHH:3,CDS:6,CSR:3,CSV:4,CFM:3,CSJ:4,CCO:4,CJF:4,CB:3</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
@@ -3821,20 +3821,20 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
-		<model name='GRF-1S'>
-			<availability>LA:5,FRR:3,MERC:4</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
+		<model name='GRF-1N'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
+		<model name='GRF-1S'>
+			<availability>LA:5,FRR:3,MERC:4</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
@@ -3867,13 +3867,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:1,Periphery.ME:1,FWL:1,NIOPS:0,MERC:1</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
@@ -3913,48 +3913,48 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>MOC:3+,CC:3+,FWL:5+,WOB:5,MERC:4+</availability>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:5,NIOPS:7,WOB:7,DC:3</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:6,CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:2</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:6,CLAN:5,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:4,CSV:5,CNC:5,CLAN:2,CSJ:6,CJF:4,CCO:2,CGB:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -3973,13 +3973,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -3991,24 +3991,24 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,MERC:3+,DC:8</availability>
-		<model name='HTM-26T'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='HTM-27T'>
 			<availability>FRR:6+,MERC:3+,DC:5+</availability>
+		</model>
+		<model name='HTM-26T'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>FRR:3,DC:4</availability>
+		<model name='HTM-27U'>
+			<availability>General:6</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4+</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaze' unitType='Mek'>
@@ -4031,15 +4031,15 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>Periphery.R:3,MERC.KH:4,LA:6,TC.PL:3,FRR:3,Periphery.MW:3,FS:5,MERC:3,DC:4</availability>
-		<model name='HCT-3NH'>
-			<availability>DC:4</availability>
+		<model name='HCT-3F'>
+			<roles>urban</roles>
+			<availability>LA:5,TC.PL:6,MERC:5,FS:5,Periphery:5</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>LA:5+,FRR:2+,FS:5+,MERC:2+</availability>
 		</model>
-		<model name='HCT-3F'>
-			<roles>urban</roles>
-			<availability>LA:5,TC.PL:6,MERC:5,FS:5,Periphery:5</availability>
+		<model name='HCT-3NH'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -4057,21 +4057,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -4082,21 +4082,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -4105,45 +4113,37 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8,WOB:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8,WOB:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:3,NIOPS:6,WOB:6,FS:3,DC:4</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,WOB:8,DC:8+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -4151,15 +4151,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:4,FS:3</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -4190,14 +4190,6 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:2,WOB:2</availability>
-		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
@@ -4206,17 +4198,17 @@
 			<roles>recon</roles>
 			<availability>MOC:4+,CC:4+,LA:4+,FWL:7+,WOB:8,FS:4+,MERC:4+,DC:4+</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:2,WOB:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:3,FRR:2,FWL:5,NIOPS:3,WOB:3,CGB:3,CB:1</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:3+,WOB:4</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:6,CS:6,CLAN:6,NIOPS:6,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:6+,WOB:6+</availability>
@@ -4229,34 +4221,42 @@
 			<roles>recon</roles>
 			<availability>CS:1,FRR:1,FWL:2,WOB:1</availability>
 		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:5+,WOB:4</availability>
-		</model>
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:2</availability>
 		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:3+,WOB:4</availability>
+		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:5+,WOB:4</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:6,CS:6,CLAN:6,NIOPS:6,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
+		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -4275,20 +4275,20 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:5,CLAN:7,NIOPS:9,CFM:8,WOB:9,SIC:1,MERC:2,FS:3,CJF:8,DC:2</availability>
+		<model name='HGN-733'>
+			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hitman' unitType='Mek'>
@@ -4313,37 +4313,37 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:3</availability>
 		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:6,CLAN:1</availability>
+		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
-		<model name='HNT-161'>
-			<availability>MERC.WD:5-</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:6</availability>
+		<model name='HNT-161'>
+			<availability>MERC.WD:5-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:5+,MERC:5+</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -4373,52 +4373,48 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='HBK-5M'>
 			<availability>CS:4+,CC:3+,FRR:3+,FWL:5+,WOB:4+,MERC:4+</availability>
+		</model>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-5S'>
 			<availability>LA:3,FRR:2,MERC:2</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4P'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>LA:7+,FS:5+</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -4428,37 +4424,41 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>LA:7+,FS:5+</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:6,FWL:5,WOB:3,MERC:2</availability>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:3,MOC:3,FWL:4</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:6,FRR:3,CLAN:5,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
-		<model name='HSR-200-D'>
-			<roles>recon</roles>
-			<availability>CS:6,General:6,CLAN:6,NIOPS:6,MERC.SI:6,WOB:6,BAN:8</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:3</availability>
+		<model name='HSR-400-D'>
+			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:3</availability>
+		</model>
+		<model name='HSR-200-D'>
+			<roles>recon</roles>
+			<availability>CS:6,General:6,CLAN:6,NIOPS:6,MERC.SI:6,WOB:6,BAN:8</availability>
+		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -4469,29 +4469,29 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,WOB:8,FS:8,DC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Level I) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [MG]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
 		<model name='(Level I) [SRM]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Level I) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -4534,27 +4534,27 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>FWL:4</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>FWL:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6,CLAN:1</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:1</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6,CLAN:1</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -4582,6 +4582,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,SIC:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -4591,11 +4596,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -4612,9 +4612,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:5,General:4,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -4624,17 +4628,13 @@
 			<roles>recon,raider</roles>
 			<availability>DC:7,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:5,General:4,Periphery.Deep:7,Periphery:7</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
@@ -4645,10 +4645,10 @@
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>WOB:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -4657,21 +4657,21 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,LA:5,FRR:5,IS:3,FWL:3,NIOPS:3,WOB:3,SIC:7,MERC:3,FS:8,DC:3</availability>
-		<model name='JM6-S'>
+		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
-			<availability>CC:6,FRR:6,IS:6,SIC:8,FS:6</availability>
+			<availability>FS:2</availability>
 		</model>
 		<model name='JM6-DG'>
 			<availability>General:2</availability>
@@ -4680,28 +4680,24 @@
 			<roles>anti_aircraft</roles>
 			<availability>FS:3+</availability>
 		</model>
-		<model name='JM6-A'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>OA:6+,LA:6+,FRR:6+,FS:6+,MERC:6+,DC:6+</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:6,FRR:6,IS:6,SIC:8,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10P'>
+		<model name='JVN-10N'>
 			<roles>recon</roles>
-			<availability>LA:5+,FS:6+,MERC:4+</availability>
+			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
@@ -4710,6 +4706,10 @@
 		<model name='JVN-11B'>
 			<roles>recon</roles>
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
+		</model>
+		<model name='JVN-10P'>
+			<roles>recon</roles>
+			<availability>LA:5+,FS:6+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
@@ -4729,14 +4729,14 @@
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:6,CGS:4,CCO:5,CB:6</availability>
+		<model name='2'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:7,CLAN:6,CNC:7</availability>
-		</model>
-		<model name='2'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -4767,19 +4767,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -4794,6 +4794,18 @@
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>DC:5</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
@@ -4801,18 +4813,6 @@
 		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
@@ -4832,30 +4832,37 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:3,PIR:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>IS:3+,Periphery:1+</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:3+,FRR:2+,DC:2+</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:2</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='CRK-5003-C'>
 			<availability>DC:2+</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>CS:4,MERC.WD:5,CW:4,LA:4,FRR:4,CLAN:5,FS:5,DC:3</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -4863,48 +4870,41 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
-		<model name='KGC-001'>
-			<availability>CS:6,LA:4+,IS:4+,WOB:5</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:6</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:6,CIH:5,FRR:6+,CLAN:6,NIOPS:6,WOB:6,BAN:8,CB:5,DC:6+</availability>
 		</model>
+		<model name='KGC-001'>
+			<availability>CS:6,LA:4+,IS:4+,WOB:5</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -4912,27 +4912,24 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:5,MERC:4,DC:5</availability>
-		<model name='KTO-C'>
-			<availability>MERC:5,DC:6+</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:6,CS:6,DC.SL:4,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,FS:6+,MERC:6+,BAN:7</availability>
-		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6,MERC:6,DC:4</availability>
-		</model>
-		<model name='KTO-20'>
-			<availability>CS:4,FRR:2,WOB:4,MERC:5,DC:8</availability>
 		</model>
 		<model name='KTO-19b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
+		<model name='KTO-20'>
+			<availability>CS:4,FRR:2,WOB:4,MERC:5,DC:8</availability>
+		</model>
+		<model name='KTO-C'>
+			<availability>MERC:5,DC:6+</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6,MERC:6,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -4942,55 +4939,46 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:5,CCC:3,CIH:5,CSR:6,CLAN:3,CGS:4,CCO:3,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='5'>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
 		<availability>FRR:5,MERC:2,DC:7</availability>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:1,CSV:1</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -5000,9 +4988,21 @@
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8,CB:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:1,CSV:1</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -5016,11 +5016,11 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='3'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>CJF:5</availability>
 		</model>
-		<model name='2'>
+		<model name='3'>
+			<roles>fire_support</roles>
 			<availability>CJF:5</availability>
 		</model>
 	</chassis>
@@ -5063,23 +5063,23 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:4,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:5</availability>
+		<model name='LNC25-03'>
+			<availability>DC:7</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
+		</model>
 		<model name='LNC25-04'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:5,DC:5</availability>
-		</model>
-		<model name='LNC25-03'>
-			<availability>DC:7</availability>
-		</model>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
-		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -5091,24 +5091,24 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>FWL:6</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:6,FWL:6,FS:6</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:6,FWL:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -5130,10 +5130,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -5143,39 +5139,43 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CIH:7,CLAN:6,WOB:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSR:5,CW:5,CCO:4,CJF:4,CWIE:6</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:4,CJF:2,CWIE:5,CGB:5,CB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -5183,13 +5183,13 @@
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CS:6,CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,WOB:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -5198,18 +5198,30 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,CLAN:4,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:5-,HL:5,CLAN:1-,IS:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,Periphery:6</availability>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:4+</availability>
+		</model>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:6,MERC:4</availability>
+		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2,SIC:2</availability>
@@ -5218,80 +5230,68 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
-			<roles>recon</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:3,General:5,FS:5</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
-		</model>
-		<model name='LCT-3S'>
-			<roles>recon</roles>
-			<availability>LA:6+,FRR:4+,MERC:4+</availability>
 		</model>
 		<model name='LCT-3M'>
 			<roles>recon</roles>
 			<availability>MOC:3+,FWL:6+,IS:3+,MERC:4+</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:6,MERC:4</availability>
+			<availability>LA:3,General:5,FS:5</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-3S'>
 			<roles>recon</roles>
-			<availability>FS:6+,MERC:4+</availability>
+			<availability>LA:6+,FRR:4+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSV:6,CLAN:5,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
-		<model name='LGB-7V'>
+		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
-			<availability>MOC:3+,FWL:4+,IS:3+</availability>
+			<availability>MOC:5,OA:5,General:5,TC:5,Periphery:5</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='LGB-7Q'>
+		<model name='LGB-7V'>
 			<roles>fire_support</roles>
-			<availability>MOC:5,OA:5,General:5,TC:5,Periphery:5</availability>
+			<availability>MOC:3+,FWL:4+,IS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -5299,26 +5299,26 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Flamer] (WoB)' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[David] (WoB)' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -5332,14 +5332,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:6+,FS:4+,MERC:3+</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:6+,FS:4+,MERC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -5348,13 +5348,13 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -5366,24 +5366,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:4,CLAN:2,MERC:3,DC:3</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:4+</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>MERC:4,DC:6</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:4+</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:6,MERC:4</availability>
@@ -5408,16 +5408,12 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:3,CWIE:2,CGB:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
@@ -5425,11 +5421,15 @@
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -5460,23 +5460,23 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:9,CSV:8,CLAN:5,BAN:6,CWIE:9,MERC.WD:8,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
-		<model name='H'>
-			<availability>CSA:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -5487,11 +5487,11 @@
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
-		<model name='(3055 Upgrade)'>
-			<availability>LA:4+,FS:4+</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,LA:5,General:6,Periphery.Deep:5,FS:5,DC:5,Periphery:6</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>LA:4+,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
@@ -5508,26 +5508,17 @@
 		<model name='MAD-5A'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='MAD-4A'>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='MAD-5C'>
 			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='MAD-4A'>
+			<availability>MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,DC:5,CGB:2</availability>
-		<model name='MAD-3D'>
-			<availability>FS:5</availability>
-		</model>
 		<model name='MAD-5D'>
 			<availability>LA:5+,FRR:5+,WOB:3+,FS:5+,MERC:3+,DC:7+</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>CS:4+,FWL:5+,IS:3+,WOB:5+,MERC:3+</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:2+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:3-,HL:6,IS:5,Periphery.Deep:7,WOB:3-,Periphery:8,TC:8</availability>
@@ -5535,14 +5526,23 @@
 		<model name='MAD-3L'>
 			<availability>CC:2,SIC:2</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:2,CGS:3,BAN:2</availability>
+		<model name='MAD-5M'>
+			<availability>CS:4+,FWL:5+,IS:3+,WOB:5+,MERC:3+</availability>
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,MERC:0,BAN:2</availability>
 		</model>
 		<model name='MAD-3M'>
 			<availability>MOC:4,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:2,CGS:3,BAN:2</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:2+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:5</availability>
 		</model>
 		<model name='MAD-5S'>
 			<availability>LA:4+,FRR:2+,FS:4+,MERC:2+</availability>
@@ -5566,26 +5566,26 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
-		<model name='H'>
-			<availability>CSA:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -5596,11 +5596,11 @@
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>FRR:4+,MERC:2+,DC:7+</availability>
-		<model name='MAL-1R'>
-			<availability>FRR:8,MERC:6,DC:4</availability>
-		</model>
 		<model name='MAL-C'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='MAL-1R'>
+			<availability>FRR:8,MERC:6,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -5620,63 +5620,63 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
-		<model name='(SRM2)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(SRM2)'>
 			<roles>apc</roles>
-			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>DC:3+</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>FRR:6+,FWL:5+,IS:4+,DC:6+</availability>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(3052 Upgrade)'>
+		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
-			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
+			<availability>DC:3+</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:4</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+			<availability>FRR:6+,FWL:5+,IS:4+,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,CGS:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -5703,35 +5703,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -5739,20 +5736,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -5760,8 +5760,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -5813,11 +5813,11 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>OA:6+,HL:2+,MERC:4+,Periphery:4+</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -5842,13 +5842,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:4+,MERC:1+,DC:4+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>General:1,MERC:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -5858,11 +5854,15 @@
 			<roles>support</roles>
 			<availability>CC:1,MERC:6,DC:1</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>General:1,MERC:8</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -5905,13 +5905,13 @@
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-68'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -5922,11 +5922,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -5943,7 +5943,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -5952,14 +5952,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mowang Courier' unitType='Small Craft'>
@@ -5982,6 +5982,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
@@ -5989,14 +5997,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
@@ -6018,11 +6018,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
@@ -6033,19 +6033,19 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CSJ:3,CJF:4</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -6088,24 +6088,24 @@
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,CS:3,LA:4+,CLAN:2,NIOPS:3,FS:4+,MERC:2+</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CNC:7</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -6141,8 +6141,8 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,CDS:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:4</availability>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>IS:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
@@ -6151,8 +6151,8 @@
 		<model name='(Standard)'>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>IS:6</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -6163,26 +6163,26 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
-		<model name='ON1-MA'>
-			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
+		<model name='ON1-M'>
+			<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:2,MH:2,TC:2</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2+,MOC:2+,FWL:4+,WOB:4+,FS:2+,MERC:2+,DC:2+</availability>
 		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
+		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
@@ -6199,25 +6199,25 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
-		<model name='OSR-3C'>
-			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		<model name='OSR-2L'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
-		</model>
-		<model name='OSR-2Cb'>
-			<roles>urban</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:3</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>CS:6+,IS:3+,Periphery:2+</availability>
 		</model>
 		<model name='OSR-2M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='OSR-2Cb'>
+			<roles>urban</roles>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -6237,14 +6237,14 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:2,IS:3,FWL:5,NIOPS:6,WOB:6,FS:5,MERC:5,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='OTL-5M'>
 			<availability>CS:3+,FWL:6+,WOB:5+,MERC:3+</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -6260,22 +6260,30 @@
 			<roles>mech_carrier</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CS:2+,DC:3+</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -6287,14 +6295,6 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
@@ -6302,13 +6302,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,SIC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -6317,29 +6317,17 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:4,CS:4,NIOPS:4,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,FWL:2,NIOPS:2,DC:10</availability>
-		<model name='PNT-10KA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4+,FRR:6+,FS.DMM:4+,MERC:4+,DC:8+</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,MERC:7,Periphery:7,DC:7</availability>
@@ -6347,6 +6335,18 @@
 		<model name='PNT-C'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4+,FRR:6+,FS.DMM:4+,MERC:4+,DC:8+</availability>
+		</model>
+		<model name='PNT-CA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -6358,16 +6358,16 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -6385,14 +6385,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -6401,6 +6393,14 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:3,WOB:4,FS:4,DC:4</availability>
@@ -6408,9 +6408,6 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>LA:4,FS:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -6420,37 +6417,40 @@
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
 		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:3,CSJ:6,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:3-,LA:2-,FRR:2-,FWL:2-,IS:2-,SIC:2-,FS:2-,MERC:2-,DC:2-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CIH:4,CW:8,CCO:4,CJF:7,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -6482,15 +6482,39 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:6,HL:3,CLAN:2,IS:9,FWL:10,NIOPS:6,Periphery.Deep:4,WOB:5,Periphery:4,CGB:2</availability>
+		<model name='PXH-3S'>
+			<roles>recon</roles>
+			<availability>LA:7+,MERC:4+</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:5+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:5,BAN:6,Periphery:5</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:3,DC:4</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:7+,IS:3+</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:4,MERC:4</availability>
@@ -6499,40 +6523,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:5,BAN:1</availability>
 		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:3,DC:4</availability>
-		</model>
 		<model name='PXH-3K'>
 			<roles>recon</roles>
 			<availability>FRR:6+,DC:6+</availability>
 		</model>
-		<model name='PXH-3S'>
-			<roles>recon</roles>
-			<availability>LA:7+,MERC:4+</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:7+,IS:3+</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:5,BAN:6,Periphery:5</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:6+,MERC:5+</availability>
-		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:4,CLAN:8</availability>
 		</model>
@@ -6540,6 +6537,9 @@
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
@@ -6551,13 +6551,13 @@
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4+,FS:6+</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -6604,33 +6604,33 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CDS:9,CW:6,General:7,CGB:6,CB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:6,CDS:9,CW:6,General:7,CGB:6,CB:7</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -6654,10 +6654,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
@@ -6666,33 +6662,37 @@
 			<roles>support</roles>
 			<availability>General:3+</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8,General:5</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:8</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -6715,14 +6715,11 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:4+,MERC:4+,DC:6+</availability>
-		</model>
 		<model name='QKD-5A'>
 			<availability>General:2,MERC:4,DC:4,Periphery:4</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>FRR:4,MERC:4,DC:6+</availability>
+		<model name='QKD-5M'>
+			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
@@ -6730,23 +6727,26 @@
 		<model name='QKD-4H'>
 			<availability>General:3</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
+		<model name='QKD-C'>
+			<availability>FRR:4,MERC:4,DC:6+</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>FRR:4+,MERC:4+,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:6</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Tsunami]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
@@ -6757,11 +6757,11 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,FS:4</availability>
-		<model name='MDG-1B'>
-			<availability>LA:4,FS:4,MERC:3</availability>
-		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
@@ -6770,11 +6770,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2,CNC:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -6785,31 +6785,42 @@
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FS:2+,DC:4+</availability>
-		<model name='RTX1-OE'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OC'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,FWL:5,SIC:3,FS:4,MERC:4,DC:3</availability>
+		<model name='RVN-2X'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:5,FWL:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='RVN-1X'>
+			<roles>recon,ew_support</roles>
+			<availability>CC:3,SIC:2,FS:2</availability>
+		</model>
 		<model name='RVN-4X'>
 			<availability>CC:8</availability>
 		</model>
@@ -6817,20 +6828,9 @@
 			<roles>fire_support</roles>
 			<availability>CC:3,FWL:4,FS:2,MERC:3,DC:2</availability>
 		</model>
-		<model name='RVN-1X'>
-			<roles>recon,ew_support</roles>
-			<availability>CC:3,SIC:2,FS:2</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:5,FWL:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:2</availability>
-		</model>
-		<model name='RVN-2X'>
-			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -6841,6 +6841,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:9,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CNC:3</availability>
@@ -6853,19 +6861,11 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
-		<model name='F-700a'>
-			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
+		<model name='F-100'>
+			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>FRR:7,DC:7</availability>
@@ -6876,17 +6876,17 @@
 		<model name='F-700'>
 			<availability>CC:6+,FWL:6+,WOB:8,MERC:6+</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
+		<model name='F-700a'>
+			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:4,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:6,CLAN:5,CNC:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:6,CLAN:5,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -6898,20 +6898,12 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:3</availability>
+		<model name='RFL-5D'>
+			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:1,Periphery:6</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='RFL-5M'>
 			<availability>CC:4+,MOC:4+,FWL:5+,IS:4+,MERC:4+,DC:4+</availability>
@@ -6919,13 +6911,17 @@
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
 		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:1,Periphery:6</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:4+,CS:5,CHH:4,CSR:2,LA:4+,FRR:4+,CLAN:2,NIOPS:5,WOB:5,FS:4+,CJF:1,DC:4+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
@@ -6934,6 +6930,10 @@
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8,BAN:2</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
@@ -6941,33 +6941,33 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:2,General:4,NIOPS:2,WOB:2</availability>
 		</model>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:5</availability>
-		</model>
 		<model name='RGU-133F'>
 			<availability>CS:4,General:6,NIOPS:4,WOB:4</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>LA:7,FRR:5,FS:6,MERC:3,CWIE:4,TC:4</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,TC:0,CWIE:0</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -6987,26 +6987,26 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,MERC.WD:7,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8,CWIE:8</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		<model name='A'>
+			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:5,CNC:4,General:5,CFM:4,CSJ:4,CCO:7,CJF:4,CWIE:6,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CWIE:5,CGB:6</availability>
@@ -7037,11 +7037,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:5</availability>
@@ -7049,42 +7049,42 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:3,CW:3,CNC:4,CSJ:5,BAN:1,CGB:3,DC:5,CWIE:3</availability>
-		<model name='S-4X'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='S-4X'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
@@ -7166,30 +7166,30 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:5+</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -7216,9 +7216,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CHH:3,CIH:3,CFM:3,CSJ:3,CJF:7,CGS:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -7227,6 +7224,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -7243,31 +7243,31 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,CS:3,LA:6,FWL:4,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:2+,LA:3+,FWL:2+,FS:4+</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,WOB:4,MERC:3,FS:3,CGS:3,CWIE:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:4,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:4,DC:4</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:7,DC:3+</availability>
 		</model>
 		<model name='STN-3KB'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3KA'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -7282,69 +7282,69 @@
 			<roles>interceptor</roles>
 			<availability>HL:3,LA:5,Periphery.Deep:8,FS:5,Periphery:5</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:6+,FRR:4+,FS:6+,MERC:4+</availability>
-		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>OA:4,FRR:4,FWL:4,TC:4,DC:4</availability>
 		</model>
-		<model name='SYD-21'>
+		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
-			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
+			<availability>LA:6+,FRR:4+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:3,FS:2</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:8,CFM:5,CSJ:6,CJF:3,CB:5</availability>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
+			<availability>CSR:3,General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:6,CWIE:7,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:5,MERC:3,DC:6</availability>
-		</model>
-		<model name='SHD-2D2'>
-			<availability>LA:4+,FS:6+</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
-		</model>
 		<model name='SHD-2Hb'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:4+,FRR:4+,FWL:7+,IS:4+,WOB:6,MERC:4+,DC:4+</availability>
 		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:5,MERC:3,DC:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:8,CCC:8,LA:2,CSV:8,CFM:8,FS:2,CGS:8,DC:2</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>LA:4+,FS:6+</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -7367,14 +7367,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:2,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:3</availability>
-		</model>
 		<model name='C'>
 			<availability>MERC.WD:4+,CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -7401,13 +7401,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -7416,8 +7416,8 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
+		<model name='SL-15'>
+			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>OA:3+,FRR:5+,FS:3+,MERC:3+,DC:6+</availability>
@@ -7425,11 +7425,11 @@
 		<model name='SL-15B'>
 			<availability>FRR:1,MERC:1,DC:1</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -7453,12 +7453,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -7490,13 +7490,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
-		<model name='SPR-6D'>
-			<availability>FRR:4+,FS:6+,MERC:4+</availability>
-		</model>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>FRR:2,General:7,Periphery.Deep:8,FS:7,MERC:7,DC:2,TC:7</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:3,FRR:6,DC:6</availability>
@@ -7504,6 +7497,13 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>LA:6,FS.CMM:2</availability>
+		</model>
+		<model name='SPR-6D'>
+			<availability>FRR:4+,FS:6+,MERC:4+</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>FRR:2,General:7,Periphery.Deep:8,FS:7,MERC:7,DC:2,TC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -7529,6 +7529,9 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>HL:3,FRR:1,IS:5,Periphery.Deep:8,FS:2,Periphery:5</availability>
 		</model>
@@ -7536,55 +7539,52 @@
 			<roles>anti_infantry</roles>
 			<availability>FRR:5,DC:5</availability>
 		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
-		</model>
 		<model name='SDR-5D'>
 			<roles>anti_infantry</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>DC:3</availability>
+		<model name='SDR-7M'>
+			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:6,FRR:6,IS:3,SIC:5,FS:6,DC:6</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Laser)'>
-			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
-		<model name='STK-5M'>
-			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,DC:5+,TC:3+</availability>
-		</model>
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='STK-3F'>
-			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STK-5M'>
+			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,DC:5+,TC:3+</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>LA:5+,CSV:2,MERC:2+,FS:4+,TC:2+</availability>
@@ -7627,59 +7627,59 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
+			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
+		</model>
 		<model name='STG-5M'>
 			<roles>recon</roles>
 			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
-		<model name='STG-3G'>
-			<roles>recon</roles>
-			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='F-94'>
 			<availability>IS:4+</availability>
-		</model>
-		<model name='F-92'>
-			<availability>FWL:6+,IS:3+</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:6,LA:4,IS:6,FS:6,Periphery:6</availability>
 		</model>
+		<model name='F-92'>
+			<availability>FWL:6+,IS:3+</availability>
+		</model>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -7694,14 +7694,13 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:2+,FWL:2+,FS:2+,MERC:2+,DC:6+</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
@@ -7711,12 +7710,16 @@
 		<model name='SR1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,FRR:4,IS:5,WOB:4-,SIC:6,FS:9,MERC:3,CS:4-,CDS:3,LA:6,PIR:3,FWL:3,DC:3</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2+,FS:2+,DC:1+</availability>
 		</model>
@@ -7727,9 +7730,6 @@
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>IS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:5</availability>
@@ -7755,17 +7755,17 @@
 		<model name='STU-K5'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:6,SIC:4</availability>
 		</model>
-		<model name='STU-K15'>
-			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
-		</model>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
+		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
@@ -7780,31 +7780,31 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>LA:3+,FS:3+,DC:4+</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OC'>
 			<availability>General:6,DC:7</availability>
@@ -7839,15 +7839,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -7855,11 +7855,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -7877,44 +7877,41 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8+,FWL:6+,WOB:5,MERC:2+</availability>
-		<model name='TMP-3M'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:4,CLAN:5,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -7923,47 +7920,50 @@
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
 		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CS:5,DC.GHO:3,CSA:1,CDS:1,CLAN:2,NIOPS:5,WOB:7,CCO:1,CJF:1,CGB:1,DC:1</availability>
+		<model name='THE-N1'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='THE-N'>
+			<availability>CS:7,CLAN:6,NIOPS:7,BAN:6</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:7,CLAN:6,NIOPS:7,BAN:6</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -8018,13 +8018,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:3+,LA:5+,FRR:4+,MH:3+,MERC:4+</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:3+,LA:5+,FRR:4+,MH:3+,MERC:4+</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -8033,29 +8033,29 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:3,CLAN:2,IS:8,Periphery.Deep:6,WOB:3-,FS:7,MERC:8,Periphery:4,TC:4,CS:4-,LA:8,NIOPS:4-,MH:4,DC:8</availability>
-		<model name='TDR-9SE'>
-			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
-		</model>
 		<model name='TDR-9S'>
 			<availability>LA:6+,FS:5+,MERC:2+</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:4,MERC:1</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:6,HL:4,LA:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='TDR-7M'>
 			<availability>CS:4+,CC:2+,FWL:7+,IS:2+,WOB:4+,MERC:2+</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>CC:6,HL:4,LA:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
+		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:6,MERC:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:4,CCC:4,LA:2,CSV:4,CFM:4,FS:2,CGS:4,DC:2,CB:4</availability>
-		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CWIE:2,CGB:2</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:4,MERC:1</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:4,CCC:4,LA:2,CSV:4,CFM:4,FS:2,CGS:4,DC:2,CB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -8077,11 +8077,11 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>FRR:8,DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='TKG-150'>
 			<availability>FRR:5,DC:4</availability>
@@ -8089,10 +8089,6 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:3,NIOPS:3,WOB:3</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
@@ -8102,6 +8098,10 @@
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:3,BAN:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -8135,11 +8135,11 @@
 		<model name='TR-13A'>
 			<availability>CC:6+,MOC:3+,General:3+</availability>
 		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:4,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:4,FWL:8</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
@@ -8157,27 +8157,27 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-7K'>
 			<roles>fire_support</roles>
 			<availability>FRR:1,DC:3</availability>
 		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -8218,32 +8218,32 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CNC:3,CSJ:3,CJF:6</availability>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CJF:7,CGS:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -8255,49 +8255,49 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:8,CSV:3,General:2,CWIE:6,CGB:2,CB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:5,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:8,CSV:3,General:2,CWIE:6,CGB:2,CB:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -8342,6 +8342,10 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
+		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:3,FS:3,MERC:3</availability>
@@ -8350,33 +8354,32 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:6-,HL:9,IS:10,Periphery.Deep:8,WOB:6-,Periphery:10,CGB:5</availability>
-		<model name='(NETC)'>
-			<availability>IS:3+</availability>
+		<model name='(AC2)'>
+			<availability>CC:4,General:5,SIC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:5,General:7,SIC:5</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:8</availability>
@@ -8384,22 +8387,19 @@
 		<model name='(Ultra)'>
 			<availability>CC:5+,MOC:6+,Periphery.CM:6+,PIR:5+,MH:5+,SIC:5+,TC:6+</availability>
 		</model>
-		<model name='(AC2)'>
-			<availability>CC:4,General:5,SIC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CC:5,General:7,SIC:5</availability>
+		<model name='(NETC)'>
+			<availability>IS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>asf_carrier</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -8416,29 +8416,29 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
-		<model name='VTR-9B'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:3+,FRR:6+,FWL:3+,MH:3+,FS:3+,MERC:3+,TC:3+,Periphery:2+,DC:6+</availability>
-		</model>
-		<model name='VTR-C'>
-			<availability>CC:2,FRR:3,MERC:2,DC:3</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:3,CIR:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-9A'>
 			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
+		<model name='VTR-9K'>
+			<availability>MOC:3+,FRR:6+,FWL:3+,MH:3+,FS:3+,MERC:3+,TC:3+,Periphery:2+,DC:6+</availability>
+		</model>
 		<model name='VTR-9D'>
 			<availability>CC:3+,LA:5+,SIC:5+,FS:6+</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:2,FRR:3,MERC:2,DC:3</availability>
+		</model>
+		<model name='VTR-9S'>
+			<availability>LA:3,CIR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -8481,26 +8481,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:4,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -8516,11 +8516,11 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:4,FRR:4,IS:1,FWL:3,WOB:6,FS:3,DC:4</availability>
-		<model name='VNL-K100'>
-			<availability>LA:1,FS:3</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:3,DC:3</availability>
@@ -8537,10 +8537,6 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:7,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:5,CIR:2,Periphery:2,TC:2</availability>
@@ -8548,6 +8544,10 @@
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:2+,FWL:6+,WOB:3+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:7,FS:4</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -8559,20 +8559,20 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:4,CDS:5,General:4,CGS:4,CCO:6,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4</availability>
+		<model name='C'>
+			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -8596,21 +8596,21 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='12'>
-			<availability>CSJ:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
+			<availability>CSJ:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='11'>
-			<availability>CSJ:6</availability>
+		<model name='12'>
+			<availability>CSJ:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
@@ -8618,30 +8618,30 @@
 		<model name='WHM-6L'>
 			<availability>CC:3,SIC:3</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:6+</availability>
-		</model>
-		<model name='WHM-6R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:2,FS.DMM:2,FS:1,DC:3</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
 		</model>
 		<model name='WHM-7S'>
 			<availability>LA:6+,FS:4+,MERC:3+</availability>
 		</model>
-		<model name='C'>
-			<availability>LA:3+,FS:3+,DC:3+</availability>
+		<model name='WHM-6D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:3+,FS:3+,DC:3+</availability>
+		</model>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -8649,62 +8649,62 @@
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
-		<model name='H-8'>
-			<availability>HL:2,LA:6,FS.CH:6,FRR:4,FS:6,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='H-8'>
+			<availability>HL:2,LA:6,FS.CH:6,FRR:4,FS:6,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='H-7C'>
 			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2+</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:3-,HL:5,IS:9,NIOPS:3-,Periphery.Deep:5,WOB:3-,CIR:2,Periphery:6</availability>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:7+</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:5</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:3,DC:3</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:7+,FS:5+,MERC:3+</availability>
 		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:4+,MOC:4+,FWL:7+,WOB:6,MH:4+,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:5</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:7+</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
@@ -8723,13 +8723,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CSJ:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -8738,13 +8738,13 @@
 			<roles>fire_support</roles>
 			<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='WTH-1S'>
-			<roles>fire_support</roles>
-			<availability>FRR:1,DC:1</availability>
-		</model>
 		<model name='WTH-2'>
 			<roles>fire_support</roles>
 			<availability>CS:6,OA:4+,FS:4+,DC:4+,TC:4+</availability>
+		</model>
+		<model name='WTH-1S'>
+			<roles>fire_support</roles>
+			<availability>FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
@@ -8758,11 +8758,11 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,MERC.WD:2,LA:6,FS:7,MERC:6</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
@@ -8770,25 +8770,25 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:2+,FWL:6+,WOB:5,MERC:4+,DC:2+</availability>
-		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>FRR:6+,MERC:4+</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:8</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:2+,FWL:6+,WOB:5,MERC:4+,DC:2+</availability>
+		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>LA:4+,FS:6+</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:8</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -8797,11 +8797,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -8822,10 +8822,6 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
@@ -8833,6 +8829,10 @@
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -8868,24 +8868,24 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:8,DC.GHO:3,CLAN:6,NIOPS:8,WOB:7,MERC:3,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:7,CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,WOB:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:7,CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>
-		</model>
 		<model name='ZRO-115'>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
@@ -8896,20 +8896,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,FRR:4,IS:3,FS:7-,MERC:5</availability>
-		<model name='ZEU-9S'>
-			<availability>LA:6+,FRR:4+,FS:5+,MERC:3+</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:1+</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:3+,FS:3+,MERC:2+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>HL:6,General:4,Periphery.Deep:6,FS:4,Periphery:8</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:1+</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>LA:6+,FRR:4+,FS:5+,MERC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>

--- a/megamek/data/forcegenerator/3058.xml
+++ b/megamek/data/forcegenerator/3058.xml
@@ -914,18 +914,18 @@
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:2,WOB:2</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -941,13 +941,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CCC:2,CIH:2,CSR:4,CSV:1,CGS:2,CWIE:1,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:1,CJF:6,CB:1</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Agamemnon Heavy Cruiser' unitType='Warship'>
@@ -1000,20 +1000,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:1,CLAN:2-,MERC:4</availability>
 		</model>
 		<model name='ANH-1E'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:4+,MERC.WD:7+,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:3</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1028,21 +1028,17 @@
 		<model name='ANV-5M'>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
+		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:3</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:4,LA:3,FWL:8,SIC:4,MERC:4,FS:3,DC:6</availability>
 		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1054,6 +1050,10 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
 		<availability>FWL:4,WOB:2</availability>
@@ -1064,66 +1064,66 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:6,CLAN:1,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7,CGB:1</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:6+,LA:3+,MERC:3+</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:5</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CCC:4,CW:3,LA:2+,CSV:4,CFM:4,FS:2+,CGS:4,CWIE:3,DC:2+</availability>
+			<availability>FRR:4,DC:6</availability>
 		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:6+,FS:4+</availability>
 		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:2,MERC.WD:2,CWIE:3</availability>
-		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-2S'>
 			<roles>fire_support</roles>
-			<availability>FRR:6+,MERC:3+,DC:3+</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+			<availability>LA:6</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6+,CC:3+,LA:3+,PIR:2+,FWL:7+,WOB:6,SIC:3+,MERC:3+,FS:3+,DC:3+</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2R'>
 			<roles>fire_support</roles>
-			<availability>FRR:4,DC:6</availability>
+			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:5</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:6+,MERC:3+,DC:3+</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:2,MERC.WD:2,CWIE:3</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:6+,LA:3+,MERC:3+</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CCC:4,CW:3,LA:2+,CSV:4,CFM:4,FS:2+,CGS:4,CWIE:3,DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,MERC:1,CWIE:2-</availability>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1D'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AF1'>
 			<availability>General:8</availability>
 		</model>
+		<model name='AF1D'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -1135,11 +1135,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -1150,23 +1150,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1174,33 +1158,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1208,12 +1208,12 @@
 		<model name='ASN-101'>
 			<availability>FS.CMM:1</availability>
 		</model>
+		<model name='ASN-21'>
+			<availability>General:3</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:2,MH:3,MERC:3,FS:3,TC:2</availability>
-		</model>
-		<model name='ASN-21'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1238,45 +1238,45 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:5,CLAN:3,IS:3,WOB:4-,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:4,NIOPS:4-,DC:8</availability>
-		<model name='AS7-K'>
-			<availability>CC:2+,CS:3+,MOC:1,FRR:4+,CNC:2,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+,TC:1</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,DC:2</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4+,IS:3+,DC:4+</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2+,MERC:2+,DC:2+</availability>
+		<model name='AS7-S'>
+			<availability>MOC:1,OA:1,LA:5+,PIR:1,FS:4,MERC:3+,TC:1</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4+,IS:3+,DC:4+</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:5</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:3+,MERC:3+,DC:4+</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:5</availability>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:1,OA:1,LA:5+,PIR:1,FS:4,MERC:3+,TC:1</availability>
+		<model name='AS7-C'>
+			<availability>FRR:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>CC:2+,CS:3+,MOC:1,FRR:4+,CNC:2,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
@@ -1284,21 +1284,18 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CS:3+,IS:3+,DC:4+</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
@@ -1315,6 +1312,9 @@
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:3,FRR:1,IS:2,SIC:3,FS:4,CIR:2,TC:2,Periphery:1,OA:2,LA:4,FWL:1,DC:1</availability>
@@ -1329,17 +1329,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
-		<model name='AWS-8R'>
-			<availability>IS:2,FWL:4</availability>
-		</model>
-		<model name='AWS-8V'>
-			<availability>IS:1</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2,CIR:4</availability>
 		</model>
-		<model name='AWS-8Q'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='AWS-9Ma'>
+			<availability>LA:4,FWL:4,FS:4</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:2+,PIR:2+,FWL:6+,IS:5+,MH:2+,TC:2+</availability>
@@ -1347,8 +1341,14 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+,TC:2+,Periphery:2+</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:4,FWL:4,FS:4</availability>
+		<model name='AWS-8R'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='AWS-8V'>
+			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1362,12 +1362,12 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5+,FRR:2+,FS:3+,MERC:2+</availability>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
+		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:6,FS:4</availability>
-		</model>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
@@ -1379,20 +1379,20 @@
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,MERC.WD:2,CW:2,CLAN:2</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
@@ -1402,15 +1402,11 @@
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1418,17 +1414,21 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
@@ -1439,7 +1439,15 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:4,CHH:4,CLAN:2</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1447,29 +1455,13 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5,MERC:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
@@ -1482,10 +1474,6 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
@@ -1494,30 +1482,42 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
-		<model name='BNC-3MC'>
-			<availability>MOC:9</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1,FWL:2,TC:1</availability>
-		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
+		<model name='BNC-5S'>
+			<availability>LA:7+,FRR:3+,FS:6+,MERC:3+</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:9</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>OA:2,LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:7+,FRR:3+,FS:6+,MERC:3+</availability>
+		<model name='BNC-3E'>
+			<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1,FWL:2,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
@@ -1528,6 +1528,12 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
@@ -1535,17 +1541,11 @@
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -1553,8 +1553,8 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -1573,26 +1573,14 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
 		</model>
 		<model name='BLR-1S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:6+,FS:4+</availability>
@@ -1602,6 +1590,18 @@
 		</model>
 		<model name='BLR-3M'>
 			<availability>CS:5+,CC:4+,PIR:2+,FWL:6+,IS:2+,WOB:5+,MH:2+,SIC:4+,MERC:4+</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1637,14 +1637,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:2,CSJ:5,CGS:3</availability>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='4'>
 			<availability>General:2</availability>
 		</model>
 		<model name='5'>
 			<availability>General:2</availability>
+		</model>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,General:8</availability>
@@ -1652,15 +1652,15 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:6,HL:4,FRR:7,IS:5,WOB:6-,SIC:7,MERC:6,FS:9,Periphery:5,CS:6-,OA:7,CDS:2,LA:7,PIR:6,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1679,11 +1679,11 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:4,FRR:2,FS:2,MERC:1</availability>
-		<model name='BRZ-A3'>
-			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
-		</model>
 		<model name='BRZ-B3'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='BRZ-A3'>
+			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
@@ -1691,57 +1691,60 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:1,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:1,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:2+,LA:4+,FRR:4+,SIC:2+,FS:2+,MERC:2+,DC:5+</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OR'>
 			<availability>DC:1+</availability>
 		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:1,CWIE:8,DC.GHO:3,OA:1,CDS:6,CBS:8,FWL:1,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:1,MERC:2,CGS:8,Periphery:1,TC:1,CS:7,CW:8,LA:1,CNC:8,CJF:6,DC:2</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
+		</model>
+		<model name='BL-7-KNT'>
+			<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>CS:6+,WOB:6+</availability>
@@ -1749,32 +1752,29 @@
 		<model name='BL-6-KNT'>
 			<availability>DC.GHO:4,CS:4,OA:2+,FRR:4,CLAN:6,FWL:3,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4</availability>
 		</model>
-		<model name='BL-7-KNT'>
-			<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CIH:4,CSV:4,CJF:5</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1790,44 +1790,44 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:3,IS:2,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-1DC'>
+		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+,Periphery:1</availability>
-		</model>
-		<model name='BJ-1DB'>
+		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:3+,CS:3+,LA:3+,PIR:1+,WOB:3+,SIC:4,FS:6+,MERC:3+</availability>
 		</model>
+		<model name='BJ-3'>
+			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FWL:2+,IS:2+,WOB:2+,SIC:2+,FS:2+,MERC:2+,DC:5+</availability>
-		<model name='BJ2-OE'>
-			<availability>General:5,FWL:6</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,DC:1+</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='BJ2-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,DC:1+</availability>
+		</model>
 		<model name='BJ2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-O'>
-			<availability>General:8</availability>
+		<model name='BJ2-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:5,FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
@@ -1876,13 +1876,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -1907,11 +1907,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -1936,25 +1936,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:8,CC:9,HL:5,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:5,CIR:7,MERC:6,Periphery:6,TC:8,LA:5,FWL:5,DC:8</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -2007,13 +2007,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -2025,74 +2025,77 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,MOC:2,LA:3,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,MH:2,SIC:5,FS:5,MERC:3,TC:2,Periphery:1</availability>
-		<model name='CTF-2X'>
-			<availability>CC:6,MOC:2,SIC:2,FS:1,MERC:1,TC:2</availability>
-		</model>
 		<model name='CTF-3D'>
 			<availability>LA:4+,FS:4+</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:7+,MOC:2,MERC:2,TC:2</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='CTF-1X'>
 			<availability>General:6,Periphery:6</availability>
 		</model>
+		<model name='CTF-4X'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:6,MOC:2,SIC:2,FS:1,MERC:1,TC:2</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:7+,MOC:2,MERC:2,TC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
-		<model name='CPLT-C4C'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
-			<availability>CC:2+,MOC:1,FS:2+,MERC:2+,TC:1</availability>
+			<availability>DC:1</availability>
 		</model>
-		<model name='CPLT-K2'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>FRR:3,DC:5</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
+			<availability>DC:5+</availability>
 		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
 		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,DC:5</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:3,SIC:3</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='CPLT-K5'>
 			<roles>fire_support</roles>
 			<availability>FRR:2,DC:4</availability>
+		</model>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:2+,MOC:1,FS:2+,MERC:2+,TC:1</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4+,CS:2,MOC:2,WOB:2,FS:3+,DC:3+,TC:2</availability>
 		</model>
-		<model name='CPLT-C1b'>
+		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='CPLT-K3'>
-			<roles>fire_support</roles>
-			<availability>DC:5+</availability>
-		</model>
-		<model name='CPLT-K2K'>
-			<roles>fire_support</roles>
-			<availability>DC:1</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:3,SIC:3</availability>
+			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:4,CCC:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:3,CSJ:6,CGS:4,CJF:4,CGB:4</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<availability>General:5</availability>
@@ -2101,39 +2104,36 @@
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,FS:6</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:4,IS:3,CM:4,FS:6,MERC:4</availability>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -2152,38 +2152,38 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:5,Periphery.HR:5,FS:5,MERC:5,Periphery.OS:5,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
+		<model name='CN10-B'>
+			<availability>LA:4+,IS:3+,FS:5+</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:4,LA:4-,FRR:4-,General:4-,FWL:4-,Periphery.Deep:6,FS:5-,MERC:5-,Periphery:6</availability>
 		</model>
+		<model name='CN9-D3'>
+			<availability>FS:2,MERC:2+</availability>
+		</model>
 		<model name='CN9-D'>
 			<availability>LA:3+,FRR:3+,FWL:3+,SIC:3+,FS:8+,MERC:3+,CIR:3+,Periphery:2+</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>IS:1,FS:3,MERC:3,Periphery:2</availability>
-		</model>
-		<model name='CN9-D3'>
-			<availability>FS:2,MERC:2+</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:4+,IS:3+,FS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -2212,11 +2212,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -2234,6 +2234,10 @@
 			<roles>training</roles>
 			<availability>IS:4,Periphery:2</availability>
 		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:4,IS:3,FS:4</availability>
+		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:3,IS:2,FS:3</availability>
@@ -2242,31 +2246,27 @@
 			<roles>training</roles>
 			<availability>General:4-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:4,IS:3,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CHH:3,FRR:2,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		</model>
 		<model name='CHP-3P'>
 			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-2N'>
-			<availability>IS:6,NIOPS:0</availability>
-		</model>
-		<model name='CHP-3N'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2,CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:6,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -2281,8 +2281,8 @@
 		<model name='CGR-3K'>
 			<availability>CC:4,FRR:5,MERC:4,DC:5</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>OA:2,FRR:5,DC:5</availability>
@@ -2291,43 +2291,43 @@
 			<roles>recon</roles>
 			<availability>CC:4-,MOC:4-,OA:4-,HL:2-,LA:4-,FRR:4-,FWL:4-,DC:4-,Periphery:4-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,SIC:2,MERC:2,Periphery:1</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
-		</model>
 		<model name='CGR-1L'>
 			<availability>CC:5,HL:2,SIC:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,SIC:2,MERC:2,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-12-S'>
-			<availability>FWL:4,WOB:4</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='F-11'>
-			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
+		<model name='F-12-S'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>FWL:7+</availability>
 		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6,WOB:6,DC:3+</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -2335,7 +2335,7 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -2348,17 +2348,17 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -2366,6 +2366,14 @@
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='CDA-3C'>
+			<roles>training</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CDA-3F'>
+			<roles>recon</roles>
+			<availability>FWL:5+,IS:2+,WOB:4+</availability>
 		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
@@ -2378,14 +2386,6 @@
 		<model name='CDA-2B'>
 			<roles>anti_infantry</roles>
 			<availability>CC:1,SIC:1</availability>
-		</model>
-		<model name='CDA-3C'>
-			<roles>training</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='CDA-3F'>
-			<roles>recon</roles>
-			<availability>FWL:5+,IS:2+,WOB:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -2412,20 +2412,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -2442,23 +2442,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -2466,14 +2466,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -2490,32 +2490,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -2523,11 +2523,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -2535,20 +2535,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -2573,14 +2573,14 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:3,IS:3,WOB:2-,SIC:4,FS:4,MERC:3,CS:2-,LA:3,FWL:3,NIOPS:2-,DC:3</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,SIC:3,FS:3</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:5+,CS:4,LA:3+,General:4+</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,SIC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -2620,22 +2620,22 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
+			<availability>LA:3,FS:1,MERC:2</availability>
 		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
 		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
+		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
 			<availability>LA:2</availability>
-		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:3,FS:1,MERC:2</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -2645,14 +2645,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:5</availability>
@@ -2660,13 +2660,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,WOB:4,CIR:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:2,DC:4</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Confederate C' unitType='Dropship'>
@@ -2678,13 +2678,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:2</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -2728,20 +2728,20 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+		<model name='CSR-V12'>
+			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
+		</model>
 		<model name='CSR-V14'>
 			<availability>LA:5+,FRR:4+,FS:5+,MERC:4+</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='CSR-V20'>
-			<availability>LA:2,FS.AH:4,Periphery:2</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
-		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:8</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:2,FS.AH:4,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -2755,15 +2755,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -2781,20 +2781,20 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,FRR:2,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+			<availability>DC.GHO:6,CS:5,FRR:2,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
 		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
 		<model name='CRB-C'>
 			<availability>DC:5+</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:6,CS:5,FRR:2,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
@@ -2802,11 +2802,11 @@
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:7,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:6,FRR:4,CLAN:6,NIOPS:6,WOB:6,BAN:8</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:7,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -2817,36 +2817,23 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CSV:8,CSJ:5,CCO:3,CB:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:5-,Periphery:5</availability>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:8,SIC:7</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
+		<model name='CRD-3D'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='CRD-3K'>
 			<availability>FRR:4,DC:4</availability>
-		</model>
-		<model name='CRD-4K'>
-			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:5</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:6+,FS:4+,MERC:4+</availability>
@@ -2854,11 +2841,24 @@
 		<model name='CRD-4L'>
 			<availability>CC:5+</availability>
 		</model>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:8,SIC:7</availability>
+		</model>
+		<model name='CRD-3R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>MERC:5</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FS:4</availability>
+		<model name='CRD-5M'>
+			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FS:6+</availability>
@@ -2866,23 +2866,23 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>CS:4+,FRR:4+,SL.2:4+,MERC:4+</availability>
+		<model name='CP-11-A'>
+			<availability>CC:2+,CS:3,MOC:3+,LA:2+,FWL:3+,IS:2+,WOB:3,FS:4+,DC:4+,TC:3+</availability>
 		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:2</availability>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-12-K'>
 			<availability>MERC:2,DC:2</availability>
 		</model>
-		<model name='CP-11-A'>
-			<availability>CC:2+,CS:3,MOC:3+,LA:2+,FWL:3+,IS:2+,WOB:3,FS:4+,DC:4+,TC:3+</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:6,General:6,IS:6,FS:6,MERC:6,DC:6,TC:6</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
+		<model name='CP-10-Q'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>CS:4+,FRR:4+,SL.2:4+,MERC:4+</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -2922,24 +2922,23 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>FRR:5,DC:6</availability>
-		<model name='DMO-4K'>
-			<availability>FRR:2,DC:4</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:2,DC:3</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:8</availability>
+		<model name='DMO-4K'>
+			<availability>FRR:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:1+,FS:1+,MERC:1+,BAN:2,CWIE:6,MERC.WD:4,CDS:5,CW:6,CBS:4,LA:1+,CNC:4,CSJ:8,CJF:5,CGB:5,CB:4,DC:1+</availability>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<availability>MERC.WD:6,General:1,CWIE:3</availability>
@@ -2953,8 +2952,9 @@
 		<model name='H'>
 			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2985,11 +2985,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
@@ -3001,54 +3004,51 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CCC:6,CIH:6,CLAN:5,IS:1+,CCO:4,BAN:5,CSA:4,MERC.WD:5,CDS:6,CJF:4,CGB:9,CB:6</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7,CB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CWIE:7,CGB:8,CB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
+		<model name='D'>
+			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CWIE:7,CGB:8,CB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7,CB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,CNC:3,FWL:8,NIOPS:6,CJF:1,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>CC:5+,CS:5,LA:5+,FRR:4+,FWL:5+,IS:4+,WOB:5,SIC:4+,FS:5+,DC:5+,CWIE:4</availability>
 		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:6,CLAN:6</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
@@ -3080,11 +3080,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
-		<model name='DV-6M'>
-			<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='DV-7D'>
 			<availability>LA:4+,FS:6+,MERC:4+,TC:4+</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -3098,11 +3098,11 @@
 		<model name='DVS-3'>
 			<availability>LA:2,FS:2</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>LA:4,FS:4,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
@@ -3135,35 +3135,35 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:7,CSV:5,CLAN:5,IS:1+,CFM:5,CSA:6,MERC.WD:5,CDS:4,CSJ:5,CJF:4,CGB:9,CB:7</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:7</availability>
+		<model name='(ERLL)'>
+			<availability>LA:1+,FS:1+</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:8,General:4</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:1+,FS:1+</availability>
+		<model name='(Standard)'>
+			<availability>CC:6,General:7</availability>
 		</model>
 		<model name='(Streak)'>
 			<availability>LA:7+,WOB:4,FS:4+</availability>
@@ -3191,35 +3191,40 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
-		<model name='EGL-R4'>
-			<availability>LA:3,FS:3</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:2,General:7,FS:2</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:2,General:7,FS:2</availability>
+		<model name='EGL-R4'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:2+,MOC:2+,FWL.MM:4,FWL:3+,FWL.FO:4+,MERC:2+</availability>
+		<model name='EGL-1M'>
+			<availability>CC:3,MOC:3,FWL:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='EGL-1M'>
-			<availability>CC:3,MOC:3,FWL:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,MERC.WD:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -3231,14 +3236,9 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -3262,19 +3262,15 @@
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>OA:2,LA:5,Periphery.HR:2,MH:2,SIC:3,FS:9,MERC:5,Periphery.OS:2,TC:2,DC:3</availability>
-		<model name='ENF-5D'>
-			<availability>LA:4+,FS:6+,MERC:2+,TC:2+</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>LA:4,General:6,FS:6,TC:6</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>LA:4+,FS:6+,MERC:2+,TC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -3283,6 +3279,10 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:3+,CIH:3+,CGS:3+,CB:2+</availability>
@@ -3290,12 +3290,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -3305,13 +3305,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,FWL:1,WOB:2,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CS:4,CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -3320,20 +3320,16 @@
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:2,MERC:1</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:2,MERC:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5,CIR:1+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:2,NIOPS:8,WOB:8</availability>
@@ -3342,28 +3338,32 @@
 			<roles>fire_support</roles>
 			<availability>CS:6,WOB:6,CIR:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3,WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:2,FWL:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4A'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
@@ -3371,12 +3371,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -3387,8 +3387,8 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>DC.GHO:2,MERC.WD:2,DC:2</availability>
-		<model name='FLC-4N'>
-			<availability>MERC.WD:4,BAN:8,DC:8</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
@@ -3396,11 +3396,11 @@
 		<model name='FLC-4P'>
 			<availability>MERC.WD:6+</availability>
 		</model>
+		<model name='FLC-4N'>
+			<availability>MERC.WD:4,BAN:8,DC:8</availability>
+		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
-		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -3425,17 +3425,8 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.KH:1+,CIH:7,CSV:5,CLAN:4,IS:1+,CWIE:8,MERC.WD:6,CDS:5,CW:8,CNC:4,CSJ:4,CJF:6,CGB:5</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:3,CBS:2,CLAN:2,General:1,CCO:5,CWIE:4</availability>
@@ -3443,35 +3434,44 @@
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4,CWIE:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -3483,78 +3483,73 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:3</availability>
+			<availability>IS:6</availability>
 		</model>
 		<model name='(LBX2)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(LBX10)'>
 			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC20)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:6</availability>
+			<availability>General:8</availability>
 		</model>
-		<model name='(LBX10)'>
+		<model name='(AC20)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:3</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CFM:2,CJF:4</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
@@ -3563,6 +3558,11 @@
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -3601,53 +3601,47 @@
 		<model name='FFL-4B'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='FFL-4A'>
-			<availability>:0,MERC.WD:2-</availability>
+		<model name='FFL-4C'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
 		</model>
-		<model name='FFL-4C'>
-			<availability>CS:6,WOB:6</availability>
+		<model name='FFL-4A'>
+			<availability>:0,MERC.WD:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
+		<model name='FS9-S1'>
 			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
+			<availability>LA:5+,General:2+,FS:4+</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:3+,CS:3+,MOC:4+,LA:5+,FRR:4+,General:3+,FS:4+,TC:3+</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='FS9-S'>
+		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
-			<availability>CC:3+,CS:3+,MOC:4+,LA:5+,FRR:4+,General:3+,FS:4+,TC:3+</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:5+,General:2+,FS:4+</availability>
+			<availability>LA:1,LA.SR:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:4+,CC:3+,LA:4+,IS:3+,WOB:4+,FS:4+,MERC:3+,DC:6+</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:1+,DC:1+</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:1</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='FS9-OA'>
 			<availability>General:7</availability>
@@ -3656,56 +3650,62 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OX'>
-			<availability>General:1</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:1+,DC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:3,CSV:5,FRR:2,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:4,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:2</availability>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:5,LA:5</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:8,CS:6,LA:2,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='FLS-C'>
 			<availability>DC:4+</availability>
 		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:5,LA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
-		<model name='FLE-4'>
-			<availability>FWL:2</availability>
-		</model>
 		<model name='FLE-15'>
 			<availability>MERC.WD:1,FWL:1</availability>
+		</model>
+		<model name='FLE-4'>
+			<availability>FWL:2</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:6+,FWL:2+,MERC:2+,Periphery:2+</availability>
@@ -3719,9 +3719,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -3729,17 +3726,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -3792,13 +3792,13 @@
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:2,FWL:4,WOB:3</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:8,General:8,FWL:8,WOB:8</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:2,FWL:4,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -3810,37 +3810,37 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:5,CW:5,CLAN:4</availability>
-		<model name='2'>
-			<availability>CSA:2,CW:6,CCO:6,CGS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:2,CW:6,CCO:6,CGS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:4,Periphery:2,CS:5,OA:2,LA:5,FWL:7,DC:3</availability>
-		</model>
-		<model name='GAL-200'>
-			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:6</availability>
 		</model>
+		<model name='GAL-200'>
+			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
+		</model>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:4,Periphery:2,CS:5,OA:2,LA:5,FWL:7,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:2+,MOC:2+,MERC.WD:6,IS:4+,FWL:2+,MH:4,MERC:6,TC:2+</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='GAL-1GLS'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='GAL-2GLS'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
@@ -3854,34 +3854,34 @@
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CLAN:5,IS:1+,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
+		<model name='B'>
+			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:4,CW:6,CNC:6,General:3,CSJ:3,CJF:4,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -3914,14 +3914,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,SIC:4,FS:5</availability>
@@ -3929,6 +3921,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,FRR:2,NIOPS:2,WOB:2,SIC:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -3950,20 +3950,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:5,CLAN:2</availability>
-		<model name='2'>
-			<availability>CSV:6,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:8,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -3971,20 +3971,20 @@
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
 		<availability>FWL:3,WOB:4</availability>
-		<model name='GRN-D-01'>
-			<availability>FWL:6,WOB:6</availability>
-		</model>
 		<model name='GRN-D-02'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='GRN-D-01'>
+			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:2,DC:8</availability>
-		<model name='DRG-1G'>
-			<availability>FRR:6,DC:6</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:4+,CNC:5,DC:6+</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>FRR:6,DC:6</availability>
 		</model>
 		<model name='DRG-C'>
 			<availability>FRR:6+,DC:6+</availability>
@@ -4004,9 +4004,6 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>CS:2,IS:2+,WOB:2,Periphery:2+</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
@@ -4015,6 +4012,9 @@
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:2+,DC:3+</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>CS:2,IS:2+,WOB:2,Periphery:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -4026,14 +4026,14 @@
 	</chassis>
 	<chassis name='Gray Death Standard Suit' unitType='BattleArmor'>
 		<availability>MERC.GDL:6,LA:2,MERC:2</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -4047,20 +4047,20 @@
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CHH:4,CDS:6,CSR:4,CSV:4,CFM:4,CSJ:4,CCO:4,CJF:4,CB:4</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
@@ -4074,20 +4074,20 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
-		<model name='GRF-1S'>
-			<availability>LA:5,FRR:3,MERC:4</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
+		<model name='GRF-1N'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
+		<model name='GRF-1S'>
+			<availability>LA:5,FRR:3,MERC:4</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
@@ -4108,11 +4108,11 @@
 			<roles>ground_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:2,MOC:2,SIC:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CC:2,IS:2,FWL:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:2,MOC:2,SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -4123,13 +4123,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:1,Periphery.ME:1,FWL:1,NIOPS:0,MERC:1</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
@@ -4174,48 +4174,48 @@
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:3,WOB:3</availability>
 		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:5,FWL:1,NIOPS:7,WOB:7,DC:3</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:6,CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:2</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:6,CLAN:5,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:4,CIH:2,CSV:5,CNC:5,CLAN:2,CSJ:6,CJF:4,CCO:2,CGB:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -4234,13 +4234,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -4258,27 +4258,27 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,MERC:3+,DC:8</availability>
-		<model name='HTM-26T'>
-			<availability>DC:6</availability>
+		<model name='HTM-27T'>
+			<availability>FRR:6+,MERC:3+,DC:5+</availability>
 		</model>
 		<model name='HTM-28T'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:6+,MERC:3+,DC:5+</availability>
+		<model name='HTM-26T'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>FRR:3,DC:4</availability>
+		<model name='HTM-27U'>
+			<availability>General:6</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4+</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaze' unitType='Mek'>
@@ -4301,15 +4301,15 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>Periphery.R:3,MERC.KH:4,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:1,DC:4</availability>
-		<model name='HCT-3NH'>
-			<availability>DC:4</availability>
+		<model name='HCT-3F'>
+			<roles>urban</roles>
+			<availability>LA:5,TC.PL:6,MERC:5,FS:5,Periphery:5</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>LA:5+,FRR:3+,FS:5+,MERC:2+,DC:1</availability>
 		</model>
-		<model name='HCT-3F'>
-			<roles>urban</roles>
-			<availability>LA:5,TC.PL:6,MERC:5,FS:5,Periphery:5</availability>
+		<model name='HCT-3NH'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -4327,21 +4327,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -4358,21 +4358,29 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Meteor'>
-			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
-		</model>
-		<model name='Inseki'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='Bat Hawk'>
 			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='Meteor'>
+			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
+		</model>
+		<model name='Inseki'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -4381,32 +4389,24 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8,WOB:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8,WOB:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -4417,15 +4417,15 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:3,CNC:1,NIOPS:6,WOB:6,FS:3,DC:4</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,WOB:8,DC:8+</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -4433,15 +4433,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:4,FS:3</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
@@ -4458,15 +4458,15 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CIH:6,CDS:2,CCO:2</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:4,General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -4491,14 +4491,6 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:2,WOB:2</availability>
-		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
-		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
@@ -4507,24 +4499,20 @@
 			<roles>recon</roles>
 			<availability>MOC:4+,CC:4+,LA:4+,PIR:2,FWL:7+,WOB:8,FS:4+,MERC:4+,DC:4+</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:2,WOB:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:3,FRR:2,FWL:5,NIOPS:3,WOB:3,CGB:3,CB:1,DC:2</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:3+,WOB:4</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:6,CS:6,CLAN:6,NIOPS:6,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:6+,WOB:6+</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>DC:3</availability>
 		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
@@ -4534,34 +4522,46 @@
 			<roles>recon</roles>
 			<availability>CS:2,FRR:2,FWL:3,WOB:2</availability>
 		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:5+,WOB:4</availability>
-		</model>
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:2</availability>
 		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:3+,WOB:4</availability>
+		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:5+,WOB:4</availability>
+		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:6,CS:6,CLAN:6,NIOPS:6,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
+		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -4580,20 +4580,20 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:5,CLAN:6,NIOPS:9,CFM:7,WOB:9,SIC:1,MERC:3,FS:4,CJF:7,DC:2</availability>
+		<model name='HGN-733'>
+			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
-		<model name='HGN-733P'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
+		</model>
+		<model name='HGN-733P'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hitman' unitType='Mek'>
@@ -4624,37 +4624,37 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:3</availability>
 		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:6,CLAN:1</availability>
+		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
-		<model name='HNT-161'>
-			<availability>MERC.WD:5-</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:6</availability>
+		<model name='HNT-161'>
+			<availability>MERC.WD:5-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:5+,MERC:5+</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -4684,58 +4684,51 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
-		<model name='HBK-4G'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='HBK-5M'>
 			<availability>CS:4+,CC:3+,MOC:1,FRR:3+,FWL:5+,WOB:4+,MERC:4+,TC:1</availability>
+		</model>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-5S'>
 			<availability>LA:3,FRR:2,MERC:2</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4P'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-6N'>
 			<availability>FWL:4,WOB:4,MERC:2</availability>
 		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(ERLL)'>
-			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>LA:7+,FS:5+</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -4745,37 +4738,44 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>LA:7+,FS:5+</availability>
+		</model>
+		<model name='(ERLL)'>
+			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:6,MOC:4,FWL:5,WOB:3,MERC:2,TC:4</availability>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:3,MOC:3,FWL:4</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:6,FRR:3,CLAN:5,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
-		<model name='HSR-200-D'>
-			<roles>recon</roles>
-			<availability>CS:6,General:6,CLAN:6,NIOPS:6,MERC.SI:6,WOB:6,BAN:8</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:3</availability>
+		<model name='HSR-400-D'>
+			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:3</availability>
+		</model>
+		<model name='HSR-200-D'>
+			<roles>recon</roles>
+			<availability>CS:6,General:6,CLAN:6,NIOPS:6,MERC.SI:6,WOB:6,BAN:8</availability>
+		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -4792,29 +4792,29 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,LA:8,FWL:8,IS:8,WOB:8,MH:8,FS:8,DC:8,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Level I) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [MG]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
 		<model name='(Level I) [SRM]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Level I) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -4877,27 +4877,27 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>FWL:4</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>FWL:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6,CLAN:1</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:1</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6,CLAN:1</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -4925,6 +4925,11 @@
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,SIC:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -4934,11 +4939,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -4955,9 +4955,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:5,General:4,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -4967,17 +4971,13 @@
 			<roles>recon,raider</roles>
 			<availability>DC:7,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:5,General:4,Periphery.Deep:7,Periphery:7</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
@@ -4988,10 +4988,10 @@
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>WOB:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -5000,14 +5000,14 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -5018,43 +5018,39 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,MOC:2,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,FS:8,Periphery.OS:1,CIR:2,TC:2,CS:3,OA:1,LA:6,Periphery.CM:1,Periphery.HR:2,Periphery.ME:1,FWL:3,NIOPS:3,MH:2,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:6,FRR:6,IS:6,SIC:6,FS:6</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:3+,MERC:3</availability>
-		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>LA:2,FRR:2,FS:2,MERC:2,DC:2</availability>
 		</model>
+		<model name='JM7-D'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:3+,MERC:3</availability>
+		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>OA:6+,LA:6+,FRR:6+,FS:6+,MERC:6+,DC:6+</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:6,FRR:6,IS:6,SIC:6,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10P'>
+		<model name='JVN-10N'>
 			<roles>recon</roles>
-			<availability>LA:5+,FS:6+,MERC:4+</availability>
+			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
@@ -5063,6 +5059,10 @@
 		<model name='JVN-11B'>
 			<roles>recon</roles>
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
+		</model>
+		<model name='JVN-10P'>
+			<roles>recon</roles>
+			<availability>LA:5+,FS:6+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
@@ -5082,14 +5082,14 @@
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:6,CGS:4,CCO:5,CB:6</availability>
+		<model name='2'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:7,CLAN:6,CNC:7</availability>
-		</model>
-		<model name='2'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -5120,19 +5120,19 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -5153,43 +5153,43 @@
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Flamer]' mechanized='true'>
+		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>MERC:1,DC:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:2</availability>
 		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:1,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
@@ -5209,30 +5209,37 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:3,PIR:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>IS:3+,Periphery:1+</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:3+,FRR:2+,DC:2+</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:2</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='CRK-5003-C'>
 			<availability>DC:2+</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>CS:5,MERC.WD:5,CW:4,LA:5,FRR:5,CLAN:5,FS:5,DC:4</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -5240,48 +5247,41 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
-		<model name='KGC-001'>
-			<availability>CS:6,LA:4+,IS:4+,WOB:5</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:6</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:6,CIH:5,FRR:6+,CLAN:6,NIOPS:6,WOB:6,BAN:8,CB:5,DC:6+</availability>
 		</model>
+		<model name='KGC-001'>
+			<availability>CS:6,LA:4+,IS:4+,WOB:5</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:2,CSR:2,CLAN:2,CNC:2,CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -5289,23 +5289,23 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:5,MERC:4,DC:5</availability>
-		<model name='KTO-C'>
-			<availability>MERC:5,DC:6+</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:6,CS:6,DC.SL:4,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,FS:6+,MERC:6+,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:6,MERC:6,DC:4</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:3</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:2,WOB:4,MERC:5,DC:8</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		<model name='KTO-C'>
+			<availability>MERC:5,DC:6+</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:3</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:6,MERC:6,DC:4</availability>
 		</model>
 		<model name='KTO-21'>
 			<availability>CS:3,WOB:3</availability>
@@ -5313,9 +5313,6 @@
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -5325,55 +5322,46 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:5,CCC:3,CIH:5,CSR:6,CNC:2,CLAN:3,CGS:4,CCO:3,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='5'>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
 		<availability>FRR:5,MERC:2,DC:7</availability>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,IS:1+,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:1,CSV:1,CNC:2,General:1</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8,CB:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -5383,9 +5371,21 @@
 			<roles>recon</roles>
 			<availability>CSA:4,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8,CB:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:1,CSV:1,CNC:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -5399,11 +5399,11 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='3'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>CSV:2,CJF:5</availability>
 		</model>
-		<model name='2'>
+		<model name='3'>
+			<roles>fire_support</roles>
 			<availability>CSV:2,CJF:5</availability>
 		</model>
 	</chassis>
@@ -5446,23 +5446,23 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:4,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:5</availability>
+		<model name='LNC25-03'>
+			<availability>DC:7</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
+		</model>
 		<model name='LNC25-04'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:5,DC:5</availability>
-		</model>
-		<model name='LNC25-03'>
-			<availability>DC:7</availability>
-		</model>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
-		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -5474,24 +5474,24 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:4,LA:4,FWL:6,WOB:4,FS:4</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:6,FWL:6,FS:6</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:6,FWL:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -5519,10 +5519,6 @@
 		<model name='Owl'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FS:5,MERC:1</availability>
 		</model>
@@ -5532,39 +5528,43 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CIH:6,CLAN:5,WOB:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CCC:2,CSR:5,CW:5,CSV:2,CCO:4,CJF:4,CWIE:6</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:4,CJF:2,CWIE:5,CGB:5,CB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -5581,13 +5581,13 @@
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CS:6,CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,WOB:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -5602,18 +5602,30 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:1,CHH:6,CW:7,LA:1,CLAN:4,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:5-,HL:5,CLAN:1-,IS:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,Periphery:6</availability>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:4+</availability>
+		</model>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:6,MERC:4</availability>
+		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2,SIC:2</availability>
@@ -5622,80 +5634,68 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
-			<roles>recon</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:3,General:5,FS:5</availability>
-		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
-		</model>
-		<model name='LCT-3S'>
-			<roles>recon</roles>
-			<availability>LA:6+,FRR:4+,MERC:4+</availability>
 		</model>
 		<model name='LCT-3M'>
 			<roles>recon</roles>
 			<availability>MOC:3+,FWL:6+,IS:3+,MERC:4+</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:6,MERC:4</availability>
+			<availability>LA:3,General:5,FS:5</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-3S'>
 			<roles>recon</roles>
-			<availability>FS:6+,MERC:4+</availability>
+			<availability>LA:6+,FRR:4+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSV:6,CLAN:5,IS:1+,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:3,CDS:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
-		<model name='LGB-7V'>
+		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
-			<availability>MOC:3+,FWL:4+,IS:3+</availability>
+			<availability>MOC:5,OA:5,General:5,TC:5,Periphery:5</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='LGB-7Q'>
+		<model name='LGB-7V'>
 			<roles>fire_support</roles>
-			<availability>MOC:5,OA:5,General:5,TC:5,Periphery:5</availability>
+			<availability>MOC:3+,FWL:4+,IS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -5703,26 +5703,26 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Flamer] (WoB)' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[David] (WoB)' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -5736,14 +5736,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:6+,FS:4+,MERC:4+</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:6+,FS:4+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -5752,13 +5752,13 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -5770,24 +5770,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:5,CLAN:2,MERC:3,DC:3</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:4+</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>MERC:4,DC:6</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:4+</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:6,MERC:4</availability>
@@ -5812,16 +5812,12 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:3,CWIE:2,CGB:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CNC:3,CLAN:2,General:1</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
@@ -5829,11 +5825,15 @@
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CNC:3,CLAN:2,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -5864,23 +5864,23 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:9,CSV:8,CLAN:5,IS:2+,BAN:6,CWIE:9,MERC.WD:8,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -5891,11 +5891,11 @@
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
-		<model name='(3055 Upgrade)'>
-			<availability>LA:4+,FS:4+,MERC:2+</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,LA:5,General:6,Periphery.Deep:5,FS:5,DC:5,Periphery:6</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>LA:4+,FS:4+,MERC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
@@ -5912,26 +5912,17 @@
 		<model name='MAD-5A'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='MAD-4A'>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='MAD-5C'>
 			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='MAD-4A'>
+			<availability>MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,DC:5,CGB:2</availability>
-		<model name='MAD-3D'>
-			<availability>FS:5</availability>
-		</model>
 		<model name='MAD-5D'>
 			<availability>LA:5+,FRR:5+,WOB:3+,FS:5+,MERC:3+,DC:7+</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>CS:4+,FWL:5+,IS:3+,WOB:5+,MERC:3+</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:3-,HL:6,IS:5,Periphery.Deep:7,WOB:3-,Periphery:8,TC:8</availability>
@@ -5939,8 +5930,8 @@
 		<model name='MAD-3L'>
 			<availability>CC:2,SIC:2</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:2,CGS:3,BAN:2</availability>
+		<model name='MAD-5M'>
+			<availability>CS:4+,FWL:5+,IS:3+,WOB:5+,MERC:3+</availability>
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,MERC:0,BAN:2</availability>
@@ -5948,17 +5939,26 @@
 		<model name='MAD-3M'>
 			<availability>MOC:4,Periphery.MW:2,PIR:2,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
 		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:2,CGS:3,BAN:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='MAD-5S'>
 			<availability>LA:4+,FRR:2+,FS:4+,MERC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CHH:4,CCO:2,CGS:2,CGB:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CHH:4,CCO:2,CGS:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
@@ -5979,26 +5979,26 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,IS:1+,CFM:4,MERC:1+,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -6009,11 +6009,11 @@
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>FRR:4+,MERC:2+,DC:7+</availability>
-		<model name='MAL-1R'>
-			<availability>FRR:8,MERC:6,DC:4</availability>
-		</model>
 		<model name='MAL-C'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='MAL-1R'>
+			<availability>FRR:8,MERC:6,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -6033,63 +6033,63 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
-		<model name='(SRM2)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(SRM2)'>
 			<roles>apc</roles>
-			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>FRR:2,IS:1,SIC:1,MERC:2,DC:3+</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:3,FRR:6+,FWL:5+,IS:4+,SIC:3,DC:6+</availability>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(3052 Upgrade)'>
+		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
-			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
+			<availability>FRR:2,IS:1,SIC:1,MERC:2,DC:3+</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:4</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+			<availability>CC:3,FRR:6+,FWL:5+,IS:4+,SIC:3,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,CW:1,WOB:1,CGS:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -6116,35 +6116,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -6152,20 +6149,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -6173,8 +6173,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -6226,11 +6226,11 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>OA:6+,HL:2+,MERC:4+,Periphery:4+</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
@@ -6261,13 +6261,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:4+,MERC:1+,DC:4+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>General:1,MERC:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -6277,11 +6273,15 @@
 			<roles>support</roles>
 			<availability>CC:1,MERC:6,DC:1</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>General:1,MERC:8</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -6324,13 +6324,13 @@
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-68'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -6341,11 +6341,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -6362,7 +6362,7 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -6371,14 +6371,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -6408,6 +6408,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
@@ -6415,14 +6423,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
@@ -6444,11 +6444,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
@@ -6459,19 +6459,19 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CSJ:3,CJF:4</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -6508,26 +6508,26 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>LA:5,FS:5,MERC:1</availability>
+		<model name='NGS-5S'>
+			<availability>LA:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>LA:2,FS:2,MERC:2</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>LA:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:2,FS:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,CS:3,LA:4+,CLAN:2,NIOPS:3,FS:4+,MERC:2+</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
@@ -6541,15 +6541,15 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CDS:2,CNC:7,CFM:2</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -6565,12 +6565,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CIH:2,CDS:3,CNC:6,CLAN:2,CSJ:4,CWIE:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -6578,9 +6572,15 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
@@ -6612,8 +6612,8 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:2,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:2,CDS:4,LA:7,PIR:4,Periphery.ME:4,CNC:2,FWL:9,MH:4,DC:4</availability>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:5,CNC:5,IS:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
@@ -6622,8 +6622,8 @@
 		<model name='(Standard)'>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:5,CNC:5,IS:6</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -6634,26 +6634,26 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
-		<model name='ON1-MA'>
-			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
+		<model name='ON1-M'>
+			<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:2,MH:2,TC:2</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2+,MOC:2+,FWL:4+,WOB:4+,FS:2+,MERC:2+,DC:2+</availability>
 		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
+		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
@@ -6670,25 +6670,25 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
-		<model name='OSR-3C'>
-			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		<model name='OSR-2L'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
-		</model>
-		<model name='OSR-2Cb'>
-			<roles>urban</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:3</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>CS:6+,IS:3+,Periphery:2+</availability>
 		</model>
 		<model name='OSR-2M'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='OSR-2Cb'>
+			<roles>urban</roles>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -6708,14 +6708,14 @@
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:2,IS:3,FWL:5,NIOPS:6,WOB:6,FS:5,MERC:5,Periphery:3</availability>
-		<model name='OTL-4D'>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='OTL-5M'>
 			<availability>CS:3+,FWL:6+,WOB:5+,MERC:3+</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -6731,17 +6731,21 @@
 			<roles>mech_carrier</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CS:2+,CC:1+,FWL:1+,WOB:1+,SIC:1+,FS:1+,MERC:1+,DC:3+</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:1+,CLAN:6</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -6750,19 +6754,15 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='OW-1'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='OW-1A'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:1+,CLAN:6</availability>
-		</model>
-		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -6779,13 +6779,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,SIC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -6794,29 +6794,17 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:4,CS:4,NIOPS:4,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:3,FWL:2,NIOPS:2,DC:10</availability>
-		<model name='PNT-10KA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2+,FRR:2+,CNC:5,FS.DMM:2+,MERC:2+,DC:2+</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4+,FRR:6+,CNC:2,FS.DMM:4+,MERC:4+,DC:8+</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,MERC:7,Periphery:7,DC:7</availability>
@@ -6824,6 +6812,18 @@
 		<model name='PNT-C'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4+,FRR:6+,CNC:2,FS.DMM:4+,MERC:4+,DC:8+</availability>
+		</model>
+		<model name='PNT-CA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2+,FRR:2+,CNC:5,FS.DMM:2+,MERC:2+,DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -6835,35 +6835,35 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:2,CS:3,LA:4,FRR:2,IS:2,WOB:2,FS:6+,DC:3,CWIE:4</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:4,FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>WOB:2,FS:2</availability>
 		</model>
-	</chassis>
-	<chassis name='Partisan Heavy Tank' unitType='Tank'>
-		<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,CDS:2,LA:8,FWL:7,DC:6</availability>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:4,FS:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+	</chassis>
+	<chassis name='Partisan Heavy Tank' unitType='Tank'>
+		<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,CDS:2,LA:8,FWL:7,DC:6</availability>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -6881,14 +6881,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(Sensors)'>
 			<roles>recon</roles>
 			<availability>IS:2</availability>
@@ -6897,6 +6889,14 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Unarmed)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:3,WOB:4,FS:4,DC:4</availability>
@@ -6904,9 +6904,6 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>LA:4,FS:4,MERC:1</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -6916,31 +6913,37 @@
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
 		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:3,CSJ:6,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:3-,LA:2-,FRR:2-,FWL:2-,IS:2-,SIC:2-,FS:2-,MERC:2-,DC:2-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>FWL:4+,WOB:3+</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
 		</model>
@@ -6954,18 +6957,15 @@
 		<model name='P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CCC:4,CIH:4,CSR:4,CW:8,CCO:4,CJF:7,CGS:2,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -6997,15 +6997,39 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:6,HL:3,CLAN:2,IS:9,FWL:10,NIOPS:6,Periphery.Deep:4,WOB:5,Periphery:4,CGB:2</availability>
+		<model name='PXH-3S'>
+			<roles>recon</roles>
+			<availability>LA:7+,MERC:4+</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:5+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:5,BAN:6,Periphery:5</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:3,DC:4</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:7+,IS:3+</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>PIR:2,FS:4,MERC:4</availability>
@@ -7014,40 +7038,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:5,BAN:1</availability>
 		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:3,DC:4</availability>
-		</model>
 		<model name='PXH-3K'>
 			<roles>recon</roles>
 			<availability>FRR:6+,DC:6+</availability>
 		</model>
-		<model name='PXH-3S'>
-			<roles>recon</roles>
-			<availability>LA:7+,MERC:4+</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:7+,IS:3+</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:5,BAN:6,Periphery:5</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:6+,MERC:5+</availability>
-		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:5,CLAN:8</availability>
 		</model>
@@ -7055,6 +7052,9 @@
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
@@ -7066,13 +7066,13 @@
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4+,FS:6+</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -7122,33 +7122,33 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:2,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CDS:9,CW:6,General:7,CGB:6,CB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:6,CDS:9,CW:6,General:7,CGB:6,CB:7</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -7172,10 +7172,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
@@ -7184,36 +7180,40 @@
 			<roles>support</roles>
 			<availability>General:4+</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8,General:6</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:8</availability>
+		</model>
 		<model name='H'>
 			<availability>CHH:4,CCC:3,CW:4,CBS:4,CLAN:2,General:1,CFM:4,CSJ:4,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -7236,14 +7236,11 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:4+,MERC:4+,DC:6+</availability>
-		</model>
 		<model name='QKD-5A'>
 			<availability>General:2,MERC:4,DC:4,Periphery:4</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>FRR:4,MERC:4,DC:6+</availability>
+		<model name='QKD-5M'>
+			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
@@ -7251,8 +7248,11 @@
 		<model name='QKD-4H'>
 			<availability>General:3</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
+		<model name='QKD-C'>
+			<availability>FRR:4,MERC:4,DC:6+</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>FRR:4+,MERC:4+,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -7264,7 +7264,13 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Tsunami]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
@@ -7273,12 +7279,6 @@
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
@@ -7289,11 +7289,11 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,FS:4,MERC:2</availability>
-		<model name='MDG-1B'>
-			<availability>LA:4,FS:4,MERC:3</availability>
-		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
@@ -7302,11 +7302,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2,CNC:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:6</availability>
@@ -7317,31 +7317,42 @@
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FS:2+,DC:4+</availability>
-		<model name='RTX1-OE'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:1+</availability>
 		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OC'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:2,FWL:5,SIC:3,FS:4,MERC:4,DC:3,TC:2</availability>
+		<model name='RVN-2X'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:2,FWL:3,MERC:3,FS:2,DC:3,TC:2</availability>
+		</model>
+		<model name='RVN-1X'>
+			<roles>recon,ew_support</roles>
+			<availability>CC:3,SIC:2,FS:2</availability>
+		</model>
 		<model name='RVN-4X'>
 			<availability>CC:8</availability>
 		</model>
@@ -7349,20 +7360,9 @@
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:1,FWL:4,FS:2,MERC:3,DC:2,TC:1</availability>
 		</model>
-		<model name='RVN-1X'>
-			<roles>recon,ew_support</roles>
-			<availability>CC:3,SIC:2,FS:2</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:2,FWL:3,MERC:3,FS:2,DC:3,TC:2</availability>
-		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:2</availability>
-		</model>
-		<model name='RVN-2X'>
-			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -7373,6 +7373,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:9,FRR:7,CLAN:6,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CNC:3</availability>
@@ -7385,19 +7393,11 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
-		<model name='F-700a'>
-			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
+		<model name='F-100'>
+			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>FRR:7,DC:7</availability>
@@ -7408,17 +7408,17 @@
 		<model name='F-700'>
 			<availability>CC:6+,FWL:6+,WOB:8,MERC:6+</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
+		<model name='F-700a'>
+			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:4,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:6,CLAN:5,CNC:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:6,CLAN:5,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -7430,20 +7430,12 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:3</availability>
+		<model name='RFL-5D'>
+			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:1,Periphery:6</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='RFL-5M'>
 			<availability>CC:4+,MOC:4+,FWL:5+,IS:4+,MERC:4+,DC:4+</availability>
@@ -7451,13 +7443,17 @@
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
 		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:1,Periphery:6</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:4+,CS:5,CHH:4,CSR:2,LA:4+,FRR:4+,CLAN:2,NIOPS:5,WOB:5,FS:4+,CJF:1,DC:4+</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
@@ -7466,13 +7462,17 @@
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>IS:2</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
@@ -7483,33 +7483,33 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:2,General:4,NIOPS:2,WOB:2</availability>
 		</model>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:5</availability>
-		</model>
 		<model name='RGU-133F'>
 			<availability>CS:4,General:6,NIOPS:4,WOB:4</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>LA:7,FRR:5,FS:6,MERC:3,CWIE:4,TC:4</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,TC:0,CWIE:0</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -7529,26 +7529,26 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CBS:9,CNC:8,CSJ:9,CJF:9,DC:1+</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		<model name='A'>
+			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:5,CCC:3,CBS:2,CSV:3,CLAN:2,General:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:5,CNC:4,General:5,CFM:4,CSJ:4,CCO:7,CJF:4,CWIE:6,CB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CWIE:5,CGB:6</availability>
@@ -7579,11 +7579,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:5</availability>
@@ -7591,42 +7591,42 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:3,CW:3,CNC:4,CSJ:5,BAN:1,CGB:3,DC:5,CWIE:3</availability>
-		<model name='S-4X'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8,DC:1</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='S-4X'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:7,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
@@ -7682,14 +7682,14 @@
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CW:2,CCO:5</availability>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -7722,21 +7722,21 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>FRR:1,FWL:1,WOB:1,FS:1,MERC:1,MERC.NH:3,DC:1</availability>
-		<model name='A'>
-			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -7758,30 +7758,30 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:5+</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -7808,9 +7808,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CHH:3,CCC:2,CIH:3,CSR:2,CSV:2,CFM:3,CGS:3,CCO:2,CWIE:2,CSA:3,CW:2,CNC:2,CSJ:3,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -7819,6 +7816,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -7835,31 +7835,31 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,CS:3,LA:6,FWL:4,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:2+,LA:3+,FWL:2+,FS:4+</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:2,CLAN:3,CFM:4,WOB:4,MERC:3,FS:3,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,CBS:2,LA:4,NIOPS:4,CJF:4,CGB:4,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='STN-3K'>
-			<availability>LA:4,DC:4</availability>
-		</model>
-		<model name='STN-3KA'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:7,DC:3+</availability>
 		</model>
 		<model name='STN-3KB'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3KA'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='STN-3K'>
+			<availability>LA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -7874,69 +7874,69 @@
 			<roles>interceptor</roles>
 			<availability>HL:3,LA:5,Periphery.Deep:8,FS:5,Periphery:5</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:6+,FRR:4+,FS:6+,MERC:4+</availability>
-		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>OA:4,HL:3,FRR:4,FWL:4,TC:4,Periphery:5,DC:4</availability>
 		</model>
-		<model name='SYD-21'>
+		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
-			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
+			<availability>LA:6+,FRR:4+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='SYD-Z3'>
 			<roles>interceptor</roles>
 			<availability>LA:3,FS:2</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:8,CFM:5,CSJ:6,CJF:4,CB:5</availability>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
+			<availability>CSR:3,General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:6,CWIE:7,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:5,MERC:3,DC:6</availability>
-		</model>
-		<model name='SHD-2D2'>
-			<availability>LA:4+,FS:6+</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
-		</model>
 		<model name='SHD-2Hb'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:4+,FRR:4+,FWL:7+,IS:4+,WOB:6,MERC:4+,DC:4+</availability>
 		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:5,MERC:3,DC:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:8,CCC:8,LA:3,CSV:8,CFM:8,FS:3,CGS:8,DC:3</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>LA:4+,FS:6+</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -7959,14 +7959,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:2,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:3</availability>
-		</model>
 		<model name='C'>
 			<availability>MERC.WD:6+,CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -8005,13 +8005,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -8020,8 +8020,8 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
+		<model name='SL-15'>
+			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>OA:3+,FRR:5+,FS:3+,MERC:3+,DC:6+,TC:2</availability>
@@ -8029,11 +8029,11 @@
 		<model name='SL-15B'>
 			<availability>FRR:1,MERC:1,DC:1</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
-		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -8057,12 +8057,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -8094,13 +8094,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
-		<model name='SPR-6D'>
-			<availability>FRR:4+,FS:6+,MERC:4+</availability>
-		</model>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>FRR:2,General:6,Periphery.Deep:8,FS:6,MERC:6,DC:2,TC:6</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:3,FRR:6,DC:6</availability>
@@ -8108,6 +8101,13 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>LA:6,FS.CMM:2</availability>
+		</model>
+		<model name='SPR-6D'>
+			<availability>FRR:4+,FS:6+,MERC:4+</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>FRR:2,General:6,Periphery.Deep:8,FS:6,MERC:6,DC:2,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -8133,6 +8133,9 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>CC:2,FWL:2,FS:2,MERC:2,DC:3</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>HL:3,FRR:1,IS:5,Periphery.Deep:8,FS:2,Periphery:5</availability>
 		</model>
@@ -8140,55 +8143,52 @@
 			<roles>anti_infantry</roles>
 			<availability>FRR:5,DC:5</availability>
 		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
-		</model>
 		<model name='SDR-5D'>
 			<roles>anti_infantry</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:2,FWL:2,FS:2,MERC:2,DC:3</availability>
+		<model name='SDR-7M'>
+			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:6,FRR:6,IS:4,SIC:5,FS:6,DC:6</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Laser)'>
-			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
-		<model name='STK-5M'>
-			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,CIR:1+,DC:5+,TC:3+</availability>
-		</model>
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='STK-3F'>
-			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='STK-4N'>
 			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
+		</model>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STK-5M'>
+			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,CIR:1+,DC:5+,TC:3+</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:2,LA:5+,CSV:2,MERC:2+,FS:4+,CJF:2,TC:2+</availability>
@@ -8237,59 +8237,59 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
+			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
+		</model>
 		<model name='STG-5M'>
 			<roles>recon</roles>
 			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
-		<model name='STG-3G'>
-			<roles>recon</roles>
-			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='F-94'>
 			<availability>IS:4+</availability>
-		</model>
-		<model name='F-92'>
-			<availability>FWL:6+,IS:3+</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:5,LA:4,IS:5,FS:5,Periphery:5</availability>
 		</model>
+		<model name='F-92'>
+			<availability>FWL:6+,IS:3+</availability>
+		</model>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -8304,17 +8304,13 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:2+,FWL:2+,FS:2+,MERC:2+,DC:6+</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6</availability>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
@@ -8324,12 +8320,19 @@
 		<model name='SR1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
+		<model name='SR1-OR'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,FRR:4,IS:5,WOB:4-,SIC:6,FS:9,MERC:3,CS:4-,CDS:3,LA:6,PIR:3,FWL:3,DC:3</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2+,FS:2+,DC:1+</availability>
 		</model>
@@ -8340,9 +8343,6 @@
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>IS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:5</availability>
@@ -8368,17 +8368,17 @@
 		<model name='STU-K5'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:6,SIC:4</availability>
 		</model>
-		<model name='STU-K15'>
-			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
-		</model>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
+		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
@@ -8393,21 +8393,25 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:2+,LA:3+,SIC:2+,FS:3+,MERC:2+,DC:4+</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
 		</model>
@@ -8415,15 +8419,11 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SD1-OR'>
-			<availability>CLAN:6,General:1+,DC:2+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SD1-OC'>
 			<availability>General:6,DC:7</availability>
+		</model>
+		<model name='SD1-OR'>
+			<availability>CLAN:6,General:1+,DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -8455,15 +8455,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -8471,11 +8471,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -8500,44 +8500,41 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8+,FWL:6+,WOB:5,MERC:2+</availability>
-		<model name='TMP-3M'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:4,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:4,CCC:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -8546,57 +8543,60 @@
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
 		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,WOB:2,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CS:5,DC.GHO:3,CSA:1,CDS:1,CLAN:2,NIOPS:5,WOB:7,CCO:1,CJF:1,CGB:1,DC:1</availability>
+		<model name='THE-N1'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='THE-N'>
+			<availability>CS:7,CLAN:6,NIOPS:7,BAN:6</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:7,CLAN:6,NIOPS:7,BAN:6</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7p'>
+			<availability>SIC:1</availability>
+		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='TR-7p'>
-			<availability>SIC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -8620,12 +8620,12 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>CS:2,LA:5,CLAN:2,NIOPS:2,MERC:3</availability>
+		<model name='TDK-7X'>
+			<availability>General:8</availability>
+		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:4</availability>
-		</model>
-		<model name='TDK-7X'>
-			<availability>General:8</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4</availability>
@@ -8648,13 +8648,13 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:5,FRR:4,MH:4,MERC:4</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:5,FRR:4,MH:4,MERC:4</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -8663,29 +8663,29 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:3,CLAN:2,IS:8,Periphery.Deep:6,WOB:3-,FS:7,MERC:8,Periphery:4,TC:4,CS:4-,LA:8,NIOPS:4-,MH:4,DC:8</availability>
-		<model name='TDR-9SE'>
-			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
-		</model>
 		<model name='TDR-9S'>
 			<availability>LA:6+,FS:5+,MERC:2+</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:4,MERC:1</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:6,HL:4,LA:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='TDR-7M'>
 			<availability>CS:4+,CC:2+,FWL:7+,IS:2+,WOB:4+,MERC:2+</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>CC:6,HL:4,LA:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
+		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:6,MERC:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:4,CCC:4,LA:2,CSV:4,CFM:4,FS:2,CGS:4,DC:2,CB:4</availability>
-		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CWIE:2,CGB:2</availability>
+		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:4,MERC:1</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:4,CCC:4,LA:2,CSV:4,CFM:4,FS:2,CGS:4,DC:2,CB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -8714,11 +8714,11 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>FRR:8,DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='TKG-150'>
 			<availability>FRR:4,DC:4</availability>
@@ -8726,10 +8726,6 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:3,NIOPS:3,WOB:3</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
@@ -8739,6 +8735,10 @@
 		</model>
 		<model name='THK-63b'>
 			<availability>CLAN:3,BAN:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -8779,11 +8779,11 @@
 		<model name='TR-13A'>
 			<availability>CC:6+,MOC:3+,General:3+</availability>
 		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:4,FWL:8</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:4,FWL:8</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
@@ -8801,31 +8801,31 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
-		</model>
-		<model name='TBT-7K'>
-			<roles>fire_support</roles>
-			<availability>FRR:1,DC:3</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 		<model name='TBT-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:2</availability>
 		</model>
+		<model name='TBT-7K'>
+			<roles>fire_support</roles>
+			<availability>FRR:1,DC:3</availability>
+		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -8839,13 +8839,13 @@
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,HL:8,CBS:5,CLAN:2,IS:9,Periphery.Deep:8,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -8870,32 +8870,32 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CNC:3,CSJ:3,CJF:6</availability>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CJF:7,CGS:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -8907,49 +8907,49 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:8,CSV:3,General:2,CWIE:6,CGB:2,CB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:5,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:8,CSV:3,General:2,CWIE:6,CGB:2,CB:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
@@ -9007,6 +9007,10 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
+		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:3,FS:3,MERC:3</availability>
@@ -9015,33 +9019,32 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:6-,HL:9,IS:10,Periphery.Deep:8,WOB:6-,Periphery:10,CGB:5</availability>
-		<model name='(NETC)'>
-			<availability>IS:3+</availability>
+		<model name='(AC2)'>
+			<availability>CC:4,General:5,SIC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:5,General:7,SIC:5</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:8</availability>
@@ -9049,22 +9052,19 @@
 		<model name='(Ultra)'>
 			<availability>CC:5+,MOC:6+,Periphery.CM:6+,PIR:5+,MH:5+,SIC:5+,TC:6+</availability>
 		</model>
-		<model name='(AC2)'>
-			<availability>CC:4,General:5,SIC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CC:5,General:7,SIC:5</availability>
+		<model name='(NETC)'>
+			<availability>IS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>asf_carrier</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -9081,29 +9081,29 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
-		<model name='VTR-9B'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:3+,FRR:6+,FWL:3+,MH:3+,FS:3+,MERC:3+,TC:3+,Periphery:2+,DC:6+</availability>
-		</model>
-		<model name='VTR-C'>
-			<availability>CC:2,FRR:3,MERC:2,FS:2,DC:3</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:3,CIR:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-9A'>
 			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
+		<model name='VTR-9K'>
+			<availability>MOC:3+,FRR:6+,FWL:3+,MH:3+,FS:3+,MERC:3+,TC:3+,Periphery:2+,DC:6+</availability>
+		</model>
 		<model name='VTR-9D'>
 			<availability>CC:3+,LA:5+,SIC:5+,FS:6+</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1,Periphery:1</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:2,FRR:3,MERC:2,FS:2,DC:3</availability>
+		</model>
+		<model name='VTR-9S'>
+			<availability>LA:3,CIR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
@@ -9153,26 +9153,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:4,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -9188,11 +9188,11 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:4,FRR:4,IS:1,FWL:3,WOB:6,FS:3,MERC:1,DC:4</availability>
-		<model name='VNL-K100'>
-			<availability>LA:1,FS:3</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:3,DC:3</availability>
@@ -9209,10 +9209,6 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:7,FS:4</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:5,CIR:2,Periphery:2,TC:2</availability>
@@ -9220,6 +9216,10 @@
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:2+,FWL:6+,WOB:3+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:7,FS:4</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -9231,20 +9231,20 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CBS:3,CSV:3,CNC:3,CLAN:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:4,CDS:5,General:4,CGS:4,CCO:6,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CBS:3,CSV:3,CNC:3,CLAN:2,General:1</availability>
+		<model name='C'>
+			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -9268,21 +9268,21 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='10'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='12'>
-			<availability>CSJ:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='11'>
+			<availability>CSJ:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='11'>
-			<availability>CSJ:6</availability>
+		<model name='12'>
+			<availability>CSJ:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
@@ -9290,30 +9290,30 @@
 		<model name='WHM-6L'>
 			<availability>CC:3,SIC:3</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:6+</availability>
-		</model>
-		<model name='WHM-6R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
-		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:2,FS.DMM:2,FS:1,DC:3</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
 		</model>
 		<model name='WHM-7S'>
 			<availability>LA:6+,FS:4+,MERC:3+</availability>
 		</model>
-		<model name='C'>
-			<availability>LA:3+,FS:3+,DC:3+</availability>
+		<model name='WHM-6D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='WHM-6R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:3+,FS:3+,DC:3+</availability>
+		</model>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -9321,62 +9321,62 @@
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
-		<model name='H-8'>
-			<availability>HL:2,LA:6,FS.CH:6,FRR:4,FS:6,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='H-8'>
+			<availability>HL:2,LA:6,FS.CH:6,FRR:4,FS:6,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='H-7C'>
 			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:3-,HL:5,IS:9,NIOPS:3-,Periphery.Deep:5,WOB:3-,CIR:2,Periphery:6</availability>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:7+</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:5</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:3,DC:3</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:7+,FS:5+,MERC:3+</availability>
 		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:4+,MOC:4+,FWL:7+,WOB:6,MH:4+,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:5</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:7+</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
@@ -9395,13 +9395,13 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CSJ:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
@@ -9410,13 +9410,13 @@
 			<roles>fire_support</roles>
 			<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='WTH-1S'>
-			<roles>fire_support</roles>
-			<availability>FRR:1,DC:1</availability>
-		</model>
 		<model name='WTH-2'>
 			<roles>fire_support</roles>
 			<availability>CS:6,OA:4+,MH:2,FS:4+,DC:4+,TC:4+</availability>
+		</model>
+		<model name='WTH-1S'>
+			<roles>fire_support</roles>
+			<availability>FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -9437,11 +9437,11 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,MERC.WD:2,HL:3,LA:6,FS:7,MERC:6,Periphery:5</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
@@ -9449,25 +9449,25 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,CNC:1,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:2+,FWL:6+,WOB:5,MERC:4+,DC:2+</availability>
-		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>FRR:6+,MERC:4+</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,PIR:2,Periphery.ME:4,FWL:8,MH:2</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:2+,FWL:6+,WOB:5,MERC:4+,DC:2+</availability>
+		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>LA:4+,FS:6+</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,PIR:2,Periphery.ME:4,FWL:8,MH:2</availability>
 		</model>
 		<model name='WVR-6K'>
 			<roles>recon</roles>
@@ -9476,11 +9476,11 @@
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -9501,10 +9501,6 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
@@ -9512,6 +9508,10 @@
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -9540,11 +9540,11 @@
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>CS:6+,LA:6+,IS:4+,FS:8+,MERC:4+,Periphery:2+</availability>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='York Destroyer Carrier' unitType='Warship'>
@@ -9570,24 +9570,24 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:8,DC.GHO:3,FRR:3,CLAN:5,NIOPS:8,WOB:7,MERC:3,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:7,CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,WOB:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:7,CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>
-		</model>
 		<model name='ZRO-115'>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
@@ -9598,20 +9598,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,FRR:4,IS:3,FS:7-,MERC:5,Periphery:2</availability>
-		<model name='ZEU-9S'>
-			<availability>LA:6+,FRR:4+,PIR:2+,FS:5+,MERC:3+,TC:2+</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2+</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>HL:6,General:4,Periphery.Deep:6,FS:4,Periphery:8</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2+</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>LA:6+,FRR:4+,PIR:2+,FS:5+,MERC:3+,TC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>

--- a/megamek/data/forcegenerator/3060.xml
+++ b/megamek/data/forcegenerator/3060.xml
@@ -955,50 +955,50 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:6,CS:6,MOC:5,LA:6,FRR:6,FWL:6,IS:5,WOB:6,SIC:6,FS:6,TC:5,Periphery:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:6,CS:6,MOC:5,LA:6,FRR:6,FWL:6,IS:5,WOB:6,SIC:6,FS:6,TC:5,Periphery:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:4,WOB:4</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
-		<model name='(WoB) [TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:5,WOB:5</availability>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='(WoB) [David]' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(WoB) [TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:5,WOB:5</availability>
 		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
-		<model name='(WoB) [David]' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1014,13 +1014,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CCC:2,CIH:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:1,CJF:6</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Agamemnon Heavy Cruiser' unitType='Warship'>
@@ -1035,11 +1035,11 @@
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='AHB-443b'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='AHB-MD'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='AHB-443b'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Zero-G Engineering Exoskeleton' unitType='BattleArmor'>
@@ -1051,15 +1051,15 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,FS:4</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
@@ -1073,20 +1073,20 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:3,CS:7,CDS:3,LA:5,CNC:3,NIOPS:7,WOB:7,FS:4,MERC:3,CWIE:4,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>FWL:4+,WOB:3,FWL.KIS:6,MERC:2</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>FWL:5,WOB:5</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
@@ -1104,20 +1104,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:3,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:3</availability>
 		</model>
 		<model name='ANH-1E'>
 			<availability>MERC.WD:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:3</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1146,28 +1146,24 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:4,FWL:6,WOB:2,MERC:2</availability>
-		<model name='ANV-8M'>
-			<roles>missile_artillery</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
 		<model name='ANV-5M'>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
-		<model name='ANV-6M'>
-			<roles>spotter</roles>
+		<model name='ANV-8M'>
+			<roles>missile_artillery</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
 		<model name='ANV-3M'>
 			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
 		</model>
+		<model name='ANV-6M'>
+			<roles>spotter</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,LA:3,FWL:8,SIC:4,MERC:4,FS:3,DC:6</availability>
 		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1178,6 +1174,10 @@
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -1205,85 +1205,85 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:5,CLAN:1,IS:7,Periphery.Deep:5,WOB:2-,SIC:6,FS:6,Periphery:5,CS:4-,LA:7,FWL:7,NIOPS:4-,DC:6,CGB:1</availability>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:4,MERC:4</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:4</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:5</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:5,CW:4,LA:3+,CSV:5,CFM:5,FS:3+,CGS:5,CWIE:4,DC:3+</availability>
+			<availability>FRR:3,DC:5</availability>
 		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:8,FS:4</availability>
 		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:4,MERC.WD:4,CWIE:4</availability>
-		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-2S'>
 			<roles>fire_support</roles>
-			<availability>FRR:8,MERC:4,DC:4</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:2,LA:4,FRR:4,IS:4,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4</availability>
+			<availability>LA:5</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6,CC:5,LA:4,PIR:3,FWL:8,WOB:6,SIC:5,MERC:5,FS:4,DC:5</availability>
 		</model>
-		<model name='ARC-2K'>
+		<model name='ARC-2R'>
 			<roles>fire_support</roles>
-			<availability>FRR:3,DC:5</availability>
+			<availability>HL:2,LA:4,FRR:4,IS:4,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,MERC:4,DC:4</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:4,MERC.WD:4,CWIE:4</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:4,MERC:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:5,CW:4,LA:3+,CSV:5,CFM:5,FS:3+,CGS:5,CWIE:4,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1D'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AF1'>
 			<availability>General:8</availability>
 		</model>
+		<model name='AF1D'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>CNC:3,CWIE:4,CGB:2</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
@@ -1294,32 +1294,16 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:4+</availability>
-		<model name='AGS-4D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AGS-4D'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1327,46 +1311,62 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
 		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>MOC:4-,CC:4-,FRR:1,IS:1,WOB:2-,MERC:1,FS:1,Periphery:2,TC:4-,CS:3-,OA:1,LA:1,FS.CMM:2-</availability>
-		<model name='ASN-23'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:4,MH:4,MERC:4,FS:4,TC:4</availability>
-		</model>
 		<model name='ASN-30'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
 		<model name='ASN-21'>
 			<availability>General:2</availability>
+		</model>
+		<model name='ASN-23'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:4,MH:4,MERC:4,FS:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1398,55 +1398,71 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:1</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:2,FRR:6,CLAN:4,IS:3,WOB:4-,SIC:3,FS:4,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:3,NIOPS:4-,DC:9</availability>
-		<model name='AS7-K'>
-			<availability>CC:3,MOC:2,CS:3,OA:2,FRR:5,CNC:3,FWL:3,WOB:3,SIC:2,MERC:4,TC:2,DC:8</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:3,MERC:2</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:3,CLAN:8,FS:3,DC:3</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,OA:2,LA:4,PIR:2,FS:3,MERC:3,TC:2</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:3,MERC:2</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:5</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:5</availability>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,OA:2,LA:4,PIR:2,FS:3,MERC:3,TC:2</availability>
+		<model name='AS7-C'>
+			<availability>FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>CC:3,MOC:2,CS:3,OA:2,FRR:5,CNC:3,FWL:3,WOB:3,SIC:2,MERC:4,TC:2,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:3,FS:3</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -1456,25 +1472,9 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1489,51 +1489,51 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CS:5+,IS:4+,DC:6+</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OR'>
-			<availability>CLAN:6,DC:1+</availability>
-		</model>
 		<model name='AV1-OE'>
 			<availability>General:6</availability>
 		</model>
+		<model name='AV1-OR'>
+			<availability>CLAN:6,DC:1+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
 		<model name='AV1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -1550,17 +1550,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-8R'>
-			<availability>IS:2,FWL:3</availability>
-		</model>
-		<model name='AWS-8V'>
-			<availability>IS:1</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2,CIR:4</availability>
 		</model>
-		<model name='AWS-8Q'>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		<model name='AWS-9Ma'>
+			<availability>LA:4,FWL:4,FS:4</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:3+,PIR:3+,FWL:8,IS:6,MH:3+,TC:3+</availability>
@@ -1568,8 +1562,14 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:3,FWL:6,IS:3,MH:3,TC:3,Periphery:3</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:4,FWL:4,FS:4</availability>
+		<model name='AWS-8R'>
+			<availability>IS:2,FWL:3</availability>
+		</model>
+		<model name='AWS-8V'>
+			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1583,70 +1583,66 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5,FRR:2,FS:3,MERC:2</availability>
-		<model name='AXM-3S'>
-			<availability>LA:3,FS:2,MERC:2</availability>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
+		<model name='AXM-3S'>
+			<availability>LA:3,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:5,CSR:4,CSV:6,CJF:4</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:2,CSV:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CSV:6,CLAN:8</availability>
 		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:2,CSV:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,CW:2,CLAN:1</availability>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:5,CLAN:4</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:5,CLAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1654,11 +1650,7 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1666,19 +1658,39 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:2,FWL:2,WOB:2,FS:2,MERC:7</availability>
-		<model name='BNDR-01A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BNDR-01B'>
 			<availability>General:3,MERC:6</availability>
+		</model>
+		<model name='BNDR-01A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:4,General:2,CCO:5</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1686,30 +1698,34 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>CLAN:4,General:2,CCO:5</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>CSA:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5,MERC:5</availability>
-		<model name='D'>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='H'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1717,97 +1733,81 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:8-,CC:3-,HL:8-,FRR:5-,IS:5-,Periphery.Deep:9-,SIC:6-,FS:6-,CIR:8-,MERC:5-,Periphery:9-,TC:8-,OA:8-,LA:7-,FWL:4-,MH:8-,DC:4-</availability>
+		<model name='BNC-3Q'>
+			<availability>FWL:2</availability>
+		</model>
+		<model name='BNC-5S'>
+			<availability>LA:7,FRR:3,FS:6,MERC:5</availability>
+		</model>
 		<model name='BNC-3MC'>
 			<availability>MOC:9</availability>
 		</model>
 		<model name='BNC-7S'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2,FWL:2,TC:2</availability>
-		</model>
-		<model name='BNC-3Q'>
-			<availability>FWL:2</availability>
+		<model name='BNC-3S'>
+			<availability>OA:3,LA:4,IS:1,FS:2,MERC:2,CIR:3,TC:3</availability>
 		</model>
 		<model name='BNC-3E'>
 			<availability>HL:2,General:4,Periphery.Deep:8,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>OA:3,LA:4,IS:1,FS:2,MERC:2,CIR:3,TC:3</availability>
-		</model>
-		<model name='BNC-5S'>
-			<availability>LA:7,FRR:3,FS:6,MERC:5</availability>
-		</model>
 		<model name='BNC-6S'>
 			<availability>LA:3</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2,FWL:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:4,FRR:3,MERC:3</availability>
-		<model name='BGS-1T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BGS-2T'>
 			<availability>LA:5,MERC:5</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:6,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,CFM:8,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,CSV:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:6,CNC:3,CLAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CCC:4</availability>
-		<model name='2'>
-			<availability>CCC:6,CSV:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CCC:6,CSV:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -1818,8 +1818,8 @@
 		<model name='H'>
 			<availability>CSA:6,General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -1827,19 +1827,19 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:4</availability>
-		<model name='BTL-C-2OA'>
-			<roles>ew_support,spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='BTL-C-2OC'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='BTL-C-2OA'>
+			<roles>ew_support,spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='BTL-C-2OB'>
 			<roles>fire_support</roles>
@@ -1865,29 +1865,21 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:1,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:5</availability>
+		<model name='BLR-2C'>
+			<availability>DC.GHO:1,CS:1,WOB:1</availability>
 		</model>
 		<model name='BLR-4S'>
 			<availability>LA:4,FRR:3,MERC:2,CJF:3</availability>
 		</model>
-		<model name='BLR-2C'>
-			<availability>DC.GHO:1,CS:1,WOB:1</availability>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:3</availability>
 		</model>
 		<model name='BLR-1S'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1,MERC:0</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:6,FS:4</availability>
@@ -1895,16 +1887,24 @@
 		<model name='BLR-1G'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,FS:2,BAN:8,Periphery:5</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:5,PIR:3,FWL:8,IS:3,WOB:7,MH:3,SIC:5,MERC:5</availability>
+		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:5,PIR:3,FWL:8,IS:3,WOB:7,MH:3,SIC:5,MERC:5</availability>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1,MERC:0</availability>
 		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:3</availability>
+		<model name='BLR-1D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1926,12 +1926,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1943,17 +1943,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:5,CSR:3,CLAN:1,CSJ:5,CGS:5</availability>
-		<model name='6'>
+		<model name='4'>
 			<availability>General:1</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
+			<availability>General:1</availability>
+		</model>
+		<model name='6'>
 			<availability>General:1</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:5,CGS:6</availability>
-		</model>
-		<model name='5'>
-			<availability>General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:6,General:6</availability>
@@ -1961,18 +1961,18 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:5,HL:4,FRR:6,IS:5,WOB:5-,SIC:6,MERC:5,FS:8,Periphery:5,CS:5-,OA:6,CDS:3,LA:6,PIR:5,DC:7</availability>
-		<model name='(Kurita)'>
-			<availability>CLAN:3,IS:3,DC:6</availability>
-		</model>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:3,IS:3,DC:6</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1991,11 +1991,11 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:5,FRR:3,FS:4,MERC:1</availability>
-		<model name='BRZ-A3'>
-			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
-		</model>
 		<model name='BRZ-B3'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='BRZ-A3'>
+			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2013,60 +2013,66 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4+,LA:6+,FRR:6+,SIC:4+,FS:4+,MERC:4+,DC:7+</availability>
-		<model name='BHKU-OX'>
-			<availability>FS:2,DC:2</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='BHKU-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OR'>
-			<availability>General:1+,DC:1+</availability>
+		<model name='BHKU-OX'>
+			<availability>FS:2,DC:2</availability>
 		</model>
-		<model name='BHKU-OD'>
+		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='BHKU-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OR'>
+			<availability>General:1+,DC:1+</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:3,CWIE:8,DC.GHO:3,OA:2,CDS:6,CBS:8,FWL:2,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:2,MERC:3,CGS:8,Periphery:2,TC:3,CS:7,CW:8,LA:2,CNC:8,CJF:6,DC:3</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
+		<model name='BL-12-KNT'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:6</availability>
+		</model>
+		<model name='BL-7-KNT'>
+			<availability>:0,LA:6,FRR:6,FWL:2,MERC:6,FS:6,DC:6</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>CS:8,WOB:8</availability>
@@ -2074,41 +2080,35 @@
 		<model name='BL-6-KNT'>
 			<availability>CS:4,DC.GHO:4,OA:3,FRR:5,CLAN:6,FWL:4,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,TC:3,DC:4</availability>
 		</model>
-		<model name='BL-7-KNT'>
-			<availability>:0,LA:6,FRR:6,FWL:2,MERC:6,FS:6,DC:6</availability>
-		</model>
-		<model name='BL-12-KNT'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:6</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CIH:4,CSV:4,CJF:6</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:5</availability>
+		<model name='E'>
+			<availability>CLAN:5,CCO:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:5,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -2130,47 +2130,47 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:3,IS:1,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-1DC'>
+		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:2,General:4,Periphery.Deep:8,Periphery:4</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:2,SIC:5,FS:4,MERC:4,Periphery:2</availability>
-		</model>
-		<model name='BJ-1DB'>
+		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:3,CS:3,LA:3,PIR:2+,WOB:3,SIC:4,FS:8,MERC:3</availability>
 		</model>
+		<model name='BJ-3'>
+			<availability>CC:2,SIC:5,FS:4,MERC:4,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CS:3+,MOC:3+,FWL:3+,IS:3+,WOB:3+,SIC:3+,FS:3+,MERC:3+,DC:6+</availability>
-		<model name='BJ2-OE'>
-			<availability>General:6,FWL:6</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:1+,DC:2+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:4</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:7</availability>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:4</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:1+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:6,FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -2181,9 +2181,6 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,CM:5,WOB:5,MERC:5,TC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>CC:4,WOB:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -2191,17 +2188,20 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>CC:4,WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:3,CCC:2,CBS:2</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<availability>CSA:7,General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -2213,8 +2213,8 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
@@ -2272,13 +2272,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -2294,14 +2294,14 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:4</availability>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-X2'>
 			<availability>General:4</availability>
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -2315,11 +2315,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -2344,25 +2344,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:7,CC:8,HL:4,FRR:7,IS:5,Periphery.Deep:7,SIC:8,FS:4,CIR:6,MERC:5,Periphery:5,TC:7,LA:4,FWL:4,DC:7</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:6,General:8,FS:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:6,General:8,FS:6,MERC:6,DC:6</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -2389,11 +2389,11 @@
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:3</availability>
 		</model>
-		<model name='BSW-L1'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,General:3,MERC:4</availability>
+		</model>
+		<model name='BSW-L1'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>General:4,MERC:6</availability>
@@ -2427,13 +2427,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -2445,135 +2445,135 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,MOC:4,LA:3,Periphery.CM:3,Periphery.HR:3,Periphery.ME:3,MH:3,SIC:5,FS:5,MERC:4,TC:4,Periphery:2</availability>
-		<model name='CTF-2X'>
-			<availability>CC:4,MOC:4,SIC:2,FS:1,MERC:1,TC:4</availability>
-		</model>
 		<model name='CTF-3D'>
 			<availability>LA:6,FS:6</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='CTF-1X'>
 			<availability>General:5,Periphery:6</availability>
 		</model>
+		<model name='CTF-4X'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:4,MOC:4,SIC:2,FS:1,MERC:1,TC:4</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,FRR:5,IS:1,SIC:2,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:4,DC:6</availability>
-		<model name='CPLT-C4C'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,FS:2,MERC:2,TC:2</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:2,DC:4</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>HL:2,PIR:4,MH:6,Periphery:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:4,HL:2,CLAN:3,IS:1,Periphery.Deep:8,MERC:4,BAN:6,Periphery:4</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:3,MOC:3,TC:3</availability>
-		</model>
-		<model name='CPLT-C4'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,OA:2,SIC:2,TC:2</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:6</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:5,CS:3,MOC:3,WOB:3,FS:4,TC:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
+			<availability>DC:2</availability>
 		</model>
 		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
 			<availability>DC:2</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+			<availability>CC:2,MOC:2,OA:2,SIC:2,TC:2</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:2,DC:4</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:2,SIC:2</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:3,MOC:3,TC:3</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:4,DC:6</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>HL:2,PIR:4,MH:6,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:2,MOC:2</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4C'>
 			<roles>fire_support</roles>
-			<availability>CC:2,SIC:2</availability>
+			<availability>CC:2,MOC:2,FS:2,MERC:2,TC:2</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:5,CS:3,MOC:3,WOB:3,FS:4,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:4,HL:2,CLAN:3,IS:1,Periphery.Deep:8,MERC:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CCC:4,CSR:4,CLAN:3,CGS:4,CSA:4,CDS:4,CW:3,CNC:4,CSJ:6,CJF:3,CGB:3,DC:2+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:5,IS:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CLAN:5,IS:2</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:3,FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:4,IS:3,CM:4,FS:6,MERC:4</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -2585,11 +2585,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:4,CSR:3,CBS:3,CNC:4,CFM:3,CSJ:5,CJF:5</availability>
-		<model name='3'>
-			<availability>CSR:4,CBS:4,CFM:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CSR:8,CNC:8,CFM:8,CSJ:8,CJF:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CSR:4,CBS:4,CFM:4,CJF:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4,CSR:4,CBS:4,CNC:4,CFM:6,CJF:4</availability>
@@ -2608,47 +2608,47 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
+		<model name='CNT-1A'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CNT-1D'>
 			<availability>LA:5,Periphery.HR:5,FS:5,MERC:5,Periphery.OS:5,Periphery:4</availability>
 		</model>
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:1,FS:3,MERC:3,Periphery:1</availability>
+		<model name='CN9-D3D'>
+			<availability>FWL:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:6,IS:4,FS:6</availability>
+		</model>
+		<model name='CN9-D4D'>
+			<availability>FWL:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:3,LA:2-,FRR:2-,FWL:2-,Periphery.Deep:8,FS:4-,MERC:4-,Periphery:5</availability>
 		</model>
+		<model name='CN9-D3'>
+			<availability>FS:3,MERC:3</availability>
+		</model>
 		<model name='CN9-D'>
 			<availability>LA:3,FRR:3,FWL:3,SIC:4,FS:8,MERC:4,CIR:3,Periphery:3</availability>
 		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CN9-D3D'>
-			<availability>FWL:2,FS:2,MERC:2</availability>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>LA:1,FS:3,MERC:3,Periphery:1</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FS:2,MERC:2,Periphery:1</availability>
 		</model>
-		<model name='CN9-D4D'>
-			<availability>FWL:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='CN9-D3'>
-			<availability>FS:3,MERC:3</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:6,IS:4,FS:6</availability>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -2680,11 +2680,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -2692,15 +2692,15 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:6,FS:7,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='XII'>
+			<availability>LA:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='XII'>
-			<availability>LA:5,FS:5,DC:5</availability>
+		<model name='X'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -2708,6 +2708,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:2,IS:6,Periphery:4</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -2717,62 +2721,54 @@
 			<roles>training</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,CHH:3,FRR:4,CLAN:3,IS:4,WOB:5,SIC:3,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:3,DC:5</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		</model>
 		<model name='CHP-3P'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='CHP-2N'>
-			<availability>IS:5,NIOPS:0</availability>
-		</model>
-		<model name='CHP-3N'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:4,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:3,CHH:2,WOB:5,SIC:5,FS:4,MERC:5,BAN:4,DC.GHO:4,CS:5,LA:5,NIOPS:5,MERC.SI:5,DC:4,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:5,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:4,MERC:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CS:4,FRR:4+,IS:4+,NIOPS:4,WOB:6,SIC:4+,MERC:3+,BAN:4,Periphery:2+</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>missile_artillery</roles>
 			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:4-,MOC:2-,OA:2-,LA:3-,FRR:5-,FWL:2-,SIC:3-,MERC:3-,TC:2-,Periphery:2,DC:5-</availability>
-		<model name='CGR-2A2'>
-			<availability>MOC:4,OA:10,PIR:4,MH:4</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='CGR-3K'>
 			<availability>CC:3-,FRR:4-,MERC:3-,DC:4-</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:4,OA:10,PIR:4,MH:4</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>OA:4,FRR:3-,DC:3-</availability>
@@ -2781,43 +2777,47 @@
 			<roles>recon</roles>
 			<availability>CC:3-,MOC:3-,OA:3-,LA:3-,FRR:3-,FWL:3-,DC:3-,Periphery:3-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,SIC:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1L'>
 			<availability>CC:4,HL:3,SIC:4,Periphery:5</availability>
 		</model>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,SIC:2,MERC:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-12-S'>
-			<availability>FWL:3,WOB:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:5,HL:3,General:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:5,HL:3,General:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='F-11'>
-			<availability>FRR:5,FWL:8,WOB:8,MERC:5</availability>
+		<model name='F-12-S'>
+			<availability>FWL:3,WOB:3</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>FRR:5,FWL:8,WOB:8,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,NIOPS:5,WOB:5,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -2825,7 +2825,7 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -2838,26 +2838,26 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>LA:4,FWL:3,FS:3,MERC:3,DC:3</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4+,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4+,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:2,LA:4,IS:4,Periphery.Deep:8,MERC:4,BAN:3,Periphery:4</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>HL:2,SIC:6,FS:5,TC:4,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:7,FRR:6,CLAN:6,WOB:6,SIC:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:7,FRR:6,CLAN:6,WOB:6,SIC:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W10'>
+			<availability>HL:2,SIC:6,FS:5,TC:4,Periphery:4</availability>
+		</model>
+		<model name='CHP-W5'>
+			<availability>:0,HL:2,LA:4,IS:4,Periphery.Deep:8,MERC:4,BAN:3,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -2866,14 +2866,6 @@
 			<roles>recon</roles>
 			<availability>General:4-</availability>
 		</model>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:4,FRR:4,FWL:5,WOB:5,MERC:4,DC:4</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6</availability>
-		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
 			<availability>IS:1</availability>
@@ -2881,6 +2873,14 @@
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:6,IS:3,WOB:5</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:4,FRR:4,FWL:5,WOB:5,MERC:4,DC:4</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -2907,20 +2907,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -2937,23 +2937,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -2961,14 +2961,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -2985,32 +2985,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3018,11 +3018,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -3030,20 +3030,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3068,18 +3068,18 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,FRR:3,IS:2,WOB:1-,SIC:3,FS:3,MERC:2,CS:2-,LA:2,FWL:2,NIOPS:2-,DC:2</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:8,CS:6,LA:4,General:6</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:4,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
 		<model name='CLNT-5U'>
 			<roles>spotter</roles>
 			<availability>LA:6,MERC:6</availability>
 		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:4,Periphery.Deep:8,NIOPS:8</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:2,SIC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -3126,48 +3126,48 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>LA:8,FRR:6,FS:4,MERC:5</availability>
+			<availability>LA:3,MERC:2</availability>
 		</model>
 		<model name='COM-4H'>
 			<roles>recon</roles>
 			<availability>PIR:6,MH:10</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>LA:8,FRR:6,FS:4,MERC:5</availability>
+		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
-		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:3,MERC:2</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:6,LA:5,General:6,Periphery.Deep:7,TC:7,Periphery:8</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>MOC:2,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6,General:7,FS:6,Periphery:7</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
 		</model>
 		<model name='(Upgrade) (Standard)'>
 			<availability>LA:6</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:5,IS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,General:7,FS:6,Periphery:7</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:5</availability>
@@ -3175,13 +3175,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,WOB:4,CIR:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:4,DC:5</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Confederate C' unitType='Dropship'>
@@ -3193,13 +3193,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -3222,12 +3222,12 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:3</availability>
-		<model name='(Avalon One)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Avalon One)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
@@ -3259,20 +3259,20 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:1,DC:2</availability>
+		<model name='CSR-V12'>
+			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:4,Periphery:5</availability>
+		</model>
 		<model name='CSR-V14'>
 			<availability>LA:6,FRR:5,FS:6,MERC:5</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='CSR-V20'>
-			<availability>LA:2,FS.AH:3,Periphery:2</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:4,Periphery:5</availability>
-		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:6</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:2,FS.AH:3,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -3293,12 +3293,11 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>General:5</availability>
@@ -3306,8 +3305,9 @@
 		<model name='H'>
 			<availability>CSA:5,General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -3325,34 +3325,34 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:3,CSR:3,FRR:4,CLAN:2,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:5</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+			<availability>DC.GHO:5,CS:4,FRR:3,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:1,Periphery.Deep:8,NIOPS:0,Periphery:1</availability>
 		</model>
-		<model name='CRB-C'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5,CS:4,FRR:3,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
-		</model>
 		<model name='CRB-30'>
 			<availability>CS:6,FRR:3,WOB:5</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
+		<model name='CRB-C'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CCC:2,CFM.MiKr:5,CBS:4,CFM:3</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='A'>
@@ -3361,20 +3361,20 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:7,CSR:5,FRR:5,CSV:5,CLAN:6,CFM:5,WOB:8,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:8,NIOPS:9,CJF:5,CGB:7</availability>
-		<model name='CRK-5004-1'>
-			<availability>CS:5,FRR:3</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:6,FRR:3</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRK-5003-0'>
-			<availability>IS:5,NIOPS:0</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:5,FRR:4,CLAN:6,NIOPS:5,WOB:5,BAN:8</availability>
 		</model>
-		<model name='CRK-5003-3'>
-			<availability>CS:6,FRR:3</availability>
+		<model name='CRK-5004-1'>
+			<availability>CS:5,FRR:3</availability>
+		</model>
+		<model name='CRK-5003-0'>
+			<availability>IS:5,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -3388,27 +3388,39 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:3,CDS:3,CW:3,CBS:5,CSV:8,CNC:3,CCO:3,CJF:3,CWIE:3,CGB:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:5,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
+		<model name='CRD-3D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:2,DC:3</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:6</availability>
+		</model>
 		<model name='CRD-8S'>
 			<availability>LA:4</availability>
 		</model>
@@ -3419,32 +3431,20 @@
 		<model name='CRD-3R'>
 			<availability>HL:2,General:4,Periphery.Deep:8,BAN:2,Periphery:4</availability>
 		</model>
-		<model name='CRD-5M'>
-			<availability>CC:4,CS:3,FWL:8,IS:4,WOB:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:2,DC:3</availability>
+		<model name='CRD-4BR'>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='CRD-4K'>
 			<availability>LA:4,FRR:8,MERC:4,FS:4,DC:8</availability>
 		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='CRD-5S'>
-			<availability>LA:8,FS:4,MERC:4</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:4,MERC:3,DC:4</availability>
-		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FS:3</availability>
+		<model name='CRD-5M'>
+			<availability>CC:4,CS:3,FWL:8,IS:4,WOB:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>FRR:4,MERC:3,DC:4</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FS:8</availability>
@@ -3452,23 +3452,23 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>CS:5,FRR:5,SL.2:5,MERC:4</availability>
+		<model name='CP-11-A'>
+			<availability>CC:4,CS:4,MOC:4,LA:4,FWL:5,IS:4,WOB:5,FS:6,DC:4,TC:4</availability>
 		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:2</availability>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-12-K'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='CP-11-A'>
-			<availability>CC:4,CS:4,MOC:4,LA:4,FWL:5,IS:4,WOB:5,FS:6,DC:4,TC:4</availability>
-		</model>
 		<model name='CP-10-Z'>
 			<availability>OA:5,General:5,IS:5,FS:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
+		<model name='CP-10-Q'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>CS:5,FRR:5,SL.2:5,MERC:4</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -3494,11 +3494,11 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:5+</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
 		<model name='DARO-1B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -3506,13 +3506,13 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -3524,30 +3524,29 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>FRR:6,DC:7</availability>
-		<model name='DMO-4K'>
-			<availability>FRR:3,DC:5</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:3,DC:4</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:8</availability>
+		<model name='DMO-4K'>
+			<availability>FRR:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:2+,FS:2+,MERC:2+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:2+,CNC:5,CSJ:8,CJF:5,CGB:5,DC:2+</availability>
-		<model name='Prime'>
-			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:1,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
@@ -3558,8 +3557,9 @@
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:1,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -3590,11 +3590,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>General:5</availability>
+			<availability>General:7</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
@@ -3606,16 +3609,22 @@
 			<roles>recon</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CHH:7,CCC:5,MERC.WD:5,CIH:5,CDS:5,CLAN:4,IS:2+,CCO:3,CJF:4,BAN:4,CGB:8</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CIH:3,CDS:3,CBS:2,General:4,CWIE:5,CGB:5</availability>
 		</model>
@@ -3623,21 +3632,12 @@
 			<roles>recon,spotter</roles>
 			<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
+		<model name='D'>
+			<availability>CSA:5,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CHH:8,CIH:6,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:5,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -3648,18 +3648,6 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,TC:9,Periphery:10,CS:6,OA:9,LA:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,CS:8,LA:8,FRR:6,FWL:8,IS:4,WOB:8,SIC:7,FS:8,DC:8,CWIE:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,SIC:4,FS:4,TC:4,DC:4</availability>
@@ -3667,8 +3655,20 @@
 		<model name='(MRM)'>
 			<availability>DC:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,CS:8,LA:8,FRR:6,FWL:8,IS:4,WOB:8,SIC:7,FS:8,DC:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(Defensive)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
@@ -3701,14 +3701,14 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,CC:4,HL:3,FRR:3,IS:3,Periphery.Deep:5,SIC:3,FS:5,MERC:3,Periphery.OS:4,Periphery:4,TC:4,OA:4,LA:3,Periphery.HR:4,DC:3</availability>
+		<model name='DV-7D'>
+			<availability>LA:5,FS:8,MERC:4,TC:4</availability>
+		</model>
 		<model name='DV-8D'>
 			<availability>FS:3,MERC:3</availability>
 		</model>
 		<model name='DV-6M'>
 			<availability>HL:5,CLAN:4,IS:5-,Periphery.Deep:7,Periphery:7</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>LA:5,FS:8,MERC:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -3722,11 +3722,11 @@
 		<model name='DVS-3'>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>LA:3,FS:3,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
@@ -3748,62 +3748,62 @@
 	</chassis>
 	<chassis name='Dragon Fire' unitType='Mek'>
 		<availability>LA:5,FRR:4,WOB:3,MERC:5,DC:5</availability>
-		<model name='DGR-6FC'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='DGR-4F'>
 			<availability>LA:4,WOB:6,MERC:4,DC:4</availability>
 		</model>
 		<model name='DGR-3F'>
 			<availability>General:8,WOB:0</availability>
 		</model>
+		<model name='DGR-6FC'>
+			<availability>WOB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:2,FRR:8,MERC:3,DC:7</availability>
-		<model name='DRG-7N'>
-			<availability>LA:4,MERC:3,DC:3</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:3,MERC:2,DC:3,Periphery:4</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>FRR:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='DRG-7N'>
+			<availability>LA:4,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,MERC.WD:5,CHH:5,CIH:7,CDS:3,CSV:4,CLAN:4,IS:1+,CFM:4,CSJ:4,CJF:3,CGB:8</availability>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,MERC:3,FS:6,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,CC.MAC:4,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:5,General:6</availability>
+		<model name='(ERLL)'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:7,General:3</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:1,FS:1</availability>
+		<model name='(Standard)'>
+			<availability>CC:5,General:6</availability>
 		</model>
 		<model name='(Streak)'>
 			<availability>LA:7,WOB:5,FS:5</availability>
@@ -3831,28 +3831,28 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
-		<model name='EGL-R4'>
-			<availability>LA:2,FS:2</availability>
-		</model>
 		<model name='EGL-R9'>
 			<availability>LA:1,FS:1</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1,General:7,FS:1</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:2,FS:2</availability>
 		</model>
-		<model name='EGL-R6'>
-			<availability>LA:1,General:7,FS:1</availability>
+		<model name='EGL-R4'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL.MM:6,FWL:5,MH:3,FWL.FO:6,MERC:4</availability>
+		<model name='EGL-1M'>
+			<availability>CC:3,MOC:3,FWL:2,MH:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:3,MOC:3,FWL:2,MH:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -3866,21 +3866,29 @@
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='EST-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:7,MERC.WD:7,CW:7,CLAN:7,CNC:7+</availability>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -3892,20 +3900,12 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='[ER Laser]' mechanized='true'>
 			<availability>MERC.WD:6,CLAN:6</availability>
 		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -3916,45 +3916,41 @@
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>CS:3,LA:5,FS:3,MERC:3</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:6,General:6,MERC:6</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FS:5,MERC:3</availability>
-		<model name='ENF-6M'>
-			<availability>FS:8,MERC:8</availability>
-		</model>
-		<model name='ENF-6H'>
-			<availability>FS:4</availability>
+		<model name='ENF-6G'>
+			<availability>FS:3,MERC:3</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='ENF-6G'>
-			<availability>FS:3,MERC:3</availability>
+		<model name='ENF-6H'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='ENF-6M'>
+			<availability>FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>OA:3,LA:5,Periphery.HR:3,MH:2,SIC:3,FS:9,MERC:5,Periphery.OS:3,TC:3,DC:3,Periphery:2</availability>
-		<model name='ENF-5D'>
-			<availability>LA:4,FS:8,MERC:5,TC:5</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>LA:2,General:5,FS:5,TC:5</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>LA:4,FS:8,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -3962,6 +3958,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
@@ -3976,12 +3976,12 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -3991,13 +3991,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CIH:1,CDS:2,CSV:1,FWL:2,WOB:2,CSJ:1,CGS:1,CCO:1,CGB:2</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CS:4,CLAN:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -4006,20 +4006,16 @@
 			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:2,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:6,FS:5</availability>
 		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,CIR:2+</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:1,NIOPS:8,WOB:8</availability>
@@ -4028,28 +4024,32 @@
 			<roles>fire_support</roles>
 			<availability>CS:8,WOB:8,CIR:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3,WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4D'>
-			<availability>CS:6,CLAN:6,NIOPS:6,WOB:6,BAN:2,DC:8</availability>
+		<model name='EXT-4C'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='EXT-4A'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='EXT-4C'>
-			<availability>BAN:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:6,CLAN:6,NIOPS:6,WOB:6,BAN:2,DC:8</availability>
 		</model>
 		<model name='EXT-5E'>
 			<availability>CS:6,WOB:6</availability>
@@ -4057,14 +4057,14 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
@@ -4076,11 +4076,11 @@
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
 		<availability>LA:2</availability>
-		<model name='FNR-5B'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='FNR-5'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='FNR-5B'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
@@ -4088,12 +4088,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -4104,23 +4104,23 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>DC.GHO:1,MERC.WD:1,MERC.KH:2,MERC:3,DC:1</availability>
-		<model name='FLC-5P'>
-			<availability>MERC:6</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4P'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='FLC-6C'>
 			<availability>MERC.WD:4+</availability>
+		</model>
+		<model name='FLC-4P'>
+			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
+		<model name='FLC-5P'>
+			<availability>MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -4145,80 +4145,80 @@
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2+,CHH:5,CIH:7,CSV:5,CLAN:3,IS:2+,CWIE:8,MERC.WD:7,CDS:4,CW:8,CNC:3,CSJ:4,CJF:6,CGB:5</availability>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>General:2,CWIE:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>General:2,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:5,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:7</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -4230,51 +4230,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -4282,25 +4242,64 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:3,CNC:2,CFM:4,CJF:5,CLAN.HW:3</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:4,IS:2,CCO:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
@@ -4310,6 +4309,11 @@
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -4324,20 +4328,16 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CSA:5,CLAN:4,IS:2</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:4,IS:2,CCO:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
-		<model name='2'>
-			<roles>urban</roles>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<roles>urban</roles>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
@@ -4367,124 +4367,124 @@
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:5,CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:5,CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:7,IS:6,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-M &apos;Mirage&apos;'>
+		<model name='FS9-S1'>
 			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
+			<availability>LA:6,General:4,FS:5</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,PIR:5,MH:5,CIR:7,Periphery:3,TC:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 		<model name='FS9-P'>
 			<availability>Periphery:2</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:6,General:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5+,CC:4+,LA:5+,IS:4+,WOB:5+,FS:5+,MERC:4+,DC:7+</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:1+,DC:1+</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:1</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:1+,DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
-		<model name='FLS-9C'>
-			<availability>CS:4</availability>
-		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:4,LA:4</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:6,CS:5,LA:4,CLAN:8,NIOPS:5,WOB:5,MERC.SI:6,BAN:8</availability>
+		</model>
+		<model name='FLS-9C'>
+			<availability>CS:4</availability>
 		</model>
 		<model name='FLS-C'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:4,LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:3,MERC:4,CIR:4,Periphery:4,TC:4</availability>
-		<model name='FLE-15'>
-			<availability>MERC.WD:1,FWL:1</availability>
-		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:2,CM:4</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MERC.WD:1,FWL:1</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:8,FWL:3,WOB:3,MERC:3,Periphery:3</availability>
@@ -4498,9 +4498,6 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
@@ -4511,17 +4508,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -4565,26 +4565,26 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CS:5,CHH:4,CW:3,CLAN:1,FS:3,CJF:3,CGB:4</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>FS:8</availability>
+		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CX-17'>
 			<availability>CS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>FS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:4,FWL:6,WOB:5</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:6,General:8,FWL:6,WOB:6</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:4,FWL:6,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -4596,28 +4596,28 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:4,CW:4,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:4,CW:6,CGS:4,CCO:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,OA:3,LA:5,FWL:7,DC:3</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:2,LA:2,FRR:2,IS:1,DC:2,Periphery:2</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,OA:3,LA:5,FWL:7,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -4625,26 +4625,26 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:5,MERC:3</availability>
 		</model>
-		<model name='GAL-2GLS'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:5,MERC:3</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:5,MERC:3</availability>
-		</model>
 		<model name='GAL-1GLS'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='GAL-2GLS'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FS:3,MERC:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:4,MERC:4</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>IS:7,CDP:7</availability>
+		</model>
+		<model name='GRM-01C'>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
@@ -4652,28 +4652,28 @@
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:3,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:7,FS:7</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:3,CDS:5,CSR:3,CNC:5,CLAN:5,IS:1+,CSJ:7,CJF:5,BAN:4,CGB:9,CWIE:4</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
+		<model name='B'>
+			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
@@ -4681,8 +4681,8 @@
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:3,CSJ:3,CJF:3,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -4722,14 +4722,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>MOC:1,CC:1,FS.CH:5,FRR:1,WOB:2,SIC:1,FS:4,CIR:1,Periphery:1,TC:3,CS:2-,LA:3,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,SIC:4,FS:5</availability>
@@ -4737,6 +4729,14 @@
 		<model name='(LRM)'>
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,LA:2,FRR:2,NIOPS:2,WOB:2,SIC:2,FS:4,DC:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
@@ -4756,35 +4756,35 @@
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CSA:5,CSR:4,CIH:3,CBS:3,CNC:3,CFM:3,CSJ:5,CJF:6,CCO:3</availability>
-		<model name='2'>
-			<availability>CSA:6,CIH:6,CFM:6,CJF:6,CCO:6</availability>
+		<model name='(Standard)'>
+			<availability>CSA:6,CSR:6,CBS:6,CNC:6,CFM:6,CSJ:8,CJF:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:4,CSR:4,CBS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:6,CSR:6,CBS:6,CNC:6,CFM:6,CSJ:8,CJF:6</availability>
+		<model name='2'>
+			<availability>CSA:6,CIH:6,CFM:6,CJF:6,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:5,CLAN:1</availability>
-		<model name='2'>
-			<availability>CSV:5,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:6,General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSV:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CSV:5,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -4801,29 +4801,29 @@
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
 		<availability>FWL:4,WOB:3</availability>
-		<model name='GRN-D-01'>
-			<availability>FWL:8,WOB:8</availability>
-		</model>
 		<model name='GRN-D-02'>
 			<availability>FWL:2,WOB:4</availability>
+		</model>
+		<model name='GRN-D-01'>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:4,DC:8</availability>
-		<model name='DRG-1G'>
-			<availability>FRR:5,DC:5</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:6,CNC:8,DC:8</availability>
+		</model>
+		<model name='DRG-7K'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>FRR:5,DC:5</availability>
 		</model>
 		<model name='DRG-C'>
 			<availability>FRR:7,DC:7</availability>
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -4837,12 +4837,6 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>CS:3,IS:3,WOB:3,Periphery:3</availability>
-		</model>
-		<model name='GHR-6K'>
-			<availability>FRR:5,MERC:2,FS:2,DC:6</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
@@ -4851,6 +4845,12 @@
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:3,DC:4</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>CS:3,IS:3,WOB:3,Periphery:3</availability>
+		</model>
+		<model name='GHR-6K'>
+			<availability>FRR:5,MERC:2,FS:2,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -4862,14 +4862,14 @@
 	</chassis>
 	<chassis name='Gray Death Standard Suit' unitType='BattleArmor'>
 		<availability>MERC.GDL:6,LA:4,MERC:4</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -4883,11 +4883,11 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:2</availability>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
@@ -4902,17 +4902,20 @@
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:5,CDS:6,CSR:4,CSV:6,CFM:4,CCO:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CSA:5,CHH:6,CLAN:4,IS:1</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:5,CHH:6,CLAN:4,IS:1</availability>
+		<model name='D'>
+			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -4920,15 +4923,9 @@
 		<model name='E'>
 			<availability>CLAN:4,IS:2,CCO:6</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:5,MERC.WD:5,CIH:6,CDS:5,CW:4,CNC:7,CLAN:4,CCO:5,CJF:4,CWIE:4,CGB:4</availability>
-		<model name='4'>
-			<availability>CSA:5,CDS:5,CNC:6,CLAN:4</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:6,CNC:4,CLAN:4,CCO:6</availability>
 		</model>
@@ -4938,42 +4935,45 @@
 		<model name='(Standard)'>
 			<availability>MERC.WD:6,CLAN:4,CNC:4</availability>
 		</model>
+		<model name='4'>
+			<availability>CSA:5,CDS:5,CNC:6,CLAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:6,HL:4,CLAN:1,IS:7,Periphery.Deep:6,WOB:2,SIC:6,MERC:8,TC:6,Periphery:5,CS:2,OA:2,LA:7,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-1S'>
-			<availability>LA:4,FRR:2,MERC:4</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
-		<model name='GRF-5M'>
-			<availability>FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
-		</model>
 		<model name='GRF-1N'>
 			<availability>HL:3,General:5,Periphery.Deep:8,BAN:2,Periphery:5</availability>
 		</model>
 		<model name='GRF-6S'>
 			<availability>LA:4,FRR:3,FS:3,MERC:3,DC:3</availability>
 		</model>
+		<model name='GRF-5M'>
+			<availability>FWL:4,WOB:4,MERC:3</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
+		</model>
+		<model name='GRF-1S'>
+			<availability>LA:4,FRR:2,MERC:4</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>CLAN:6,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,WOB:4,MERC:4,DC:4</availability>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>WOB:5+,MERC:4</availability>
-		</model>
 		<model name='GRM-R-PR30'>
 			<availability>WOB:4+,MERC:2</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>CS:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>WOB:5+,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -4992,11 +4992,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:4,MOC:4,SIC:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CC:2,IS:1,FWL:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:4,MOC:4,SIC:3</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3,SIC:2</availability>
@@ -5010,13 +5010,13 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:5,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:3,IS:5,FWL:5,Periphery.Deep:8,NIOPS:0,MERC:5,Periphery:5</availability>
-		</model>
 		<model name='GLT-8D'>
 			<roles>raider</roles>
 			<availability>FS:5</availability>
+		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:3,IS:5,FWL:5,Periphery.Deep:8,NIOPS:0,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
@@ -5039,13 +5039,13 @@
 	</chassis>
 	<chassis name='Gurkha' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='GUR-2G'>
-			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='GUR-4G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='GUR-2G'>
+			<deployedWith>Vanquisher</deployedWith>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -5057,13 +5057,13 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CDS:4,CBS:2,LA:3,CNC:3,CFM:2,DC:4</availability>
-		<model name='HKO-1C'>
-			<roles>fire_support</roles>
-			<availability>LA:8,DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='HKO-1C'>
+			<roles>fire_support</roles>
+			<availability>LA:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -5082,60 +5082,60 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>MOC:4,CC:4,FWL:5,MH:4,WOB:6,MERC:4</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:3,WOB:3,MERC:3</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,WOB:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:3,WOB:3,MERC:3</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:4</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:6,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:3</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:6,CLAN:4,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:3,CDS:4,CSV:5,CNC:5,CLAN:2,IS:2+,CSJ:6,CJF:4,CCO:3,CGB:3</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:5,IS:1</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
-		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
-			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CLAN:5,IS:1</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -5154,13 +5154,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:4,WOB:5,MERC:5,Periphery:5,CS:5,FWL.pm:7,LA:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,FWL:7,MH:5,DC:5</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -5172,39 +5172,39 @@
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:2,CHH:4,CBS:2,CFM:2,CSJ:6,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CSA:6,CHH:6,CBS:6,CFM:6,CSJ:8,CJF:6</availability>
+		<model name='3'>
+			<availability>CSA:4,CHH:3,CFM:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:6,CBS:6,CFM:6</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:4,CHH:3,CFM:4</availability>
+		<model name='(Standard)'>
+			<availability>CSA:6,CHH:6,CBS:6,CFM:6,CSJ:8,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,MERC:4,DC:8</availability>
-		<model name='HTM-26T'>
-			<availability>DC:5</availability>
+		<model name='HTM-27T'>
+			<availability>FRR:8,MERC:6,DC:7</availability>
 		</model>
 		<model name='HTM-28T'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:8,MERC:6,DC:7</availability>
+		<model name='HTM-26T'>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>FRR:3,DC:4</availability>
+		<model name='HTM-27U'>
+			<availability>General:5</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaze' unitType='Mek'>
@@ -5230,14 +5230,8 @@
 		<model name='HCT-6S'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='HCT-5D'>
 			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>LA:6,FRR:4,FS:6,MERC:4,DC:2</availability>
 		</model>
 		<model name='HCT-5DD'>
 			<availability>FS:2,MERC:2</availability>
@@ -5245,6 +5239,12 @@
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>LA:4,TC.PL:6,MERC:4,FS:4,Periphery:4</availability>
+		</model>
+		<model name='HCT-5S'>
+			<availability>LA:6,FRR:4,FS:6,MERC:4,DC:2</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='HCT-6D'>
 			<availability>FS:6,MERC:4</availability>
@@ -5289,21 +5289,21 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -5315,11 +5315,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -5330,23 +5330,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:2,FWL:3</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:4,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:2,FWL:3</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -5357,6 +5357,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -5365,32 +5373,24 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8,WOB:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8,WOB:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
@@ -5408,24 +5408,24 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,CS:8,MOC:8,SIC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:3,CNC:2,NIOPS:6,WOB:6,FS:3,DC:4</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,WOB:8,DC:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
@@ -5433,15 +5433,15 @@
 		<model name='HCT-213S'>
 			<availability>LA:3,FS:2</availability>
 		</model>
+		<model name='HCT-213D'>
+			<availability>LA:2,FS:3</availability>
+		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
-		</model>
-		<model name='HCT-213D'>
-			<availability>LA:2,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
@@ -5464,18 +5464,18 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CHH:2,CIH:8,CDS:3,CNC:3,CLAN:3,CFM:3,CCO:3</availability>
-		<model name='B'>
-			<availability>CSA:8,General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:4,General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:3,General:7,CJF:3</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:3,General:6,CJF:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:8,General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:4,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
@@ -5487,9 +5487,9 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:3+,CHH:3+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
@@ -5499,9 +5499,9 @@
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -5522,25 +5522,13 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>MOC:3-,CC:4,LA:3,FRR:4-,PIR:4,FWL:10,WOB:4,MH:4,MERC:4,FS:5,DC:4-</availability>
-		<model name='HER-4K &apos;Hermes III&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:3,WOB:3</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
 		<model name='HER-5C'>
 			<roles>recon</roles>
 			<availability>WOB:10</availability>
 		</model>
-		<model name='HER-2S'>
+		<model name='HER-4K &apos;Hermes III&apos;'>
 			<roles>recon</roles>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+			<availability>FWL:3</availability>
 		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
@@ -5550,60 +5538,72 @@
 			<roles>recon</roles>
 			<availability>MOC:5,CC:5,LA:5,PIR:4,FWL:8,WOB:8,FS:5,MERC:5,DC:5</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:3,WOB:3</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:3,FRR:3,FWL:6,NIOPS:3,WOB:3,CGB:3,DC:3</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:5,CS:5,CLAN:6,NIOPS:5,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:8,WOB:8</availability>
-		</model>
-		<model name='HER-4M'>
-			<roles>recon</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>DC:5</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>CS:2,FRR:2,FWL:4,WOB:2</availability>
 		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='HER-4M'>
+			<roles>recon</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
 		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:6,WOB:5</availability>
 		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:5,CS:5,CLAN:6,NIOPS:5,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,SIC:8,MERC:3,Periphery:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LB-X)'>
+			<availability>CC:4,MOC:2,TC:3</availability>
 		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:4,MOC:2,TC:3</availability>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
 		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -5622,14 +5622,14 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:6,CLAN:6,NIOPS:9,CFM:7,WOB:9,SIC:1,MERC:4,FS:5,CJF:7,DC:1</availability>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
-		</model>
-		<model name='HGN-734'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 		<model name='HGN-736'>
 			<availability>CS:6,WOB:4</availability>
+		</model>
+		<model name='HGN-733'>
+			<availability>CC:3,:0,LA:3,SIC:3,DC:3</availability>
+		</model>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:4,BAN:2</availability>
@@ -5637,14 +5637,14 @@
 		<model name='HGN-694'>
 			<availability>LA:3</availability>
 		</model>
+		<model name='HGN-732'>
+			<availability>MOC:6,DC.GHO:8,CS:4,LA:6,CLAN:6,IS:6,NIOPS:4,WOB:4,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
+		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:3,:0,LA:3,SIC:3,DC:3</availability>
-		</model>
-		<model name='HGN-732'>
-			<availability>MOC:6,DC.GHO:8,CS:4,LA:6,CLAN:6,IS:6,NIOPS:4,WOB:4,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
+		<model name='HGN-734'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hitman' unitType='Mek'>
@@ -5660,11 +5660,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:5,MERC:4,FS:4</availability>
-		<model name='BZK-F7'>
-			<availability>General:5</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -5678,37 +5678,37 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:1,CGS:2</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:5,CLAN:1</availability>
+		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2</availability>
-		<model name='HNT-161'>
-			<availability>MERC.WD:4-</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:5</availability>
+		<model name='HNT-161'>
+			<availability>MERC.WD:4-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:6,MERC:6</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -5732,11 +5732,11 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:6,CDS:7,CSR:6,CW:6,CSV:5,CLAN:2,IS:3,CSJ:5,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='2'>
-			<availability>CSA:6,CBS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSR:6,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CBS:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:6,CCO:6</availability>
@@ -5744,64 +5744,60 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:4,FRR:6,IS:4,Periphery.Deep:5,WOB:3-,SIC:5,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='HBK-4G'>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		<model name='HBK-4N'>
+			<availability>IS:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 		<model name='HBK-6S'>
 			<availability>LA:2,MERC:1</availability>
 		</model>
-		<model name='HBK-4J'>
-			<availability>CC:2,IS:2,FWL:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='HBK-4H'>
-			<availability>IS:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='HBK-5H'>
-			<availability>MH:4,Periphery:2</availability>
-		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:1,FWL:2,MERC:2,DC:2,Periphery:2</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='HBK-5M'>
 			<availability>CS:4,CC:3,MOC:2,FRR:3,FWL:4,WOB:4,MERC:3,TC:2</availability>
 		</model>
+		<model name='HBK-4J'>
+			<availability>CC:2,IS:2,FWL:2,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>MH:4,Periphery:2</availability>
+		</model>
 		<model name='HBK-5S'>
 			<availability>LA:4,FRR:3,MERC:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-4P'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>IS:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 		<model name='HBK-6N'>
 			<availability>FWL:6,WOB:6,MERC:4</availability>
 		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:7</availability>
+			<availability>General:2</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>LA:8,FS:5</availability>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -5811,12 +5807,16 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
-			<availability>General:2</availability>
+			<availability>LA:8,FS:5</availability>
 		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:2,FS:2</availability>
@@ -5824,15 +5824,15 @@
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:5</availability>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
@@ -5843,33 +5843,33 @@
 		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:6,FRR:3,CLAN:5,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		</model>
+		<model name='HSR-300-D'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='HSR-500-D'>
 			<availability>CS:4,WOB:8</availability>
+		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:5,General:8,CLAN:6,NIOPS:5,MERC.SI:5,WOB:5,BAN:8</availability>
 		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='HSR-300-D'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -5899,35 +5899,35 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,LA:5,FWL:5,IS:8,WOB:5,MH:8,FS:4,DC:5,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -5948,14 +5948,14 @@
 		<model name='C'>
 			<availability>MERC.WD:4,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:5</availability>
-		</model>
 		<model name='IMP-2E'>
 			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-4E'>
+			<availability>MERC.WD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -5980,22 +5980,22 @@
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
 		<availability>LA:3,FS:3,MERC:3,TC:2</availability>
-		<model name='&apos;Waddle&apos;' mechanized='true'>
-			<roles>recon</roles>
-			<availability>LA:6,FS:6,TC:6</availability>
-		</model>
 		<model name='(Special Ops)' mechanized='true'>
 			<roles>specops</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='&apos;Waddle&apos;' mechanized='true'>
+			<roles>recon</roles>
+			<availability>LA:6,FS:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:2</availability>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
-		</model>
 		<model name='(Sensor)' mechanized='true'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
@@ -6006,27 +6006,27 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:5</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>FWL:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -6048,15 +6048,20 @@
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSR:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,SIC:6,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -6066,11 +6071,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -6087,9 +6087,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:5,MOC:4,CC:2,DC.LV:6,HL:3,FRR:4,DC.GR:6,FS.AH:5,IS:4,Periphery.Deep:5,WOB:4-,SIC:2,FS:3,CIR:4,Periphery:4,TC:6,CS:3-,OA:4,LA:5,FWL:2,NIOPS:3-,DC:4</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:4,General:4,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -6099,53 +6103,49 @@
 			<roles>recon,raider</roles>
 			<availability>DC:8,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:4,General:4,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>CC:5,MOC:5,Periphery.MW:3,Periphery.ME:3,FWL:6,IS:3,MH:5,WOB:6,SIC:4,FS:4,MERC:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>HL:6,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>LA:5,FWL:5,MERC:5,FS:6</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>HL:6,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>WOB:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='D'>
-			<availability>CSR:4,CW:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:4,CW:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -6156,63 +6156,63 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,OA:2,LA:5,Periphery.CM:2,Periphery.HR:3,PIR:2,Periphery.ME:2,FWL:3,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-S'>
+		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
-			<availability>CC:5,FRR:4,IS:5,SIC:5,FS:5,Periphery:8</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:6,MERC:5</availability>
+			<availability>PIR:2,MH:4</availability>
 		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2-</availability>
 		</model>
-		<model name='JM6-H'>
-			<roles>anti_aircraft</roles>
-			<availability>PIR:2,MH:4</availability>
-		</model>
 		<model name='JM7-F'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>LA:3,FRR:3,FS:3,MERC:3,DC:3</availability>
 		</model>
+		<model name='JM7-D'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:6,MERC:5</availability>
+		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>OA:8,LA:8,FRR:8,FS:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:5,FRR:4,IS:5,SIC:5,FS:5,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
-		<model name='JVN-10P'>
+		<model name='JVN-10N'>
 			<roles>recon</roles>
-			<availability>LA:6,FS:6,MERC:6</availability>
+			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:1,FS:2,MERC:2,TC:2,Periphery:1</availability>
 		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='JVN-11D'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='JVN-11B'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>LA:3,FS:3,MERC:3</availability>
+			<availability>LA:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
@@ -6220,35 +6220,35 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:5,CJF:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:5,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:5,CJF:5</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='E'>
+			<availability>CSR:5,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:5,CW:5,CSV:6,CNC:8,CLAN:3,CSJ:6,CGS:5,CCO:5,DC:1</availability>
-		<model name='3'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CW:6,CLAN:5,CNC:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:4,CNC:6,IS:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:6,CLAN:5,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -6285,22 +6285,22 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -6321,43 +6321,43 @@
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Flamer]' mechanized='true'>
+		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>MERC:2,DC:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -6368,12 +6368,9 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:3,PIR:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:3,MERC:3</availability>
+		<model name='(BA)'>
+			<roles>apc</roles>
+			<availability>CS:4,FWL:5,IS:5,WOB:4</availability>
 		</model>
 		<model name='(Periphery)'>
 			<availability>MOC:4,OA:4,HL:2,PIR:5,MH:4,CIR:4,Periphery:4,TC:4</availability>
@@ -6382,26 +6379,36 @@
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery:2</availability>
 		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>CS:4,FWL:5,IS:5,WOB:4</availability>
+		<model name='(AC)'>
+			<availability>MH:3,MERC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:4,FRR:2,DC:4</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:3</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:7</availability>
 		</model>
 		<model name='CRK-5003-C'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>CS:5,MERC.WD:4,CW:3,LA:5,FRR:5,CLAN:4,WOB:4,FS:5,DC:4</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -6409,54 +6416,44 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:1,FRR:3,CLAN:3,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:4,DC:1</availability>
-		<model name='KGC-001'>
-			<availability>CS:8,LA:5,IS:5,WOB:5</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:5,FRR:8,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8</availability>
 		</model>
+		<model name='KGC-001'>
+			<availability>CS:8,LA:5,IS:5,WOB:5</availability>
+		</model>
 		<model name='KGC-005'>
 			<availability>CS:4,WOB:3</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CSR:3,CLAN:3,CNC:3,IS:2+,CSJ:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:2</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -6464,26 +6461,29 @@
 		<model name='H'>
 			<availability>CLAN:5,IS:2</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:2,CDS:2,CSV:2,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:4,MERC:5,DC:5</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:8</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:6,CS:5,DC.SL:4,CLAN:6,NIOPS:5,WOB:5,MERC.SI:6,FS:8,MERC:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:5,MERC:5,DC:4</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:5</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:4,WOB:4,MERC:6,DC:6</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:5,MERC:5,DC:4</availability>
 		</model>
 		<model name='KTO-21'>
 			<availability>CS:5,WOB:5</availability>
@@ -6491,9 +6491,6 @@
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -6502,6 +6499,9 @@
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -6513,28 +6513,28 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:4,CCC:3,CIH:5,CSR:6,CNC:3,CLAN:3,CGS:4,CCO:3,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -6543,43 +6543,23 @@
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:7</availability>
+		<model name='KIM-2C'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:6</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:4,IS:2+,CCO:4,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:6,CLAN:5,IS:2</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -6589,33 +6569,53 @@
 			<roles>recon</roles>
 			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:2,CCO:6</availability>
 		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:6,CLAN:5,IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-2A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='KTO-3A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='KTO-2A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:4,CLAN:2,CJF:4</availability>
-		<model name='4'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='3'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>CSV:3,CJF:5</availability>
 		</model>
-		<model name='2'>
+		<model name='4'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='3'>
+			<roles>fire_support</roles>
 			<availability>CSV:3,CJF:5</availability>
 		</model>
 	</chassis>
@@ -6645,13 +6645,13 @@
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:4,FRR:6,IS:4,SIC:6,FS:8,CIR:3,TC:5,Periphery:3,CS:7,LA:8,FWL:6,DC:6</availability>
-		</model>
 		<model name='(WoB)'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:4,FRR:6,IS:4,SIC:6,FS:8,CIR:3,TC:5,Periphery:3,CS:7,LA:8,FWL:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -6662,6 +6662,17 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:4,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:6</availability>
+		<model name='LNC25-03'>
+			<availability>DC:6-</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:6,FRR:6,CLAN:8,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:6</availability>
+		</model>
+		<model name='LNC25-05'>
+			<roles>anti_infantry</roles>
+			<availability>CS:3,NIOPS:3,WOB:3</availability>
+		</model>
 		<model name='LNC25-04'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
@@ -6669,38 +6680,27 @@
 			<roles>fire_support</roles>
 			<availability>:0,FRR:4,DC:4</availability>
 		</model>
-		<model name='LNC25-03'>
-			<availability>DC:6-</availability>
-		</model>
-		<model name='LNC25-05'>
-			<roles>anti_infantry</roles>
-			<availability>CS:3,NIOPS:3,WOB:3</availability>
-		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:6,FRR:6,CLAN:8,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>FWL:3,WOB:2</availability>
-		<model name='LX-2A'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LX-2A'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:5,MOC:3,TC:3</availability>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='LHU-3C'>
 			<availability>CC:4+,MOC:4+</availability>
 		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -6722,24 +6722,24 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:6,LA:6,FWL:8,WOB:6,FS:6</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:8,FWL:8,FS:8</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:8,FWL:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -6764,85 +6764,85 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>FWL:3</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1</availability>
+		</model>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:3</availability>
+		</model>
+		<model name='Owl II'>
+			<availability>Periphery.R:5,HL:4,LA:5</availability>
+		</model>
+		<model name='Andurien'>
+			<availability>FWL:2</availability>
+		</model>
+		<model name='Suzume (&apos;Sparrow&apos;)'>
+			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
-		</model>
-		<model name='Owl II'>
-			<availability>Periphery.R:5,HL:4,LA:5</availability>
-		</model>
-		<model name='Suzume (&apos;Sparrow&apos;)'>
-			<availability>Periphery.DD:1,DC:5</availability>
-		</model>
-		<model name='Andurien'>
-			<availability>FWL:2</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CIH:6,CLAN:5,WOB:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,FS:4,Periphery:4,TC:4,CS:3-,OA:6,LA:4,FWL:2,NIOPS:3-,DC:6</availability>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='LGH-5W'>
+		<model name='LGH-4W'>
 			<roles>recon</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='LGH-4Y'>
 			<roles>recon</roles>
 			<availability>WOB:5</availability>
 		</model>
-		<model name='LGH-4W'>
+		<model name='LGH-5W'>
 			<roles>recon</roles>
-			<availability>WOB:8</availability>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CCC:4,CSR:5,CW:5,CSV:4,CCO:4,CJF:4,CWIE:6</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:4,CSV:5,CLAN:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:5,CJF:2,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
-		</model>
 		<model name='E'>
 			<availability>CDS:5,CLAN:4,CCO:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:5,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -6853,25 +6853,25 @@
 		<model name='KW1-LH3'>
 			<availability>General:2,CM:6,WOB:3,FS:3</availability>
 		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='KW1-LH2'>
 			<availability>General:8,WOB:2,FS:2</availability>
 		</model>
 		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CS:6,CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,WOB:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -6886,14 +6886,8 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:2,CHH:6,CW:7,LA:2,CLAN:3,CJF:6,CGB:6</availability>
-		<model name='3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:6,General:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:3,CS:6,CHH:3,CW:3,LA:6,CJF:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:3,CIH:3,CJF:3</availability>
@@ -6901,9 +6895,27 @@
 		<model name='5'>
 			<availability>CHH:4,CW:4,CCO:2,CGB:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:2</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:3,CS:6,CHH:3,CW:3,LA:6,CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:4-,HL:5,CLAN:2-,IS:8,NIOPS:4-,Periphery.Deep:5,WOB:4-,Periphery:5</availability>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FS:8,MERC:5</availability>
+		</model>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:5,MERC:4</availability>
+		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:1,SIC:1</availability>
@@ -6912,85 +6924,65 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-1E'>
 			<roles>recon</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>PIR:3,FWL:4,WOB:3,FS:3,MERC:3</availability>
+			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
 		</model>
 		<model name='LCT-1V2'>
 			<roles>recon</roles>
 			<availability>PIR:4,MH:4</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:4,FWL:8,IS:4,MERC:5</availability>
+		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:3,General:4,FS:4</availability>
-		</model>
-		<model name='LCT-1E'>
-			<roles>recon</roles>
-			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
 		</model>
 		<model name='LCT-3S'>
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,MERC:6</availability>
 		</model>
-		<model name='LCT-3M'>
+		<model name='LCT-5M'>
 			<roles>recon</roles>
-			<availability>MOC:4,FWL:8,IS:4,MERC:5</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:5,MERC:4</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FS:8,MERC:5</availability>
+			<availability>PIR:3,FWL:4,WOB:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSV:5,CLAN:4,IS:2+,CFM:5,BAN:6,CWIE:6,CDS:4,CW:5,CBS:5,CSJ:5,CJF:5,CGB:4</availability>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:1,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:5,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,SIC:5,FS:6,Periphery:7,TC:6,CS:3,OA:6,LA:6,FWL:8,NIOPS:3,DC:6</availability>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,FWL:6,IS:4</availability>
-		</model>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:4,OA:4,General:4,TC:4,Periphery:4</availability>
@@ -6999,32 +6991,40 @@
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:3,LA:2,FWL:2,SIC:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,FWL:6,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:8,WOB:8,MH:3</availability>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Flamer] (WoB)' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[David] (WoB)' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -7038,14 +7038,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,FS:6,MERC:5</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>LA:2,General:2,Periphery.Deep:4,MERC:8,Periphery:2</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:5,FS:5</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,FS:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -7054,13 +7054,13 @@
 			<roles>support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -7072,24 +7072,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,CLAN:1,MERC:3,DC:3</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -7120,16 +7120,12 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CSJ:3,CJF:3,CWIE:2,CGB:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CFM:4,CSJ:4,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3</availability>
@@ -7137,11 +7133,15 @@
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CSJ:3,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
@@ -7179,13 +7179,13 @@
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>FWL:6</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(XL)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(C3)'>
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
@@ -7198,26 +7198,26 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:9,CSV:8,CLAN:5,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:6,CSJ:7,CJF:9,CGB:5</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
+		<model name='D'>
+			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -7228,33 +7228,33 @@
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:4+,FS:4+</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7,FS:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
-		<model name='(LB-X)'>
-			<availability>LA:4,WOB:4,FS:4</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>FS:5,DC:7</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>LA:6,FS:6,MERC:4+</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,LA:4,General:6,Periphery.Deep:5,FS:4,DC:4,Periphery:6</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>LA:4,WOB:4,FS:4</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>FS:2,DC:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>LA:6,FS:6,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
@@ -7268,20 +7268,26 @@
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,CLAN:5,CJF:6,CGB:6</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:5,CLAN:3,CJF:4,CGB:4</availability>
+		<model name='8'>
+			<availability>CLAN:3,CJF:6,CGB:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:4,CCC:2,CDS:2,CSR:2,CBS:2,CGS:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='8'>
-			<availability>CLAN:3,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>CSA:5,CLAN:3,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CS:3,MERC.WD:6,LA:3,FRR:3,CNC:3,FWL:2,SL.2:3,FS:3,MERC:4,DC:3</availability>
+		<model name='C'>
+			<availability>MERC.WD:2</availability>
+		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:8,CNC:8,FWL:8,SL.2:8,FS:8,MERC:3,DC:8</availability>
@@ -7289,26 +7295,11 @@
 		<model name='MAD-4A'>
 			<availability>MERC:5</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:4,CLAN:1,IS:3,WOB:7,SIC:4,FS:6,TC:3,Periphery:1,CS:6,LA:5,FWL:3,NIOPS:6,DC:4,CGB:2</availability>
-		<model name='MAD-3D'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='MAD-5D'>
 			<availability>LA:3,FRR:6,WOB:4,FS:6,MERC:4,DC:8</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>CS:6,FWL:8,IS:3,WOB:7,MERC:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:4</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:2-,HL:4,IS:4,Periphery.Deep:6,WOB:2-,Periphery:6,TC:6</availability>
@@ -7316,8 +7307,8 @@
 		<model name='MAD-3L'>
 			<availability>CC:1,SIC:2</availability>
 		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:1,CGS:2,BAN:1</availability>
+		<model name='MAD-5M'>
+			<availability>CS:6,FWL:8,IS:3,WOB:7,MERC:4</availability>
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:4,CLAN:1,NIOPS:4,WOB:4,MERC:0,BAN:1</availability>
@@ -7325,20 +7316,29 @@
 		<model name='MAD-3M'>
 			<availability>MOC:4,Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:3,MH:4,MERC:4</availability>
 		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:1,CGS:2,BAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:4</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='MAD-5S'>
 			<availability>LA:6,FRR:3,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CHH:4,CCC:3,CIH:3,CGS:3,CCO:3,CGB:3</availability>
+		<model name='(ATM)'>
+			<availability>General:4,CCO:6,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:4,CCO:6,CJF:2</availability>
+		<model name='(XL)'>
+			<availability>CHH:4,CCC:3,CIH:3,CGS:3,CCO:3,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
@@ -7362,26 +7362,26 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:2,CLAN:3,IS:1+,CFM:6,MERC:1+,CGS:4,BAN:3,CWIE:3,CSA:4,MERC.WD:3,CDS:4,CW:3,CBS:4,CNC:3,CSJ:8,CJF:4,CGB:5</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -7392,17 +7392,17 @@
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>LA:3,FRR:5,MERC:3,FS:3,DC:7</availability>
+		<model name='MAL-3R'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='MAL-C'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='MAL-1R'>
 			<availability>FRR:8,MERC:6,DC:4</availability>
 		</model>
 		<model name='MAL-2R'>
 			<availability>LA:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='MAL-C'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='MAL-3R'>
-			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -7422,14 +7422,14 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
@@ -7441,51 +7441,51 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,CLAN:4,IS:4,Periphery.Deep:5,WOB:5-,SIC:5,MERC:4,FS:3,CIR:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='(SRM2)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(SRM2)'>
 			<roles>apc</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>FRR:3,IS:2,SIC:2,MERC:3,DC:4</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:5,FRR:5,FWL:5,IS:4,SIC:5,DC:5</availability>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(3052 Upgrade)'>
+		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
-			<availability>LA:2,FRR:2,IS:2,FS:2,DC:3</availability>
+			<availability>FRR:3,IS:2,SIC:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:2,FRR:2,IS:2,FS:2,DC:3</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+			<availability>CC:5,FRR:5,FWL:5,IS:4,SIC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,WOB:1,CGS:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -7522,35 +7522,32 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -7558,20 +7555,23 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -7579,8 +7579,8 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -7615,25 +7615,25 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:4+,MOC:3+</availability>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mercer' unitType='Dropship'>
@@ -7669,24 +7669,24 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>OA:8,HL:3,MERC:5,Periphery:5</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
 		<availability>LA:5,FS:4</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Targeting Computer)'>
 			<roles>urban</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
@@ -7694,12 +7694,12 @@
 		<model name='(Standard)'>
 			<availability>CLAN:6,CSJ:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CCC:4,CGS:4</availability>
+		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CCC:4,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -7731,13 +7731,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:4+,MERC:2+,DC:4+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>General:1,MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -7747,11 +7743,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>General:1,MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -7790,13 +7790,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-68'>
 			<roles>recon</roles>
 			<availability>DC:2</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -7807,22 +7807,22 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Morningstar City Command Vehicle' unitType='Tank'>
 		<availability>FS:3,MERC:3</availability>
-		<model name='(Laser)'>
-			<roles>urban</roles>
-			<availability>CC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>urban,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>urban</roles>
+			<availability>CC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
@@ -7848,7 +7848,7 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -7857,14 +7857,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -7907,6 +7907,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
@@ -7914,14 +7922,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
@@ -7954,11 +7954,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
@@ -7972,26 +7972,26 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CSJ:3,CJF:5,CGS:2</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='E'>
+			<availability>CLAN:5,IS:2</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:5,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:2</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -8027,26 +8027,26 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>LA:6,FS:6,MERC:2</availability>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,CS:3,LA:5,CLAN:1,NIOPS:3,FS:5,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:3,MERC:2,FS:3</availability>
@@ -8060,11 +8060,11 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:5,DC.SL:2,FRR:3,MERC:2,DC:4</availability>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
+		</model>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:8,MERC:8,DC:8</availability>
@@ -8072,6 +8072,9 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:4,CNC:8,CFM:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -8079,19 +8082,16 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,CNC:4,CFM:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -8103,12 +8103,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CIH:4,CDS:5,CNC:7,CLAN:3,CSJ:4,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -8116,13 +8110,19 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='E'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
@@ -8154,21 +8154,21 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:4,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:3,FWL:9,MH:4,DC:4</availability>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:5,MOC:4,IS:4,FWL:5</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:8,CNC:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,LA:3,FWL:3,SIC:3,FS:3,MERC:3</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<availability>CC:5,MOC:4,IS:4,FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:8,CNC:8,IS:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
@@ -8185,38 +8185,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:4,CC:4,HL:3,FRR:4,CLAN:1,IS:4,Periphery.Deep:4,WOB:3-,SIC:4,FS:4,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
+		<model name='ON1-M'>
+			<availability>CS:6,MOC:6,Periphery.MW:3+,PIR:3+,Periphery.ME:3+,FWL:8,IS:6,WOB:6,MH:3+,DC:6</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:2,MH:2,TC:2</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>HL:3,General:5,CLAN:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>CS:6,MOC:6,Periphery.MW:3+,PIR:3+,Periphery.ME:3+,FWL:8,IS:6,WOB:6,MH:3+,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>FWL:4,WOB:4,MERC:3</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:3,General:5,CLAN:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:4,DC:6</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -8233,31 +8233,31 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:3,CC:3,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:3,SIC:3,TC:3,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
-		<model name='OSR-3C'>
-			<availability>IS:2,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		<model name='OSR-4L'>
+			<availability>CC:4,MOC:3</availability>
+		</model>
+		<model name='OSR-2L'>
+			<availability>IS:2</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:8,MERC:5,BAN:1,Periphery:5</availability>
 		</model>
-		<model name='OSR-2Cb'>
-			<roles>urban</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='OSR-2D'>
 			<availability>CS:8,HL:2,IS:4,Periphery:4</availability>
-		</model>
-		<model name='OSR-4C'>
-			<availability>CIR:6,TC:4</availability>
 		</model>
 		<model name='OSR-2M'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='OSR-4L'>
-			<availability>CC:4,MOC:3</availability>
+		<model name='OSR-3C'>
+			<availability>IS:2,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='OSR-2Cb'>
+			<roles>urban</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='OSR-4C'>
+			<availability>CIR:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -8266,21 +8266,21 @@
 			<roles>recon,spotter</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='OTT-9CS'>
+			<roles>recon,spotter</roles>
+			<availability>CS:4,WOB:3</availability>
+		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:6,BAN:1</availability>
-		</model>
-		<model name='OTT-9S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,MERC:2</availability>
 		</model>
 		<model name='OTT-7Jb'>
 			<roles>recon</roles>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='OTT-9CS'>
+		<model name='OTT-9S'>
 			<roles>recon,spotter</roles>
-			<availability>CS:4,WOB:3</availability>
+			<availability>LA:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -8288,23 +8288,23 @@
 		<model name='OTL-7M'>
 			<availability>FWL:4,WOB:3,MERC:4</availability>
 		</model>
-		<model name='OTL-4D'>
-			<availability>HL:3,IS:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:3,MERC:2,DC:2</availability>
+		<model name='OTL-8M'>
+			<availability>FWL:4,WOB:3,MERC:2</availability>
 		</model>
 		<model name='OTL-5M'>
 			<availability>CS:4,FWL:6,WOB:6,MERC:4</availability>
 		</model>
-		<model name='OTL-8M'>
-			<availability>FWL:4,WOB:3,MERC:2</availability>
+		<model name='OTL-4F'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:3,MERC:2,DC:2</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:3,IS:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-4F'>
-			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
@@ -8327,17 +8327,21 @@
 			<roles>mech_carrier</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:6,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:2+,CS:3+,FWL:2+,WOB:2+,SIC:2+,FS:2+,MERC:2+,DC:4+</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:1+,CLAN:6</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -8346,23 +8350,19 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1A'>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:1+,CLAN:6</availability>
 		</model>
 		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='OW-1B'>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -8382,13 +8382,13 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,MERC.KH:2,FRR:2,IS:2,Periphery.Deep:6,SIC:2,MERC:2,FS:2,Periphery:3,PIR:2,General:2,FWL:2,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,SIC:5</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,MERC.KH:2,FRR:2,IS:2,Periphery.Deep:6,SIC:2,MERC:2,FS:2,Periphery:3,PIR:2,General:2,FWL:2,DC:2</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -8397,33 +8397,17 @@
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:5,CS:4,NIOPS:4,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,FS:2,Periphery.OS:5,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:5,FWL:2,NIOPS:2,DC:10</availability>
-		<model name='PNT-10KA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3+,FRR:3+,CNC:8,FS.DMM:3+,MERC:3+,DC:3+</availability>
-		</model>
-		<model name='PNT-12A'>
-			<roles>fire_support</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3+,FRR:3+,FS.DMM:3+,MERC:3+,DC:3+</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,MERC:5,DC:9</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
@@ -8431,6 +8415,22 @@
 		<model name='PNT-C'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='PNT-12A'>
+			<roles>fire_support</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,MERC:5,DC:9</availability>
+		</model>
+		<model name='PNT-CA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3+,FRR:3+,FS.DMM:3+,MERC:3+,DC:3+</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3+,FRR:3+,CNC:8,FS.DMM:3+,MERC:3+,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -8442,28 +8442,28 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:3,CS:5,LA:6,FRR:3,CNC:3,IS:4,WOB:4,FS:7,DC:5,CWIE:5</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:6,FS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>WOB:2,FS:2</availability>
 		</model>
-	</chassis>
-	<chassis name='Partisan Heavy Tank' unitType='Tank'>
-		<availability>MOC:8,CC:5,HL:7,FRR:5,IS:6,Periphery.Deep:8,WOB:7,SIC:7,FS:7,CIR:5,Periphery:8,TC:8,CS:7-,OA:4,CDS:3,LA:6,FWL:6,DC:5</availability>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:4,FS:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Partisan Heavy Tank' unitType='Tank'>
+		<availability>MOC:8,CC:5,HL:7,FRR:5,IS:6,Periphery.Deep:8,WOB:7,SIC:7,FS:7,CIR:5,Periphery:8,TC:8,CS:7-,OA:4,CDS:3,LA:6,FWL:6,DC:5</availability>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
@@ -8472,9 +8472,9 @@
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -8495,6 +8495,14 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:8,WOB:5-,SIC:5,FS:6,CIR:3,Periphery:3,TC:3,CWIE:4,CS:5-,OA:3,LA:6,FWL:4,DC:6</availability>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -8507,14 +8515,6 @@
 			<roles>recon</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:5,WOB:6,FS:6,DC:6</availability>
@@ -8522,9 +8522,6 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>LA:6,FS:6,MERC:2</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -8534,41 +8531,47 @@
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
 		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:2,CSJ:5,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CGS:6</availability>
+		<model name='3'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:2</availability>
 		</model>
+		<model name='5'>
+			<availability>CGS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='4'>
 			<availability>CSR:8,CBS:7,CGS:6</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:2-,LA:4-,FRR:1-,FWL:1-,IS:1-,SIC:1-,FS:4-,MERC:1-,DC:2-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>FWL:5+,WOB:4+</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
 		</model>
@@ -8582,17 +8585,14 @@
 		<model name='P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:4,WOB:3</availability>
-		<model name='(A)' mechanized='true'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='(WoB-A)' mechanized='true'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(A)' mechanized='true'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
@@ -8603,18 +8603,15 @@
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CIH:6,CSR:6,CW:8,CGS:4,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSA:7,CIH:6,General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,CIH:6,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:4,CSV:5,CLAN:4</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>CSA:7,CIH:6,General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -8627,17 +8624,20 @@
 		<model name='C'>
 			<availability>CSA:5,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CIH:5,CSR:5,CDS:5,CBS:3,CSV:5,CLAN:3,CFM:5,CCO:5</availability>
-		<model name='(Standard)'>
-			<availability>CCC:6,CSR:6,CIH:6,CDS:6,CSV:6,CLAN:6,CNC:6,CFM:6,CCO:6</availability>
+		<model name='3'>
+			<availability>CDS:4,CLAN:3</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:3,CSV:5,CLAN:3</availability>
 		</model>
-		<model name='3'>
-			<availability>CDS:4,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>CCC:6,CSR:6,CIH:6,CDS:6,CSV:6,CLAN:6,CNC:6,CFM:6,CCO:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
@@ -8652,70 +8652,70 @@
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:4,CLAN:1,IS:9,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:4,Periphery:5,CGB:1</availability>
-		<model name='PXH-4L'>
-			<availability>CC:4,MOC:3,MH:3,WOB:3,CIR:2,TC:3</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>PIR:3,FS:3,MERC:3</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,BAN:1</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:2,DC:3</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>FRR:8,DC:8</availability>
-		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:8,MERC:5</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:4</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:4,BAN:6,Periphery:4</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
 		</model>
 		<model name='PXH-3D'>
 			<roles>recon</roles>
 			<availability>FS:8,MERC:6</availability>
 		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:2,DC:3</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:4</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>PIR:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:4,MOC:3,MH:3,WOB:3,CIR:2,TC:3</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>FRR:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3,CHH:5,HL:2,FRR:4,CLAN:5,IS:4,WOB:5-,SIC:3,FS:4,MERC:4,CIR:3,CWIE:6,TC:4,Periphery:3,CS:5-,OA:4,MERC.WD:5,CDS:6,LA:3,CNC:6,FWL:3,MH:5,DC:4</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:6,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>FS:5,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>FS:5,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
@@ -8730,13 +8730,13 @@
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -8766,12 +8766,12 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:4-,HL:3-,LA:6-,FRR:6,FWL:5-,IS:4-,TC:8,Periphery:4-</availability>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -8796,39 +8796,39 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CWIE:1,CSA:1,CS:1,CDS:5,NIOPS:1,CSJ:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8</availability>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CSJ:3,CGB:3</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,CSV:6,General:8,CSJ:5,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CSJ:3,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,CSV:6,General:8,CSJ:5,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -8845,11 +8845,11 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:3,CBS:2,CCO:4</availability>
-		<model name='2'>
-			<availability>CHH:3,CCO:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CBS:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:3,CCO:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -8867,10 +8867,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:6,Periphery:8</availability>
@@ -8879,39 +8875,43 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8,General:7</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:5,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CHH:6,CDS:6,CW:6,CBS:6,CSV:6,CNC:7,General:8,CFM:6,CSJ:5,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='H'>
 			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CFM:6,CSJ:6,CJF:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:6,CDS:6,CW:6,CBS:6,CSV:6,CNC:7,General:8,CFM:6,CSJ:5,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -8931,25 +8931,25 @@
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:5,WOB:5,Periphery:5</availability>
-		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CS:7,WOB:7,Periphery:7</availability>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Narc]' mechanized='true'>
 			<availability>CS:4,WOB:4,Periphery:4</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:5,WOB:5,Periphery:5</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CS:7,WOB:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
@@ -8963,17 +8963,14 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='QKD-5A'>
 			<availability>General:1,MERC:3,DC:3,Periphery:3</availability>
 		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:4,FWL:8,IS:4,MH:4,TC:4</availability>
+		</model>
 		<model name='QKD-8K'>
 			<availability>FRR:3,MERC:2,DC:5</availability>
-		</model>
-		<model name='QKD-C'>
-			<availability>FRR:6,MERC:5,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4,OA:4,HL:2,Periphery.Deep:8,FWL:4,IS:4,Periphery:4,DC:4,TC:4</availability>
@@ -8981,8 +8978,11 @@
 		<model name='QKD-4H'>
 			<availability>General:2</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:4,FWL:8,IS:4,MH:4,TC:4</availability>
+		<model name='QKD-C'>
+			<availability>FRR:6,MERC:5,DC:8</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>FRR:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -9000,45 +9000,45 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
 		<availability>CS:5,WOB:5</availability>
-		<model name='RJN101-C'>
-			<availability>General:6</availability>
-		</model>
 		<model name='RJN101-A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='RJN101-C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,FS:5,MERC:3</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
@@ -9047,11 +9047,11 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:6,NIOPS:8,WOB:8</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:6,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:5</availability>
@@ -9062,41 +9062,34 @@
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3+,FS:3+,DC:6+</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:1+</availability>
 		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:5,FS:4,MERC:4,DC:3,TC:4</availability>
-		<model name='RVN-4X'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:2,FWL:4,FS:2,MERC:3,DC:2,TC:2</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,TC:2</availability>
@@ -9108,6 +9101,13 @@
 		<model name='RVN-4L'>
 			<roles>spotter</roles>
 			<availability>CC:7,MOC:7,TC:7</availability>
+		</model>
+		<model name='RVN-4X'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:2,FWL:4,FS:2,MERC:3,DC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
@@ -9121,15 +9121,15 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='RDS-2A'>
-			<roles>spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='RDS-2B'>
 			<roles>recon,spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:5</availability>
+		</model>
+		<model name='RDS-2A'>
+			<roles>spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -9144,6 +9144,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:6,CLAN:6,Periphery.Deep:9,IS:6,WOB:7,SIC:6,FS:7,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:8,NIOPS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
@@ -9156,19 +9164,11 @@
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
-		<model name='F-700a'>
-			<availability>CC:7,FWL:7,WOB:7,FS:4,MERC:7</availability>
+		<model name='F-100'>
+			<availability>CC:5,HL:3,LA:2,FRR:2,FWL:5,Periphery.Deep:8,SIC:5,MERC:5,DC:2,Periphery:5</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>FRR:6,DC:6</availability>
@@ -9179,23 +9179,23 @@
 		<model name='F-700'>
 			<availability>CC:8,FWL:8,WOB:8,MERC:8</availability>
 		</model>
-		<model name='F-100'>
-			<availability>CC:5,HL:3,LA:2,FRR:2,FWL:5,Periphery.Deep:8,SIC:5,MERC:5,DC:2,Periphery:5</availability>
+		<model name='F-700a'>
+			<availability>CC:7,FWL:7,WOB:7,FS:4,MERC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:3,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CDS:5,CLAN:4,CNC:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:5,CCC:4,CDS:4,CBS:4</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:4,CCC:5,CDS:4,CIH:3</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:5,CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:5,CLAN:4,CNC:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:5,CCC:4,CDS:4,CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -9207,26 +9207,15 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:5,HL:3,FRR:7,CSV:5,IS:7,Periphery.Deep:5,WOB:5,CFM:5,SIC:7-,FS:8,CGS:5,Periphery:4,CS:5,CSA:5,FWL:7,NIOPS:5</availability>
+		<model name='RFL-5D'>
+			<availability>LA:6,FS:6,MERC:5</availability>
+		</model>
 		<model name='RFL-7M'>
 			<availability>FWL:4,WOB:3</availability>
-		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:2</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:1,MERC:1</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>LA:6,FS:6,MERC:5</availability>
-		</model>
-		<model name='RFL-8D'>
-			<availability>LA:3,FS:4</availability>
 		</model>
 		<model name='RFL-6X'>
 			<availability>FS:2,MERC:2</availability>
@@ -9236,6 +9225,17 @@
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,BAN:3,DC:2</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='RFL-8D'>
+			<availability>LA:3,FS:4</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Riot Police' unitType='Infantry'>
@@ -9247,10 +9247,6 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CS:6,CHH:4,CSR:1,LA:5,FRR:5,CLAN:2,NIOPS:6,WOB:6,FS:5,CJF:1,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
@@ -9259,56 +9255,60 @@
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>IS:3</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:2,CHH:4,CSR:5,CBS:5,CNC:6,CFM:3,CSJ:5,CGS:5,CCO:6,CWIE:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:6,CSJ:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:4,CSR:6,CBS:6,CNC:4,CFM:6,CCO:6,CGS:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:4,CBS:4,CNC:3,CFM:4,CCO:3,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:6,CSJ:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:5,General:8,NIOPS:5,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
 		</model>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:6</availability>
-		</model>
 		<model name='RGU-133F'>
 			<availability>CS:3,General:6,NIOPS:3,WOB:4</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:1</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>LA:7,FRR:5,FS:6,MERC:3,CWIE:5,TC:5</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6,TC:0,CWIE:0</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -9335,26 +9335,26 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CBS:9,CNC:8,CSJ:9,CJF:9,DC:2+</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		<model name='A'>
+			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:6,CNC:4,General:5,CFM:4,CSJ:4,CCO:7,CJF:4,CWIE:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CWIE:5,CGB:6</availability>
@@ -9366,13 +9366,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:3,Periphery:2</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:5,LA:6,FWL:5,IS:4,FS:6,DC:5,Periphery:4</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:3,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -9389,11 +9389,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
-		<model name='SB-27'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CLAN:4</availability>
@@ -9401,18 +9401,18 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -9423,55 +9423,51 @@
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:4,CW:4,FRR:4,CNC:5,CSJ:5,FS:2,BAN:1,CGB:4,DC:7,CWIE:4</availability>
-		<model name='S-4X'>
-			<availability>DC:1</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8,DC:2</availability>
-		</model>
-		<model name='S-3'>
-			<availability>DC:3</availability>
 		</model>
 		<model name='S-4'>
 			<availability>FRR:6,FS:5,DC:6</availability>
 		</model>
+		<model name='S-3'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='S-7'>
 			<availability>CNC:3,DC:3</availability>
+		</model>
+		<model name='S-4X'>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,SIC:7,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:3,DC:4</availability>
+		</model>
 		<model name='(LB-X)'>
 			<availability>IS:3,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:3,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3,CFM:6</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CSR:6,CW:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CSR:6,CW:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:3,LA:7,FS:5,MERC:3</availability>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -9479,6 +9475,10 @@
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:2,FS:2</availability>
+		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
@@ -9502,11 +9502,11 @@
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7-,Periphery.DD:7,HL:5,FRR:8-,IS:6-,Periphery.Deep:4,WOB:4,SIC:6-,Periphery.OS:7,FS:6-,CIR:6,Periphery:6,TC:5,CS:4,OA:7,CDS:5,FWL.MM:9,CW:3,LA:6-,FWL:8-,DC:8-</availability>
-		<model name='(MRM)'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sasquatch' unitType='Mek'>
@@ -9527,32 +9527,32 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:2,CSR:2,CIH:5,CBS:3,CNC:2,CSJ:5,CFM:2,CGS:5,CCO:5,CWIE:5</availability>
-		<model name='2'>
+		<model name='3'>
 			<roles>recon,raider</roles>
-			<availability>CLAN:6</availability>
+			<availability>CIH:4,CGS:2,CWIE:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<roles>recon,raider</roles>
-			<availability>CIH:4,CGS:2,CWIE:2</availability>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:2,CW:4,CCO:6</availability>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -9585,25 +9585,25 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>FRR:2,FWL:2,WOB:2,FS:2,MERC:2,MERC.NH:3,DC:2</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -9625,45 +9625,45 @@
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:7,CC:7,Periphery.DD:7,HL:5,FRR:9,IS:6,Periphery.Deep:4,WOB:4-,SIC:7,MERC:6,Periphery.OS:7,FS:5,CIR:6,Periphery:6,TC:7,CS:4-,OA:7,LA:6,FWL:5,DC:8</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,HL:6,LA:6,FRR:9,FWL:6,IS:7,Periphery.Deep:7,SIC:6,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(MRM)'>
+			<availability>IS:3,DC:4,Periphery:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>IS:3,DC:4,Periphery:2</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,SIC:2-,MERC:2-,Periphery:3-,CS:2-,LA:2,FWL:2-,NIOPS:2-,DC:2-</availability>
+		<model name='SCP-12S'>
+			<availability>LA:4,MERC:2</availability>
+		</model>
 		<model name='SCP-1N'>
 			<availability>HL:6,FRR:8,General:2,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='SCP-1O'>
 			<availability>IS:6</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -9687,9 +9687,6 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CHH:3,CCC:3,CIH:3,CSR:3,CSV:3,CFM:3,CGS:3,CCO:4,CWIE:4,CSA:3,CW:4,CNC:3,CSJ:3,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
@@ -9698,6 +9695,9 @@
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<availability>General:4</availability>
@@ -9717,20 +9717,17 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,CS:3,LA:6,FWL:4,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:3,LA:5,FWL:3,FS:6</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:4,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:6,DC:3</availability>
 		</model>
@@ -9739,6 +9736,9 @@
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -9753,19 +9753,23 @@
 			<roles>interceptor</roles>
 			<availability>HL:2,LA:4,Periphery.Deep:8,FS:4,Periphery:4</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
+		<model name='SYD-Z3A'>
+			<availability>LA:4,FRR:2,MERC:2</availability>
 		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>OA:5,HL:6,FRR:5,Periphery.Deep:6,FWL:5,Periphery:8,TC:5,DC:5</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:4,FRR:2,MERC:2</availability>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
 		</model>
 		<model name='SYD-Z4'>
 			<availability>OA:2,LA:4</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2,FS:2</availability>
 		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -9774,49 +9778,45 @@
 		<model name='SYD-Z2B'>
 			<availability>OA:2,LA:4</availability>
 		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2,FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:5+,MOC:3+</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:4,CDS:4,CW:4,CBS:2,CSV:5,CNC:8,CFM:5,CLAN.IS:3,CJF:4,CWIE:4</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:4,IS:1,CCO:5</availability>
 		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:5,IS:2</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:5,IS:2</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:5,CWIE:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:5,CCC:5,CIH:5,CGB:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:4,CNC:4</availability>
@@ -9827,23 +9827,17 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:4,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:4,MERC:2,DC:5</availability>
-		</model>
-		<model name='SHD-2D2'>
-			<availability>LA:5,FS:8</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:1,Periphery:5</availability>
-		</model>
 		<model name='SHD-2Hb'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:5,FRR:5,Periphery.MW:3,Periphery.ME:2,FWL:8,IS:4,WOB:6,MERC:5,DC:5</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:2,FS:4,MERC:2</availability>
+		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:4,MERC:2,DC:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,DC:4</availability>
@@ -9851,11 +9845,17 @@
 		<model name='SHD-7M'>
 			<availability>CC:3,MOC:3,FWL:4,TC:3</availability>
 		</model>
+		<model name='SHD-2H'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:1,Periphery:5</availability>
+		</model>
 		<model name='SHD-7CS'>
 			<availability>CS:4,WOB:3</availability>
 		</model>
-		<model name='SHD-5D'>
-			<availability>LA:2,FS:4,MERC:2</availability>
+		<model name='SHD-2D2'>
+			<availability>LA:5,FS:8</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -9881,14 +9881,14 @@
 		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SHV-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
@@ -9899,14 +9899,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:2,CIH:2,CBS:2,CCO:2</availability>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:2</availability>
-		</model>
 		<model name='C'>
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -9921,14 +9921,14 @@
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
-		<model name='ST-8A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ST-8C'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='ST-9C'>
 			<availability>CS:4,WOB:4</availability>
+		</model>
+		<model name='ST-8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shugenja' unitType='Mek'>
@@ -9952,34 +9952,34 @@
 	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:4,CIH:4,CSJ:5,CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CSA:6,CCC:6,CIH:6,CSJ:8,CCO:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:6,CCC:6,CIH:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4,CIH:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:6,CCC:6,CIH:6,CSJ:8,CCO:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>CC:2,FWL:4,WOB:3,MERC:2</availability>
-		<model name='SRC-5C'>
-			<availability>FWL:5,WOB:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>FWL:5,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:3,FRR:5,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -9988,23 +9988,23 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:7</availability>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
+		<model name='SL-15'>
+			<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,FRR:8,FS:6,MERC:6,DC:8,TC:4</availability>
 		</model>
-		<model name='SL-15B'>
-			<availability>FRR:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>FRR:2,DC:2</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
+		<model name='SL-15B'>
+			<availability>FRR:1,MERC:1,DC:1</availability>
 		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -10028,12 +10028,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6,CNC:4</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8,CNC:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CIH:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -10071,16 +10071,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:3</availability>
-		<model name='SPR-6D'>
-			<availability>FRR:5,FS:8,MERC:5</availability>
-		</model>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>FRR:1,General:5,Periphery.Deep:8,FS:5,MERC:5,DC:1,TC:5</availability>
-		</model>
-		<model name='SPR-7D'>
-			<availability>FS:3,MERC:3</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:2,FRR:5,DC:5</availability>
@@ -10088,6 +10078,16 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>LA:4,FS.CMM:1</availability>
+		</model>
+		<model name='SPR-7D'>
+			<availability>FS:3,MERC:3</availability>
+		</model>
+		<model name='SPR-6D'>
+			<availability>FRR:5,FS:8,MERC:5</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>FRR:1,General:5,Periphery.Deep:8,FS:5,MERC:5,DC:1,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -10117,6 +10117,12 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,SIC:4,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>CC:3,FWL:3,FS:3,MERC:3,DC:6</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>FWL:6,MERC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>HL:2,IS:4,Periphery.Deep:8,FS:1,Periphery:4</availability>
 		</model>
@@ -10124,18 +10130,12 @@
 			<roles>anti_infantry</roles>
 			<availability>FRR:4,DC:4</availability>
 		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:3,CC:8,FWL:8,MH:3,SIC:8,MERC:3,FS:8,DC:6</availability>
-		</model>
 		<model name='SDR-5D'>
 			<roles>anti_infantry</roles>
 			<availability>FS:5</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:3,FWL:3,FS:3,MERC:3,DC:6</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>FWL:6,MERC:2</availability>
+		<model name='SDR-7M'>
+			<availability>MOC:3,CC:8,FWL:8,MH:3,SIC:8,MERC:3,FS:8,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
@@ -10146,51 +10146,51 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:7,FRR:7,IS:5,SIC:6,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Laser)'>
-			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:9,CC:6,HL:9,FRR:6,CLAN:3,IS:8,Periphery.Deep:9,WOB:4,SIC:6,FS:6,CIR:9,Periphery:10,TC:9,CS:5,OA:9,LA:8,FWL:9,NIOPS:5,DC:6</availability>
-		<model name='STK-8S'>
-			<availability>LA:3</availability>
-		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:2+,DC:6,TC:3</availability>
-		</model>
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='STK-3F'>
-			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,BAN:2</availability>
+		<model name='STK-8S'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
+		<model name='STK-6M'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='STK-4N'>
 			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
 		</model>
-		<model name='STK-6M'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:2+,DC:6,TC:3</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,CSV:3,MERC:4,FS:5,CJF:3,TC:4</availability>
@@ -10198,12 +10198,12 @@
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:5+,CBS:2+</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -10231,6 +10231,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>CS:4,LA:5,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>LA:2,FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:2,FS:4,MERC:2</availability>
@@ -10238,10 +10242,6 @@
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STH-2D'>
-			<roles>recon</roles>
-			<availability>LA:2,FS:6,MERC:4</availability>
 		</model>
 		<model name='STH-2D1'>
 			<roles>recon</roles>
@@ -10264,68 +10264,68 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:5,CLAN:1-,IS:8,Periphery.Deep:5,WOB:3-,SIC:8,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-3R'>
+		<model name='STG-3G'>
 			<roles>recon</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:8,BAN:8,Periphery:4</availability>
+			<availability>IS:2,Periphery.Deep:4,Periphery:2</availability>
 		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:8,BAN:8,Periphery:4</availability>
+		</model>
 		<model name='STG-5M'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,DC:4,TC:4</availability>
 		</model>
-		<model name='STG-3G'>
-			<roles>recon</roles>
-			<availability>IS:2,Periphery.Deep:4,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='F-94'>
 			<availability>IS:6</availability>
-		</model>
-		<model name='F-92'>
-			<availability>FWL:7,IS:4</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:4,LA:3,IS:4,FS:4,Periphery:4</availability>
 		</model>
+		<model name='F-92'>
+			<availability>FWL:7,IS:4</availability>
+		</model>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -10337,17 +10337,13 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4+,FWL:4+,FS:4+,MERC:4+,DC:6+</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:1+</availability>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
@@ -10357,15 +10353,25 @@
 		<model name='SR1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:1+</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,FRR:4,IS:5,WOB:3-,SIC:6,FS:9,MERC:3,CS:3-,CDS:3,LA:6,PIR:3,FWL:3,DC:3</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,FS:2,DC:1</availability>
 		</model>
@@ -10377,17 +10383,11 @@
 			<roles>fire_support</roles>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>LA:3,FS.DMM:6,FS:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
+		<model name='(Laser)'>
+			<availability>LA:3,FS.DMM:6,FS:3</availability>
 		</model>
 		<model name='(3053 Upgrade)'>
 			<availability>LA:6,FS:7,DC:5</availability>
@@ -10410,30 +10410,30 @@
 		<model name='STU-K5'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:3,FS.DMM:5,SIC:4</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,CDS:3,HL:3,LA:7,FRR:1,CNC:4,SIC:1,MERC:3,FS:5,CWIE:4</availability>
+		<model name='(Heavy Gauss)'>
+			<availability>LA:5,CNC:5,CWIE:5</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8,WOB:0</availability>
-		</model>
-		<model name='(Heavy Gauss)'>
-			<availability>LA:5,CNC:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
@@ -10456,12 +10456,6 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:4,General:2,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
 		</model>
@@ -10471,9 +10465,19 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:4,General:2,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:4,General:2,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:3+,LA:5+,SIC:3+,FS:5+,MERC:3+,DC:6+</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
 		</model>
@@ -10481,30 +10485,26 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>CLAN:6,General:1+,DC:2+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CDS:4,CW:5,CNC:9,CLAN:2,CGB:3,CWIE:5</availability>
-		<model name='2'>
-			<availability>CNC:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -10530,15 +10530,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -10546,11 +10546,11 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
@@ -10578,32 +10578,32 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>CS:3,MOC:3,CC:4,FWL:5,IS:3,WOB:4,MERC:4,DC:5</availability>
-		<model name='ZPH-2A'>
+		<model name='ZPH-3A'>
 			<roles>recon</roles>
-			<availability>CC:6,FWL:6,IS:6,MERC:6,DC:6</availability>
+			<availability>FWL:3,IS:4,MERC:3,DC:3</availability>
 		</model>
 		<model name='ZPH-1A'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,General:6,FWL:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='ZPH-3A'>
+		<model name='ZPH-2A'>
 			<roles>recon</roles>
-			<availability>FWL:3,IS:4,MERC:3,DC:3</availability>
+			<availability>CC:6,FWL:6,IS:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:3+,DC:4+</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -10615,23 +10615,24 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8,FWL:6,WOB:5,MERC:2</availability>
-		<model name='TMP-3M'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:3,WOB:3,MERC:3</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:3+</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OE'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='TLR1-O'>
 			<availability>General:8</availability>
@@ -10639,12 +10640,11 @@
 		<model name='TLR1-OC'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OE'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
@@ -10660,13 +10660,13 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -10687,21 +10687,18 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CSJ:6,CJF:9,CGB:5</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
@@ -10710,64 +10707,70 @@
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
 		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,WOB:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>CS:6,NIOPS:8,WOB:6</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>CS:6,NIOPS:8,WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CS:5,DC.GHO:2,CSA:2,CDS:1,CLAN:1,NIOPS:5,WOB:7,CCO:1,CJF:1,CGB:1,DC:1</availability>
+		<model name='THE-N1'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='THE-N'>
+			<availability>CS:6,CLAN:6,NIOPS:6,BAN:6</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>DC:5</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:6,CLAN:6,NIOPS:6,BAN:6</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:2,CLAN:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>SIC:2</availability>
 		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:3,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
+		<model name='THG-12E'>
+			<availability>CS:6,WOB:3</availability>
+		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:5,FRR:6,CLAN:6,IS:4,FWL:8,NIOPS:5,WOB:5,FS:8,BAN:8,DC:8</availability>
 		</model>
@@ -10776,9 +10779,6 @@
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:6,MERC:6,DC:2</availability>
-		</model>
-		<model name='THG-12E'>
-			<availability>CS:6,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -10790,15 +10790,15 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>CS:2,LA:6,CLAN:1,NIOPS:2,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:2</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4</availability>
@@ -10815,22 +10815,22 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,MERC:3,TC:4</availability>
-		<model name='THR-1L'>
-			<availability>General:8</availability>
-		</model>
 		<model name='THR-2L'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='THR-1L'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:2,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:4-,OA:5,LA:6,FWL:5,NIOPS:4-,DC:5</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:6,FRR:5,MH:4,MERC:5</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:6,FRR:5,MH:4,MERC:5</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -10839,39 +10839,39 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:3,CLAN:2,IS:7,Periphery.Deep:6,WOB:2-,FS:6,MERC:7,Periphery:4,TC:4,CS:3-,LA:7,NIOPS:3-,MH:4,DC:7</availability>
-		<model name='TDR-9SE'>
-			<availability>LA:3,MERC.ELH:8,MERC:3,FS:3</availability>
-		</model>
 		<model name='TDR-9S'>
 			<availability>LA:8,FS:6,MERC:3</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:2</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:5,HL:3,LA:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='TDR-7M'>
 			<availability>CS:6,CC:3,FWL:8,IS:3,WOB:6,MERC:3</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>CC:5,HL:3,LA:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>LA:3,MERC.ELH:8,MERC:3,FS:3</availability>
+		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:5,MERC:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:5,CCC:5,LA:2,CSV:5,CFM:5,FS:2,CGS:5,DC:2</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:1,CSR:1,CDS:1,CW:1,CLAN:2,CNC:1,CJF:1,CWIE:1,CGB:1</availability>
 		</model>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:5,CCC:5,LA:2,CSV:5,CFM:5,FS:2,CGS:5,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:5,MOC:2,TC:2</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -10893,15 +10893,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:2,FRR:6,CNC:4,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>FRR:7,DC:7</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,CNC:8,DC:2</availability>
 		</model>
@@ -10909,19 +10900,21 @@
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>FRR:7,DC:7</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>FRR:3-,DC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:3</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:2,NIOPS:2,WOB:2</availability>
-		</model>
-		<model name='CH'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
@@ -10932,12 +10925,16 @@
 		<model name='THK-63b'>
 			<availability>CLAN:2,BAN:2</availability>
 		</model>
+		<model name='CH'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:2,NIOPS:2,WOB:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CW:1</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -10946,6 +10943,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -10957,28 +10957,28 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2</availability>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
 		</model>
 		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,WOB:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
-		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
 		</model>
 		<model name='G13 [Machine Gun]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toyama' unitType='Mek'>
@@ -11001,11 +11001,11 @@
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
 		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:4,FWL:6</availability>
-		</model>
 		<model name='TR-13'>
 			<availability>CC:5,HL:3,IS:5,MERC:5,Periphery:5</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:4,FWL:6</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>CC:5,MOC:5,SIC:2,MERC:5,TC:5</availability>
@@ -11013,12 +11013,12 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:7,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:7,TC:3</availability>
+		<model name='TR-12'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:4</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>CC:7,MOC:7,General:7,TC:7</availability>
@@ -11026,31 +11026,31 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,SIC:4,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3-,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CS:2,MOC:6,LA:4,FWL:3,IS:6,NIOPS:2,WOB:2,FS:4,MERC:6,DC:4,Periphery:6</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,LA:2,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
-		</model>
-		<model name='TBT-7K'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:3,IS:3,Periphery.Deep:4,FWL:3,MERC:3,Periphery:3,TC:3</availability>
 		</model>
 		<model name='TBT-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='TBT-7K'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,LA:2,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:3,IS:3,Periphery.Deep:4,FWL:3,MERC:3,Periphery:3,TC:3</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:2,MOC:6,LA:4,FWL:3,IS:6,NIOPS:2,WOB:2,FS:4,MERC:6,DC:4,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -11067,25 +11067,25 @@
 		<model name='(Theseus)[MRR]' mechanized='true'>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:6,TC:6</availability>
-		</model>
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:6,TC:6</availability>
 		</model>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,HL:8,CBS:5,CLAN:2,IS:9,Periphery.Deep:8,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -11122,27 +11122,32 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:4,CGB:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CSR:2,CNC:4,CSJ:3,CLAN.HW:3,CJF:7</availability>
-		<model name='Z'>
-			<roles>spotter</roles>
-			<availability>CCO:4</availability>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CFM:7,CJF:7,CGS:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:5,CW:5,CNC:5,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CFM:7,CGS:7,CJF:7</availability>
@@ -11150,17 +11155,12 @@
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CFM:8,CJF:8,CCO:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:5,CW:5,CNC:5,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CFM:7,CJF:7,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
 		<model name='H'>
 			<availability>CHH:4,CW:5,CNC:4,CJF:4</availability>
+		</model>
+		<model name='Z'>
+			<roles>spotter</roles>
+			<availability>CCO:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -11169,13 +11169,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
@@ -11187,49 +11187,49 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:3,CCO:3,CWIE:4,MERC.WD:4,CDS:4,CW:4,CBS:6,CNC:3,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
@@ -11272,17 +11272,13 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
-		<model name='UM-R69'>
+		<model name='UM-R60L'>
 			<roles>urban</roles>
-			<availability>FWL:6,IS:3,Periphery:3</availability>
+			<availability>CC:4,SIC:4,Periphery:3</availability>
 		</model>
 		<model name='UM-R68'>
 			<roles>urban</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='UM-R60L'>
-			<roles>urban</roles>
-			<availability>CC:4,SIC:4,Periphery:3</availability>
 		</model>
 		<model name='UM-R60'>
 			<roles>urban</roles>
@@ -11291,6 +11287,10 @@
 		<model name='UM-R63'>
 			<roles>urban</roles>
 			<availability>CC:8,CS:6,MOC:3+,MERC:4,TC:3+</availability>
+		</model>
+		<model name='UM-R69'>
+			<roles>urban</roles>
+			<availability>FWL:6,IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
@@ -11312,6 +11312,10 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:3,FS:5,MERC:5,TC:5</availability>
+		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
@@ -11320,34 +11324,30 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:3,FS:5,MERC:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='D'>
 			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanquisher' unitType='Mek'>
@@ -11358,8 +11358,11 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:4</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
+		<model name='(AC2)'>
+			<availability>CC:3,General:4,SIC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:4,General:6,SIC:4</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:7,SIC:7</availability>
@@ -11367,22 +11370,19 @@
 		<model name='(Ultra)'>
 			<availability>CC:6,MOC:7,Periphery.CM:7,PIR:6,MH:6,SIC:6,CDP:7,TC:7</availability>
 		</model>
-		<model name='(AC2)'>
-			<availability>CC:3,General:4,SIC:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CC:4,General:6,SIC:4</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:3,FRR:3,IS:1,WOB:5,SIC:2,FS:3,Periphery:1,TC:1,CS:5,OA:1,LA:3,FWL:3,NIOPS:5,DC:3</availability>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>asf_carrier</roles>
 			<availability>FS:6</availability>
+		</model>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -11406,35 +11406,35 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:3,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:3-,CJF:2,DC:6</availability>
-		<model name='VTR-9B'>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FRR:8,FWL:4,MH:4,FS:2,MERC:4,TC:4,Periphery:3,DC:8</availability>
-		</model>
-		<model name='VTR-10S'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='VTR-C'>
-			<availability>CC:3,FRR:6,MERC:3,FS:3,DC:6</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:2,CIR:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-10D'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='VTR-9A'>
 			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FRR:8,FWL:4,MH:4,FS:2,MERC:4,TC:4,Periphery:3,DC:8</availability>
+		</model>
 		<model name='VTR-9D'>
 			<availability>CC:4,LA:5,SIC:5,FS:4</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1,MERC:1,Periphery:1</availability>
+		</model>
+		<model name='VTR-10D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:3,FRR:6,MERC:3,FS:3,DC:6</availability>
+		</model>
+		<model name='VTR-9S'>
+			<availability>LA:2,CIR:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
@@ -11463,20 +11463,20 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>FRR:8,TC:3</availability>
 		</model>
-		<model name='VND-5L'>
-			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:3,MOC:2,TC:2</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:8,MOC:3,General:4,TC:3</availability>
 		</model>
+		<model name='VND-4L'>
+			<availability>CC:3,MOC:2,TC:2</availability>
+		</model>
 		<model name='VND-1SIC'>
 			<availability>SIC:2</availability>
+		</model>
+		<model name='VND-5L'>
+			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -11496,23 +11496,23 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:6,CJF:6</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:3,CGS:6,CJF:6</availability>
-		<model name='2'>
-			<availability>CLAN:3</availability>
+		<model name='5'>
+			<availability>CIH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5,CJF:8</availability>
@@ -11523,8 +11523,8 @@
 		<model name='3'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CIH:4</availability>
+		<model name='2'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -11540,14 +11540,14 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:3,FRR:4,FWL:2,WOB:6,MERC:2,FS:3,DC:5-</availability>
-		<model name='VNL-K100'>
-			<availability>LA:1,FS:3</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:6</availability>
 		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:6,FRR:5,FWL:6,FS:6,DC:6</availability>
 		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:6</availability>
+		<model name='VNL-K100'>
+			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:3,DC:3</availability>
@@ -11564,10 +11564,6 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:6,FRR:4,FWL:6,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>General:6,FS:3</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:5,CIR:2,Periphery:2,TC:2</availability>
@@ -11575,6 +11571,10 @@
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>General:6,FS:3</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -11586,20 +11586,20 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:1</availability>
+		<model name='C'>
+			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -11626,11 +11626,21 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='10'>
+			<availability>CSJ:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='10'>
+		<model name='11'>
 			<availability>CSJ:6</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:4,CDS:4,CLAN:4</availability>
 		</model>
 		<model name='12'>
 			<availability>CSJ:5</availability>
@@ -11638,25 +11648,20 @@
 		<model name='4'>
 			<availability>CSA:4,CDS:4,CNC:4,CCO:4,CWIE:4,CGB:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CCC:4,CDS:4,CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='11'>
-			<availability>CSJ:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:4-,TC:7,Periphery:6</availability>
 		<model name='WHM-6L'>
 			<availability>CC:2,SIC:2</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:8</availability>
+		<model name='WHM-6K'>
+			<availability>FS.RR:1,FRR:1,FS.DMM:1,FS:1,DC:2</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>LA:8,FS:6,MERC:4</availability>
+		</model>
+		<model name='WHM-6D'>
+			<availability>FS:2</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:2,IS:3,FS:4,MERC:3,TC:2</availability>
@@ -11664,23 +11669,18 @@
 		<model name='WHM-6R'>
 			<availability>HL:2,General:4,Periphery.Deep:8,BAN:8,Periphery:4</availability>
 		</model>
-		<model name='WHM-6K'>
-			<availability>FS.RR:1,FRR:1,FS.DMM:1,FS:1,DC:2</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FS:2</availability>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='WHM-7M'>
 			<availability>CS:6,CC:3,FRR:3,FWL:8,WOB:7,MERC:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>LA:8,FS:6,MERC:4</availability>
-		</model>
 		<model name='C'>
 			<availability>LA:3+,FS:3+,DC:3+</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -11688,62 +11688,62 @@
 		<model name='H-7'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='H-8'>
-			<availability>HL:4,LA:7,FS.CH:8,FRR:6,Periphery.Deep:4,FS:8,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:3,IS:5,Periphery:5</availability>
+		</model>
+		<model name='H-8'>
+			<availability>HL:4,LA:7,FS.CH:8,FRR:6,Periphery.Deep:4,FS:8,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='H-7C'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:2-,HL:5,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:2-,CIR:2,Periphery:6</availability>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:2,DC:2</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:8,FS:6,MERC:4</availability>
 		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,FWL:8,WOB:7,MH:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
@@ -11756,22 +11756,22 @@
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:3,FS:8,MERC:3,DC:2</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FS:6,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:1,CSV:2,CSJ:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='White Flame' unitType='Mek'>
@@ -11812,14 +11812,14 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,MERC.WD:2,HL:6,LA:5,Periphery.Deep:6,FS:4,MERC:5,Periphery:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:4,MERC:6</availability>
-		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:6</availability>
 		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:4,MERC:6</availability>
 		</model>
 		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
@@ -11827,40 +11827,40 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:6,IS:6,Periphery.Deep:5,WOB:3-,SIC:5,FS:7,Periphery:5,TC:5,CS:3-,LA:6,CNC:2,FWL:9,NIOPS:3-,MH:4,DC:6</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:4,CNC:8,MERC:2,DC:4</availability>
-		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>FRR:8,MERC:5,DC:4</availability>
-		</model>
-		<model name='WVR-8D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:6,MH:4</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>FRR:4,CNC:8,MERC:2,DC:4</availability>
+		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
+		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:8</availability>
 		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:6,MH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -11881,14 +11881,6 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:5,CLAN:2,IS:4,CFM:3,WOB:4,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:5,CS:5,FRR:8,NIOPS:5,WOB:5,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
-		</model>
-		<model name='WVE-10N'>
-			<roles>urban</roles>
-			<availability>CS:4,WOB:3</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
@@ -11897,9 +11889,17 @@
 			<roles>urban</roles>
 			<availability>CS:8,WOB:8</availability>
 		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:5,CS:5,FRR:8,NIOPS:5,WOB:5,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
+		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
 			<availability>FRR:1,IS:4,DC:4,Periphery:4</availability>
+		</model>
+		<model name='WVE-10N'>
+			<roles>urban</roles>
+			<availability>CS:4,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -11924,14 +11924,14 @@
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>CS:6,HL:2,LA:6,IS:5,FS:8,MERC:5,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(RAC)'>
 			<availability>CS:4,IS:3,FS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -11950,11 +11950,11 @@
 	</chassis>
 	<chassis name='Yu Huang' unitType='Mek'>
 		<availability>CC:5,MOC:4,TC:4</availability>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zechetinu Corvette' unitType='Warship'>
@@ -11973,24 +11973,24 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:7,DC.GHO:2,FRR:5,CLAN:5,NIOPS:7,WOB:7,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,WOB:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>
-		</model>
 		<model name='ZRO-115'>
 			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
@@ -12001,20 +12001,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,FRR:4,PIR:2,IS:3,MH:2,FS:7-,MERC:5,Periphery:4,TC:2</availability>
-		<model name='ZEU-9S'>
-			<availability>LA:8,FRR:6,PIR:4+,FS:4,MERC:4,TC:4+</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:3,FS:4</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>HL:6,General:3,Periphery.Deep:6,FS:2,Periphery:8</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>LA:8,FRR:6,PIR:4+,FS:4,MERC:4,TC:4+</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:4,MERC:3</availability>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -943,50 +943,50 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,CS:8,MOC:6,LA:8,FRR:8,FWL:8,IS:6,WOB:8,FS:8,TC:6,Periphery:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,CS:8,MOC:6,LA:8,FRR:8,FWL:8,IS:6,WOB:8,FS:8,TC:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:4,WOB:4</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
-		<model name='(WoB) [TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:5,WOB:5</availability>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='(WoB) [David]' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(WoB) [TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:5,WOB:5</availability>
 		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
-		<model name='(WoB) [David]' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1002,13 +1002,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CCC:2,CIH:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:2,CJF:5</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aerie PA(L)' unitType='BattleArmor'>
@@ -1024,11 +1024,11 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:3,CIH:6,CJF:3</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Jade Falcon)' mechanized='true'>
 			<availability>CJF:6</availability>
@@ -1043,17 +1043,17 @@
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
 		<availability>CS:7,CLAN:1,FWL:4,NIOPS:7,WOB:7,DC:3</availability>
-		<model name='AHB-643'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='AHB-443b'>
-			<availability>CLAN:1,WOB:3</availability>
-		</model>
 		<model name='AHB-MD'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='AHB-643'>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='AHB-443b'>
+			<availability>CLAN:1,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Zero-G Engineering Exoskeleton' unitType='BattleArmor'>
@@ -1065,18 +1065,18 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,FS:6</availability>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
@@ -1084,29 +1084,29 @@
 		<model name='AKU-1X'>
 			<availability>WOB:6,DC:6</availability>
 		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,WOB:4,DC:5</availability>
-		</model>
 		<model name='AKU-2X'>
 			<availability>DC:2</availability>
+		</model>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,WOB:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:3,CS:7,CDS:4,LA:6,CNC:4,NIOPS:7,WOB:7,FS:5,MERC:3,CWIE:5,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>FWL:4+,WOB:3,FWL.KIS:7,MERC:2</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>FWL:6,WOB:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
@@ -1117,12 +1117,12 @@
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CSA:6,CHH:6,CIH:4,CSR:4,CBS:6,CLAN:2,CFM:4,CGS:4</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,CGB:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,CGB:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1133,23 +1133,23 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:8,CHH:2,CSR:2,LA:5,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
+		<model name='ANH-4A'>
+			<availability>MERC.WD:5,CHH:5,MERC.KH:5,CWIE:5</availability>
+		</model>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:3-</availability>
 		</model>
-		<model name='ANH-4A'>
-			<availability>MERC.WD:5,CHH:5,MERC.KH:5,CWIE:5</availability>
+		<model name='C'>
+			<availability>CLAN:8,BAN:3</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1168,11 +1168,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:3,MOC:5,PIR:3,TC:3</availability>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
+		</model>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
@@ -1181,34 +1181,30 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:4,FWL:6,WOB:2,MERC:2</availability>
-		<model name='ANV-8M'>
-			<roles>missile_artillery</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
 		<model name='ANV-5M'>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
-		<model name='ANV-6M'>
-			<roles>spotter</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='ANV-5Q'>
+		<model name='ANV-8M'>
+			<roles>missile_artillery</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
 		<model name='ANV-3R'>
 			<availability>FWL:4,WOB:4,MERC:4</availability>
 		</model>
+		<model name='ANV-5Q'>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
 		<model name='ANV-3M'>
 			<availability>CC:8,FWL:5,WOB:5,MERC:5</availability>
+		</model>
+		<model name='ANV-6M'>
+			<roles>spotter</roles>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,LA:3,FWL:8,MERC:4,FS:3,DC:6</availability>
 		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1220,9 +1216,17 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
 		<availability>FWL:4,WOB:4</availability>
+		<model name='W1'>
+			<roles>missile_artillery,escort</roles>
+			<availability>WOB:6</availability>
+		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6</availability>
@@ -1230,10 +1234,6 @@
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='W1'>
-			<roles>missile_artillery,escort</roles>
-			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Arcadia' unitType='Dropship'>
@@ -1254,11 +1254,21 @@
 	</chassis>
 	<chassis name='Archangel' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:4</availability>
+		<model name='C-ANG-OE Eminus'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C-ANG-OD Luminos'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-ANG-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OS Caelestis'>
 			<availability>General:4</availability>
+		</model>
+		<model name='C-ANG-OA Dominus'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OC Comminus'>
 			<availability>General:7</availability>
@@ -1266,150 +1276,140 @@
 		<model name='C-ANG-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-ANG-OE Eminus'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OB Infernus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5-,Periphery.Deep:5,WOB:2-,FS:5-,Periphery:5,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
-		<model name='ARC-7L'>
+		<model name='ARC-9K'>
 			<roles>fire_support</roles>
-			<availability>CC:5</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:3,BAN:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:4,MERC:4</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:4-</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FRR:3,MERC:3</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:3,WOB:3</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:4-</availability>
+			<availability>CNC:4,DC:3</availability>
 		</model>
 		<model name='ARC-6W'>
 			<roles>fire_support</roles>
 			<availability>FVC:2,TC:3,Periphery:2</availability>
 		</model>
-		<model name='ARC-9K'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CNC:4,DC:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:6,CCC:6,CW:3,LA:3+,CSV:6,CFM:6,FS:3+,CGS:6,CWIE:3,CB:6,DC:3+</availability>
+			<availability>FRR:3-,DC:5-</availability>
 		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:8,FS:3</availability>
 		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:5,MERC.WD:5,CWIE:4</availability>
-		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-2S'>
 			<roles>fire_support</roles>
-			<availability>FRR:8,MERC:4,DC:3</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:2-,LA:4-,FRR:4-,IS:4-,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4-</availability>
+			<availability>LA:4-</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6,CC:5,FVC:3,LA:3,PIR:4,FWL:8,WOB:6,MERC:5,FS:3,DC:5</availability>
 		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:3-,DC:5-</availability>
-		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,MOC:3,FRR:2,PIR:2,FWL:4,WOB:3,MERC:2,DC:2</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:2-,LA:4-,FRR:4-,IS:4-,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:3,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:4-</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,MERC:4,DC:3</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:5</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:5,MERC.WD:5,CWIE:4</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:4,MERC:4</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:3,WOB:3</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FRR:3,MERC:3</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CCC:6,CW:3,LA:3+,CSV:6,CFM:6,FS:3+,CGS:6,CWIE:3,CB:6,DC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>CNC:4,CWIE:6,CGB:3</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2,MERC.WD:2,CWIE:3</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CW:8,CLAN:6,CCO:7,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CW:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CW:4,CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
@@ -1417,35 +1417,19 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='AGS-4D'>
-			<availability>General:5</availability>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='AGS-5D'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
+		<model name='AGS-4D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1453,33 +1437,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1488,15 +1488,15 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
-		<model name='ASN-23'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:5,FVC:4,MH:4,MERC:4,FS:4,CDP:6,TC:5</availability>
-		</model>
 		<model name='ASN-30'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
 		<model name='ASN-21'>
 			<availability>General:2-</availability>
+		</model>
+		<model name='ASN-23'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:5,FVC:4,MH:4,MERC:4,FS:4,CDP:6,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1515,17 +1515,20 @@
 	</chassis>
 	<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CBS:4,CLAN:8</availability>
-		<model name='(Proto AC)'>
-			<roles>recon</roles>
-			<availability>CBS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(Proto AC)'>
+			<roles>recon</roles>
+			<availability>CBS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Asura Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:6</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>WOB:4</availability>
 		</model>
@@ -1533,73 +1536,86 @@
 			<roles>anti_infantry</roles>
 			<availability>WOB:5</availability>
 		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:4,CSR:5,CDS:5,CW:5,CSV:5,CFM:3,CGS:5,CJF:3,CCO:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:2,CLAN:1,WOB:3</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:2,FRR:6,CLAN:4,IS:2,WOB:4-,FS:4,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:3,NIOPS:4-,DC:9</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CC:3,MOC:3,CS:3,OA:3,FRR:5,CNC:4,FWL:3,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:4,MERC:2</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1-,MERC:0,DC:2-</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:3,CLAN:8,FS:3,DC:3</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
 		<model name='AS7-D'>
 			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:4,MERC:2</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:2,MERC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:5,MERC:5,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:4</availability>
+		<model name='AS7-RS'>
+			<availability>IS:2-,Periphery:2-</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
+		<model name='AS7-C'>
+			<availability>FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>CC:3,MOC:3,CS:3,OA:3,FRR:5,CNC:4,FWL:3,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:5,FS:5</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -1609,25 +1625,9 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1642,54 +1642,54 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CS:6+,IS:4+,DC:6+</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OR'>
-			<availability>General:1+,CLAN:6,DC:2+</availability>
-		</model>
 		<model name='AV1-OE'>
 			<availability>General:6</availability>
 		</model>
+		<model name='AV1-OR'>
+			<availability>General:1+,CLAN:6,DC:2+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
 		<model name='AV1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -1706,20 +1706,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-8R'>
-			<availability>IS:2-,FWL:2-</availability>
-		</model>
-		<model name='AWS-8V'>
-			<availability>IS:1</availability>
-		</model>
-		<model name='AWS-10KM'>
-			<availability>FWL:3+,WOB:3,DC:3+</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2-,CIR:4</availability>
 		</model>
-		<model name='AWS-8Q'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		<model name='AWS-9Ma'>
+			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:4,PIR:4,FWL:8,IS:6,MH:4,TC:4</availability>
@@ -1727,17 +1718,26 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:3,FWL:6,IS:3,MH:3,TC:3,Periphery:3</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
+		<model name='AWS-10KM'>
+			<availability>FWL:3+,WOB:3,DC:3+</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>IS:2-,FWL:2-</availability>
+		</model>
+		<model name='AWS-8V'>
+			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>FRR:4,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>FRR:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1751,83 +1751,79 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:3,LA:4,FRR:2,FS:3,MERC:2</availability>
-		<model name='AXM-3S'>
-			<availability>LA:4,FS:3,MERC:3</availability>
-		</model>
 		<model name='AXM-4D'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:3,FS:4</availability>
+		</model>
+		<model name='AXM-1N'>
+			<availability>FVC:7,LA:7,FRR:7,MERC:7,FS:7</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>FVC:2,LA:4,FS:2</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:7,LA:7,FRR:7,MERC:7,FS:7</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:3,FS:4</availability>
+		<model name='AXM-3S'>
+			<availability>LA:4,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:5,CSR:5,CSV:6,CJF:5,CB:4</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:4,CSV:8</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>CSR:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>CSR:5</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:4,CSV:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,CW:2,CLAN:1</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:2</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:2</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -1839,34 +1835,50 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:3,FWL:3,WOB:3,FS:2,MERC:8</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:3</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1874,45 +1886,25 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
@@ -1924,14 +1916,6 @@
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>apc</roles>
@@ -1941,57 +1925,73 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='I'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:7-,CC:3-,HL:8-,FRR:4-,IS:3-,Periphery.Deep:9-,FS:4-,CIR:7-,MERC:4-,Periphery:9-,TC:7-,OA:7-,LA:6-,FWL:3-,MH:7-,DC:3-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:3,FWL:3,WOB:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:8-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:2</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:4,WOB:9</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2-,FWL:2-,CDP:2-,TC:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:7,FRR:3,FS:6,MERC:5</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:8-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:4,WOB:9</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>OA:3-,LA:4-,IS:1-,FS:2-,MERC:2-,CIR:3,CDP:3,TC:3-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:7,FRR:3,FS:6,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2-,FWL:2-,CDP:2-,TC:2-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:3,FWL:3,WOB:4,CDP:3,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,FRR:4,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BGS-2T'>
 			<availability>LA:5,MERC:5</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:6</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2000,40 +2000,40 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:6,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,CFM:8,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,CSV:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>CSR:3,General:1</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:6,CNC:3,CLAN:2</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:3,CCC:5,SOC:4,CSV:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4,SOC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2044,11 +2044,8 @@
 		<model name='H'>
 			<availability>CSA:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2056,12 +2053,19 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:5</availability>
+		<model name='BTL-C-2OC'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='BTL-C-2OE'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
@@ -2070,9 +2074,12 @@
 			<roles>ew_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='BTL-C-2OC'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='BTL-C-2OF'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='BTL-C-2OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='BTL-C-2OB'>
 			<roles>fire_support</roles>
@@ -2080,13 +2087,6 @@
 		</model>
 		<model name='BTL-C-2O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='BTL-C-2OF'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='BTL-C-2OD'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2109,11 +2109,11 @@
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
 		<availability>LA:3-,FS:4-,MERC:2-</availability>
-		<model name='BKX-7K'>
-			<availability>FS:6-,MERC:6-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='BKX-7K'>
+			<availability>FS:6-,MERC:6-</availability>
 		</model>
 		<model name='BKX-1X'>
 			<availability>LA:8-,FS:6-</availability>
@@ -2121,32 +2121,27 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:6,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1,WOB:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,WOB:4,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1,WOB:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:4-,FS:5-</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:5,FRR:3,WOB:4,MERC:3,CJF:3</availability>
+		<model name='C'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
 		</model>
-		<model name='BLR-1S'>
-			<availability>LA:3-</availability>
-		</model>
 		<model name='BLR-10S'>
 			<availability>LA:4,FS:2</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
+		<model name='BLR-4S'>
+			<availability>LA:5,FRR:3,WOB:4,MERC:3,CJF:3</availability>
+		</model>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-1S'>
+			<availability>LA:3-</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,WOB:4,BAN:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:5,FS:3</availability>
@@ -2154,32 +2149,37 @@
 		<model name='BLR-1G'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,FS:2-,BAN:8,Periphery:5-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:6,FVC:5,PIR:4,FWL:6,IS:3,WOB:7,MH:4,MERC:6</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:5</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>FWL:2,WOB:3</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:4-,FS:5-</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1,WOB:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1,WOB:1</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>FWL:4,WOB:3</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>FRR:3,WOB:2,DC:3</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:3</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:6,FVC:5,PIR:4,FWL:6,IS:3,WOB:7,MH:4,MERC:6</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2191,12 +2191,12 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CHH:6,CIH:6,SOC:6,CSV:8,CFM:7,CGS:6,CCO:4,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CJF:7,CGB:6,DC:3+,CB:6</availability>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
@@ -2204,47 +2204,50 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>CS:4,NIOPS:4,WOB:6</availability>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>WOB:4</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3i)'>
 			<roles>spotter</roles>
 			<availability>WOB:7</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,CSR:4,CLAN:1,CGS:5</availability>
-		<model name='6'>
+		<model name='4'>
 			<availability>General:1</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
+			<availability>General:1</availability>
+		</model>
+		<model name='6'>
 			<availability>General:1</availability>
 		</model>
 		<model name='2'>
@@ -2253,27 +2256,24 @@
 		<model name='3'>
 			<availability>CHH:5</availability>
 		</model>
-		<model name='5'>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSR:5,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:4,HL:4,FRR:5,IS:4,WOB:4-,MERC:4,FS:7,Periphery:5,CS:4-,OA:5,CDS:5,LA:5,PIR:4,FWL:3,DC:6</availability>
-		<model name='(Kurita)'>
-			<availability>CLAN:4,IS:4,DC:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<availability>IS:2,DC:1</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:6</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:4,IS:4,DC:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2302,14 +2302,14 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:7,FRR:3,FS:3,MERC:2</availability>
-		<model name='BRZ-A3'>
-			<availability>LA:6,FRR:8,FS:8,MERC:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:3</availability>
+		<model name='BRZ-A3'>
+			<availability>LA:6,FRR:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2327,51 +2327,45 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4+,LA:6+,FRR:6+,FS:4+,MERC:4+,DC:7+</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:1,DC:1</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OR'>
-			<availability>General:2+,DC:2+</availability>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BHKU-OF'>
 			<availability>General:4</availability>
@@ -2379,8 +2373,14 @@
 		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OR'>
+			<availability>General:2+,DC:2+</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2391,8 +2391,14 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:5,FRR:4,CLAN:6,CFM:5,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,FVC:3,CW:7,LA:3,CNC:7,CJF:5,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
+		<model name='BL-12-KNT'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:4-,TC:4-</availability>
+		</model>
+		<model name='BL-7-KNT'>
+			<availability>:0,LA:5-,FRR:5-,FWL:2-,MERC:5-,FS:5-,CIR:6,DC:5-</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>CS:8,WOB:8</availability>
@@ -2400,41 +2406,35 @@
 		<model name='BL-6-KNT'>
 			<availability>DC.GHO:4,CS:4,OA:4,FRR:6,CLAN:6,FWL:6,NIOPS:4,WOB:4,MERC.SI:3,BAN:6,TC:4,DC:6</availability>
 		</model>
-		<model name='BL-7-KNT'>
-			<availability>:0,LA:5-,FRR:5-,FWL:2-,MERC:5-,FS:5-,CIR:6,DC:5-</availability>
-		</model>
-		<model name='BL-12-KNT'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:4-,TC:4-</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CIH:4,CSV:4,CJF:7,CCO:4</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
+		<model name='E'>
+			<availability>CLAN:6,CCO:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:6,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -2450,76 +2450,73 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>MERC:3,MERC.NH:5</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,FVC:6,HL:3,IS:1,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-1DC'>
+		<model name='BJ-4'>
+			<availability>FVC:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='BJ-1DB'>
 			<availability>FS:1-</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:2,General:4-,Periphery.Deep:8,Periphery:4</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:3,FS:4,MERC:4,Periphery:3</availability>
-		</model>
-		<model name='BJ-1DB'>
+		<model name='BJ-1DC'>
 			<availability>FS:1-</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:3,CS:4,FVC:5,LA:4,PIR:3+,WOB:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:4,FS:4,MERC:3</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4+,CS:3+,MOC:4+,FVC:3+,FWL:4+,IS:3+,WOB:5+,FS:3+,MERC:3+,DC:5+</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:1+,DC:2+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:1+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>LA:6,FWL:3</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,CM:5,WOB:5,MERC:5,TC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>CC:4,General:2,WOB:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -2527,20 +2524,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>CC:4,General:2,WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:4,CCC:3,CBS:3,CB:6</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>CSA:7,General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -2552,17 +2552,17 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CFM.MiKr:6,CBS:10,CFM:3,CB:5</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CBS:4,CB:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CBS:4,CB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -2576,11 +2576,11 @@
 	</chassis>
 	<chassis name='Blue Flame' unitType='Mek'>
 		<availability>WOB.SD:5,WOB:3</availability>
-		<model name='BLF-21'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLF-40'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLF-21'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -2606,6 +2606,10 @@
 			<roles>fire_support</roles>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
+		<model name='BMB-14K'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
 		<model name='BMB-14C'>
 			<roles>fire_support</roles>
 			<availability>CS:6,WOB:6</availability>
@@ -2613,10 +2617,6 @@
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>OA:8</availability>
-		</model>
-		<model name='BMB-14K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -2628,13 +2628,13 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:2,CGS:2</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
@@ -2650,14 +2650,14 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,CIR:2,MERC:2,TC:3</availability>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-X2'>
 			<availability>General:4</availability>
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -2671,11 +2671,11 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
@@ -2715,25 +2715,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:5-,CC:6-,HL:4-,FRR:5-,IS:4-,Periphery.Deep:7,FS:4-,CIR:5-,MERC:4-,TC:6-,Periphery:5-,LA:3-,FWL:3-,DC:5-</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:5,General:8,FS:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:5,General:8,FS:5,MERC:5,DC:5</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -2772,11 +2772,11 @@
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:3</availability>
 		</model>
-		<model name='BSW-L1'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,General:3,MERC:4</availability>
+		</model>
+		<model name='BSW-L1'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>General:3,MERC:5</availability>
@@ -2784,17 +2784,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>CS:3,FVC:6,LA:4,FS:6,MERC:3</availability>
-		<model name='CES-4R'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>CS:8,FVC:8,General:4,FS:6,MERC:6</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:5,FS:5</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -2810,22 +2810,22 @@
 	</chassis>
 	<chassis name='Canis' unitType='Mek'>
 		<availability>CDS:2,CCO:6,CJF:2</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:3,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -2837,121 +2837,121 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:6,MOC:5,WOB:4,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:3,Periphery.CM:4,Periphery.HR:3,Periphery.ME:3,MH:3</availability>
-		<model name='CTF-2X'>
-			<availability>CC:3-,MOC:3,FVC:2,FS:1,MERC:1,TC:3</availability>
+		<model name='CTF-3LL'>
+			<availability>CC:2,MOC:2,MERC:2,TC:2</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:5,LA:6,FS:6</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:2,MOC:2,MERC:2,TC:2</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4</availability>
+		<model name='CTF-1X'>
+			<availability>General:5-,Periphery:6-</availability>
 		</model>
 		<model name='CTF-4L'>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>General:5-,Periphery:6-</availability>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:3-,MOC:3,FVC:2,FS:1,MERC:1,TC:3</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,FRR:5,IS:1,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,DC:6</availability>
-		<model name='CPLT-C4C'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:2-,DC:3-</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:6,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
-			<roles>fire_support</roles>
-			<availability>WOB:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:4-,HL:2-,CLAN:2,IS:1-,Periphery.Deep:8,MERC:4-,BAN:5,Periphery:4-</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-C4'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,MOC:2-,OA:2-,CDP:2-,TC:2-</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:5,DC:8</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:5,CS:3,MOC:3,WOB:3,FS:4,CDP:3,TC:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C6'>
-			<roles>fire_support</roles>
-			<availability>CC:3</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CC:2,FVC:1,CLAN:6,IS:2,MERC:1,DC:2</availability>
-		</model>
-		<model name='CPLT-C5A'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,TC:3</availability>
+			<availability>DC:3</availability>
 		</model>
 		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
 			<availability>DC:1</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>DC:3</availability>
+			<availability>CC:2-,MOC:2-,OA:2-,CDP:2-,TC:2-</availability>
+		</model>
+		<model name='CPLT-C5A'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:2-,DC:3-</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:2-</availability>
+		</model>
+		<model name='CPLT-C6'>
+			<roles>fire_support</roles>
+			<availability>CC:3</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,TC:4</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:2,FVC:1,CLAN:6,IS:2,MERC:1,DC:2</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:5,DC:8</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:6,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:3,MOC:3</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4C'>
 			<roles>fire_support</roles>
-			<availability>CC:2-</availability>
+			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>WOB:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:5,CS:3,MOC:3,WOB:3,FS:4,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:4-,HL:2-,CLAN:2,IS:1-,Periphery.Deep:8,MERC:4-,BAN:5,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CW:3,CLAN:3,CNC:5,CGS:6,CJF:3,CGB:3,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:2</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:2</availability>
@@ -2959,52 +2959,52 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,IS:2,CM:3,FS:6,MERC:3</availability>
-		<model name='(SRM)'>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:2,CBS:4+,SOC:3</availability>
-		<model name='4'>
-			<availability>CBS:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CSR:6,CBS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,CBS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>SOC:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:6,CBS:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -3016,14 +3016,14 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:5,CIH:4,CBS:4,SOC:4,CSV:4,CNC:6,CFM:5,CJF:7</availability>
+		<model name='(Standard)'>
+			<availability>CHH:8,CSR:6,SOC:6,CNC:8,CFM:6,CJF:6</availability>
+		</model>
 		<model name='4'>
 			<availability>CIH:3</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:6,CIH:4,CBS:6,CSV:4,CFM:6,CJF:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CHH:8,CSR:6,SOC:6,CNC:8,CFM:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4,CSR:4,CBS:4,CNC:4,CFM:8,CJF:4</availability>
@@ -3031,6 +3031,10 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -3039,19 +3043,9 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:3-,Periphery.HR:3-,FS:4-,MERC:3-,Periphery.OS:3-,Periphery:4</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8,WOB:8</availability>
@@ -3059,72 +3053,78 @@
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>LA:3-,Periphery.HR:3-,FS:4-,MERC:3-,Periphery.OS:3-,Periphery:4</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:1,IS:2,WOB:2-,Periphery.OS:4,FS:9,MERC:2,CDP:2,Periphery:2,CS:2-,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:3-,FS:3-,MERC:3-</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='CN9-D3D'>
+			<availability>FVC:2,FWL:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:6,IS:4,FS:6</availability>
+		</model>
+		<model name='CN9-D4D'>
+			<availability>FWL:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:4-,HL:2-,LA:1-,FRR:1-,FWL:1-,Periphery.Deep:8,FS:3-,MERC:3-,Periphery:4-</availability>
 		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,FS:3,MERC:3</availability>
+		</model>
 		<model name='CN9-D'>
 			<availability>FVC:5,HL:2,LA:2,FRR:2,FWL:2,FS:6,MERC:6,CIR:3,Periphery:4</availability>
 		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CN9-D3D'>
-			<availability>FVC:2,FWL:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:3-,FS:3-,MERC:3-</availability>
 		</model>
 		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,FS:2-,MERC:2-</availability>
 		</model>
-		<model name='CN9-D4D'>
-			<availability>FWL:2,FS:2,MERC:2</availability>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='CN9-D3'>
-			<availability>FVC:2,FS:3,MERC:3</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:6,IS:4,FS:6</availability>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cephalus' unitType='Mek' omni='Clan'>
 		<availability>SOC:3,CCO:1,CB:2</availability>
-		<model name='E'>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>spotter</roles>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
+		<model name='A'>
 			<roles>spotter</roles>
-			<availability>General:8</availability>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -3135,11 +3135,11 @@
 		<model name='MR-V2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-6B'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3162,11 +3162,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5,CB:7</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3178,15 +3178,15 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='XII'>
+			<availability>LA:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='XII'>
-			<availability>LA:5,FS:5,DC:5</availability>
+		<model name='X'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -3194,6 +3194,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -3203,66 +3207,58 @@
 			<roles>training</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,CHH:2,FRR:4,CLAN:2,IS:4,WOB:5,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:2,DC:5</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		</model>
 		<model name='CHP-3P'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='CHP-2N'>
-			<availability>IS:4-,NIOPS:0</availability>
-		</model>
-		<model name='CHP-3N'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:3,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:3,CHH:2,WOB:4,FS:3,MERC:5,BAN:4,DC.GHO:4-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:3,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:4-,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:3,MERC:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CS:4,FRR:3+,IS:3+,NIOPS:4,WOB:6,MERC:2+,BAN:4,Periphery:2+</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
+		<model name='(SRM)'>
 			<roles>missile_artillery</roles>
-			<availability>WOB:4</availability>
+			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:4-,MOC:2-,OA:2-,FVC:2,LA:3-,FRR:4-,FWL:2-,MERC:3-,TC:2-,Periphery:2,DC:4-</availability>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='CGR-3K'>
 			<availability>CC:3-,FRR:3-,MERC:3-,DC:3-</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:3,MERC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FVC:4-,OA:4-,FRR:2-,DC:2-</availability>
@@ -3271,49 +3267,53 @@
 			<roles>recon</roles>
 			<availability>CC:2-,MOC:2-,OA:2-,LA:2-,FRR:2-,FWL:2-,DC:2-,Periphery:2-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:3,MERC:4</availability>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1L'>
 			<availability>CC:4-,FVC:5,HL:3,Periphery:5</availability>
 		</model>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,MERC:4,DC:4</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:2</availability>
-		<model name='F-13'>
-			<availability>FWL:4</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:3-,WOB:3-</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:5-,HL:3-,General:4-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2-,FWL:2-,MERC:2-</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:5-,HL:3-,General:4-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>FRR:6,FWL:8,WOB:8,MERC:6</availability>
+		<model name='F-12-S'>
+			<availability>FWL:3-,WOB:3-</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2-,FWL:2-,MERC:2-</availability>
+		</model>
+		<model name='F-11'>
+			<availability>FRR:6,FWL:8,WOB:8,MERC:6</availability>
+		</model>
+		<model name='F-13'>
+			<availability>FWL:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,NIOPS:5,WOB:5,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -3321,13 +3321,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:4</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>WOB:3</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3338,63 +3338,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>DTA:4,FVC:4,LA:6,FWL:4,WOB:4,FS:4,MERC:5,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4+,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4+,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:4,DC:2</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:2-,LA:4-,IS:3-,Periphery.Deep:8,MERC:4-,BAN:3,Periphery:4-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:4,FS:4-,CDP:4,TC:4,Periphery:3-</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:4,FS:4-,CDP:4,TC:4,Periphery:3-</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:2-,LA:4-,IS:3-,Periphery.Deep:8,MERC:4-,BAN:3,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CSR:5,CBS:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,LA:2,IS:2,FWL:6,WOB:4-,FS:2,MERC:3,DC:4</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>FWL:4</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:6,IS:4,WOB:5</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -3421,20 +3421,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -3451,23 +3451,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -3475,14 +3475,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -3499,32 +3499,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3532,11 +3532,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3545,11 +3545,11 @@
 			<roles>marine</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>CDS:8,CW:4,CNC:8,CGB:4,CWIE:8</availability>
-		</model>
 		<model name='(Volk)' mechanized='true'>
 			<availability>CW:8</availability>
+		</model>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>CDS:8,CW:4,CNC:8,CGB:4,CWIE:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -3557,20 +3557,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3589,20 +3589,23 @@
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>CSR:3,CDS:3,CW:5,CBS:2,CLAN:2,CNC:5,CJF:3,CGB:5</availability>
-		<model name='2'>
-			<availability>CSR:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,FRR:2,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,CS:1-,FVC:2,LA:3,FWL:2,NIOPS:1-,DC:2</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:2-,FS:2-</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:8,CS:6,LA:4,General:6</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:2-,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>TC:8</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6</availability>
@@ -3611,14 +3614,11 @@
 			<roles>spotter</roles>
 			<availability>LA:8,MERC:8</availability>
 		</model>
+		<model name='CLNT-2-4T'>
+			<availability>CC:2-,FS:2-</availability>
+		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:6,TC:4</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:2-,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -3672,73 +3672,73 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:4,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>FVC:3,LA:8,FRR:6,FS:2,MERC:5</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>PIR:8,MH:10</availability>
-		</model>
-		<model name='COM-1B'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>WOB:10</availability>
+			<availability>LA:3-,MERC:2-</availability>
 		</model>
 		<model name='COM-1A'>
 			<roles>recon</roles>
 			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
 		</model>
-		<model name='COM-3A'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:3-,MERC:2-</availability>
+			<availability>PIR:8,MH:10</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:6,WOB:6</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:8,FRR:6,FS:2,MERC:5</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>WOB:10</availability>
+		</model>
+		<model name='COM-1B'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:4-,LA:4-,General:5-,Periphery.Deep:6-,TC:5,Periphery:6-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:6,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:6-,FVC:4,General:5-,FS:6-,Periphery:5-</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:5-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:4</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
 		</model>
 		<model name='(Upgrade) (Standard)'>
 			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:5,IS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6-,FVC:4,General:5-,FS:6-,Periphery:5-</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:8-</availability>
 		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,WOB:4,CIR:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:4,DC:6</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Confederate C' unitType='Dropship'>
@@ -3750,13 +3750,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -3779,12 +3779,12 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:4</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
@@ -3813,11 +3813,11 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
@@ -3828,29 +3828,29 @@
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:4,CCC:3,CSV:3,CLAN.IS:2,CCO:2,CB:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>CSA:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:7,FWL:1,DC:2</availability>
+		<model name='CSR-V12'>
+			<availability>HL:3-,IS:5-,Periphery.Deep:8,BAN:4,Periphery:5-</availability>
+		</model>
 		<model name='CSR-V14'>
 			<availability>FVC:6,LA:6,FRR:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,FS:2,BAN:2</availability>
 		</model>
-		<model name='CSR-V20'>
-			<availability>LA:1,FS.AH:3-,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>HL:3-,IS:5-,Periphery.Deep:8,BAN:4,Periphery:5-</availability>
-		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:4</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:1,FS.AH:3-,Periphery:1</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FS:5</availability>
@@ -3871,11 +3871,11 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -3883,16 +3883,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CW:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -3900,8 +3899,9 @@
 		<model name='H'>
 			<availability>CSA:6,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -3919,26 +3919,26 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:2,CSR:2,FRR:4,CLAN:2,CFM:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CS:5,FRR:4,CLAN:4,WOB:5,CGS:6,BAN:2,DC:4</availability>
+			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
+		<model name='CRB-30'>
+			<availability>CS:8,FRR:5,WOB:6</availability>
+		</model>
 		<model name='CRB-45'>
 			<availability>WOB:5</availability>
 		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CS:5,FRR:4,CLAN:4,WOB:5,CGS:6,BAN:2,DC:4</availability>
+		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
-		</model>
-		<model name='CRB-30'>
-			<availability>CS:8,FRR:5,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
@@ -3952,21 +3952,21 @@
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CFM.MiKr:7,CDS:2,CBS:6,CFM:4,CB:3</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
@@ -3974,23 +3974,23 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,CFM:5,WOB:8,CIR:3,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
-		<model name='CRK-5004-1'>
-			<availability>CS:6,FRR:4</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:8,FRR:4</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>WOB:8,CIR:6</availability>
+		<model name='CRK-5003-1'>
+			<availability>CS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
+		</model>
+		<model name='CRK-5004-1'>
+			<availability>CS:6,FRR:4</availability>
 		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:5-,NIOPS:0</availability>
 		</model>
-		<model name='CRK-5003-1'>
-			<availability>CS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-3'>
-			<availability>CS:8,FRR:4</availability>
+		<model name='CRK-5005-1'>
+			<availability>WOB:8,CIR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -4013,30 +4013,34 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CSR:4,CDS:4,CW:4,CBS:5,CSV:8,CLAN:3,CNC:4,CCO:3,CJF:4,CWIE:4,CGB:4</availability>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:5,IS:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:5,IS:2</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>MERC:1,DC:2</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>MERC:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
@@ -4045,13 +4049,30 @@
 			<roles>recon,spotter</roles>
 			<availability>IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:7,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
+		<model name='CRD-7W'>
+			<availability>FWL:3,WOB:4,MERC:3</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>FWL:3,WOB:3,MERC:3</availability>
+		</model>
+		<model name='CRD-3D'>
+			<availability>FVC:3-,FS:3-</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:2-,DC:3-</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:8,FS:3,MERC:4</availability>
+		</model>
+		<model name='CRD-7L'>
+			<availability>CC:5,WOB:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='CRD-8S'>
 			<availability>LA:4,FS:3</availability>
 		</model>
@@ -4059,44 +4080,23 @@
 			<roles>raider</roles>
 			<availability>CC:4-</availability>
 		</model>
-		<model name='CRD-7L'>
-			<availability>CC:5,WOB:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:4,CS:4,FWL:8,IS:3,WOB:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:2-,DC:3-</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>FWL:3,WOB:4,MERC:3</availability>
-		</model>
-		<model name='CRD-4K'>
-			<availability>LA:3,FRR:8,MERC:3,FS:3,DC:8</availability>
 		</model>
 		<model name='CRD-4BR'>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:8,FS:3,MERC:4</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:5,WOB:4,MERC:4,DC:5</availability>
+		<model name='CRD-4K'>
+			<availability>LA:3,FRR:8,MERC:3,FS:3,DC:8</availability>
 		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:4,FWL:3,WOB:4,MERC:3,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FVC:3-,FS:3-</availability>
+		<model name='CRD-5M'>
+			<availability>CC:4,CS:4,FWL:8,IS:3,WOB:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>FWL:3,WOB:3,MERC:3</availability>
+		<model name='CRD-5K'>
+			<availability>FRR:5,WOB:4,MERC:4,DC:5</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4104,26 +4104,30 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>CS:6,FRR:6,SL.2:6,MERC:4</availability>
-		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:2-</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:5,DC:5</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:6,IS:6,WOB:6,FS:8,CDP:4,DC:4,TC:4</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:4-,General:5-,IS:4-,FS:4-,MERC:4-,DC:4-,TC:4-</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:5,DC:5</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:4-,General:5-,IS:4-,FS:4-,MERC:4-,DC:4-,TC:4-</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:2-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>CS:6,FRR:6,SL.2:6,MERC:4</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -4134,10 +4138,6 @@
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4150,13 +4150,13 @@
 			<roles>recon,escort</roles>
 			<availability>CS:6,General:4,NIOPS:6,WOB:6</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>TC:5</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
@@ -4173,32 +4173,32 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>WOB:4,FS:6+</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>DC:7</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -4218,14 +4218,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>FRR:6,DC:7</availability>
-		<model name='DMO-4K'>
-			<availability>FRR:4,DC:6</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:6</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:4,DC:5</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:6</availability>
+		<model name='DMO-4K'>
+			<availability>FRR:4,DC:6</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -4234,21 +4234,20 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,CB:4,DC:3+</availability>
-		<model name='Prime'>
-			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
+		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
@@ -4259,8 +4258,9 @@
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4298,11 +4298,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:4,FS:7</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:5,General:5</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
 		</model>
@@ -4314,25 +4317,15 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:2</availability>
+			<availability>FVC:5,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CCC:4,CIH:4,CLAN:4,IS:3+,CCO:3,BAN:4,CSA:3,MERC.WD:4,CDS:4,CJF:3,CGB:7,CB:4</availability>
-		<model name='H'>
-			<availability>CSA:6,CIH:3,CDS:3,CBS:2,General:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,CIH:6,General:2,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:3</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7,CB:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
@@ -4340,18 +4333,25 @@
 		<model name='K'>
 			<availability>General:2,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CHH:8,CIH:6,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8,CB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CIH:3,CDS:3,CBS:2,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:3</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8,CB:6</availability>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,CIH:6,General:2,CWIE:5,CGB:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7,CB:5</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CHH:8,CIH:6,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
@@ -4373,15 +4373,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4+,WOB:5+</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4396,11 +4396,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='DFN-3S'>
-			<availability>General:1</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -4418,18 +4418,6 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:6,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,CS:8,MOC:4,LA:8,FRR:6,FWL:8,IS:5,WOB:8,FS:8,DC:8,TC:4,CWIE:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,FS:4,CDP:4,TC:4,DC:4</availability>
@@ -4437,9 +4425,21 @@
 		<model name='(MRM)'>
 			<availability>DC:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,CS:8,MOC:4,LA:8,FRR:6,FWL:8,IS:5,WOB:8,FS:8,DC:8,TC:4,CWIE:4</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
@@ -4471,26 +4471,20 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CS:4,CHH:6,CLAN:4,NIOPS:4,WOB:4</availability>
-		</model>
 		<model name='CX-2'>
 			<availability>CS:3</availability>
+		</model>
+		<model name='(Royal)'>
+			<availability>CS:4,CHH:6,CLAN:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:2,FRR:3,IS:3,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:3,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
-		<model name='DV-8D'>
-			<availability>FS:4,MERC:4</availability>
-		</model>
-		<model name='DV-6M'>
-			<availability>HL:4,CLAN:4,IS:5-,Periphery.Deep:6,Periphery:6</availability>
+		<model name='DV-7D'>
+			<availability>FVC:6,LA:6,FS:8,MERC:4,TC:4</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:6,LA:6,FS:8,MERC:4,TC:4</availability>
 		</model>
 		<model name='DV-6Mr'>
 			<availability>General:2</availability>
@@ -4498,18 +4492,20 @@
 		<model name='DV-1S'>
 			<availability>IS:2-</availability>
 		</model>
+		<model name='DV-8D'>
+			<availability>FS:4,MERC:4</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>HL:4,CLAN:4,IS:5-,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Deva' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-DVA-OS Caelestis'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-DVA-OD Luminos'>
+		<model name='C-DVA-OC Comminus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OB Infernus'>
+		<model name='C-DVA-OD Luminos'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
@@ -4517,21 +4513,25 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OA Dominus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-DVA-OU Exanimus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-DVA-OC Comminus'>
+		<model name='C-DVA-OB Infernus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-DVA-O Invictus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='C-DVA-OS Caelestis'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-DVA-OU Exanimus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-DVA-OA Dominus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -4545,35 +4545,35 @@
 		<model name='DVS-3'>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,LA:2,FS:2,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:4</availability>
+		<model name='(Stealth)' mechanized='true'>
+			<availability>WOB:4</availability>
+		</model>
 		<model name='(Standard)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>WOB.SD:8</availability>
 		</model>
-		<model name='(Stealth)' mechanized='true'>
-			<availability>WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Close Support)'>
-			<roles>spotter</roles>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6,CB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8,CJF:2</availability>
+		</model>
+		<model name='(Close Support)'>
+			<roles>spotter</roles>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau Assault Interceptor' unitType='Dropship'>
@@ -4585,40 +4585,40 @@
 	</chassis>
 	<chassis name='Dragon Fire' unitType='Mek'>
 		<availability>LA:6,FRR:4,WOB:5,MERC:6,DC:5</availability>
-		<model name='DGR-6FC'>
-			<availability>WOB:6</availability>
-		</model>
 		<model name='DGR-4F'>
 			<availability>LA:4,WOB:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='DGR-3F'>
 			<availability>General:8,WOB:0</availability>
 		</model>
+		<model name='DGR-6FC'>
+			<availability>WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:2,FRR:7,MERC:3,DC:6</availability>
-		<model name='DRG-7N'>
-			<availability>LA:3,MERC:4,DC:4</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:2-,DC:2-,Periphery:4</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>FRR:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='DRG-7N'>
+			<availability>LA:3,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,MERC.WD:5,CHH:5,CIH:9,CDS:2,CSV:4,CLAN:2,IS:2+,CFM:4,CJF:2,CGB:7</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CIH:5,General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='Z'>
 			<roles>spotter</roles>
 			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
@@ -4626,39 +4626,39 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
+		</model>
 		<model name='I'>
+			<availability>CIH:5,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>CIH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
-		<model name='(Standard)'>
-			<availability>CC:4-,General:5-</availability>
+		<model name='(ERLL)'>
+			<availability>LA:1,WOB:2,FS:1</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:6-,General:3</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:1,WOB:2,FS:1</availability>
+		<model name='(Standard)'>
+			<availability>CC:4-,General:5-</availability>
 		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,WOB:6,FS:6</availability>
@@ -4673,11 +4673,11 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,SL.2:4,TC:3</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle Frigate' unitType='Warship'>
@@ -4689,31 +4689,31 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R4'>
-			<availability>LA:2,FS:2</availability>
+		<model name='EGL-R11'>
+			<availability>LA:3,MERC:3</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:1-,FS:1-</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1-,General:6-,FS:1-</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:2-,FS:2-</availability>
 		</model>
-		<model name='EGL-R11'>
-			<availability>LA:3,MERC:3</availability>
-		</model>
-		<model name='EGL-R6'>
-			<availability>LA:1-,General:6-,FS:1-</availability>
+		<model name='EGL-R4'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL.MM:6,FWL:5,MH:4,FWL.FO:6,MERC:4</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -4727,53 +4727,26 @@
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='EST-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:7,MERC.WD:7,CW:7,CLAN:7,CNC:7+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CJF:3</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:3,CLAN:2</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CJF:3</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CJF:3</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -4781,37 +4754,60 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:3,CLAN:2</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CJF:3</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CJF:3</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:3,MOC:4,CLAN:2,IS:4,WOB:7,FS:3,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='EMP-7L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='EMP-6A'>
-			<availability>CC:6,CS:8,HL:6,LA:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:6,FS:6,BAN:4,Periphery:8</availability>
+		<model name='EMP-6D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='EMP-6M'>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
+		<model name='EMP-7L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='EMP-6L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='EMP-6S'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>FS:6</availability>
+		<model name='EMP-6A'>
+			<availability>CC:6,CS:8,HL:6,LA:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:6,FS:6,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>CS:3-,LA:5-,FS:3-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:6,General:4,MERC:6</availability>
@@ -4820,37 +4816,37 @@
 			<roles>urban</roles>
 			<availability>LA:3,MERC:3</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,FS:6,MERC:4</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='ENF-6H'>
-			<availability>FS:3</availability>
+		<model name='ENF-6G'>
+			<availability>FS:2,MERC:4</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='ENF-6G'>
-			<availability>FS:2,MERC:4</availability>
+		<model name='ENF-6H'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>CC:2,FS:8,MERC:5,Periphery.OS:3,CDP:3,TC:3,Periphery:2,FVC:7,OA:3,LA:4,Periphery.HR:3,MH:2,DC:2</availability>
-		<model name='ENF-5D'>
-			<availability>FVC:8,LA:3,FS:8,MERC:5,CDP:5,TC:5</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>FVC:4-,General:4-,FS:5-,TC:5-</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>FVC:8,LA:3,FS:8,MERC:5,CDP:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -4858,6 +4854,10 @@
 		<model name='(Flamer)'>
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
@@ -4868,13 +4868,17 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CIH:3+,CDS:4+,CW:4+,CNC:3+,CGS:3+,CGB:3+,CWIE:4+,CB:3+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -4884,10 +4888,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -4895,25 +4895,25 @@
 	</chassis>
 	<chassis name='Erinyes' unitType='ProtoMek'>
 		<availability>SOC:4,CJF:2</availability>
+		<model name='(Standard)'>
+			<availability>SOC:4,CJF:8</availability>
+		</model>
 		<model name='3'>
 			<availability>SOC:8</availability>
 		</model>
 		<model name='2'>
 			<availability>SOC:5,CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>SOC:4,CJF:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CIH:1,CSR:1,CDS:2,CSV:1,FWL:2,WOB:2,CGS:1,CCO:1,DC:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CS:4,CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CS:4,CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -4922,20 +4922,16 @@
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>WOB:4,FS:3,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,FS:6</availability>
 		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>WOB:4,FS:3,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,CIR:2+,DC:4</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,WOB:4,CGS:6,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:1,NIOPS:8,WOB:8</availability>
@@ -4948,6 +4944,10 @@
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,WOB:4,CGS:6,BAN:2</availability>
+		</model>
 		<model name='EXC-CS'>
 			<roles>fire_support</roles>
 			<availability>CS:8,WOB:8,DC:8</availability>
@@ -4955,25 +4955,25 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3,WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4D'>
-			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
-		</model>
 		<model name='EXT-5F'>
 			<availability>CS:6</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
 		</model>
 		<model name='EXT-5E'>
 			<availability>CS:8,WOB:8</availability>
@@ -4995,39 +4995,39 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
 		<availability>LA:3,WOB:3</availability>
-		<model name='FNR-5WB'>
-			<availability>WOB:8</availability>
+		<model name='FNR-5'>
+			<availability>LA:6</availability>
 		</model>
 		<model name='FNR-5B'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='FNR-5'>
-			<availability>LA:6</availability>
+		<model name='FNR-5WB'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
@@ -5035,12 +5035,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5051,23 +5051,23 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>MERC.KH:2,WOB:2,MERC:3</availability>
-		<model name='FLC-5P'>
-			<availability>WOB:8,MERC:6</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4P'>
-			<availability>MERC.WD:3</availability>
-		</model>
 		<model name='FLC-6C'>
 			<availability>MERC.WD:6+</availability>
+		</model>
+		<model name='FLC-4P'>
+			<availability>MERC.WD:3</availability>
 		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
+		<model name='FLC-5P'>
+			<availability>WOB:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -5085,97 +5085,97 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:4</availability>
-		<model name='(Standard)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:2</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:3+,CHH:4,CIH:6,CSV:4,CLAN:2,IS:3+,CWIE:7,MERC.WD:7,CDS:2,CW:7,CNC:2,CJF:5,CGB:4</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:4,HL:4,LA:5,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:4,FS:6</availability>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:6</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -5187,59 +5187,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5247,39 +5199,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CIH:5,SOC:5,CNC:3,CFM:6,CLAN.HW:5,CJF:7</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:2,CCO:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -5294,13 +5298,13 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CSA:7,CLAN:6,IS:2</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:2,CCO:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CLAN:6</availability>
@@ -5308,10 +5312,6 @@
 		<model name='3'>
 			<roles>urban</roles>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
@@ -5344,14 +5344,8 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:2,CIH:4,CLAN:2,WOB:5,BAN:1</availability>
-		<model name='FFL-4D'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
@@ -5359,141 +5353,147 @@
 		<model name='FFL-4DA'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='C'>
+			<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
+		</model>
+		<model name='FFL-4D'>
+			<availability>MERC.WD:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-B'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
+		<model name='FS9-S1'>
 			<roles>recon</roles>
-			<availability>LA:1-,LA.SR:2-</availability>
+			<availability>LA:6,General:4,FS:5</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,CIR:7,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1-,LA.SR:2-</availability>
+		</model>
+		<model name='FS9-B'>
+			<availability>WOB:6</availability>
+		</model>
 		<model name='FS9-P'>
 			<availability>FVC:2,Periphery:2</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:6,General:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5+,CC:4+,FVC:4+,LA:5+,IS:4+,WOB:5+,FS:5+,MERC:4+,DC:7+</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:1+,DC:1+</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:1+,DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:5,CBS:3,FWL:2,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
-		<model name='FLS-9C'>
-			<availability>CS:6</availability>
-		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:4-,LA:4-</availability>
+		<model name='FLS-9M'>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,CS:4,LA:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
 		</model>
+		<model name='FLS-9C'>
+			<availability>CS:6</availability>
+		</model>
 		<model name='FLS-C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='FLS-9M'>
-			<availability>FWL:6</availability>
 		</model>
 		<model name='FLS-9B'>
 			<availability>WOB:6</availability>
 		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:4-,LA:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4</availability>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-</availability>
-		</model>
-		<model name='FLE-20'>
-			<availability>CC:2</availability>
-		</model>
-		<model name='FLE-15'>
-			<availability>MERC.WD:1,FWL:1</availability>
-		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:2,CM:4</availability>
 		</model>
+		<model name='FLE-15'>
+			<availability>MERC.WD:1,FWL:1</availability>
+		</model>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-</availability>
+		</model>
 		<model name='FLE-17'>
 			<availability>CC:8,FWL:4,WOB:4,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -5504,8 +5504,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -5517,20 +5517,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -5573,13 +5573,13 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
@@ -5588,29 +5588,29 @@
 			<roles>apc,spotter</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:4,WOB:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>WOB:8,FS:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:4,WOB:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:5,FWL:6,WOB:6</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:4,General:8,FWL:4,WOB:4</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:5,FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -5619,31 +5619,31 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:4,CW:4,CLAN:3</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CB:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,CLAN:4,CGS:6,CCO:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
 		</model>
 		<model name='GAL-104'>
 			<availability>WOB:5</availability>
@@ -5651,13 +5651,13 @@
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,FRR:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='GAL-103'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -5665,32 +5665,32 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,MERC:4</availability>
 		</model>
+		<model name='GAL-4GLSA'>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,MERC:4</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:3</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,MERC:4</availability>
-		</model>
-		<model name='GAL-4GLSA'>
-			<availability>MERC.WD:4</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:5,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
+		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
@@ -5698,43 +5698,43 @@
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,FS:7</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:3,CDS:5,CSR:2,CNC:5,CLAN:5,IS:2+,CJF:4,BAN:4,CGB:9,CB:4,CWIE:3</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='B'>
+			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
 		<model name='P'>
 			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -5782,20 +5782,20 @@
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -5814,14 +5814,6 @@
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,CS:2-,FVC:3,LA:2-,FS.CH:3-,FRR:1,WOB:2-,FS:3-,TC:3-,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FVC:5,FS:5</availability>
@@ -5830,52 +5822,60 @@
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,FVC:4,LA:2,FRR:2,NIOPS:2,WOB:2,FS:4,DC:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CGB:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>CGB:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:3,MOC:2,IS:1,FS:3,MERC:3,TC:2,Periphery:2,CS:1,OA:1,FVC:2,LA:5,Periphery.MW:1,FWL:6,MH:1</availability>
-		<model name='GOL-4S'>
+		<model name='GOL-5W'>
 			<roles>fire_support</roles>
-			<availability>LA:4</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,FWL:8,WOB:8,MERC:6</availability>
 		</model>
-		<model name='GOL-5W'>
+		<model name='GOL-6H'>
 			<roles>fire_support</roles>
-			<availability>WOB:4</availability>
+			<availability>Periphery.HR:2,Periphery.CM:2,Periphery.MW:2,Periphery.ME:2,MH:3,Periphery:2</availability>
 		</model>
 		<model name='GOL-5D'>
 			<roles>fire_support</roles>
 			<availability>FS:8</availability>
 		</model>
-		<model name='GOL-6H'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>Periphery.HR:2,Periphery.CM:2,Periphery.MW:2,Periphery.ME:2,MH:3,Periphery:2</availability>
+			<availability>LA:4</availability>
 		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>CC:4-,HL:2-,LA:5-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
-		<model name='GOL-2H'>
-			<roles>fire_support</roles>
-			<availability>Periphery.MW:2,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,MH:3,Periphery:2</availability>
-		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:5,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>Periphery.MW:2,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,MH:3,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
@@ -5884,21 +5884,18 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:3</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CIH:8,CSV:8,CFM:8,CJF:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CFM:5,CJF:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:6,CBS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CFM:5,CJF:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CIH:8,CSV:8,CFM:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:4,CLAN:1</availability>
-		<model name='2'>
-			<availability>CSV:4,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:4,General:8</availability>
 		</model>
@@ -5908,20 +5905,23 @@
 		<model name='4'>
 			<availability>CSV:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CSV:4,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6-</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:4,FWL:4,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-400'>
-			<availability>PIR:5-,FWL:5-,MH:5-,MERC:5-</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:4,FWL:4,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>FWL:5,WOB:5</availability>
+		</model>
+		<model name='GTHA-400'>
+			<availability>PIR:5-,FWL:5-,MH:5-,MERC:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader II' unitType='Mek'>
@@ -5935,20 +5935,23 @@
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
 		<availability>FWL:4,WOB:2</availability>
-		<model name='GRN-D-01'>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
 		<model name='GRN-D-02'>
 			<availability>FWL:2,WOB:2</availability>
+		</model>
+		<model name='GRN-D-01'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:5,WOB:4,DC:8</availability>
-		<model name='DRG-1G'>
-			<availability>FRR:5-,DC:5-</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:6,CNC:8,WOB:8,DC:6</availability>
+		</model>
+		<model name='DRG-7K'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>FRR:5-,DC:5-</availability>
 		</model>
 		<model name='DRG-C'>
 			<availability>FRR:7,DC:7</availability>
@@ -5959,9 +5962,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -5978,12 +5978,6 @@
 		<model name='GHR-7K'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='GHR-5J'>
-			<availability>CS:3,IS:3,WOB:3,Periphery:3</availability>
-		</model>
-		<model name='GHR-6K'>
-			<availability>FRR:5,MERC:3,FS:3,DC:6</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
@@ -5992,6 +5986,12 @@
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:3,DC:4</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>CS:3,IS:3,WOB:3,Periphery:3</availability>
+		</model>
+		<model name='GHR-6K'>
+			<availability>FRR:5,MERC:3,FS:3,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -6006,14 +6006,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -6030,11 +6030,11 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:2</availability>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
@@ -6049,20 +6049,23 @@
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:6,CDS:4,CSR:3,CSV:6,CFM:4,CCO:6,CJF:6,CB:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CSA:7,CHH:8,CLAN:5,IS:2</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:3,IS:1</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:7,CHH:8,CLAN:5,IS:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -6070,26 +6073,23 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CIH:6,CDS:6,CW:4,CNC:7,CLAN:4,CCO:6,CJF:4,CWIE:4,CGB:4,DC:3</availability>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,CLAN:4</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,CLAN:4,CCO:8</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CIH:4,CNC:5,CLAN:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:4-,CNC:4</availability>
+		</model>
 		<model name='6'>
 			<availability>CNC:4,DC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:4-,CNC:4</availability>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,CLAN:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
@@ -6097,64 +6097,48 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:4,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:5,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-1S'>
-			<availability>LA:4-,FRR:2-,MERC:4-</availability>
-		</model>
-		<model name='GRF-6CS'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CLAN:6,FWL:2,WOB:3,MERC:2,BAN:4</availability>
+		<model name='GRF-1N'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:2,Periphery:5-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:2-,MERC:2-,TC:2-</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>FWL:4,WOB:5,MERC:4</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:6,LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
+		<model name='GRF-6S'>
+			<availability>LA:4,FRR:3,FS:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CNC:4,DC:4</availability>
 		</model>
+		<model name='GRF-5M'>
+			<availability>FWL:4,WOB:5,MERC:4</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:6,LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
+		</model>
+		<model name='GRF-1S'>
+			<availability>LA:4-,FRR:2-,MERC:4-</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
+		</model>
+		<model name='GRF-6CS'>
+			<availability>CS:5,WOB:4</availability>
+		</model>
 		<model name='GRF-5L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:2,Periphery:5-</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:4,FRR:3,FS:3,MERC:3,DC:3</availability>
+		<model name='GRF-2N'>
+			<availability>CLAN:6,FWL:2,WOB:3,MERC:2,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grigori' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-GRG-OS Caelestis'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-GRG-OC Comminus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-GRG-OB Infernus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OA Dominus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-GRG-OD Luminos'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-GRG-OE Eminus'>
+		<model name='C-GRG-OC Comminus'>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
@@ -6167,9 +6151,31 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C-GRG-OD Luminos'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OE Eminus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OA Dominus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OS Caelestis'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,WOB:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR30'>
+			<availability>WOB:6+,MERC:3</availability>
+		</model>
+		<model name='GRM-R-PR29'>
+			<availability>CS:8,MERC:8,DC:8</availability>
+		</model>
 		<model name='GRM-R (Einar)'>
 			<roles>spotter</roles>
 			<availability>CS:1</availability>
@@ -6177,12 +6183,6 @@
 		<model name='GRM-R-PR31'>
 			<roles>fire_support</roles>
 			<availability>WOB:6+,MERC:4</availability>
-		</model>
-		<model name='GRM-R-PR30'>
-			<availability>WOB:6+,MERC:3</availability>
-		</model>
-		<model name='GRM-R-PR29'>
-			<availability>CS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -6201,11 +6201,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CC:2,IS:1,FWL:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3</availability>
@@ -6213,36 +6213,36 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CHH:3-,CW:3-,CLAN:2-,CNC:3-,CCO:3-,CWIE:3-</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:3,CSR:3,FRR:3,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:3</availability>
-		<model name='GLT-4L'>
+		<model name='GLT-6WB'>
 			<roles>raider</roles>
-			<availability>HL:2-,IS:4-,FWL:5-,Periphery.Deep:8,NIOPS:0,MERC:5-,Periphery:4-</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='GLT-8D'>
 			<roles>raider</roles>
 			<availability>FS:6</availability>
 		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>HL:2-,IS:4-,FWL:5-,Periphery.Deep:8,NIOPS:0,MERC:5-,Periphery:4-</availability>
+		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,FWL:8,WOB:4,FS:5,MERC:2</availability>
-		</model>
-		<model name='GLT-6WB2'>
-			<roles>raider</roles>
-			<availability>WOB:4</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
 			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
 		</model>
-		<model name='GLT-6WB'>
+		<model name='GLT-6WB2'>
 			<roles>raider</roles>
 			<availability>WOB:4</availability>
 		</model>
@@ -6259,21 +6259,21 @@
 	</chassis>
 	<chassis name='Gurkha' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='GUR-2G'>
+		<model name='GUR-4G'>
 			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='GUR-8G'>
-			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:3</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='GUR-6G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='GUR-4G'>
+		<model name='GUR-8G'>
 			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:4</availability>
+			<availability>WOB:3</availability>
+		</model>
+		<model name='GUR-2G'>
+			<deployedWith>Vanquisher</deployedWith>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6285,27 +6285,27 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:2,CDS:5,CBS:3,LA:4,CNC:5,CFM:3,DC:4</availability>
-		<model name='HKO-1C'>
-			<roles>fire_support</roles>
-			<availability>LA:8,DC:8</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>LA:2+,CLAN:8,DC:2+</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='HKO-1C'>
+			<roles>fire_support</roles>
+			<availability>LA:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:7,CBS:6,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>OA:4,CSR:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>OA:4,CSR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -6317,79 +6317,79 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>MOC:4,CC:4,FWL:6,MH:4,WOB:6,MERC:5</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,WOB:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>FS:3</availability>
-		<model name='HMH-6D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='HMH-3D'>
 			<availability>General:6-,MERC:6-</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:4,MERC:4</availability>
 		</model>
+		<model name='HMH-6D'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:4</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8,WOB:6</availability>
-		</model>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HF'>
 			<availability>WOB:6</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
 		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
+		</model>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8,WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:3,CDS:4,CSV:5,CNC:5,CLAN:2,IS:3+,CJF:4,CCO:3,CGB:3</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -6408,13 +6408,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5-,CC:5-,HL:4-,FRR:5-,IS:5-,Periphery.Deep:4,WOB:5-,MERC:5-,Periphery:5-,CS:5-,FWL.pm:6-,LA:5-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,DC:5-</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:6-</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
@@ -6426,45 +6426,45 @@
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:3,CHH:6,CBS:2,CSV:6,CFM:3,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CSA:4,CHH:4,CBS:4,CFM:4,CJF:4</availability>
+		<model name='3'>
+			<availability>CSA:6,CHH:3,CFM:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8,CBS:8,CSV:8,CFM:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:6,CHH:3,CFM:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:4,CHH:4,CBS:4,CFM:4,CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,WOB:4,MERC:4,DC:8</availability>
-		<model name='HTM-26T'>
-			<availability>DC:4-</availability>
-		</model>
-		<model name='HTM-28T'>
-			<availability>WOB:6,DC:5</availability>
+		<model name='HTM-27T'>
+			<availability>FRR:8,MERC:6,DC:7</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>WOB:5,DC:2</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:8,MERC:6,DC:7</availability>
+		<model name='HTM-28T'>
+			<availability>WOB:6,DC:5</availability>
+		</model>
+		<model name='HTM-26T'>
+			<availability>DC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>FRR:3,DC:4</availability>
+		<model name='HTM-27U'>
+			<availability>General:5-</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaze' unitType='Mek'>
@@ -6490,14 +6490,8 @@
 		<model name='HCT-6S'>
 			<availability>LA:5,MERC:5</availability>
 		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:3-</availability>
-		</model>
 		<model name='HCT-5D'>
 			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:5,LA:6,FRR:4,FS:6,MERC:4,DC:2</availability>
 		</model>
 		<model name='HCT-5DD'>
 			<availability>FS:4,MERC:4</availability>
@@ -6505,6 +6499,12 @@
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:3,LA:3,TC.PL:5,MERC:3,FS:2,Periphery:3</availability>
+		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:5,LA:6,FRR:4,FS:6,MERC:4,DC:2</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:3-</availability>
 		</model>
 		<model name='HCT-6D'>
 			<availability>FS:6,MERC:5</availability>
@@ -6525,18 +6525,14 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:5+</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OD'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='HA1-OA'>
 			<availability>General:7</availability>
@@ -6544,14 +6540,18 @@
 		<model name='HA1-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HA1-OD'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,CS:3,LA:3,FRR:3,FWL:5,IS:3,WOB:3,FS:4,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -6572,25 +6572,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -6602,11 +6602,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -6624,23 +6624,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -6651,6 +6651,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -6659,20 +6667,20 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8,WOB:6</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -6682,14 +6690,6 @@
 			<roles>apc,support</roles>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,CSV:2,CWIE:5</availability>
@@ -6697,12 +6697,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -6710,11 +6710,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,CS:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 		<model name='HEL-6X'>
 			<availability>WOB:8</availability>
@@ -6722,8 +6722,8 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:3,CNC:3,NIOPS:6,WOB:6,FS:3,DC:4</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='HCT-215'>
 			<availability>CS:4</availability>
@@ -6732,14 +6732,17 @@
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,WOB:8,DC:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,OA:4,FVC:2,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:2-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='HCT-313'>
 			<availability>OA:8,FVC:4,CSR:8,CDP:4</availability>
@@ -6751,31 +6754,28 @@
 		<model name='HCT-213'>
 			<availability>General:4</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:2,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:4,CB:5</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CB:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSA:8,CCC:8,CB:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:2,CHH:4,CIH:4,CDS:3,DC.AL:2,CLAN:2,CNC:5,CJF:4</availability>
-		<model name='5'>
-			<availability>CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
+			<availability>CNC:5</availability>
+		</model>
+		<model name='5'>
 			<availability>CNC:5</availability>
 		</model>
 		<model name='2'>
@@ -6787,34 +6787,34 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CIH:10,SOC:5,CSV:4,CLAN:3,CFM:5,CGS:4,CCO:5,CSA:5,CDS:5,CBS:2,CNC:5,CJF:2,CB:5</availability>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:4,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>FS:5,MERC:3</availability>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
@@ -6825,25 +6825,25 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CB:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -6864,29 +6864,13 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>MOC:2-,CC:4,LA:4,FRR:3-,PIR:4,FWL:9,WOB:4,MH:4,MERC:4,FS:5,DC:3-</availability>
-		<model name='HER-4K &apos;Hermes III&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
 		<model name='HER-5C'>
 			<roles>recon</roles>
 			<availability>WOB:10</availability>
 		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>FWL:4</availability>
-		</model>
-		<model name='HER-2S'>
+		<model name='HER-4K &apos;Hermes III&apos;'>
 			<roles>recon</roles>
-			<availability>HL:3-,IS:5-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
+			<availability>FWL:3</availability>
 		</model>
 		<model name='HER-2M &apos;Mercury&apos;'>
 			<roles>recon</roles>
@@ -6896,64 +6880,80 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:5,FWL:8,WOB:8,FS:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:3-,IS:5-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:2,FRR:3,FWL:7,NIOPS:3,WOB:3,CGB:2,DC:5</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:5-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:8,WOB:8</availability>
-		</model>
-		<model name='HER-4M'>
-			<roles>recon</roles>
-			<availability>FWL:5,WOB:5</availability>
-		</model>
-		<model name='HER-4WB'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>CS:3,FRR:3,FWL:5,WOB:3</availability>
 		</model>
+		<model name='HER-4WB'>
+			<roles>recon</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='HER-4M'>
+			<roles>recon</roles>
+			<availability>FWL:5,WOB:5</availability>
+		</model>
 		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:6,WOB:5</availability>
 		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:5-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:2,Periphery:2,CWIE:3,CGB:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8-</availability>
+		<model name='(LB-X)'>
+			<availability>CC:6,MOC:4,TC:5</availability>
 		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:6,MOC:4,TC:5</availability>
+		<model name='(Laser)'>
+			<availability>CC:3,IS:3,Periphery:3</availability>
 		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CC:3,IS:3,Periphery:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -6966,23 +6966,26 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>MERC.WD:3,CHH:3,CDS:4,CW:6,CLAN:3,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CW:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:6,CW:6,CLAN:6,CNC:6,IS:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:6,CLAN:6,NIOPS:9,CFM:7,WOB:9,MERC:4,FS:5,CJF:7,DC:1</availability>
+		<model name='HGN-736'>
+			<availability>CS:8,WOB:6</availability>
+		</model>
+		<model name='HGN-733'>
+			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:1,:0,LA:1</availability>
 		</model>
-		<model name='HGN-734'>
-			<availability>LA:6,MERC:6</availability>
-		</model>
-		<model name='HGN-736'>
-			<availability>CS:8,WOB:6</availability>
+		<model name='HGN-738'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CS:4,LA:2,CLAN:4,WOB:4,FS:2,BAN:2</availability>
@@ -6990,29 +6993,26 @@
 		<model name='HGN-694'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='HGN-641-X-2'>
-			<availability>CS:1</availability>
+		<model name='HGN-732'>
+			<availability>MOC:6,DC.GHO:8,CS:3,LA:6,CLAN:6,IS:6,NIOPS:3,WOB:3,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		<model name='HGN-641-X-2'>
+			<availability>CS:1</availability>
 		</model>
-		<model name='HGN-732'>
-			<availability>MOC:6,DC.GHO:8,CS:3,LA:6,CLAN:6,IS:6,NIOPS:3,WOB:3,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
-		</model>
-		<model name='HGN-738'>
-			<availability>LA:4</availability>
+		<model name='HGN-734'>
+			<availability>LA:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:2</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7038,11 +7038,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:5,MERC:4,FS:4</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7056,34 +7056,34 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:1,CGS:2</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:4,CLAN:1</availability>
 		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2,MERC.WD:6,FVC:8,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9</availability>
-		<model name='HNT-161'>
-			<availability>MERC.WD:3-</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>FVC:2-,IS:2-</availability>
 		</model>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:4-</availability>
+		<model name='HNT-161'>
+			<availability>MERC.WD:3-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -7118,11 +7118,11 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:6,CDS:7,CSR:6,CW:6,CSV:5,CLAN:2,IS:3,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='2'>
-			<availability>CSA:8,CBS:8,CB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSR:5,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:8,CBS:8,CB:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:8,CCO:8</availability>
@@ -7130,70 +7130,66 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:4,CC:4,HL:4,FRR:6,IS:4-,Periphery.Deep:5,WOB:3-,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,IS:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6S'>
 			<availability>LA:3,MERC:3</availability>
 		</model>
-		<model name='HBK-4J'>
-			<availability>CC:2-,IS:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='HBK-4H'>
-			<availability>FVC:2-,IS:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5H'>
-			<availability>MH:5,Periphery:2</availability>
-		</model>
 		<model name='HBK-4SP'>
 			<availability>FVC:2-,IS:1-,FWL:2-,MERC:2-,DC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:2-,Periphery:2</availability>
 		</model>
 		<model name='HBK-5M'>
 			<availability>CS:4,CC:2,MOC:2,FRR:2,FWL:2,WOB:4,MERC:2,CDP:2,TC:2</availability>
 		</model>
+		<model name='HBK-4J'>
+			<availability>CC:2-,IS:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>MH:5,Periphery:2</availability>
+		</model>
+		<model name='HBK-5SS'>
+			<availability>LA:2</availability>
+		</model>
 		<model name='HBK-5S'>
 			<availability>LA:5,FRR:3,MERC:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-5P'>
+			<availability>FWL:4,WOB:4,MERC:3</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:2-,Periphery:2</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>FVC:2-,IS:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6N'>
 			<availability>FWL:5,WOB:6,MERC:5</availability>
 		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:6-</availability>
+			<availability>General:2-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>LA:8,FS:5</availability>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -7203,12 +7199,16 @@
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
-			<availability>General:2-</availability>
+			<availability>LA:8,FS:5</availability>
 		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:6-</availability>
 		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:2,FS:2</availability>
@@ -7216,18 +7216,18 @@
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,MERC:4</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
@@ -7245,54 +7245,54 @@
 		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HSCL-1-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='HSCL-1-OD'>
 			<availability>General:4</availability>
 		</model>
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:5,FRR:3,CLAN:4,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		</model>
+		<model name='HSR-300-D'>
+			<availability>DC:4-</availability>
+		</model>
 		<model name='HSR-500-D'>
 			<availability>CS:4,WOB:8</availability>
+		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:2-</availability>
+		</model>
+		<model name='HSR-900-D'>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='HSR-950-D'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:4,General:8,CLAN:6,NIOPS:4,MERC.SI:4,WOB:4,BAN:8</availability>
 		</model>
-		<model name='HSR-900-D'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:2-</availability>
-		</model>
-		<model name='HSR-300-D'>
-			<availability>DC:4-</availability>
-		</model>
-		<model name='HSR-950-D'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -7300,13 +7300,13 @@
 		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='4'>
-			<roles>anti_infantry</roles>
-			<availability>CBS:3</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5,CFM:5</availability>
+		</model>
+		<model name='4'>
+			<roles>anti_infantry</roles>
+			<availability>CBS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CHH:6,CBS:6,CFM:6</availability>
@@ -7321,44 +7321,44 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MOC:8,LA:4,FWL:4,IS:8,WOB:3,MH:8,FS:2,DC:3,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
 		<availability>FWL.pm:2,FWL:2,WOB:2</availability>
-		<model name='ICR-1S'>
-			<availability>General:6-</availability>
-		</model>
 		<model name='ICR-2S'>
 			<availability>General:6</availability>
+		</model>
+		<model name='ICR-1S'>
+			<availability>General:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus' unitType='Mek'>
@@ -7383,13 +7383,13 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='IMP-2E'>
 			<availability>MERC.WD:1</availability>
 		</model>
 		<model name='IMP-3E'>
+			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-4E'>
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
@@ -7409,43 +7409,43 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,CNC:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CW:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
 		<availability>LA:2,FS:2,MERC:2,TC:2</availability>
-		<model name='&apos;Waddle&apos;' mechanized='true'>
-			<roles>recon</roles>
-			<availability>LA:6,FS:6,TC:6</availability>
-		</model>
 		<model name='(Special Ops)' mechanized='true'>
 			<roles>specops</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='&apos;Waddle&apos;' mechanized='true'>
+			<roles>recon</roles>
+			<availability>LA:6,FS:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FS:3</availability>
 		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
 		<availability>WOB:7</availability>
-		<model name='INI-02'>
-			<availability>WOB:6</availability>
-		</model>
 		<model name='INI-04'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='INI-02'>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Inquisitor' unitType='Mek'>
@@ -7456,37 +7456,37 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>FWL:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:2</availability>
-		<model name='IRN-SD3'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:4</availability>
+		</model>
+		<model name='IRN-SD3'>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
@@ -7494,26 +7494,31 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CIH:3,CLAN:4,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSR:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -7523,11 +7528,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -7544,9 +7544,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:5-,FS.AH:4-,IS:4-,Periphery.Deep:5,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,DC:4-</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -7556,17 +7560,13 @@
 			<roles>recon,raider</roles>
 			<availability>DC:8,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -7592,39 +7592,29 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>CC:4,MOC:5,FVC:3,Periphery.MW:4,Periphery.ME:4,FWL:6,IS:3,MH:5,WOB:6,FS:4,MERC:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>HL:6,General:4,FWL:5,Periphery.Deep:6,MERC:5,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>LA:5,FWL:5,MERC:5,FS:6</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>HL:6,General:4,FWL:5,Periphery.Deep:6,MERC:5,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>WOB:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
 		<model name='JKR-9W'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:4,CW:5,General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CSR:6,CW:4</availability>
@@ -7632,8 +7622,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:4,CW:5,General:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -7647,47 +7647,67 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:5-,FRR:5,IS:2,WOB:3,MERC:3,Periphery.OS:2,FS:8,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:4,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:2,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-S'>
+		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
-			<availability>CC:4-,FRR:3-,IS:4-,FS:4-,Periphery:8</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:6,MERC:5</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
+			<availability>PIR:2,MH:4</availability>
 		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,FS:2-</availability>
 		</model>
-		<model name='JM6-H'>
-			<roles>anti_aircraft</roles>
-			<availability>PIR:2,MH:4</availability>
-		</model>
 		<model name='JM7-F'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:3</availability>
+		</model>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:3,LA:3,FRR:3,WOB:2,FS:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='JM7-G'>
-			<availability>FS:4</availability>
+		<model name='JM7-D'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:6,MERC:5</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:6,OA:8,LA:8,FRR:8,WOB:6,FS:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:4-,FRR:3-,IS:4-,FS:4-,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,HL:3,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:4,LA:3,Periphery.HR:6</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:2,IS:1,FS:2-,MERC:2,TC:2,Periphery:1</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>FS:5</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:4,LA:6,Periphery.HR:4,PIR:4,FS:6,MERC:6,CDP:4,TC:4</availability>
@@ -7696,37 +7716,11 @@
 			<roles>recon</roles>
 			<availability>FS:2</availability>
 		</model>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:2,IS:1,FS:2-,MERC:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>FS:5</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,FS:3,MERC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:5,General:2,CJF:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -7734,23 +7728,29 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:5,General:2,CJF:5</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='E'>
+			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:6,CW:5,CSV:6,CNC:8,CLAN:3,CGS:5,CCO:5,CB:4,DC:2</availability>
-		<model name='3'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CW:5,CLAN:4,CNC:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:8,IS:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:5,CLAN:4,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
@@ -7759,13 +7759,17 @@
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>DC:3+</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -7775,17 +7779,9 @@
 			<roles>raider</roles>
 			<availability>MERC:4+,FS:4+,DC:8</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:3,FS:4,TC:3</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -7793,6 +7789,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -7805,11 +7805,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:4,MOC:3,TC:3</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -7824,26 +7824,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -7864,15 +7864,31 @@
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>DC:5</availability>
-		<model name='KBO-7A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='KBO-7B'>
 			<availability>General:5</availability>
+		</model>
+		<model name='KBO-7A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>DC:2</availability>
+		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
@@ -7881,46 +7897,30 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -7931,12 +7931,9 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:3,PIR:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:6,MERC:6</availability>
+		<model name='(BA)'>
+			<roles>apc</roles>
+			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
 		</model>
 		<model name='(Periphery)'>
 			<availability>MOC:5,OA:5,HL:3,PIR:7,MH:6,CIR:6,Periphery:5,TC:5</availability>
@@ -7945,13 +7942,20 @@
 			<roles>cargo</roles>
 			<availability>HL:2,IS:6,Periphery:4</availability>
 		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
+		<model name='(AC)'>
+			<availability>MH:6,MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:5,FRR:2,DC:5</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:6-</availability>
 		</model>
@@ -7961,13 +7965,16 @@
 		<model name='CRK-5003-C'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>CS:5,MERC.WD:4,CW:2,LA:4,FRR:4,CLAN:4,WOB:4,FS:4,DC:3</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -7975,18 +7982,11 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
-		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -7998,14 +7998,23 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:2,FRR:4,CLAN:3,IS:2,WOB:6,FS:6,MERC:3,CIR:2,CGS:5,DC.GHO:6,CS:6,FVC:5,LA:2,FWL:2,NIOPS:6,CGB:4,DC:2</availability>
-		<model name='KGC-001'>
-			<availability>CS:8,FVC:8,LA:6,IS:6,WOB:5,CIR:6,MERC:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CS:4,FRR:3,CLAN:4,WOB:3,CGS:6,BAN:2,DC:3</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:5,FS:5,MERC:5</availability>
+		</model>
+		<model name='KGC-008'>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
+		</model>
+		<model name='KGC-001'>
+			<availability>CS:8,FVC:8,LA:6,IS:6,WOB:5,CIR:6,MERC:6</availability>
+		</model>
+		<model name='KGC-005'>
+			<availability>CS:5,WOB:4</availability>
 		</model>
 		<model name='KGC-0000'>
 			<availability>IS:5-,CIR:5</availability>
@@ -8013,35 +8022,23 @@
 		<model name='KGC-008B'>
 			<availability>WOB.PM:8</availability>
 		</model>
-		<model name='KGC-000'>
-			<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-005'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
-		<model name='KGC-008'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CSR:3,CLAN:3,CNC:3,IS:2+,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:1</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8049,26 +8046,29 @@
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:2,CDS:2,CSV:2,FRR:4,CLAN:1,NIOPS:7,WOB:7,FS:3,MERC:5,DC:5</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:8</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:5,CS:4,DC.SL:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:5-,MERC:5-,DC:4-</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:6</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:4,WOB:5,FS:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:5,WOB:4,MERC:6,DC:6</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:4,WOB:5,FS:4,CGS:6,BAN:2</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:5-,MERC:5-,DC:4-</availability>
 		</model>
 		<model name='KTO-21'>
 			<availability>CS:6,WOB:5</availability>
@@ -8076,23 +8076,23 @@
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5,CGS:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8104,13 +8104,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
@@ -8118,9 +8118,16 @@
 		<model name='[GL]' mechanized='true'>
 			<availability>FRR:4</availability>
 		</model>
+		<model name='(CS) [SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:8</availability>
+		</model>
 		<model name='(CS) [GL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:6</availability>
+		</model>
+		<model name='(CS) [GL]' mechanized='true'>
+			<availability>CS:4</availability>
 		</model>
 		<model name='[SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
@@ -8132,15 +8139,8 @@
 		<model name='(CS) [GL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='(CS) [GL]' mechanized='true'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='(CS) [SL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
-		</model>
-		<model name='(CS) [SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:8</availability>
 		</model>
 		<model name='[GL/Flamer]' mechanized='true'>
 			<availability>FRR:6</availability>
@@ -8152,8 +8152,8 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:4,CCC:3,CIH:5,CSR:6,CNC:3,CLAN:3,CGS:4,CCO:3,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -8162,11 +8162,11 @@
 		<model name='2'>
 			<availability>CGB:5</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -8175,66 +8175,42 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:6</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,WOB:4,MERC:4</availability>
+		<model name='KSC-5MC'>
+			<availability>MOC:8</availability>
+		</model>
 		<model name='KSC-4I'>
+			<availability>MERC:2</availability>
+		</model>
+		<model name='KSC-4L'>
 			<availability>MERC:2</availability>
 		</model>
 		<model name='KSC-5I'>
 			<availability>WOB:8,MERC:4</availability>
 		</model>
-		<model name='KSC-5MC'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:3,IS:3+,CCO:3,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CJF:6,CB:7</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:2</availability>
-		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
-		</model>
 		<model name='Z'>
 			<roles>recon</roles>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -8244,36 +8220,60 @@
 			<roles>recon</roles>
 			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
 		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
+		<model name='KTO-3A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='KTO-2A'>
 			<availability>General:3</availability>
 		</model>
-		<model name='KTO-3A'>
-			<availability>General:8</availability>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:4,CLAN:2,CJF:4</availability>
-		<model name='4'>
-			<availability>CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='3'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>CSV:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='2'>
+		<model name='4'>
+			<availability>CJF:6</availability>
+		</model>
+		<model name='3'>
+			<roles>fire_support</roles>
 			<availability>CSV:4,CLAN:2,CJF:4</availability>
 		</model>
 	</chassis>
@@ -8316,13 +8316,13 @@
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>CC:7,CS:8,MOC:6,LA:8,FRR:8,FWL:7,IS:6,FS:8,CIR:4,DC:7,TC:6,Periphery:4</availability>
-		</model>
 		<model name='(WoB)'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>CC:7,CS:8,MOC:6,LA:8,FRR:8,FWL:7,IS:6,FS:8,CIR:4,DC:7,TC:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -8333,18 +8333,12 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:3,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:6</availability>
-		<model name='LNC25-06'>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='LNC25-04'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,FRR:4-,DC:4-</availability>
-		</model>
 		<model name='LNC25-03'>
 			<availability>DC:4-</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:6</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
@@ -8353,21 +8347,27 @@
 		<model name='LNC25-08'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:6</availability>
+		<model name='LNC25-04'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,FRR:4-,DC:4-</availability>
+		</model>
+		<model name='LNC25-06'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>FWL:4,WOB:3</availability>
-		<model name='LX-2A'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LX-2A'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
@@ -8375,15 +8375,15 @@
 		<model name='LHU-3L'>
 			<availability>CC:4,MOC:4,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='LHU-3C'>
 			<availability>CC:4+,MOC:4+</availability>
 		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -8395,46 +8395,46 @@
 	</chassis>
 	<chassis name='Legacy' unitType='Mek'>
 		<availability>WOB:6</availability>
+		<model name='LGC-05'>
+			<availability>WOB:2</availability>
+		</model>
 		<model name='LGC-02'>
 			<roles>fire_support</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGC-04-WVR'>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='LGC-01'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='LGC-05'>
-			<availability>WOB:2</availability>
 		</model>
 		<model name='LGC-03'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='LGC-04-WVR'>
+			<availability>WOB:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,LA:8,FWL:8,WOB:8,FS:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
+		<model name='(2537)'>
 			<roles>mech_carrier</roles>
-			<availability>LA:8,FWL:8,FS:8</availability>
+			<availability>General:5-</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(2537)'>
+		<model name='(3056)'>
 			<roles>mech_carrier</roles>
-			<availability>General:5-</availability>
+			<availability>LA:8,FWL:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -8466,30 +8466,30 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>FWL:4</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1</availability>
-		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:4,DC:2,Periphery:4</availability>
 		</model>
 		<model name='Comet'>
 			<availability>FVC:5,FS:5,MERC:1</availability>
 		</model>
+		<model name='Owl III'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,HL:4,LA:4</availability>
-		</model>
-		<model name='Suzume (&apos;Sparrow&apos;)'>
-			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
 		<model name='Andurien'>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>FWL:4</availability>
+		<model name='Suzume (&apos;Sparrow&apos;)'>
+			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Owl III'>
-			<availability>LA:4</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:4,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -8500,21 +8500,21 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:2,CIH:6,CLAN:5,NIOPS:2,WOB:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6,WOB:4</availability>
+		<model name='(RL)'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='(ERML)'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(RL)'>
-			<availability>WOB:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6,WOB:4</availability>
+		</model>
+		<model name='(ERSL)'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='CX-3'>
 			<availability>CS:8</availability>
@@ -8522,73 +8522,73 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:6-</availability>
+		<model name='LTN-G16D'>
+			<availability>FS:4,MERC:3</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:3,MOC:3,CLAN:3,MERC:2</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>FS:4,MERC:3</availability>
+		<model name='LTN-G16O'>
+			<availability>OA:4,FVC:3,CDP:3</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:6-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:4,MOC:4,MERC:3</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>OA:4,FVC:3,CDP:3</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGH-5W'>
+		<model name='LGH-4W'>
 			<roles>recon</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='LGH-7W'>
-			<roles>recon</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='LGH-4Y'>
 			<roles>recon</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='LGH-4W'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='LGH-6W'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
 		</model>
+		<model name='LGH-7W'>
+			<roles>recon</roles>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='LGH-5W'>
+			<roles>recon</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:3,CCC:4,CSR:5,CW:5,SOC:4,CSV:4,CCO:4,CJF:4,CWIE:6,CB:4</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CIH:5,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,CCO:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:4,CIH:5,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -8599,25 +8599,25 @@
 		<model name='KW1-LH3'>
 			<availability>General:2,CM:6,WOB:3,FS:3</availability>
 		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='KW1-LH2'>
 			<availability>General:8,WOB:2,FS:2</availability>
 		</model>
 		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
 			<availability>WOB:4,FS:7</availability>
 		</model>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CS:6,CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,WOB:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -8626,24 +8626,18 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CW:6</availability>
+		<model name='(Standard)'>
+			<availability>CW:8</availability>
+		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:3,CHH:6,CW:7,LA:2,CLAN:3,IS:2,CJF:6,DC:2,CGB:6</availability>
-		<model name='3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:5,General:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CS:6,CCC:3,CHH:4,CW:4,LA:6,CJF:6,CB:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:2,CIH:2,CJF:2</availability>
@@ -8651,16 +8645,26 @@
 		<model name='5'>
 			<availability>CHH:4,CW:4,CCO:3,CGB:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:2</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CS:6,CCC:3,CHH:4,CW:4,LA:6,CJF:6,CB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:3-,HL:5,CLAN:2-,IS:8,NIOPS:3-,Periphery.Deep:5,WOB:3-,Periphery:5</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>FWL:2,WOB:3</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:3,CC:3,TC:4</availability>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:5-,MERC:4</availability>
 		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
@@ -8670,118 +8674,114 @@
 			<roles>recon</roles>
 			<availability>CC:3,CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-1E'>
 			<roles>recon</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
+			<availability>IS:2,Periphery.Deep:4,Periphery:2</availability>
 		</model>
 		<model name='LCT-1V2'>
 			<roles>recon</roles>
 			<availability>PIR:4,MH:4</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:4,FWL:8,IS:4,MERC:6</availability>
+		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:3,General:4,FS:4</availability>
-		</model>
-		<model name='LCT-5V'>
-			<roles>recon</roles>
-			<availability>MOC:4,CC:2,PIR:3,TC:4</availability>
-		</model>
-		<model name='LCT-1E'>
-			<roles>recon</roles>
-			<availability>IS:2,Periphery.Deep:4,Periphery:2</availability>
 		</model>
 		<model name='LCT-3S'>
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,MERC:6</availability>
 		</model>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:4,FWL:8,IS:4,MERC:6</availability>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:3,CC:3,TC:4</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-5M'>
 			<roles>recon</roles>
-			<availability>LA:5-,MERC:4</availability>
+			<availability>PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>FWL:2,WOB:3</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:2,PIR:3,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CDS:3,CW:5,CBS:5,CSV:5,CLAN:3,IS:3+,CFM:5,CJF:3,BAN:6,CWIE:6,CGB:3</availability>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:3,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:4,MERC.WD:2,CDS:2,CW:1,CNC:3,CB:1</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,FVC:4,FWL:7,IS:4</availability>
-		</model>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:5-</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>LA:2,FRR:2,FWL:2,FS:3,MERC:2</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:4-,OA:4-,General:4-,TC:4-,Periphery:4-</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,CS:3,LA:3,FS:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:4,LA:3,FWL:3,MH:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>WOB:2,FS:3</availability>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:5-</availability>
+		</model>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,FVC:4,FWL:7,IS:4</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:3,FWL:3,FS:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,CS:3,LA:3,FS:3,MERC:3,DC:3</availability>
+		<model name='LGB-13NAIS'>
+			<availability>WOB:2,FS:3</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>LA:2,FRR:2,FWL:2,FS:3,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -8789,32 +8789,32 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:4</availability>
-		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[Flamer] (WoB)' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(Magnetic) (WOB)' mechanized='true'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[David] (WoB)' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
+		<model name='[Flamer] (WoB)' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Magnetic) (WOB)' mechanized='true'>
-			<availability>WOB:4</availability>
+		<model name='[David] (WoB)' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -8828,14 +8828,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,TC:2,Periphery:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,FS:4,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>LA:2-,General:2-,Periphery.Deep:4,MERC:8-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:5-,FS:5-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,FS:4,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -8844,13 +8844,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:2-</availability>
@@ -8865,24 +8865,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,CLAN:1,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -8890,13 +8890,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,WOB:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='W1'>
 			<roles>missile_artillery,escort</roles>
@@ -8928,22 +8928,12 @@
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CFM:4,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4</availability>
@@ -8951,20 +8941,30 @@
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		<model name='F'>
+			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CIH:4,CDS:5,CW:4,LA:3,CNC:6,FS:3,CWIE:4,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -8990,23 +8990,23 @@
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FRR:2,NIOPS:5,WOB:5,WOB.PM:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(UCSV)'>
 			<roles>apc,urban</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>FWL:8,WOB:3</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(XL)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(C3)'>
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
@@ -9019,6 +9019,12 @@
 	</chassis>
 	<chassis name='Malak' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
+		<model name='C-MK-OE Eminus'>
+			<availability>General:5</availability>
+		</model>
+		<model name='C-MK-O Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C-MK-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
@@ -9027,12 +9033,6 @@
 		</model>
 		<model name='C-MK-OD Luminos'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-OE Eminus'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C-MK-O Invictus'>
-			<availability>General:8</availability>
 		</model>
 		<model name='C-MK-OC Comminus'>
 			<roles>spotter</roles>
@@ -9048,33 +9048,33 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:9,CSV:8,CLAN:4,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:5,CJF:9,CGB:4</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1,CFM:3</availability>
-		</model>
-		<model name='G'>
-			<availability>CIH:4,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CJF:2,CGB:4</availability>
+		<model name='G'>
+			<availability>CIH:4,General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CJF:2,CGB:4</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1,CFM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mandrill' unitType='Mek'>
@@ -9091,79 +9091,94 @@
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:5+,FS:5+</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:7,HL:7,FRR:9,IS:8,Periphery.Deep:8,WOB:8,MERC:8,FS:8,CIR:7,Periphery:8,TC:8,CS:8,OA:8,LA:8,FWL:7,NIOPS:8,DC:10</availability>
-		<model name='(LB-X)'>
-			<availability>LA:5,WOB:5,FS:5</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>FS:6,DC:7</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,LA:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,LA:3-,General:6-,Periphery.Deep:5,FS:3-,DC:3-,Periphery:6</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:3</availability>
+		<model name='(LB-X)'>
+			<availability>LA:5,WOB:5,FS:5</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>FS:3,DC:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,LA:8,FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,CS:2,LA:3,FRR:3,FWL:4,IS:3,WOB:2,FS:5,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>WOB:4,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>WOB:4,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:7,MERC.WD:6,CSR:5,CW:6,LA:2,CLAN:4,CNC:6,CJF:7,CWIE:6,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,CLAN:4,CJF:5,CGB:5</availability>
+		<model name='4'>
+			<availability>CNC:4,CGB:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CW:2,LA:8,CJF:3,CWIE:4,CGB:2</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:6,CLAN:3,CJF:5,CGB:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:5,CCC:3,CDS:2,CSR:2,CGS:3,CJF:3,CWIE:2,CGB:3,CB:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CNC:4,CGB:3</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,CLAN:4,CJF:5,CGB:5</availability>
 		</model>
 		<model name='8'>
 			<availability>CLAN:2,CJF:6,CGB:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:5,CCC:3,CDS:2,CSR:2,CGS:3,CJF:3,CWIE:2,CGB:3,CB:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:6,CLAN:3,CJF:5,CGB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:3,FRR:4,WOB:2,FS:5,MERC:5,TC:3,CS:3,MERC.WD:6,LA:4,PIR:3,CNC:3,FWL:4,MH:3,SL.2:4,DC:4</availability>
-		<model name='MAD-5A'>
-			<availability>MERC.WD:8</availability>
+		<model name='C'>
+			<availability>MERC.WD:3</availability>
+		</model>
+		<model name='MAD-5W'>
+			<availability>CC:4,CS:4,WOB:8</availability>
+		</model>
+		<model name='MAD-4H'>
+			<availability>PIR:8,MH:8,TC:8</availability>
 		</model>
 		<model name='MAD-6M'>
 			<availability>FWL:3,MERC:3</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='MAD-5A'>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:8,CNC:8,FWL:6,SL.2:8,FS:8,MERC:4,DC:8</availability>
@@ -9171,79 +9186,64 @@
 		<model name='MAD-4A'>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
-		</model>
-		<model name='MAD-5W'>
-			<availability>CC:4,CS:4,WOB:8</availability>
-		</model>
-		<model name='MAD-4K'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='MAD-4H'>
-			<availability>PIR:8,MH:8,TC:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:4,CGB:2</availability>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:4-,MH:3-,FS:4-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:5,LA:2,FRR:6,WOB:4,FS:6,MERC:4,DC:8</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:3,MERC:3</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:5,LA:2,FRR:6,WOB:4,FS:6,MERC:4,DC:8</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>CS:6,FWL:8,IS:3,WOB:7,MERC:4</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:3</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>CS:2-,HL:3-,IS:4-,Periphery.Deep:8,WOB:2-,Periphery:5-,TC:5-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:4,FRR:3,MERC:2</availability>
-		</model>
-		<model name='MAD-3L'>
-			<availability>CC:1</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:1,CGS:1,BAN:1,TC:2</availability>
-		</model>
-		<model name='MAD-1R'>
-			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-,MERC:0,BAN:1</availability>
+		<model name='MAD-7D'>
+			<availability>FS:3</availability>
 		</model>
 		<model name='MAD-5R'>
 			<availability>FS:4,MERC:2</availability>
 		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:4-,Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:3-,MH:4-,MERC:4-</availability>
+		<model name='MAD-9S'>
+			<availability>LA:4,FRR:3,MERC:2</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>CS:2-,HL:3-,IS:4-,Periphery.Deep:8,WOB:2-,Periphery:5-,TC:5-</availability>
+		</model>
+		<model name='MAD-3L'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>CS:6,FWL:8,IS:3,WOB:7,MERC:4</availability>
+		</model>
+		<model name='MAD-1R'>
+			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-,MERC:0,BAN:1</availability>
 		</model>
 		<model name='MAD-5L'>
 			<availability>CC:4,MOC:3,WOB:3,CIR:3,TC:2</availability>
 		</model>
+		<model name='MAD-6L'>
+			<availability>CC:3,MOC:3</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:4-,Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:3-,MH:4-,MERC:4-</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:1,CGS:1,BAN:1,TC:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:3</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FVC:4-,MH:3-,FS:4-</availability>
+		</model>
 		<model name='MAD-5S'>
 			<availability>FVC:4,LA:6,FRR:3,FS:5,MERC:4</availability>
 		</model>
-		<model name='MAD-7D'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='MAD-5T'>
-			<availability>FS:3</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>FWL:4,WOB:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -9259,14 +9259,14 @@
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CSA:3,CHH:4,CCC:3,CIH:4,CGS:3,CCO:3,CGB:3,CB:3</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
+		<model name='(XL)'>
+			<availability>CSA:3,CHH:4,CCC:3,CIH:4,CGS:3,CCO:3,CGB:3,CB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -9296,11 +9296,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:1,CLAN:2,IS:2+,CFM:8,MERC:2+,CGS:7,BAN:3,CWIE:2,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4,CFM:6</availability>
@@ -9308,8 +9305,14 @@
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
@@ -9317,40 +9320,37 @@
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:2,CSV:5,CLAN.IS:3,CJF:3</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>LA:3,FRR:5,MERC:4,FS:3,DC:7</availability>
+		<model name='MAL-3R'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='MAL-C'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='MAL-1K'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='MAL-1R'>
 			<availability>FRR:8,MERC:6,DC:3</availability>
 		</model>
 		<model name='MAL-2R'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MAL-C'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='MAL-3R'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='MAL-1K'>
-			<availability>DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:4,CLAN:2,MH:4,FS:2,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>TC:4</availability>
 		</model>
@@ -9358,17 +9358,17 @@
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(Intermediate)'>
-			<roles>apc</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:4</availability>
+		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:2</availability>
 		</model>
 		<model name='(Basic)'>
 			<roles>apc</roles>
@@ -9377,82 +9377,82 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,FRR:5,CLAN:3,IS:3,Periphery.Deep:5,WOB:4-,MERC:3,FS:2,CIR:3,Periphery:3,TC:3,CS:4-,OA:3,LA:5,FWL:4,NIOPS:4-,DC:4</availability>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:2-,Periphery:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>FRR:3,IS:2,MERC:3,DC:4</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:2-,Periphery:2</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>FRR:3,IS:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:5,FRR:5,FWL:5,IS:4,DC:5</availability>
-		</model>
-		<model name='(C3S)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>LA:1,FRR:1,IS:1,FS:1,DC:2</availability>
+			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:1,FRR:1,IS:1,FS:1,DC:2</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+			<availability>CC:5,FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CIH:1,CSR:1,WOB:1,CGS:1,CWIE:1,CB:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -9489,39 +9489,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -9533,33 +9530,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -9594,29 +9594,29 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7+,MOC:5+</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mercer' unitType='Dropship'>
@@ -9638,13 +9638,13 @@
 			<roles>recon</roles>
 			<availability>CS:4,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6</availability>
 		</model>
-		<model name='MCY-97'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='MCY-102'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='MCY-97'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
 		</model>
 		<model name='MCY-104'>
 			<roles>recon,spotter</roles>
@@ -9666,14 +9666,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>OA:6,FVC:3,MERC:3</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -9683,31 +9683,31 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Targeting Computer)'>
 			<roles>urban</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:3,CIH:3,CBS:4,CSV:4,CFM:3,CGS:6</availability>
-		<model name='4'>
-			<availability>CBS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:5,CHH:8,CCC:5,CGS:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CBS:3</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CIH:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:5,CHH:8,CCC:5,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -9739,13 +9739,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -9755,11 +9751,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -9822,11 +9822,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -9837,13 +9837,13 @@
 	</chassis>
 	<chassis name='Morningstar City Command Vehicle' unitType='Tank'>
 		<availability>CC:3,WOB:4,FS:5,MERC:4</availability>
-		<model name='(Laser)'>
-			<roles>urban</roles>
-			<availability>CC:2,WOB:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>urban,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>urban</roles>
+			<availability>CC:2,WOB:2,FS:2</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>urban,spotter</roles>
@@ -9876,7 +9876,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -9889,17 +9892,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -9931,23 +9931,23 @@
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(Armored Pocket Warship)'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='(2737)'>
 			<roles>cargo,civilian</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Armored Pocket Warship)'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>FS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
@@ -9962,6 +9962,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
@@ -9969,14 +9977,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
@@ -10010,11 +10010,11 @@
 	</chassis>
 	<chassis name='Nephilim Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:1</availability>
-		<model name='(Gauss)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Seeker) [MG]' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -10022,11 +10022,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10057,29 +10057,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:2,CGS:3,CJF:5,CB:3</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:2</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:7,CLAN:5,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:2</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CSA:7,CLAN:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -10109,18 +10109,18 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CHH:2,CW:2,CLAN:1,NIOPS:3,WOB:7,CWIE:2,CGB:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8,WOB:2</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>WOB:4</availability>
 		</model>
 		<model name='(Light PPC)'>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,WOB:2</availability>
+		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -10129,32 +10129,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,LA:8,WOB:3,FS:7,MERC:4,CIR:2</availability>
+		<model name='NGS-6T'>
+			<availability>LA:4,WOB:8,MERC:4,FS:4</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:6,General:8,Periphery.Deep:6,FS:6,MERC:6,Periphery:8</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>LA:4,WOB:8,MERC:4,FS:4</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:5</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,CS:3,LA:6,CLAN:1,NIOPS:3,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -10171,48 +10171,48 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:6,DC.SL:2,FRR:4,WOB:3,MERC:2,DC:5</availability>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>MERC:5,DC:5</availability>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:8,WOB:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>MERC:5,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:3,CNC:8,CFM:4,CB:6</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,CNC:4,CFM:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,CNC:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,CNC:4,CFM:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,CNC:4,CFM:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -10224,12 +10224,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CIH:4,CDS:6,CNC:9,CLAN:3,CWIE:4,CB:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -10237,20 +10231,26 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support,anti_infantry</roles>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support,anti_infantry</roles>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='O-66 &apos;Oppie&apos; Hazardous Materials Recovery Vehicle' unitType='Tank'>
@@ -10262,13 +10262,13 @@
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>CS:2,DC:3+</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -10316,33 +10316,33 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,TC:5,FVC:7,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:4,FWL:9,MH:5,DC:4</availability>
-		<model name='(Fusion)'>
-			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:6,MOC:5,IS:5,FWL:6</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:8,CNC:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,LA:3,FWL:3,FS:3,MERC:3</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<availability>CC:6,MOC:5,IS:5,FWL:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,General:5,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:8,CNC:8,IS:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:4,CGS:3,CCO:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4</availability>
@@ -10356,38 +10356,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:3,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
+		<model name='ON1-M'>
+			<availability>CS:6,MOC:6,Periphery.MW:5,PIR:5,Periphery.ME:5,FWL:8,IS:6,WOB:6,MH:5,DC:6</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>HL:3-,General:5-,CLAN:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>CS:6,MOC:6,Periphery.MW:5,PIR:5,Periphery.ME:5,FWL:8,IS:6,WOB:6,MH:5,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>FWL:4,WOB:4,MERC:3</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:3-,General:5-,CLAN:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:6</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -10401,75 +10401,75 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,LA:4,FS:6,MERC:4</availability>
-		<model name='OSR-3D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='OSR-4D'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='OSR-3D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Osteon' unitType='Mek' omni='Clan'>
 		<availability>SOC:5,CCO:3,CB:3</availability>
-		<model name='F'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
+		<model name='F'>
 			<availability>General:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='G'>
 			<roles>missile_artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
-		<model name='OSR-3C'>
-			<availability>FVC:2-,IS:2-,Periphery.Deep:4,MERC:3-,Periphery:3-</availability>
+		<model name='OSR-4L'>
+			<availability>CC:5,MOC:4</availability>
+		</model>
+		<model name='OSR-2L'>
+			<availability>IS:2-</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:3-,IS:4-,Periphery.Deep:8,MERC:5-,BAN:1,Periphery:5-</availability>
 		</model>
-		<model name='OSR-2Cb'>
-			<roles>urban</roles>
-			<availability>CLAN:4,IS:3,BAN:2</availability>
-		</model>
-		<model name='OSR-2L'>
-			<availability>IS:2-</availability>
-		</model>
 		<model name='OSR-2D'>
 			<availability>CS:8,HL:2,IS:4,Periphery:4</availability>
-		</model>
-		<model name='OSR-4C'>
-			<availability>CIR:8,TC:5</availability>
 		</model>
 		<model name='OSR-2M'>
 			<availability>FWL:3-</availability>
 		</model>
-		<model name='OSR-4L'>
-			<availability>CC:5,MOC:4</availability>
-		</model>
 		<model name='OSR-5W'>
 			<roles>urban</roles>
 			<availability>WOB:2</availability>
+		</model>
+		<model name='OSR-3C'>
+			<availability>FVC:2-,IS:2-,Periphery.Deep:4,MERC:3-,Periphery:3-</availability>
+		</model>
+		<model name='OSR-2Cb'>
+			<roles>urban</roles>
+			<availability>CLAN:4,IS:3,BAN:2</availability>
+		</model>
+		<model name='OSR-4C'>
+			<availability>CIR:8,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -10478,25 +10478,25 @@
 			<roles>recon,spotter</roles>
 			<availability>FVC:7,IS:8,DC:7</availability>
 		</model>
-		<model name='OTT-7J'>
-			<roles>recon</roles>
-			<availability>General:5,BAN:1</availability>
-		</model>
-		<model name='OTT-9S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,MERC:3</availability>
-		</model>
 		<model name='OTT-10CS'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:3</availability>
+		</model>
+		<model name='OTT-9CS'>
+			<roles>recon,spotter</roles>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='OTT-7J'>
+			<roles>recon</roles>
+			<availability>General:5,BAN:1</availability>
 		</model>
 		<model name='OTT-7Jb'>
 			<roles>recon</roles>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='OTT-9CS'>
+		<model name='OTT-9S'>
 			<roles>recon,spotter</roles>
-			<availability>CS:5,WOB:4</availability>
+			<availability>LA:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -10507,23 +10507,23 @@
 		<model name='OTL-8D'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='OTL-4D'>
-			<availability>HL:2-,IS:4-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4,MERC:2,DC:2</availability>
+		<model name='OTL-8M'>
+			<availability>FWL:4,WOB:3,MERC:3</availability>
 		</model>
 		<model name='OTL-5M'>
 			<availability>CS:4,FWL:6,WOB:6,MERC:4</availability>
 		</model>
-		<model name='OTL-8M'>
-			<availability>FWL:4,WOB:3,MERC:3</availability>
+		<model name='OTL-4F'>
+			<availability>FVC:2-,FS:2-</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4,MERC:2,DC:2</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:2-,IS:4-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
-		</model>
-		<model name='OTL-4F'>
-			<availability>FVC:2-,FS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -10534,13 +10534,13 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:5,CW:4,CFM:3</availability>
-		<model name='(3070)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(3070)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -10556,17 +10556,21 @@
 			<roles>mech_carrier</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:5,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:3+,CS:3+,CNC:3,FWL:3+,WOB:3+,FS:3+,MERC:3+,DC:4+</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2+,CLAN:6</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -10574,6 +10578,14 @@
 		<model name='OW-1C'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1'>
 			<roles>recon,spotter</roles>
@@ -10583,32 +10595,20 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2+,CLAN:6</availability>
-		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,MERC.KH:1,CDS:3,CIH:3,CSR:3,CSV:3,CNC:4,CLAN:3,CCO:3,CWIE:7</availability>
-		<model name='2'>
-			<availability>CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -10617,51 +10617,47 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5</availability>
-		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4</availability>
 		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
 		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:5,CS:4,NIOPS:4,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:9,WOB:4,MERC:5,FS:2,Periphery.OS:5,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:5,FWL:2,NIOPS:2,DC:10</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:3+,FRR:3+,CNC:8,FS.DMM:3+,MERC:3+,DC:3+</availability>
+			<availability>HL:3-,IS:5-,Periphery.Deep:8,MERC:5-,Periphery:5-,DC:5-</availability>
 		</model>
-		<model name='PNT-14S'>
+		<model name='PNT-C'>
 			<roles>fire_support</roles>
-			<availability>WOB:8</availability>
+			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
@@ -10675,13 +10671,17 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
+		<model name='PNT-CA'>
 			<roles>fire_support</roles>
-			<availability>HL:3-,IS:5-,Periphery.Deep:8,MERC:5-,Periphery:5-,DC:5-</availability>
+			<availability>FS.RR:3,FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-14S'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3+,FRR:3+,CNC:8,FS.DMM:3+,MERC:3+,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -10697,85 +10697,85 @@
 	</chassis>
 	<chassis name='Pariah (Septicemia)' unitType='Mek' omni='Clan'>
 		<availability>SOC:10,CCO:6,CB:5</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D-Z'>
-			<availability>SOC:7,General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='UW'>
+			<availability>General:4</availability>
 		</model>
 		<model name='US'>
 			<availability>General:2</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B-Z'>
-			<roles>spotter</roles>
+		<model name='C-Z'>
 			<availability>SOC:7,General:4</availability>
-		</model>
-		<model name='F'>
-			<roles>missile_artillery</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='A-Z'>
 			<roles>spotter</roles>
 			<availability>SOC:7,General:4</availability>
 		</model>
-		<model name='C-Z'>
+		<model name='D-Z'>
 			<availability>SOC:7,General:4</availability>
 		</model>
-		<model name='UW'>
-			<availability>General:4</availability>
+		<model name='B-Z'>
+			<roles>spotter</roles>
+			<availability>SOC:7,General:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='Z'>
 			<availability>SOC:3,General:1</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>missile_artillery</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,CS:6,HL:2,LA:7,FRR:4,CNC:4,IS:5,WOB:6,FS:8,DC:6,Periphery:3,CWIE:5</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>WOB:1,FS:2+</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:5</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:6,FS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>WOB:2,FS:2</availability>
 		</model>
-	</chassis>
-	<chassis name='Partisan Heavy Tank' unitType='Tank'>
-		<availability>MOC:7-,CC:4-,HL:6-,FRR:4-,IS:5-,Periphery.Deep:7-,WOB:6-,FS:6-,CIR:4-,Periphery:7-,TC:7-,CS:6-,OA:3-,CDS:4,LA:5-,FWL:5-,DC:4-</availability>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>WOB:1,FS:2+</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:4,FS:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Partisan Heavy Tank' unitType='Tank'>
+		<availability>MOC:7-,CC:4-,HL:6-,FRR:4-,IS:5-,Periphery.Deep:7-,WOB:6-,FS:6-,CIR:4-,Periphery:7-,TC:7-,CS:6-,OA:3-,CDS:4,LA:5-,FWL:5-,DC:4-</availability>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
@@ -10784,20 +10784,20 @@
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>FWL:3</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:4,FWL.RH:8</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:4,FWL.RH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -10818,9 +10818,17 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:2,CC:3,FRR:3,IS:3,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:2,TC:2,CWIE:3,CS:5-,OA:2,LA:6,FWL:3,DC:6</availability>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:3,WOB:3,FS:3,DC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
@@ -10834,14 +10842,6 @@
 			<roles>recon</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
@@ -10849,62 +10849,71 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:3</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:2,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:3</availability>
-		</model>
-		<model name='5'>
-			<availability>CGS:9</availability>
+		<model name='3'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:5</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1</availability>
 		</model>
+		<model name='5'>
+			<availability>CGS:9</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:3</availability>
+		</model>
 		<model name='4'>
 			<availability>CSR:8,CBS:7,CGS:6</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:1-,LA:3-,FRR:1-,FWL:1-,IS:1-,FS:3-,MERC:1-,DC:2-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>FWL:6+,WOB:5+</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2,WOB:6</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:3</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
@@ -10912,32 +10921,23 @@
 		<model name='P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2,WOB:6</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:5,WOB:4</availability>
+		<model name='(WoB-A)' mechanized='true'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(A)' mechanized='true'>
 			<availability>FWL:8</availability>
-		</model>
-		<model name='(WoB-C)' mechanized='true'>
-			<availability>WOB:4</availability>
 		</model>
 		<model name='(C)' mechanized='true'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='(WoB-A)' mechanized='true'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='(WoB-C)' mechanized='true'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='(B)' mechanized='true'>
 			<availability>FWL:1</availability>
@@ -10945,18 +10945,18 @@
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CIH:6,CSR:6,CW:8,CGS:8,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSA:7,CIH:6,General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,CIH:6,General:5,CCO:4,CGB:4</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>CSA:7,CIH:6,General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -10966,111 +10966,111 @@
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:5,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CIH:5,CSR:5,CDS:5,CBS:3,CSV:5,CLAN:3,CFM:5,CCO:5,CB:3</availability>
-		<model name='(Standard)'>
-			<availability>CCC:5,CSR:5,CIH:5,CDS:5,CSV:5,CLAN:4,CNC:5,CFM:5,CCO:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:4,CSV:6,CLAN:3</availability>
+		<model name='6'>
+			<availability>CDS:4,CGB:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:5,CLAN:3</availability>
 		</model>
-		<model name='6'>
-			<availability>CDS:4,CGB:4</availability>
+		<model name='4'>
+			<availability>CDS:4,CSV:6,CLAN:3</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:5,CSR:5,CIH:5,CDS:5,CSV:5,CLAN:4,CNC:5,CFM:5,CCO:5</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CSR:6,CDS:2,CSV:6,CNC:2,CFM:6,CCO:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CLAN:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='PHX-HK1'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>IS:2+</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:5,CLAN:1,IS:9,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:1</availability>
+		<model name='PXH-3PL'>
+			<availability>WOB:3,FS:4,MERC:3</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>LA:4,MERC:3</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:5,MOC:4,MH:4,WOB:4,CIR:3,TC:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FVC:3-,PIR:3-,FS:3-,MERC:3-</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:2,MOC:2</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:3,WOB:3,BAN:1</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:2-,DC:3-</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:8,MERC:6</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>DTA:8,FWL:8,IS:4</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='PXH-7CS'>
 			<availability>CS:4</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>WOB:3,FS:4,MERC:3</availability>
+		<model name='PXH-5L'>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>General:4-,BAN:6,Periphery:4-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>LA:4,MERC:3</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:2-,DC:3-</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,FWL:8,IS:4</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:3,FWL:2,WOB:3,CGS:5</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>FVC:3-,PIR:3-,FS:3-,MERC:3-</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:5,MOC:4,MH:4,WOB:4,CIR:3,TC:4</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:3,WOB:3,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -11078,47 +11078,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:4-,WOB:4-,FS:3-,MERC:4-,CIR:3-,CWIE:6,Periphery:3-,TC:4-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:3-,CNC:6,FWL:2-,MH:5-,DC:4-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:7,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>MOC:4,FS:6,TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:6,Periphery.Deep:6,Periphery:8</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>MOC:4,FS:6,TC:4</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,CS:4,MOC:3,MERC.WD:4,MERC.KH:4,CNC:6,CLAN:1,NIOPS:4,FS:2,MERC:4,TC:2</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -11126,11 +11126,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -11144,6 +11144,9 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:4,CIH:6,CDS:3,CSR:3,CBS:3,CLAN:2,CFM:3,CWIE:3</availability>
+		<model name='2'>
+			<availability>CIH:8</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -11153,9 +11156,6 @@
 		</model>
 		<model name='3'>
 			<availability>CIH:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -11170,12 +11170,12 @@
 		<model name='(Streak)'>
 			<availability>HL:2,IS:4,TC:5,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>HL:3,FWL:5,IS:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -11194,51 +11194,51 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:3,CCO:2,CWIE:1,CSA:1,CS:1,CDS:5,NIOPS:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8,CB:6</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CGB:3</availability>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -11255,16 +11255,16 @@
 	</chassis>
 	<chassis name='Preta' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:4,WOB:1+</availability>
-		<model name='C-PRT-OE Eminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-PRT-OD Luminos'>
+		<model name='C-PRT-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-PRT-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-PRT-OA Dominus'>
+		<model name='C-PRT-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-PRT-OC Comminus'>
@@ -11277,20 +11277,20 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:4,CBS:3,SOC:6,CCO:5</availability>
-		<model name='2'>
-			<availability>CHH:3,CCO:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CHH:8,CBS:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>SOC:8,CCO:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:8,CBS:8,CCO:8</availability>
+		<model name='4'>
+			<availability>CCO:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:3,CCO:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -11308,10 +11308,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:5,Periphery:8</availability>
@@ -11320,43 +11316,47 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
+		<model name='(Support)'>
+			<roles>apc</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8,General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,IS:2+,CFM:8,MERC:2+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:6,CDS:9,CW:9,CBS:7,CNC:9,CJF:6,CGB:7</availability>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CFM:6,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CGB:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CSV:6,CNC:7,General:8,CFM:6,CJF:7,CGB:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CFM:6,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CGB:3</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -11364,11 +11364,11 @@
 		<model name='PAT-005'>
 			<availability>CS:5,CHH:2,CW:2,FRR:8,NIOPS:8,WOB:8,CWIE:2</availability>
 		</model>
-		<model name='PAT-007'>
-			<availability>CS:7,WOB:6</availability>
-		</model>
 		<model name='PAT-008'>
 			<availability>WOB:5+</availability>
+		</model>
+		<model name='PAT-007'>
+			<availability>CS:7,WOB:6</availability>
 		</model>
 		<model name='PAT-005b'>
 			<availability>CLAN:8,BAN:2</availability>
@@ -11382,34 +11382,34 @@
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:5,WOB:5,Periphery:5</availability>
-		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CS:7,WOB:7,Periphery:7</availability>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Narc]' mechanized='true'>
 			<availability>CS:4,WOB:4,Periphery:4</availability>
 		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:5,WOB:5,Periphery:5</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CS:7,WOB:7,Periphery:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>CM:2-,Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>HL:2,CM:4,Periphery:4</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>HL:2,CM:6,Periphery:4</availability>
@@ -11420,17 +11420,17 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:6,MERC:6,DC:8</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:2,FWL:4</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>General:1-,MERC:3-,DC:3-,Periphery:3-</availability>
 		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:5,FVC:5,Periphery.CM:5,Periphery.ME:5,FWL:8,IS:5,MH:5,TC:5</availability>
+		</model>
 		<model name='QKD-8K'>
 			<availability>FRR:4,MERC:2,DC:6</availability>
-		</model>
-		<model name='QKD-C'>
-			<availability>FRR:7,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:4-,IS:4-,Periphery:4-,DC:4-,TC:4-</availability>
@@ -11438,11 +11438,11 @@
 		<model name='QKD-4H'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:5,FVC:5,Periphery.CM:5,Periphery.ME:5,FWL:8,IS:5,MH:5,TC:5</availability>
+		<model name='QKD-C'>
+			<availability>FRR:7,MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:2,FWL:4</availability>
+		<model name='QKD-5K'>
+			<availability>FRR:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -11454,40 +11454,37 @@
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:3,CCO:5-</availability>
-		<model name='(Standard)'>
-			<availability>CCC:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin II' unitType='Mek'>
 		<availability>WOB:6+</availability>
-		<model name='RJN-200-C'>
-			<availability>General:4+</availability>
-		</model>
 		<model name='RJN-200-B'>
 			<roles>recon,spotter</roles>
 			<availability>General:5+</availability>
@@ -11495,26 +11492,29 @@
 		<model name='RJN-200-A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='RJN-200-C'>
+			<availability>General:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
 		<availability>CS:5,WOB:1</availability>
-		<model name='RJN101-C'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RJN101-A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RJN101-C'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,FS:5,MERC:3</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
@@ -11523,20 +11523,20 @@
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:5,NIOPS:8,WOB:8</availability>
+		<model name='RPR-300'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:5,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:4-</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='RPR-300'>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -11552,37 +11552,53 @@
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3+,FS:3+,DC:6+</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:2+</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:3</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:2+</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:5,FS:3,MERC:5,TC:4,DC:2</availability>
+		<model name='RVN-4LC'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2,TC:2</availability>
+		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:3,FWL:2,FS:2,MERC:3,DC:3,TC:3</availability>
+		</model>
+		<model name='RVN-SS &apos;Shattered Raven&apos;'>
+			<roles>spotter</roles>
+			<availability>FS.CMM:3</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:7,TC:7</availability>
+		</model>
 		<model name='RVN-4X'>
 			<availability>CC:4</availability>
 		</model>
@@ -11593,33 +11609,17 @@
 		<model name='RVN-SR &apos;Shattered Raven&apos;'>
 			<availability>FS.CMM:3</availability>
 		</model>
-		<model name='RVN-4LC'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2,TC:2</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:3,FWL:2,FS:2,MERC:3,DC:3,TC:3</availability>
-		</model>
-		<model name='RVN-4L'>
-			<roles>spotter</roles>
-			<availability>CC:7,MOC:7,TC:7</availability>
-		</model>
-		<model name='RVN-SS &apos;Shattered Raven&apos;'>
-			<roles>spotter</roles>
-			<availability>FS.CMM:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>LA:6,FRR:4,MERC:4,FS:4</availability>
-		<model name='RZK-10T'>
-			<availability>LA:3</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -11631,11 +11631,6 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='RDS-2A'>
-			<roles>spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='RDS-2B'>
 			<roles>recon,spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
@@ -11645,15 +11640,20 @@
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:4</availability>
 		</model>
+		<model name='RDS-2A'>
+			<roles>spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -11661,6 +11661,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:5,CLAN:6,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
@@ -11669,27 +11677,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,FVC:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
-		<model name='F-700a'>
-			<availability>CC:7,FWL:7,WOB:7,FS:5,MERC:7</availability>
+		<model name='F-100'>
+			<availability>CC:4-,FVC:5-,HL:3-,LA:2,FRR:2,FWL:5-,Periphery.Deep:8,MERC:5-,DC:2,Periphery:5-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>FWL:4,WOB:5,MERC:4,DC:4</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>FRR:5-,DC:5-</availability>
@@ -11700,32 +11703,29 @@
 		<model name='F-700'>
 			<availability>CC:8,FWL:8,WOB:8,MERC:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>FWL:4,WOB:5,MERC:4,DC:4</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:4-,FVC:5-,HL:3-,LA:2,FRR:2,FWL:5-,Periphery.Deep:8,MERC:5-,DC:2,Periphery:5-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,FWL:7,WOB:7,FS:5,MERC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:2,CNC:5,IS:1,CGB:5</availability>
-		<model name='5'>
-			<availability>CSA:4,CDS:2,SOC:3,IS:2,CLAN.HW:3,CB:4</availability>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,CIH:4,CBS:3,CCO:3,CB:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4,CNC:5,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CDS:4,CLAN:3,CNC:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CSA:4,CDS:2,SOC:3,IS:2,CLAN.HW:3,CB:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,CIH:3,CDS:4,CBS:5,CCO:3,CB:6</availability>
 		</model>
 		<model name='6'>
 			<availability>CSA:4,CHH:2,CDS:2</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,CIH:4,CBS:3,CCO:3,CB:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4,CNC:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -11737,47 +11737,47 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:7,Periphery.Deep:5,WOB:5,CFM:6,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CB:6</availability>
-		<model name='RFL-6D'>
-			<availability>FS:3</availability>
+		<model name='RFL-5D'>
+			<availability>FVC:5,LA:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='RFL-7M'>
 			<availability>FRR:3,FWL:5,WOB:4,DC:3</availability>
-		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:2</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:1-,MERC:1-</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:5,LA:5,FS:5,MERC:5</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:3,MERC:2</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:1</availability>
-		</model>
-		<model name='RFL-8D'>
-			<availability>LA:3,FS:5</availability>
-		</model>
-		<model name='RFL-9T'>
-			<availability>TC:3</availability>
-		</model>
-		<model name='RFL-8X'>
-			<availability>MERC:3</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:3,MERC:2</availability>
 		</model>
 		<model name='RFL-5M'>
 			<availability>CC:5,MOC:5,IS:4,FWL:4,MERC:5,DC:5</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,BAN:2,DC:2</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='RFL-8X'>
+			<availability>MERC:3</availability>
+		</model>
+		<model name='RFL-6D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='RFL-8D'>
+			<availability>LA:3,FS:5</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-9T'>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -11803,45 +11803,45 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,CSR:1,FRR:5,CLAN:2,WOB:6,FS:5,CS:6,FVC:4,LA:5,NIOPS:6,CJF:1,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:3,CHH:4,CSR:7,CBS:7,SOC:8,CSV:4,CNC:7,CFM:5,CGS:6,CCO:8,CWIE:8</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:5,CSR:8,CBS:8,CSV:6,CNC:5,CFM:8,CCO:8,CGS:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:6,CBS:6,CSV:5,CNC:4,CFM:6,CCO:4,CWIE:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:4,CCO:3</availability>
@@ -11855,33 +11855,33 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
 		</model>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='RGU-133F'>
 			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:1</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>OA:3,LA:7,FRR:5,FS:5,MERC:3,CWIE:6,TC:6</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:5,TC:0,CWIE:0</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
@@ -11907,12 +11907,12 @@
 			<roles>recon</roles>
 			<availability>LA:8</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -11925,6 +11925,14 @@
 	</chassis>
 	<chassis name='Rusalka' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:5</availability>
+		<model name='S-RSL-OE Eminus'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-RSL-OD Luminos'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='S-RSL-OB Infernus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
@@ -11933,15 +11941,7 @@
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-RSL-OE Eminus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='S-RSL-OA Dominus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='S-RSL-OD Luminos'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
@@ -11952,23 +11952,23 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CSV:7,CLAN:8,WOB:3+,MERC:2+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CBS:9,CNC:6,CJF:9,DC:3+</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
+		<model name='F'>
+			<availability>General:2,CJF:5</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:2,CJF:5</availability>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:1</availability>
@@ -11976,8 +11976,8 @@
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:6,CNC:4,General:5,CFM:4,CCO:7,CJF:4,CWIE:6</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CWIE:5,CGB:6</availability>
@@ -12014,13 +12014,13 @@
 			<roles>sr_fire_support,spotter</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:4,Periphery:3</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:6,LA:7,FWL:6,IS:4,FS:7,DC:6,Periphery:5</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:4,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -12037,14 +12037,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:2,MOC:2,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:2,MERC:2,Periphery:3-,OA:2-,LA:2,FWL:2-,DC:4</availability>
-		<model name='SB-27'>
-			<availability>General:6-</availability>
+		<model name='SB-28'>
+			<availability>CS:6,LA:6,NIOPS:6,WOB:6,FS:4,MERC:4</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>MERC:4,DC:6</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>CS:6,LA:6,NIOPS:6,WOB:6,FS:4,MERC:4</availability>
+		<model name='SB-27'>
+			<availability>General:6-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:6,MOC:4,CLAN:4,FS:6,MERC:4</availability>
@@ -12052,17 +12052,11 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='E'>
-			<availability>CSR:5,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -12071,11 +12065,17 @@
 		<model name='D'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>CSR:3,General:1,CJF:3</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='E'>
+			<availability>CSR:5,CJF:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -12090,50 +12090,50 @@
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:4,CW:4,FRR:6,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
-		<model name='S-4X'>
-			<availability>DC:1</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8,DC:3</availability>
-		</model>
-		<model name='S-3'>
-			<availability>DC:3-</availability>
-		</model>
-		<model name='S-8'>
-			<availability>DC:2</availability>
 		</model>
 		<model name='S-4'>
 			<availability>FRR:6,FS:5,DC:6</availability>
 		</model>
+		<model name='S-8'>
+			<availability>DC:2</availability>
+		</model>
+		<model name='S-3'>
+			<availability>DC:3-</availability>
+		</model>
 		<model name='S-7'>
 			<availability>CNC:4,DC:4</availability>
+		</model>
+		<model name='S-4X'>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:5,DC:6</availability>
+		</model>
 		<model name='(LB-X)'>
 			<availability>IS:6,DC:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:8-,Periphery:8-</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:5,DC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3,CFM:6</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CSR:6,CW:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CSR:6,CW:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -12142,10 +12142,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:5,LA:7,FS:5,MERC:5</availability>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -12153,6 +12149,10 @@
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:3,FS:3</availability>
+		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
@@ -12169,21 +12169,21 @@
 			<roles>ground_support</roles>
 			<availability>OA:6,FRR:6-,DC:6</availability>
 		</model>
-		<model name='SL-27'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:5,CC:6-,Periphery.DD:7,HL:4,FRR:7-,IS:6-,WOB:4,Periphery.OS:7,FS:5-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:5,FWL.MM:8,CW:3,LA:5-,FWL:7-,DC:8-</availability>
-		<model name='(MRM)'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sasquatch' unitType='Mek'>
@@ -12204,14 +12204,6 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:3,CIH:7,CBS:4,CSV:3,CNC:2,CFM:3,CGS:6,CCO:7,CWIE:7</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='4'>
 			<roles>recon,raider,spotter</roles>
 			<availability>CIH:3,CSR:3,CNC:3</availability>
@@ -12220,26 +12212,34 @@
 			<roles>recon,raider</roles>
 			<availability>CIH:6,CGS:3,CWIE:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CW:5,SOC:7,CCO:7,CB:4</availability>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
 		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -12265,10 +12265,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:4,MERC:2</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -12276,6 +12272,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -12295,33 +12295,33 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>FRR:4,FWL:4,WOB:4,FS:4,MERC:4,MERC.NH:4,DC:4</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -12332,6 +12332,9 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:5,CC:3,HL:5,FRR:4,IS:5,Periphery.Deep:5,WOB:5,MERC:5,FS:5,CIR:6,Periphery:6,TC:5,CS:5,OA:6,LA:5,FWL:4,DC:3</availability>
+		<model name='(Armor)'>
+			<availability>CNC:4,IS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -12340,21 +12343,18 @@
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>CNC:4,IS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:6-,CC:6-,Periphery.DD:6-,HL:4-,FRR:7-,IS:5-,WOB:4-,MERC:5-,Periphery.OS:6-,FS:4-,CIR:5-,Periphery:5-,TC:6-,CS:4-,OA:6-,LA:5-,FWL:4-,DC:7-</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8-</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8-</availability>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>DC:6</availability>
@@ -12362,45 +12362,45 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:3</availability>
+		<model name='(MRM)'>
+			<availability>IS:4,DC:5,Periphery:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6-</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(LAC)'>
 			<availability>CC:3,LA:3,FWL:3,WOB:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ML)'>
-			<availability>General:3</availability>
-		</model>
-		<model name='(MRM)'>
-			<availability>IS:4,DC:5,Periphery:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2-,CS:2-,HL:2-,LA:3,FRR:2-,Periphery.Deep:4-,FWL:2-,NIOPS:2-,WOB:2-,MERC:2-,Periphery:3-,DC:2-</availability>
-		<model name='SCP-1N'>
-			<availability>HL:4-,FRR:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
-		</model>
-		<model name='SCP-12C'>
-			<availability>WOB:4</availability>
+		<model name='SCP-12S'>
+			<availability>LA:4,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>HL:4-,FRR:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,MERC:2</availability>
-		</model>
 		<model name='SCP-1TB'>
 			<availability>MERC:4</availability>
+		</model>
+		<model name='SCP-12C'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -12424,20 +12424,20 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CHH:3,CCC:4,CIH:3,CSR:4,CSV:4,CLAN:3,CFM:3,CGS:3,CCO:5,CWIE:5,CSA:3,CW:5,CNC:4,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<availability>General:4</availability>
@@ -12445,15 +12445,15 @@
 	</chassis>
 	<chassis name='Se&apos;irim Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Capture Team)' mechanized='true'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -12470,20 +12470,17 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,CS:3,HL:2,LA:6,FRR:3,IS:4,FWL:4,WOB:3,FS:5,CIR:3,Periphery:3,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:6,FWL:4,FS:8</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:5-,DC:2</availability>
 		</model>
@@ -12492,6 +12489,9 @@
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 		<model name='STN-5WB'>
 			<availability>WOB:8</availability>
@@ -12512,9 +12512,6 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-SRP-O Invictus'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C-SRP-O (Havalah)'>
 			<availability>General:8</availability>
 		</model>
@@ -12527,6 +12524,9 @@
 		<model name='C-SRP-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
+		<model name='C-SRP-O Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C-SRP-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
@@ -12537,19 +12537,23 @@
 			<roles>interceptor</roles>
 			<availability>HL:2-,LA:4-,Periphery.Deep:8,FS:3-,Periphery:4-</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
+		<model name='SYD-Z3A'>
+			<availability>LA:6,FRR:3,MERC:3</availability>
 		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>OA:5-,HL:6,FRR:5-,Periphery.Deep:6,FWL:5-,WOB:4-,Periphery:8,TC:5-,DC:5-</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:6,FRR:3,MERC:3</availability>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
 		</model>
 		<model name='SYD-Z4'>
 			<availability>OA:3,LA:5,FRR:2,MERC:4</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2-,FS:2-</availability>
 		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -12558,21 +12562,17 @@
 		<model name='SYD-Z2B'>
 			<availability>OA:3,LA:4</availability>
 		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2-,FS:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6+,MOC:4+</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -12584,14 +12584,14 @@
 		<model name='S-HA-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='S-HA-O Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='S-HA-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-HA-OB Infernus'>
 			<availability>General:7</availability>
-		</model>
-		<model name='S-HA-O Invictus'>
-			<availability>General:8</availability>
 		</model>
 		<model name='S-HA-OD Luminos'>
 			<availability>General:7</availability>
@@ -12599,16 +12599,12 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:4,CDS:5,CW:3,CBS:2,CSV:5,CNC:7,CFM:5,CLAN.IS:3,CJF:4,CWIE:3</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:2,CCO:7</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
 		<model name='J'>
 			<availability>General:4</availability>
@@ -12616,18 +12612,28 @@
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
+		<model name='A'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:3,CW:3,General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,FRR:2,CLAN:5,FS:2,MERC:2,CWIE:6,CS:2,CDS:6,LA:2,CNC:6,FWL:2,CJF:4,DC:2,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:4</availability>
+		<model name='6'>
+			<availability>CHH:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CS:4,CDS:4,LA:4,FRR:4,FWL:4,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:4,CCC:4,CIH:4,CGB:4,CB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5</availability>
@@ -12635,38 +12641,23 @@
 		<model name='3'>
 			<availability>CSA:4,CDS:5,CNC:5,CB:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CS:4,CDS:4,LA:4,FRR:4,FWL:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:3,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:3-,MERC:2-,DC:5-</availability>
-		</model>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,LA:6,FS:8</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:3,MOC:3,CLAN:4,FWL:3,MERC:3,BAN:2</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:2-,MOC:2-,FWL:2-,MERC:2-</availability>
 		</model>
-		<model name='SHD-2D'>
-			<availability>FVC:4-,FS:3-</availability>
-		</model>
-		<model name='SHD-11CS'>
-			<availability>CS:6,WOB:5</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:1,Periphery:5-</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:3,MOC:3,CLAN:4,FWL:3,MERC:3,BAN:2</availability>
-		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:8,IS:3,WOB:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:3,WOB:3,FS:4,MERC:3</availability>
+		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:3-,MERC:2-,DC:5-</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,CB:8,DC:4</availability>
@@ -12674,14 +12665,23 @@
 		<model name='SHD-7M'>
 			<availability>CC:3,MOC:3,FWL:4,TC:3</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>WOB:2,FS:3</availability>
+		<model name='SHD-2H'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:1,Periphery:5-</availability>
 		</model>
 		<model name='SHD-7CS'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='SHD-5D'>
-			<availability>LA:3,WOB:3,FS:4,MERC:3</availability>
+		<model name='SHD-9D'>
+			<availability>WOB:2,FS:3</availability>
+		</model>
+		<model name='SHD-11CS'>
+			<availability>CS:6,WOB:5</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,LA:6,FS:8</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FVC:4-,FS:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -12698,26 +12698,26 @@
 		<model name='(Capture Team)' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(PPC)' mechanized='false'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(PPC)' mechanized='false'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>OA:4,FRR:6,MERC:4,DC:6</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='SL-17AC'>
 			<availability>FRR:1-,DC:1-</availability>
@@ -12726,6 +12726,9 @@
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>FWL:4+,WOB:3+,FWL.KIS:6+,FWL.FWG:5+</availability>
 		<model name='SHV-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
@@ -12737,21 +12740,18 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,CNC:5,CJF:3,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:4,DC:4</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
+		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -12765,12 +12765,12 @@
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:7,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
-		<model name='SL-22'>
-			<availability>FRR:6,DC:6</availability>
-		</model>
 		<model name='SL-21L'>
 			<roles>raider,ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='SL-22'>
+			<availability>FRR:6,DC:6</availability>
 		</model>
 		<model name='SL-21'>
 			<availability>HL:5,LA:6,Periphery.Deep:7,MERC:7,DC:7,Periphery:7</availability>
@@ -12778,14 +12778,14 @@
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
 		<availability>CS:3,CLAN:1,NIOPS:3,WOB:3</availability>
-		<model name='ST-8A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ST-8C'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='ST-9C'>
 			<availability>CS:4,WOB:4</availability>
+		</model>
+		<model name='ST-8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shugenja' unitType='Mek'>
@@ -12813,29 +12813,29 @@
 	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CIH:6,CCO:4</availability>
+		<model name='5'>
+			<availability>CIH:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CIH:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:4,CCC:4,CIH:4,CCO:4</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:8,CCC:8,CIH:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4,CIH:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:4,CCC:4,CIH:4,CCO:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CIH:5</availability>
-		</model>
-		<model name='5'>
-			<availability>CIH:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>CC:3,FWL:5,WOB:4,MERC:3</availability>
-		<model name='SRC-5C'>
-			<availability>FWL:5,WOB:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>FWL:5,WOB:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>FWL:3,WOB:3</availability>
@@ -12843,13 +12843,13 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
@@ -12858,23 +12858,23 @@
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
+		<model name='SL-15'>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,FRR:8,FS:6,MERC:6,CDP:4,DC:8,TC:4</availability>
 		</model>
-		<model name='SL-15B'>
-			<availability>FRR:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>FRR:3,DC:3</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
+		<model name='SL-15B'>
+			<availability>FRR:1,MERC:1,DC:1</availability>
 		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
+		</model>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -12904,15 +12904,15 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6,CNC:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CIH:8,CNC:8</availability>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:8</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -12944,25 +12944,15 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>CS:6,WOB:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3,DC:2-</availability>
-		<model name='SPR-6D'>
-			<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
-		</model>
-		<model name='SPR-H5'>
-			<roles>interceptor</roles>
-			<availability>FVC:5-,General:4-,Periphery.Deep:8,FS:5-,MERC:5-,CDP:5-,DC:1,TC:5-</availability>
-		</model>
-		<model name='SPR-7D'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:2,FRR:4-,DC:4-</availability>
@@ -12970,6 +12960,16 @@
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
 			<availability>FS.CMM:1-</availability>
+		</model>
+		<model name='SPR-7D'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
+		<model name='SPR-6D'>
+			<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
+		</model>
+		<model name='SPR-H5'>
+			<roles>interceptor</roles>
+			<availability>FVC:5-,General:4-,Periphery.Deep:8,FS:5-,MERC:5-,CDP:5-,DC:1,TC:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -12995,25 +12995,35 @@
 		<model name='SPR-5S'>
 			<availability>CS:4,CC:4,LA:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,CS:4,LA:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8,CIR:8</availability>
 		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,CS:4,LA:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>FWL:8,MERC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:1-,Periphery:4-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:4-,DC:4-</availability>
 		</model>
-		<model name='SDR-7Kr'>
-			<availability>MERC:2,DC:2</availability>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:4-</availability>
 		</model>
 		<model name='SDR-7K'>
 			<availability>MERC:4,DC:4</availability>
@@ -13024,18 +13034,8 @@
 		<model name='SDR-7KC'>
 			<availability>MERC:4,DC:5</availability>
 		</model>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:4-</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>MERC:3,DC:4</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>FWL:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
@@ -13049,25 +13049,25 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:7,FRR:7,IS:6,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='(C3i)'>
-			<roles>recon</roles>
-			<availability>CS:5,WOB:6</availability>
-		</model>
-		<model name='(Laser)'>
-			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(C3i)'>
+			<roles>recon</roles>
+			<availability>CS:5,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -13081,32 +13081,32 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:8,CC:6,HL:9,FRR:6,CLAN:3,IS:7,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:9,CS:5,OA:9,LA:7,FWL:8,NIOPS:5,DC:6</availability>
-		<model name='STK-8S'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
-		</model>
 		<model name='STK-4P'>
 			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='STK-3F'>
-			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='STK-3Fb'>
-			<availability>CLAN:8,FWL:2,MERC:2,BAN:2</availability>
+		<model name='STK-8S'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='STK-3H'>
 			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
 		</model>
+		<model name='STK-6M'>
+			<availability>FWL:6,WOB:6,MERC:6</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='STK-4N'>
 			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
-		<model name='STK-6M'>
-			<availability>FWL:6,WOB:6,MERC:6</availability>
+		<model name='STK-3Fb'>
+			<availability>CLAN:8,FWL:2,MERC:2,BAN:2</availability>
+		</model>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
+		</model>
+		<model name='STK-3F'>
+			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,CSV:3,MERC:4,FS:5,CJF:3,TC:4</availability>
@@ -13114,12 +13114,12 @@
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -13150,6 +13150,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>CS:4,LA:5,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>LA:2,FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:2,FS:4,MERC:2</availability>
@@ -13158,17 +13162,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>LA:2,FS:6,MERC:4</availability>
+			<availability>LA:2,FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>LA:2,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
@@ -13187,43 +13187,39 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,CC:2,TC:2</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:3,MERC:3</availability>
 		</model>
-		<model name='STG-3Gb'>
+		<model name='STG-6L'>
 			<roles>recon</roles>
-			<availability>CLAN:8,FWL:3,WOB:4,BAN:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FVC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,CDP:4,DC:4,TC:4</availability>
+			<availability>CC:4,MOC:3</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
 		</model>
-		<model name='STG-6L'>
+		<model name='STG-3Gb'>
 			<roles>recon</roles>
-			<availability>CC:4,MOC:3</availability>
+			<availability>CLAN:8,FWL:3,WOB:4,BAN:2</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,CC:2,TC:2</availability>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -13233,9 +13229,22 @@
 			<roles>recon</roles>
 			<availability>CC:3,MOC:3,PIR:3,WOB:4,CIR:4,CDP:3,TC:4</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,FVC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,CDP:4,DC:4,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
+		<model name='F-94'>
+			<availability>IS:6</availability>
+		</model>
+		<model name='F-90'>
+			<availability>CS:4-,LA:3-,IS:4-,FS:4-,Periphery:4-</availability>
+		</model>
+		<model name='F-92'>
+			<availability>FWL:7,IS:4</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:6</availability>
@@ -13243,29 +13252,17 @@
 		<model name='F-95'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='F-94'>
-			<availability>IS:6</availability>
-		</model>
-		<model name='F-92'>
-			<availability>FWL:7,IS:4</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:4-,LA:3-,IS:4-,FS:4-,Periphery:4-</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -13273,11 +13270,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -13289,20 +13289,16 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4+,FWL:4+,FS:4+,MERC:4+,DC:7+</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:1+</availability>
-		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
@@ -13312,36 +13308,46 @@
 		<model name='SR1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:1+</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striga' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6</availability>
-		<model name='S-STR-OB Infernus'>
+		<model name='S-STR-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OE Eminus'>
+		<model name='S-STR-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OD Luminos'>
+		<model name='S-STR-OA Dominus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-STR-OE Eminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-STR-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:3,FRR:4,IS:5,WOB:3-,FS:8,MERC:3,CS:3-,FVC:7,CDS:3,LA:5,PIR:3,FWL:3,DC:3</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,FS:2,DC:1</availability>
 		</model>
@@ -13353,17 +13359,11 @@
 			<roles>fire_support</roles>
 			<availability>FVC:4-,IS:4-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>LA:3,FS.DMM:7,FS:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>FVC:4-,IS:4-</availability>
 		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
+		<model name='(Laser)'>
+			<availability>LA:3,FS.DMM:7,FS:3</availability>
 		</model>
 		<model name='(3053 Upgrade)'>
 			<availability>FVC:7,LA:6,FS:7,DC:5</availability>
@@ -13386,24 +13386,27 @@
 		<model name='STU-K5'>
 			<availability>FVC:5-,HL:3-,IS:5-,Periphery.Deep:8,BAN:8,Periphery:5-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,FS:2,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:3,LA:3,FS.DMM:4-</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:2,FS:1-,TC:2,Periphery:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,FS:2,BAN:2</availability>
+		</model>
+		<model name='STU-D7'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:2,FS:1-,TC:2,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,CDS:3,HL:3,LA:7,CNC:4,MERC:3,FS:5,CWIE:4</availability>
+		<model name='(Heavy Gauss)'>
+			<availability>LA:6,CNC:6,CWIE:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
@@ -13411,12 +13414,13 @@
 			<roles>fire_support</roles>
 			<availability>General:6,WOB:0</availability>
 		</model>
-		<model name='(Heavy Gauss)'>
-			<availability>LA:6,CNC:6,CWIE:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,WOB:4</availability>
+		<model name='(WOB)'>
+			<roles>recon,fire_support</roles>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
@@ -13424,10 +13428,6 @@
 		<model name='(Standard)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(WOB)'>
-			<roles>recon,fire_support</roles>
-			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Suffren Destroyer' unitType='Warship'>
@@ -13442,12 +13442,6 @@
 		<model name='E'>
 			<availability>CW:4,CLAN:2,CGB:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:6,General:2,CGB:6,CB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
 		</model>
@@ -13456,6 +13450,12 @@
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:6,General:2,CGB:7,CB:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:6,General:2,CGB:6,CB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
@@ -13466,8 +13466,12 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4+,LA:5+,FS:5+,MERC:3+,DC:7+</availability>
-		<model name='SD1-OX'>
-			<availability>General:2</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OE'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
@@ -13476,36 +13480,32 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:1+,CLAN:6,DC:2+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
+		<model name='SD1-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CDS:4,CW:5,CNC:9,CLAN:1,CGB:3,CWIE:5</availability>
-		<model name='2'>
-			<availability>CNC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CNC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -13535,15 +13535,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -13551,32 +13551,32 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CSR:3,CDS:2,CB:2</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>WOB:2,DC:4</availability>
+		<model name='TSH-8S'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -13590,51 +13590,51 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:5,CC:3,MERC:2</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(RL)'>
+		<model name='2'>
 			<availability>MOC:4</availability>
 		</model>
-		<model name='2'>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(RL)'>
 			<availability>MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>CS:3,MOC:3,CC:5,FVC:3,FWL:6,IS:3,WOB:4,MERC:4,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>CC:6,FVC:5,FWL:6,IS:6,MERC:6,DC:6</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,General:4,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>FVC:4,FWL:5,IS:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,General:4,FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>CC:6,FVC:5,FWL:6,IS:6,MERC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:4+,CNC:4,DC:5+</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
@@ -13649,56 +13649,56 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8,FWL:7,WOB:6,MERC:3</availability>
-		<model name='TMP-3M'>
-			<availability>FWL:6,WOB:6,MERC:6</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:4,WOB:4,MERC:4</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>FWL:5,WOB:5</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>FWL:6,WOB:6,MERC:6</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>FWL:5,WOB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:4+</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
+		<model name='TLR1-OF'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OF'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tengu Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:4</availability>
-		<model name='(Support)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Plasma)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Support)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(VSP)' mechanized='true'>
 			<availability>General:4</availability>
@@ -13713,24 +13713,24 @@
 			<roles>recon,spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='TSN-1Cr'>
-			<roles>recon,spotter</roles>
-			<availability>CS:4,DC:4</availability>
-		</model>
 		<model name='TSN-1C'>
 			<roles>recon,spotter</roles>
 			<availability>CS:8,WOB:8,SL.2:8</availability>
 		</model>
+		<model name='TSN-1Cr'>
+			<roles>recon,spotter</roles>
+			<availability>CS:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -13758,11 +13758,15 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:2+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CJF:8,CGB:5,CB:3</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,CIH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
@@ -13770,35 +13774,35 @@
 		<model name='D'>
 			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>raider</roles>
+			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
-		<model name='Prime'>
-			<roles>raider</roles>
-			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='HH'>
 			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,WOB:3,BAN:5</availability>
+		<model name='(Clan)'>
+			<roles>artillery</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='(C3i)'>
 			<roles>artillery</roles>
 			<availability>CS:4,WOB:8</availability>
@@ -13807,68 +13811,64 @@
 			<roles>artillery</roles>
 			<availability>CS:5,NIOPS:8,WOB:5</availability>
 		</model>
-		<model name='(Clan)'>
-			<roles>artillery</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>MOC:2,CLAN:1,WOB:7,CCO:1,Periphery:2,TC:2,CS:5,DC.GHO:2,CSA:2,OA:2,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+		<model name='THE-N1'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='THE-N'>
+			<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>HL:6,Periphery.Deep:6,DC:4-,Periphery:8</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:1-</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
-		</model>
 		<model name='THE-N2'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:2,CLAN:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:6-,FVC:5-,HL:4-,General:5-,FWL:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:3</availability>
 		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:6-,FVC:5-,HL:4-,General:5-,FWL:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
+		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:4,FRR:2,CSV:6,CLAN:5,IS:3,CFM:7,WOB:7,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,FVC:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
+		<model name='THG-12E'>
+			<availability>CS:6,WOB:3</availability>
+		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:4,OA:4,FRR:6,CLAN:6,IS:6,FWL:8,NIOPS:4,WOB:4,FS:8,BAN:8,DC:8</availability>
 		</model>
 		<model name='THG-11Eb'>
 			<availability>CLAN:4,FWL:4,WOB:4,MERC:4,BAN:2</availability>
 		</model>
-		<model name='THG-10E'>
-			<availability>FWL:5,MERC:5</availability>
-		</model>
-		<model name='THG-12E'>
-			<availability>CS:6,WOB:3</availability>
-		</model>
 		<model name='THG-13K'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='THG-10E'>
+			<availability>FWL:5,MERC:5</availability>
 		</model>
 		<model name='THG-12K'>
 			<availability>WOB:3,DC:4</availability>
@@ -13876,10 +13876,6 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>HL:3,IS:4,Periphery.Deep:8,Periphery:4</availability>
-		<model name='TAV-2'>
-			<roles>artillery</roles>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:4,WOB:6</availability>
@@ -13888,18 +13884,22 @@
 			<roles>artillery</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='TAV-2'>
+			<roles>artillery</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>CS:2,LA:8,CLAN:1,NIOPS:2,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:4</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4</availability>
@@ -13907,27 +13907,27 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5,CGS:3,CGB:2</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6,CGS:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,MERC:4,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
 		<model name='THR-1L'>
 			<availability>General:8</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
@@ -13938,13 +13938,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:5+</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:3</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -13953,60 +13953,60 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:6,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:6,MERC:6,Periphery:4,TC:4,CS:3-,LA:6,NIOPS:3-,MH:4,DC:6</availability>
-		<model name='TDR-1C'>
-			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:3,LA:3,MERC.ELH:8,MERC:3,FS:3</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,MERC:5,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:5,LA:8,FS:6,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,FWL:2,WOB:3,MERC:3,FS:2</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:5-,HL:3-,LA:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CS:6,CC:4,FWL:8,IS:3,WOB:6,MERC:4</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,CC:3,FWL:4,MH:3,WOB:3</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:5-,MERC:2-</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CCC:6,LA:2,CSV:6,CFM:6,FS:2,CGS:6,CB:6,DC:2</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>CLAN:2,TC:3</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
 		</model>
 		<model name='TDR-17S'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,MERC:5,FS:2</availability>
+		<model name='TDR-7SE'>
+			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,FWL:2,WOB:3,MERC:3,FS:2</availability>
+		</model>
+		<model name='TDR-9M'>
+			<availability>MOC:3,CC:3,FWL:4,MH:3,WOB:3</availability>
 		</model>
 		<model name='TDR-9NAIS'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>CC:5-,HL:3-,LA:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:3,LA:3,MERC.ELH:8,MERC:3,FS:3</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:5-,MERC:2-</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CLAN:2,TC:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CCC:6,LA:2,CSV:6,CFM:6,FS:2,CGS:6,CB:6,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:6,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -14034,15 +14034,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,FRR:6,CNC:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>FRR:6-,DC:6-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,CNC:8,DC:4</availability>
 		</model>
@@ -14050,18 +14041,23 @@
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>FRR:6-,DC:6-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>FRR:3-,DC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:4</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:2,NIOPS:2,WOB:2</availability>
-		</model>
-		<model name='CH'>
-			<availability>CLAN:3</availability>
+		<model name='THK-63CS'>
+			<availability>CS:8,WOB:6</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -14073,15 +14069,16 @@
 		<model name='THK-63b'>
 			<availability>CLAN:2,BAN:2</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>CS:8,WOB:6</availability>
+		<model name='CH'>
+			<availability>CLAN:3</availability>
+		</model>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:2,NIOPS:2,WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CW:1</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -14090,6 +14087,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -14101,25 +14101,18 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2,MH:1</availability>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
 		</model>
 		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G14' mechanized='true'>
-			<availability>WOB:3</availability>
-		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,WOB:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
-		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
 		</model>
 		<model name='G17' mechanized='true'>
 			<availability>WOB:3</availability>
@@ -14129,6 +14122,13 @@
 		</model>
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='G14' mechanized='true'>
+			<availability>WOB:3</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -14140,11 +14140,11 @@
 	</chassis>
 	<chassis name='Toyama' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='TYM-1C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='TYM-1A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TYM-1C'>
+			<availability>General:4</availability>
 		</model>
 		<model name='TYM-1B'>
 			<availability>General:6</availability>
@@ -14161,17 +14161,17 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:4-,FWL:4</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
 		<model name='TR-13'>
 			<availability>CC:5-,HL:3-,IS:4-,MERC:5-,Periphery:5-</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:4-,FWL:4</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>CC:7,MOC:5,MERC:5,TC:5</availability>
@@ -14179,12 +14179,12 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:4,Periphery.CM:3,Periphery.ME:3,FWL:3,TC:4</availability>
+		<model name='TR-12'>
+			<availability>CC:6</availability>
+		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:6</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>CC:6,MOC:6,General:6,TC:6</availability>
@@ -14192,81 +14192,78 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,CS:2-,MOC:6-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
-		</model>
-		<model name='TBT-7K'>
-			<roles>fire_support</roles>
-			<availability>DC:1</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>WOB:4</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:3-,IS:3-,Periphery.Deep:4,FWL:3-,MERC:3-,CDP:3,Periphery:3-,TC:3-</availability>
 		</model>
 		<model name='TBT-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='TBT-7K'>
+			<roles>fire_support</roles>
+			<availability>DC:1</availability>
+		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:3-</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:3-,IS:3-,Periphery.Deep:4,FWL:3-,MERC:3-,CDP:3,Periphery:3-,TC:3-</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,CS:2-,MOC:6-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
-		<model name='TRN-3V'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
 		</model>
+		<model name='TRN-3V'>
+			<availability>WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MOC:4,MH:2,TC:4</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:6,TC:6</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:4</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:4</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:6,TC:6</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:6,TC:6</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Triton' unitType='ProtoMek'>
 		<availability>CGS:4</availability>
-		<model name='3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
@@ -14277,16 +14274,19 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,HL:8,CBS:5,CLAN:2,IS:9,Periphery.Deep:8,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -14327,27 +14327,32 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CSR:2,SOC:4,CNC:4,CLAN.HW:4,CJF:7</availability>
-		<model name='Z'>
-			<roles>spotter</roles>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CFM:7,CJF:7,CGS:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CFM:7,CGS:7,CJF:7</availability>
@@ -14355,20 +14360,15 @@
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CFM:8,CJF:8,CCO:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CFM:7,CJF:7,CGS:7</availability>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		<model name='Z'>
+			<roles>spotter</roles>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -14377,13 +14377,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -14395,72 +14395,72 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,FRR:2,CGB:5,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>FRR:8,CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>FRR:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:2,CCO:3,CWIE:4,MERC.WD:4,CDS:3,CW:4,CBS:6,CNC:2,CJF:7,CGB:2</availability>
-		<model name='F'>
-			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2,CB:6</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2,CB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:4,CW:4,CGS:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6,CGS:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -14472,13 +14472,13 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:2,LA.SR:4</availability>
-		<model name='(3071)'>
-			<roles>troop_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(3071)'>
+			<roles>troop_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -14487,12 +14487,12 @@
 			<roles>mech_carrier</roles>
 			<availability>CS:8,LA:6,IS:6,WOB:8,FS:8</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>WOB:4</availability>
+		</model>
 		<model name='(2708)'>
 			<roles>mech_carrier</roles>
 			<availability>General:5,BAN:4</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -14508,42 +14508,38 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
-		<model name='UM-R69'>
-			<roles>urban</roles>
-			<availability>FWL:6,IS:4,Periphery:4</availability>
-		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:4,FS:4,DC:6</availability>
-		</model>
-		<model name='UM-R60L'>
-			<roles>urban</roles>
-			<availability>CC:4-,Periphery:3</availability>
-		</model>
-		<model name='UM-R60'>
-			<roles>urban</roles>
-			<availability>CC:5-,HL:3-,General:4-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='UM-R70'>
-			<roles>urban</roles>
-			<availability>FS.CMM:6,FS:4</availability>
-		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:8,CS:6,MOC:4,MERC:4,TC:4</availability>
-		</model>
 		<model name='UM-AIV'>
 			<roles>missile_artillery,urban</roles>
 			<deployedWith>missile artillery,fire support</deployedWith>
 			<availability>CC:3</availability>
 		</model>
+		<model name='UM-R60L'>
+			<roles>urban</roles>
+			<availability>CC:4-,Periphery:3</availability>
+		</model>
+		<model name='UM-R68'>
+			<roles>urban</roles>
+			<availability>CC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='UM-R70'>
+			<roles>urban</roles>
+			<availability>FS.CMM:6,FS:4</availability>
+		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>CC:5-,HL:3-,General:4-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:8,CS:6,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-R69'>
+			<roles>urban</roles>
+			<availability>FWL:6,IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CGB:6</availability>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -14552,6 +14548,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -14578,37 +14578,37 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:4,WOB:4,FS:9,MERC:4,CDP:2,TC:2</availability>
-		<model name='VLK-QF'>
+		<model name='VLK-QD3'>
 			<roles>recon,fire_support</roles>
-			<availability>LA:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:3</availability>
+			<availability>WOB:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='VLK-QW5'>
 			<roles>recon,fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VLK-QD'>
+		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
-			<availability>LA:8,FS:8,MERC:6</availability>
+			<availability>FVC:4-,LA:2-,FS:5-,MERC:5-,CDP:4-,TC:5-</availability>
+		</model>
+		<model name='VLK-QS5'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:3</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:2,FS:2</availability>
 		</model>
-		<model name='VLK-QA'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4-,LA:2-,FS:5-,MERC:5-,CDP:4-,TC:5-</availability>
+			<availability>LA:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='VLK-QD'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:2,WOB:2,FS:2,MERC:2,CDP:2,TC:2</availability>
-		</model>
-		<model name='VLK-QD3'>
-			<roles>recon,fire_support</roles>
-			<availability>WOB:2,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -14623,24 +14623,24 @@
 		<model name='D'>
 			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanquisher' unitType='Mek'>
@@ -14654,49 +14654,49 @@
 		<model name='VQR-7U'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='VQR-2B'>
+		<model name='VQR-7V'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='VQR-7V'>
+		<model name='VQR-2B'>
 			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:3</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Liao)'>
-			<availability>CC:6-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:6,MOC:7,FVC:6,Periphery.CM:7,PIR:6,MH:6,CDP:7,TC:7</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,DTA:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:2,FS:4</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:3-,General:3-</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:3-,General:5-</availability>
 		</model>
+		<model name='(Liao)'>
+			<availability>CC:6-</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,DTA:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:6,MOC:7,FVC:6,Periphery.CM:7,PIR:6,MH:6,CDP:7,TC:7</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:2,FS:4</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>asf_carrier</roles>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -14716,73 +14716,73 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:2,LA:2,ARDC:2,CWIE:2</availability>
-		<model name='VR5-R'>
-			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
+		<model name='VR5-R'>
+			<deployedWith>Wolfhound</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='VTR-9B'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:3,HL:2,FRR:8,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,IS:1,FS:1</availability>
+		</model>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:1</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:3,HL:2,FRR:8,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>FS:2,MERC:1</availability>
 		</model>
+		<model name='VTR-9D'>
+			<availability>CC:4,FVC:3,LA:4,FS:3,CDP:3</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 		<model name='VTR-9A1'>
 			<availability>CC:1,CS:1,FVC:1,IS:1,FS:1,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:2-,CIR:2-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,IS:1,FS:1</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
 		</model>
-		<model name='VTR-9D'>
-			<availability>CC:4,FVC:3,LA:4,FS:3,CDP:3</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='VTR-9S'>
+			<availability>LA:2-,CIR:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CS:6,FRR:6,WOB:4,CGB:4</availability>
-		<model name='VKG-2G'>
-			<availability>CS:5,FRR:6,CGB:6</availability>
-		</model>
 		<model name='VKG-3W'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='VKG-2F'>
-			<roles>fire_support</roles>
-			<availability>General:8,WOB:2</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
 			<availability>CS:4</availability>
+		</model>
+		<model name='VKG-2G'>
+			<availability>CS:5,FRR:6,CGB:6</availability>
+		</model>
+		<model name='VKG-2F'>
+			<roles>fire_support</roles>
+			<availability>General:8,WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -14801,23 +14801,23 @@
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>FRR:8,TC:3</availability>
 		</model>
-		<model name='VND-5L'>
-			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:5,MOC:4,TC:4</availability>
-		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:9,MOC:5,General:5,TC:5</availability>
 		</model>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
+		<model name='VND-4L'>
+			<availability>CC:5,MOC:4,TC:4</availability>
 		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-5L'>
+			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -14828,10 +14828,10 @@
 		<model name='2'>
 			<availability>CSV:6,CLAN:4</availability>
 		</model>
-		<model name='4'>
+		<model name='3'>
 			<availability>CSV:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CSV:8</availability>
 		</model>
 	</chassis>
@@ -14840,26 +14840,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:6,General:2,CJF:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:3,CGS:6,CJF:5</availability>
-		<model name='2'>
-			<availability>CLAN:3</availability>
+		<model name='5'>
+			<availability>CHH:4,CIH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4,CJF:6</availability>
@@ -14870,18 +14870,18 @@
 		<model name='3'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:4,CIH:6</availability>
+		<model name='2'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:3,DC:4+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CNC:8</availability>
@@ -14900,20 +14900,20 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:2,FRR:4,FWL:1,WOB:6,MERC:2,FS:3,DC:4</availability>
-		<model name='VNL-K100'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='VNL-K75N'>
-			<availability>LA:8,FRR:6,FWL:8,FS:8,DC:8</availability>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:4</availability>
 		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,FRR:6,FWL:8,FS:8,DC:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>FS:2</availability>
+		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:2,DC:2</availability>
-		</model>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -14921,34 +14921,34 @@
 		<model name='VLC-5N'>
 			<availability>General:3</availability>
 		</model>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:6,FRR:4,FWL:6,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:3-,General:5-,FS:3-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:4,PIR:2,IS:2,FS:5-,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VT-6C'>
+			<roles>anti_infantry</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='VT-6C'>
+		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
-			<availability>WOB:8</availability>
+			<availability>FVC:3-,General:5-,FS:3-</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -14960,29 +14960,29 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
+		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:5,CLAN:3,General:1,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:1</availability>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -15006,8 +15006,12 @@
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CDS:3,CLAN:2,IS:2</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:3,CDS:4,CLAN:3</availability>
 		</model>
 		<model name='6'>
 			<availability>CSR:4,CGB:4</availability>
@@ -15015,28 +15019,29 @@
 		<model name='4'>
 			<availability>CSA:5,CDS:6,CNC:5,CCO:5,CWIE:5,CGB:5,CB:5</availability>
 		</model>
-		<model name='3'>
-			<availability>CCC:3,CDS:4,CLAN:3</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CLAN:2,IS:2</availability>
+		<model name='5'>
+			<availability>CDS:3,CLAN:2,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
+		<model name='WHM-9D'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='WHM-6L'>
 			<availability>CC:2-</availability>
 		</model>
-		<model name='WHM-9S'>
-			<availability>LA:4,WOB:3,CIR:3,MERC:3</availability>
+		<model name='WHM-6K'>
+			<availability>FS.RR:1,FVC:1-,FS.DMM:1,FS:1,DC:2-</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>FWL:2,WOB:4</availability>
+		<model name='WHM-8K'>
+			<availability>DC:4</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:8</availability>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:8,FS:6,MERC:4</availability>
+		</model>
+		<model name='WHM-6D'>
+			<availability>FVC:2-,FS:2-</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:3,FVC:4,PIR:2,IS:3,FS:4,MERC:3,TC:3</availability>
@@ -15044,44 +15049,39 @@
 		<model name='WHM-6R'>
 			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='WHM-6K'>
-			<availability>FS.RR:1,FVC:1-,FS.DMM:1,FS:1,DC:2-</availability>
-		</model>
-		<model name='WHM-4L'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FVC:2-,FS:2-</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:6,CC:3,FVC:2,FRR:3,FWL:8,WOB:7,MERC:4,DC:3,Periphery:3</availability>
-		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:8,FS:6,MERC:4</availability>
-		</model>
-		<model name='WHM-9D'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='WHM-10T'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='C'>
-			<availability>LA:2+,FS:2+,DC:2+</availability>
+		<model name='WHM-8M'>
+			<availability>FWL:2,WOB:4</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2,TC:3</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CS:6,CC:3,FVC:2,FRR:3,FWL:8,WOB:7,MERC:4,DC:3,Periphery:3</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:4,WOB:3,CIR:3,MERC:3</availability>
+		</model>
+		<model name='WHM-4L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:2+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:4,FS:3</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -15089,119 +15089,122 @@
 		<model name='H-7'>
 			<availability>HL:3-,IS:5-,Periphery:5-</availability>
 		</model>
-		<model name='H-10'>
-			<roles>apc</roles>
-			<availability>LA:3,FWL:3</availability>
+		<model name='H-7A'>
+			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='H-8'>
 			<availability>HL:4,LA:6,FS.CH:8,FRR:6,Periphery.Deep:4,FS:8,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='H-7A'>
-			<availability>HL:2-,IS:4-,Periphery:4-</availability>
+		<model name='H-10'>
+			<roles>apc</roles>
+			<availability>LA:3,FWL:3</availability>
 		</model>
 		<model name='H-7C'>
 			<availability>IS:3-,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-110'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:2-,HL:5,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:2-,CIR:4,Periphery:6</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,CC:2,TC:2</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:4-</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,FRR:2,FS:2,MERC:2</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:2,DC:2</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:4-</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:5,LA:8,FS:6,MERC:4</availability>
 		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,CC:2,TC:2</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:4-</availability>
+		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='WSP-1L'>
+		<model name='WSP-1W'>
 			<roles>recon</roles>
-			<availability>CC:2</availability>
+			<availability>MERC.WD:4-</availability>
 		</model>
-		<model name='WSP-1D'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>FVC:2,FS:2</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-1'>
 			<roles>recon</roles>
 			<availability>CC:2-,MOC:2-,FWL:2-</availability>
 		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,FRR:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:2</availability>
+		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:3,PIR:3,WOB:3,TC:3</availability>
 		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FVC:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:7,FS:8,MERC:3,CDP:4,DC:3</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='White Flame' unitType='Mek'>
 		<availability>WOB.SD:6,WOB:4</availability>
-		<model name='WHF-3B'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='WHF-3C'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='WHF-3B'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='White Tip Submarine' unitType='Naval'>
@@ -15212,8 +15215,8 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,Periphery.DD:3,HL:3,MERC:3,Periphery.OS:3,Periphery:4,TC:3,CS:2-,OA:3,FVC:3,FS.CMM:4,NIOPS:2-,MH:3,DC:4</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:3</availability>
+		<model name='WTH-1H'>
+			<availability>PIR:5,MH:5</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -15226,20 +15229,20 @@
 			<roles>fire_support</roles>
 			<availability>CS:8,OA:6,MH:4,FS:4,CDP:6,DC:4,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>PIR:5,MH:5</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>DC:4</availability>
-		<model name='WGT-4NC &apos;Dezgra&apos;'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='WGT-4NC &apos;Dezgra&apos;'>
+			<availability>CNC:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>DC:8</availability>
@@ -15254,39 +15257,39 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>FRR:3,WOB:3,MERC:3,DC:5</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>WOB:6</availability>
-		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
 		<model name='WFT-C'>
 			<availability>FRR:4,DC:4</availability>
 		</model>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,MERC.WD:5,FVC:3,LA:7,FRR:5,MH:4,FS:4,CIR:4,MERC:4,CWIE:5</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:1,MERC.WD:1,LA:1,CWIE:1</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:2,MERC:2,CWIE:5</availability>
 		</model>
 		<model name='WLF-1'>
 			<availability>MERC.KH:4,MERC.WD:2,HL:6,LA:4,Periphery.Deep:6,FS:2,MERC:4,Periphery:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:2,MERC:2,CWIE:5</availability>
-		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:1,MERC.WD:1,LA:1,CWIE:1</availability>
+		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:2,MERC:6</availability>
 		</model>
 		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
@@ -15294,50 +15297,50 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='WVR-7M'>
+		<model name='WVR-7K'>
 			<roles>recon</roles>
-			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
+			<availability>FRR:8,MERC:6,DC:5</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:4,MERC:3</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:5,CNC:8,MERC:3,DC:5</availability>
-		</model>
-		<model name='WVR-7K'>
-			<roles>recon</roles>
-			<availability>FRR:8,MERC:6,DC:5</availability>
-		</model>
-		<model name='WVR-8D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:4-,MH:4</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>FRR:5,CNC:8,MERC:3,DC:5</availability>
+		</model>
 		<model name='WVR-9M'>
 			<availability>FWL:3</availability>
+		</model>
+		<model name='WVR-8C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:6,LA:6,WOB:4,FS:8</availability>
 		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:4-,MH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -15364,14 +15367,6 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:3,CIH:2,FRR:5,CLAN:2,IS:3,CFM:3,WOB:4-,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:4-,CS:4,FRR:8,NIOPS:4,WOB:4,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
-		</model>
-		<model name='WVE-10N'>
-			<roles>urban</roles>
-			<availability>CS:5,WOB:4</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:1,CGS:1</availability>
@@ -15380,9 +15375,17 @@
 			<roles>urban</roles>
 			<availability>CS:8,WOB:8</availability>
 		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:4-,CS:4,FRR:8,NIOPS:4,WOB:4,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
+		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
 			<availability>IS:3-,DC:3,Periphery:3-</availability>
+		</model>
+		<model name='WVE-10N'>
+			<roles>urban</roles>
+			<availability>CS:5,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -15394,11 +15397,11 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:4,LA:3,MERC:3,DC:2,TC:2</availability>
-		<model name='XNT-2O'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='XNT-4O'>
 			<availability>CC:4,MOC:4,LA:4</availability>
+		</model>
+		<model name='XNT-2O'>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -15410,30 +15413,30 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CIH:5,CSR:6,CLAN:5,CFM:6</availability>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CIH:3,CB:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CIH:3,CB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>CS:6,FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>CS:4,IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>CS:4,IS:3,FS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -15461,15 +15464,15 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zechetinu Corvette' unitType='Warship'>
@@ -15488,58 +15491,49 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:7,DC.GHO:2,FRR:5,CLAN:5,NIOPS:7,WOB:7,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
+		<model name='(C3i)'>
 			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,WOB:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>
-		</model>
 		<model name='ZRO-115'>
 			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='ZRO-114'>
+			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:3,MERC.KH:2,LA:3-</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X'>
 			<availability>LA:7</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>HL:5,FRR:4,IS:2,WOB:3,FS:6-,MERC:5,CDP:4,Periphery:4,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:4,LA:8,FRR:6,PIR:5,FS:3,MERC:5,CDP:5,TC:5</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>FVC:3-,LA:3-,FS:3-</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,WOB:8</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,FS:4,MERC:4</availability>
@@ -15547,17 +15541,26 @@
 		<model name='ZEU-6S'>
 			<availability>HL:5,General:3-,Periphery.Deep:5,Periphery:7</availability>
 		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:4,LA:8,FRR:6,PIR:5,FS:3,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,WOB:8</availability>
+		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,DC:4</availability>
-		<model name='(LB-X)'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='(WoB)'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -15565,11 +15568,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CW:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -1181,50 +1181,50 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,CS:8,MOC:6,LA:8,FRR:8,FWL:8,IS:6,WOB:8,FS:8,TC:6,Periphery:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>HL:3,General:5,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,CS:8,MOC:6,LA:8,FRR:8,FWL:8,IS:6,WOB:8,FS:8,TC:6,Periphery:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:4,FWL:4,WOB:4,RCM:4</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
-		<model name='(WoB) [TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:5,WOB:5</availability>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='(WoB) [David]' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(WoB) [TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:5,WOB:5</availability>
 		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
-		<model name='(WoB) [David]' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1240,13 +1240,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CCC:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:2,CJF:5</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aerie PA(L)' unitType='BattleArmor'>
@@ -1269,11 +1269,11 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CSL:5,CJF:5</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
@@ -1291,17 +1291,17 @@
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
 		<availability>CS:7,CLAN:1,FWL:2,NIOPS:7,WOB:7,DC:2</availability>
-		<model name='AHB-643'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='AHB-443b'>
-			<availability>CLAN:1,WOB:4</availability>
-		</model>
 		<model name='AHB-MD'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='AHB-643'>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='AHB-443b'>
+			<availability>CLAN:1,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Zero-G Engineering Exoskeleton' unitType='BattleArmor'>
@@ -1313,6 +1313,16 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
@@ -1320,48 +1330,38 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>CNC:4,WOB:4,DC:6</availability>
 		<model name='AKU-1X'>
 			<availability>WOB:6,DC:5</availability>
 		</model>
-		<model name='AKU-2XC'>
+		<model name='AKU-2X'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='AKU-1XJ'>
 			<availability>CNC:5,WOB:4,DC:5</availability>
 		</model>
-		<model name='AKU-2X'>
+		<model name='AKU-2XC'>
 			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:3,CS:7,CDS:4,LA:6,CNC:4,NIOPS:7,WOB:7,FS:5,MERC:3,CWIE:6,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>DTA:5,FWL:4,WOB:3,FWL.KIS:7,MERC:2</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,FWL:6,WOB:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
 		<model name='ALB-3Ur'>
 			<availability>FWL:3,WOB:3,MERC:3</availability>
@@ -1369,11 +1369,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CGB:4</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:2</availability>
@@ -1381,12 +1381,12 @@
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CSA:6,CHH:6,CSR:4,CBS:6,CLAN:2,CGS:4</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,CGB:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,CGB:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1397,23 +1397,23 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:3,MERC.WD:8,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
-		<model name='C 2'>
-			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
+		<model name='ANH-4A'>
+			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,MERC:2,CWIE:5</availability>
+		</model>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5,CHH:3,LA:4,MERC:4,CWIE:3</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:2-</availability>
 		</model>
-		<model name='ANH-4A'>
-			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,MERC:2,CWIE:5</availability>
+		<model name='C'>
+			<availability>CLAN:8,IS:2,BAN:3</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,IS:2,BAN:3</availability>
-		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5,CHH:3,LA:4,MERC:4,CWIE:3</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1432,11 +1432,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:4,MOC:6,PIR:3,TC:3</availability>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
+		</model>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
@@ -1445,34 +1445,30 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:2,DTA:6,FWL:5,WOB:2,MERC:3</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,FWL:6,WOB:6</availability>
+		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-5M'>
-			<availability>DTA:5,FWL:6,WOB:6</availability>
+		<model name='ANV-3R'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='ANV-5Q'>
+			<availability>DTA:4,FWL:4,WOB:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:4,WOB:4,MERC:5</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-5Q'>
-			<availability>DTA:4,FWL:4,WOB:4</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:4,WOB:4,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,LA:2,FWL:8,MH:2,MERC:4,FS:2,DC:6</availability>
 		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1484,9 +1480,17 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
 		<availability>FWL:4,WOB:4</availability>
+		<model name='W1'>
+			<roles>missile_artillery,escort</roles>
+			<availability>WOB:6</availability>
+		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6</availability>
@@ -1494,10 +1498,6 @@
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='W1'>
-			<roles>missile_artillery,escort</roles>
-			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
@@ -1530,11 +1530,21 @@
 	</chassis>
 	<chassis name='Archangel' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
+		<model name='C-ANG-OE Eminus'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C-ANG-OD Luminos'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-ANG-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OS Caelestis'>
 			<availability>General:4</availability>
+		</model>
+		<model name='C-ANG-OA Dominus'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OC Comminus'>
 			<availability>General:7</availability>
@@ -1542,51 +1552,9 @@
 		<model name='C-ANG-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-ANG-OE Eminus'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OB Infernus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:4-,Periphery.Deep:5,WOB:2-,FS:4-,Periphery:4,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,BAN:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:4,MERC:4</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:2-</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FRR:3,MERC:3</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,WOB:4</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:2-</availability>
-		</model>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:3,TC:4,Periphery:3</availability>
-		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>CNC:4,DC:4</availability>
@@ -1595,83 +1563,115 @@
 			<roles>fire_support</roles>
 			<availability>LA:4,FWL:3,WOB:4,MERC:3,DC:3</availability>
 		</model>
-		<model name='C'>
+		<model name='ARC-6W'>
 			<roles>fire_support</roles>
-			<availability>CSA:6,CCC:6,CW:2,LA:3+,CSV:6,FS:3+,CGS:6,CWIE:2,DC:3+</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:6,FS:2</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6,CWIE:2</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:8,MERC:4,DC:2</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:2-,LA:3-,FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
-		</model>
-		<model name='ARC-4M'>
-			<roles>fire_support</roles>
-			<availability>CS:6,CC:5,FVC:3,LA:2,PIR:4,FWL:6,WOB:6,MERC:5,FS:2,DC:5</availability>
+			<availability>FVC:3,TC:4,Periphery:3</availability>
 		</model>
 		<model name='ARC-2K'>
 			<roles>fire_support</roles>
 			<availability>FRR:2-,DC:4-</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:6,FS:2</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:2-</availability>
+		</model>
+		<model name='ARC-4M'>
+			<roles>fire_support</roles>
+			<availability>CS:6,CC:5,FVC:3,LA:2,PIR:4,FWL:6,WOB:6,MERC:5,FS:2,DC:5</availability>
+		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,MOC:3,DTA:5,FRR:3,PIR:3,FWL:4,WOB:3,MERC:3,DC:2</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:2-,LA:3-,FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:4,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:2-</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,MERC:4,DC:2</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6,CWIE:2</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:4,MERC:4</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,WOB:4</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FRR:3,MERC:3</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CCC:6,CW:2,LA:3+,CSV:6,FS:3+,CGS:6,CWIE:2,DC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>CNC:4,CWIE:6,CGB:3</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2,MERC.WD:2,CWIE:4</availability>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
 		<model name='J'>
 			<availability>General:8</availability>
@@ -1679,11 +1679,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Attack Craft' unitType='Small Craft'>
@@ -1695,11 +1695,11 @@
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CW:8,CLAN:6,CCO:7,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CW:5,CJF:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CW:5,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
@@ -1707,35 +1707,19 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='AGS-4D'>
-			<availability>General:5</availability>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='AGS-5D'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
+		<model name='AGS-4D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1743,33 +1727,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1789,15 +1789,15 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
-		<model name='ASN-23'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:3,PIR:2,MH:4,MERC:4,FS:4,RCM:4,CDP:6,TC:6</availability>
-		</model>
 		<model name='ASN-30'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
 		<model name='ASN-21'>
 			<availability>General:1-</availability>
+		</model>
+		<model name='ASN-23'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:3,PIR:2,MH:4,MERC:4,FS:4,RCM:4,CDP:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1816,17 +1816,20 @@
 	</chassis>
 	<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CBS:4,CLAN:8</availability>
-		<model name='(Proto AC)'>
-			<roles>recon</roles>
-			<availability>CBS:3,CSL:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(Proto AC)'>
+			<roles>recon</roles>
+			<availability>CBS:3,CSL:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Asura Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:7</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>WOB:4</availability>
 		</model>
@@ -1834,76 +1837,89 @@
 			<roles>anti_infantry</roles>
 			<availability>WOB:5</availability>
 		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CSR:5,CDS:5,CW:5,CSV:5,CSL:8,CGS:5,CJF:3,CCO:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:3,CLAN:1,WOB:3</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:2,FRR:6,CLAN:4,IS:2,WOB:4-,FS:4,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:2,NIOPS:4-,DC:9</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:3,MERC:3</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CC:2,MOC:3,CS:3,OA:3,FRR:5,CNC:5,FWL:2,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:5,MERC:2</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>FS:3</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1-,MERC:0,DC:1-</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:2,FS:4,DC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
+		<model name='AS8-D'>
+			<availability>FS:3</availability>
 		</model>
 		<model name='AS7-D'>
 			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:5,MERC:2</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:3,MERC:2</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:3,MERC:3</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:3,MERC:2</availability>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
+		<model name='AS7-C'>
+			<availability>FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>CC:2,MOC:3,CS:3,OA:3,FRR:5,CNC:5,FWL:2,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -1913,25 +1929,9 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1946,59 +1946,59 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CS:6,CNC:3,IS:4,DC:6</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OR'>
-			<availability>General:2+,CLAN:6,DC:2+</availability>
-		</model>
 		<model name='AV1-OE'>
 			<availability>General:6</availability>
 		</model>
+		<model name='AV1-OR'>
+			<availability>General:2+,CLAN:6,DC:2+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -2014,17 +2014,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-8R'>
-			<availability>IS:1-,FWL:2-</availability>
-		</model>
-		<model name='AWS-10KM'>
-			<availability>DTA:4,FWL:4,WOB:4,DC:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2-,CIR:4</availability>
 		</model>
-		<model name='AWS-8Q'>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='AWS-9Ma'>
+			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:4,PIR:4,FWL:6,IS:5,MH:4,TC:4,Periphery:2</availability>
@@ -2032,17 +2026,23 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:4,HL:2,FWL:6,IS:4,MH:4,TC:4,Periphery:4</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
+		<model name='AWS-10KM'>
+			<availability>DTA:4,FWL:4,WOB:4,DC:4</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>IS:1-,FWL:2-</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>FRR:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>FRR:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -2056,83 +2056,79 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:3,FRR:2,FS:2,MERC:1</availability>
-		<model name='AXM-3S'>
-			<availability>LA:5,FS:4,MERC:4</availability>
-		</model>
 		<model name='AXM-4D'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:4,FS:5</availability>
+		</model>
+		<model name='AXM-1N'>
+			<availability>FVC:6,LA:6,FRR:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>FVC:1,LA:3,FS:1</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:6,LA:6,FRR:6,MERC:6,FS:6</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:4,FS:5</availability>
+		<model name='AXM-3S'>
+			<availability>LA:5,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CSR:5,CSV:6,CJF:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:5,CSV:8</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>CSR:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>CSR:6</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:5,CSV:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:2,MERC.WD:2,CW:2,CSL:2</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:3</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -2144,56 +2140,72 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:3+</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:3,FWL:3,WOB:3,FS:3,MERC:8</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:4</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1,CSL:3</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2201,33 +2213,21 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank'>
@@ -2235,14 +2235,6 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
@@ -2254,14 +2246,6 @@
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>apc</roles>
@@ -2271,57 +2255,73 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='I'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:7-,CC:2-,HL:8-,FRR:3-,IS:2-,Periphery.Deep:9-,FS:2-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,OA:7-,FVC:3-,LA:5-,FWL:3-,MH:7-,DC:2-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:6-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:3</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6,WOB:9</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>HL:2-,General:2-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:5,FRR:3,MH:2,FS:6,MERC:5</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:6-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6,WOB:9</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>OA:2-,LA:3-,IS:1-,FS:1-,MERC:2-,CIR:3,CDP:2,TC:2-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:5,FRR:3,MH:2,FS:6,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>HL:2-,General:2-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,FRR:4,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:7</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BGS-2T'>
 			<availability>LA:5,MERC:5</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2330,40 +2330,40 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:7,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:6,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,CSV:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>CSR:3,General:1</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:6,CNC:3,CLAN:2</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6,CSV:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2374,11 +2374,8 @@
 		<model name='H'>
 			<availability>CSA:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2386,12 +2383,19 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:5</availability>
+		<model name='BTL-C-2OC'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='BTL-C-2OE'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
@@ -2400,9 +2404,12 @@
 			<roles>ew_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='BTL-C-2OC'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='BTL-C-2OF'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='BTL-C-2OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='BTL-C-2OB'>
 			<roles>fire_support</roles>
@@ -2410,13 +2417,6 @@
 		</model>
 		<model name='BTL-C-2O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='BTL-C-2OF'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='BTL-C-2OD'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2439,11 +2439,11 @@
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
 		<availability>LA:3-,FS:5,MERC:3-</availability>
-		<model name='BKX-7K'>
-			<availability>FS:4-,MERC:5-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='BKX-7K'>
+			<availability>FS:4-,MERC:5-</availability>
 		</model>
 		<model name='BKX-1X'>
 			<availability>LA:8-,FS:4-</availability>
@@ -2451,32 +2451,27 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1,WOB:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,WOB:5,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1,WOB:1</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:4-</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:5,FRR:3,WOB:5,MERC:4,CJF:2</availability>
+		<model name='C'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>CS:1,DC.GHO:1,WOB:1</availability>
 		</model>
-		<model name='BLR-1S'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='BLR-10S'>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
+		<model name='BLR-4S'>
+			<availability>LA:5,FRR:3,WOB:5,MERC:4,CJF:2</availability>
+		</model>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-1S'>
+			<availability>LA:2-</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,WOB:5,BAN:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:4,FS:2</availability>
@@ -2484,32 +2479,37 @@
 		<model name='BLR-1G'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:4-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:6,FVC:5,PIR:5,FWL:5,IS:2,WOB:7,MH:5,MERC:6</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:5,FS:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>DTA:4,FWL:3,WOB:4,MERC:3</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:4-</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1,WOB:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1,WOB:1</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:5,FWL:4,WOB:3</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>FRR:4,WOB:3,DC:4</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:6,FVC:5,PIR:5,FWL:5,IS:2,WOB:7,MH:5,MERC:6</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2521,12 +2521,12 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CHH:6,SOC:6,CSV:8,CGS:6,CCO:4,CWIE:4,CSA:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CGB:6,DC:2+</availability>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8,CGS:7</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CGS:8,CJF:6</availability>
@@ -2534,24 +2534,16 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>CSA:7,CCC:7,CSV:5,General:6,CGS:3</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>CS:5,NIOPS:5,WOB:8</availability>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -2559,25 +2551,36 @@
 		<model name='(Sealed)'>
 			<availability>CS:8,WOB:4</availability>
 		</model>
+		<model name='(C3i)'>
+			<roles>spotter</roles>
+			<availability>WOB:7</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,CSR:4,CLAN:1,CGS:5</availability>
-		<model name='6'>
+		<model name='4'>
 			<availability>General:1</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
+			<availability>General:1</availability>
+		</model>
+		<model name='6'>
 			<availability>General:1</availability>
 		</model>
 		<model name='2'>
@@ -2586,27 +2589,24 @@
 		<model name='3'>
 			<availability>CHH:7</availability>
 		</model>
-		<model name='5'>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSR:4,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:5,Periphery:4,CS:4-,OA:4,CDS:5,LA:4,PIR:3,CNC:3,FWL:2,DC:5</availability>
-		<model name='(Kurita)'>
-			<availability>CLAN:5,IS:5,DC:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>FVC:3,CDS:3,General:8,DC:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:1</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>FVC:3,CDS:3,General:8,DC:4</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:5,IS:5,DC:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2627,13 +2627,13 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CS:6,FRR:6,CNC:4,CGB:4</availability>
-		<model name='BEO-12'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='BEO-14'>
 			<roles>recon</roles>
 			<availability>CS:4</availability>
+		</model>
+		<model name='BEO-12'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='BEO-X-7a'>
 			<roles>recon,spotter</roles>
@@ -2642,14 +2642,14 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:7,FRR:3,FS:3,MERC:2</availability>
-		<model name='BRZ-A3'>
-			<availability>LA:5,FRR:8,FS:8,MERC:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>LA:5,MERC:5</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:3</availability>
+		<model name='BRZ-A3'>
+			<availability>LA:5,FRR:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2657,63 +2657,69 @@
 		<model name='BSN-3K'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BSN-4K'>
-			<roles>spotter</roles>
+		<model name='BSN-5KC'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='BSN-5KC'>
+		<model name='BSN-4K'>
+			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:4,CSR:3,CW:2,CLAN:1,IS:3+,CGS:2,CCO:2,CJF:3,BAN:4,CWIE:4,CGB:3</availability>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:6,FRR:6,FS:4,MERC:4,DC:7</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>DC:1</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
@@ -2723,14 +2729,8 @@
 		<model name='BHKU-OR'>
 			<availability>General:2+,DC:2+</availability>
 		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2741,8 +2741,14 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:5,FRR:4,CLAN:6,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:7,LA:3,CNC:7,RCM:5,CJF:5,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>DTA:6,CS:6,LA:4,CLAN:5,FWL:6,NIOPS:6,MERC:4,FS:4,CGS:6,BAN:2,DC:4</availability>
+		<model name='BL-12-KNT'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:2-,TC:2-</availability>
+		</model>
+		<model name='BL-7-KNT'>
+			<availability>:0,LA:4-,FRR:4-,FWL:1-,MERC:4-,FS:4-,CIR:6,DC:4-</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>CS:8,WOB:8</availability>
@@ -2750,44 +2756,38 @@
 		<model name='BL-6-KNT'>
 			<availability>FRR:6,CLAN:6,WOB:4,BAN:6,TC:4,Periphery:4,DC.GHO:4,CS:4,OA:4,FWL:6,NIOPS:4,MERC.SI:3,DC:6</availability>
 		</model>
-		<model name='BL-7-KNT'>
-			<availability>:0,LA:4-,FRR:4-,FWL:1-,MERC:4-,FS:4-,CIR:6,DC:4-</availability>
-		</model>
-		<model name='BL-12-KNT'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:2-,TC:2-</availability>
+		<model name='BL-6b-KNT'>
+			<availability>DTA:6,CS:6,LA:4,CLAN:5,FWL:6,NIOPS:6,MERC:4,FS:4,CGS:6,BAN:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CSV:4,CJF:7,CCO:4</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>CJF:2</availability>
+		<model name='E'>
+			<availability>CLAN:6,CCO:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:6,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='X'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -2803,76 +2803,73 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>MERC:3,MERC.NH:5</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:4-,MOC:4,OA:4,FVC:6,HL:3,IS:1,FS:6,MERC:4,TC:4,Periphery:4</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:6,MERC:5</availability>
+		</model>
 		<model name='BJ-1'>
 			<availability>General:2-,Periphery.Deep:8,Periphery:3</availability>
-		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:2,CS:4,FVC:5,LA:4,PIR:3,WOB:4,FS:5,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:6,MERC:5</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,CS:3,MOC:4,FVC:3,FWL:5,IS:3,WOB:5,FS:5,MERC:3,DC:6</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:2+,DC:2+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
+		<model name='BJ2-OX'>
+			<availability>General:1</availability>
 		</model>
-		<model name='BJ2-OU'>
-			<availability>General:2</availability>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:1</availability>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:2+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
+		</model>
+		<model name='BJ2-OU'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>LA:6,FWL:3</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,WOB:5,MERC:5,TC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>CC:4,General:3,WOB:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -2880,20 +2877,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>CC:4,General:3,WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CBS:4,CSL:5</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>CSA:7,General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -2905,17 +2905,17 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CBS:10</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CBS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -2929,11 +2929,11 @@
 	</chassis>
 	<chassis name='Blue Flame' unitType='Mek'>
 		<availability>WOB.SD:5,WOB:3</availability>
-		<model name='BLF-21'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLF-40'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLF-21'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -2951,16 +2951,16 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank' unitType='Tank' omni='IS'>
 		<availability>WOB:4</availability>
-		<model name='Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='Dominus'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Comminus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='Infernus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2974,6 +2974,10 @@
 			<roles>fire_support</roles>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:2-</availability>
 		</model>
+		<model name='BMB-14K'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
 		<model name='BMB-14C'>
 			<roles>fire_support</roles>
 			<availability>CS:6,WOB:6</availability>
@@ -2981,10 +2985,6 @@
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>OA:8</availability>
-		</model>
-		<model name='BMB-14K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -2996,19 +2996,19 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:1,CGS:2</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
+			<availability>CHH:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
@@ -3021,12 +3021,6 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2,CIR:2,TC:3</availability>
-		<model name='LDT-X3'>
-			<availability>PIR:3</availability>
-		</model>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-5'>
 			<availability>PIR:6</availability>
 		</model>
@@ -3035,6 +3029,12 @@
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X3'>
+			<availability>PIR:3</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -3048,17 +3048,17 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(PPC)'>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:3,MOC:2</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3095,25 +3095,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,FWL:1-,DC:3-</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:4,General:8,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:4,General:8,FS:4,MERC:4,DC:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3149,17 +3149,17 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,FS:5,MERC:3</availability>
-		<model name='BSW-S2r'>
-			<availability>General:2</availability>
-		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:2</availability>
+		</model>
+		<model name='BSW-X2'>
+			<availability>LA:4,General:2,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BSW-X2'>
-			<availability>LA:4,General:2,MERC:4</availability>
+		<model name='BSW-S2r'>
+			<availability>General:2</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>General:2,MERC:5</availability>
@@ -3167,17 +3167,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>CS:4,FVC:6,LA:4,FS:6,MERC:4</availability>
-		<model name='CES-4R'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>CS:8,FVC:8,FS:5,MERC:5</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3193,22 +3193,22 @@
 	</chassis>
 	<chassis name='Canis' unitType='Mek'>
 		<availability>CDS:3,CCO:6,CJF:3</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CSR:3,CDS:3,CW:1,CSV:1,CNC:5,CCO:1,CGS:1,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3220,123 +3220,123 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:2,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
-		<model name='CTF-2X'>
-			<availability>CC:2-,MOC:2,FVC:2,MERC:1,TC:2</availability>
+		<model name='CTF-3LL'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:5,LA:4,FS:5</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4</availability>
+		<model name='CTF-1X'>
+			<availability>General:4-,Periphery:5-</availability>
 		</model>
 		<model name='CTF-4L'>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>General:4-,Periphery:5-</availability>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:2-,MOC:2,FVC:2,MERC:1,TC:2</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,FRR:5,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,RCM:2,DC:6</availability>
-		<model name='CPLT-C4C'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:1-,DC:2-</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
-			<roles>fire_support</roles>
-			<availability>WOB:4,DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CDP:1-,TC:1-</availability>
 		</model>
-		<model name='CPLT-K5'>
+		<model name='CPLT-C5A'>
 			<roles>fire_support</roles>
-			<availability>FRR:6,DC:8</availability>
+			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
 		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:4,CS:3,MOC:3,FWL:2,WOB:3,MERC:2,FS:4,CDP:3,TC:3,DC:4</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:1-,DC:2-</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:1-</availability>
 		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:2,MERC:2,TC:2</availability>
 		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
+		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:3,FVC:2,CLAN:6,IS:1,MERC:2,Periphery:1,DC:3</availability>
 		</model>
-		<model name='CPLT-C5A'>
+		<model name='CPLT-K5'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
+			<availability>FRR:6,DC:8</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-H2'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,MERC:2,RCM:2</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4C'>
 			<roles>fire_support</roles>
-			<availability>CC:1-</availability>
+			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>WOB:4,DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:4,CS:3,MOC:3,FWL:2,WOB:3,MERC:2,FS:4,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CW:2,CLAN:2,CNC:5,CGS:6,CJF:2,CGB:2,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='X'>
-			<availability>CHH:2,CW:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<availability>CHH:2,CW:2</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:2</availability>
@@ -3344,49 +3344,49 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,IS:2,FS:6,MERC:3</availability>
-		<model name='(SRM)'>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:2,CBS:5+</availability>
-		<model name='4'>
-			<availability>CBS:4</availability>
+		<model name='(Standard)'>
+			<availability>CSR:8,CBS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CSR:6,CBS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSR:8,CBS:8</availability>
+		<model name='4'>
+			<availability>CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -3398,11 +3398,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:5,CBS:4,SOC:4,CSV:4,CNC:6,CSL:5,CJF:7</availability>
-		<model name='3'>
-			<availability>CSR:6,CBS:6,CSV:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,SOC:5,CNC:8,CSL:5,CJF:5</availability>
+		</model>
+		<model name='3'>
+			<availability>CSR:6,CBS:6,CSV:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:5</availability>
@@ -3410,30 +3410,24 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='Commando'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='Commando'>
-			<availability>LA:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:3-,Periphery.HR:3-,FS:3-,MERC:3-,Periphery.OS:3-,Periphery:3</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8,WOB:8</availability>
@@ -3441,32 +3435,23 @@
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>LA:3-,Periphery.HR:3-,FS:3-,MERC:3-,Periphery.OS:3-,Periphery:3</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:1,IS:1,WOB:2-,Periphery.OS:4,FS:8,MERC:2,CDP:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:4,DC:1</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='CN9-A'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:3-,Periphery.Deep:8,FS:2-,MERC:2-,Periphery:3-</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:4,MERC:6,CIR:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-AH'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,FS:2-,MERC:2-</availability>
+		<model name='CN10-B'>
+			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
 		</model>
 		<model name='CN9-H'>
 			<availability>MH:6</availability>
@@ -3474,17 +3459,32 @@
 		<model name='CN9-D4D'>
 			<availability>DTA:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:2</availability>
+		<model name='CN9-A'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:3-,Periphery.Deep:8,FS:2-,MERC:2-,Periphery:3-</availability>
 		</model>
 		<model name='CN9-D3'>
 			<availability>FVC:2,FS:3,MERC:3</availability>
 		</model>
-		<model name='CN10-B'>
-			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
+		<model name='CN9-D'>
+			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:4,MERC:6,CIR:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:2-,FS:2-,MERC:2-</availability>
 		</model>
 		<model name='CN9-Da'>
 			<availability>FVC:1,FWL:1,FS:1,MERC:1,Periphery:1</availability>
+		</model>
+		<model name='CN9-AH'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:2-,FS:2-,MERC:2-</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -3495,11 +3495,11 @@
 		<model name='MR-V2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-6B'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3522,11 +3522,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3538,18 +3538,18 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='XII'>
+			<availability>LA:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='X'>
+			<availability>General:8</availability>
+		</model>
 		<model name='XIVs'>
 			<availability>LA:2,FS:2,DC:2</availability>
-		</model>
-		<model name='XII'>
-			<availability>LA:5,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -3557,6 +3557,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -3566,70 +3570,62 @@
 			<roles>training</roles>
 			<availability>General:2-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CHH:2,FRR:4,IS:3,WOB:5,FS:3,MERC:2,DC.GHO:5,CS:5,DTA:2,FVC:2,LA:4,FWL:3,NIOPS:5,RCM:2,CGB:2,DC:4</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		</model>
 		<model name='CHP-3P'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='CHP-2N'>
-			<availability>IS:2-,NIOPS:0</availability>
-		</model>
-		<model name='CHP-3N'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:2,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2,CHH:2,WOB:4,FS:2,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:2,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:2-,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:2,MERC:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CS:4,FRR:3+,IS:3+,NIOPS:4,WOB:6,MERC:2+,BAN:4,Periphery:2+</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>General:4,WOB:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4,WOB:4</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>missile_artillery</roles>
+			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:3-,MOC:2-,OA:2-,FVC:2,LA:3-,FRR:4-,FWL:1-,MERC:2-,TC:2-,Periphery:2,DC:4-</availability>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:3,MERC:4,DC:4</availability>
-		</model>
 		<model name='CGR-3K'>
 			<availability>CC:2-,FRR:3-,MERC:3-,DC:3-</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:2,MERC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FVC:4-,OA:4-</availability>
@@ -3638,49 +3634,53 @@
 			<roles>recon</roles>
 			<availability>CC:1-,MOC:1-,OA:1-,LA:1-,FRR:1-,FWL:1-,DC:1-,Periphery:1-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:3,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:2,MERC:4</availability>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:3,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1L'>
 			<availability>CC:3-,FVC:4,HL:2,Periphery:4</availability>
 		</model>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:3,MERC:4,DC:4</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,OA:4,FVC:2,LA:2-,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,RCM:10,DC:2-</availability>
-		<model name='F-13'>
-			<availability>DTA:4,FWL:4</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:2-,WOB:2-</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:4-,DTA:2-,HL:2-,General:2-,Periphery.Deep:8,FWL:4-,MERC:4-,RCM:2-,Periphery:4-</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,DTA:2,FWL:2,MERC:2,RCM:2</availability>
 		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2-,FVC:1,FWL:2-,MERC:2-,Periphery:1</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:4-,DTA:2-,HL:2-,General:2-,Periphery.Deep:8,FWL:4-,MERC:4-,RCM:2-,Periphery:4-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>CC:2,MOC:2,DTA:8,FRR:6,Periphery.MW:2,PIR:2,FWL:8,WOB:8,MERC:6,RCM:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:2-,WOB:2-</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>DTA:8,FWL:8,MH:2,MERC:2,RCM:8</availability>
 		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2-,FVC:1,FWL:2-,MERC:2-,Periphery:1</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:2,MOC:2,DTA:8,FRR:6,Periphery.MW:2,PIR:2,FWL:8,WOB:8,MERC:6,RCM:8</availability>
+		</model>
+		<model name='F-13'>
+			<availability>DTA:4,FWL:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,CDS:2,LA:1,CNC:2,NIOPS:5,WOB:5,FS:1,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -3688,13 +3688,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:4</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:3,LA:3,WOB:4,FS:3,RCM:3,DC:3</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3705,63 +3705,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>DTA:4,FVC:4,LA:6,FWL:4,WOB:4,MH:3,FS:3,MERC:5,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:2-,LA:3-,IS:2-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:4,FS:2-,CDP:4,TC:4,Periphery:2-</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:4,FS:2-,CDP:4,TC:4,Periphery:2-</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:2-,LA:3-,IS:2-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CSA:4,CSR:7,CBS:7,CNC:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,LA:2,IS:2,FWL:6,WOB:4-,FS:1,MERC:3,DC:4</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:5,IS:4,WOB:5</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>FWL:6,WOB:6</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -3788,20 +3788,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -3818,23 +3818,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -3842,14 +3842,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -3866,32 +3866,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3899,11 +3899,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3912,14 +3912,14 @@
 			<roles>marine</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>CDS:8,CW:4,CNC:8,CGB:4,CWIE:8</availability>
+		<model name='(Volk)' mechanized='true'>
+			<availability>CW:6</availability>
 		</model>
 		<model name='(Rache)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Volk)' mechanized='true'>
-			<availability>CW:6</availability>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>CDS:8,CW:4,CNC:8,CGB:4,CWIE:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -3927,20 +3927,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3963,20 +3963,23 @@
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>CSR:3,CDS:2,CW:5,CBS:2,CLAN:2,CNC:5,CJF:2,CGB:5</availability>
-		<model name='2'>
-			<availability>CSR:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,FRR:1,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,FWL:1,NIOPS:1-,MH:2,RCM:2,DC:2</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:1,FS:1</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:6,LA:3,General:6</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6</availability>
@@ -3985,14 +3988,11 @@
 			<roles>spotter</roles>
 			<availability>LA:8,General:4,MERC:8</availability>
 		</model>
+		<model name='CLNT-2-4T'>
+			<availability>CC:1,FS:1</availability>
+		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:8,MOC:3,TC:6</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -4050,13 +4050,29 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>MOC:3+,FVC:3,LA:8,FRR:6,MH:3+,FS:2,MERC:5,CDP:3+,TC:3+</availability>
+			<availability>LA:2-,MERC:1-,Periphery:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
 		</model>
 		<model name='COM-4H'>
 			<roles>recon</roles>
 			<availability>PIR:8,MH:10</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,WOB:8,MERC:5</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>MOC:3+,FVC:3,LA:8,FRR:6,MH:3+,FS:2,MERC:5,CDP:3+,TC:3+</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>WOB:10</availability>
 		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
@@ -4066,61 +4082,45 @@
 			<roles>recon</roles>
 			<availability>HL:2,LA:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>WOB:10</availability>
-		</model>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
-		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:2-,MERC:1-,Periphery:1</availability>
-		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:2-,LA:2-,General:4-,Periphery.Deep:8,TC:4-,Periphery:4-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:7,WOB:8,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:5-,FVC:4-,General:3-,FS:5-,Periphery:3-</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:3-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
 		</model>
 		<model name='(Upgrade) (Standard)'>
 			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,IS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:5-,FVC:4-,General:3-,FS:5-,Periphery:3-</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:6-</availability>
 		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,WOB:4,CIR:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:5,IS:2,DC:6</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Confederate C' unitType='Dropship'>
@@ -4132,13 +4132,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -4161,12 +4161,12 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:4</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
@@ -4195,50 +4195,50 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='CRX-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-OR'>
 			<availability>OA:2,CLAN:8</availability>
+		</model>
+		<model name='CRX-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:5,CCC:4,CSV:4,CLAN.IS:2,CSL:4,CCO:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>CSA:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:5,FWL:1,DC:2</availability>
+		<model name='CSR-V12'>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
+		</model>
 		<model name='CSR-V14'>
 			<availability>FVC:6,LA:6,FRR:6,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,FS:3,BAN:2</availability>
 		</model>
-		<model name='CSR-V20'>
-			<availability>LA:1,FS.AH:2-,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
-		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:2</availability>
+		</model>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:1,FS.AH:2-,Periphery:1</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FVC:5,FS:5</availability>
@@ -4265,11 +4265,11 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -4277,16 +4277,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CW:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -4294,8 +4293,9 @@
 		<model name='H'>
 			<availability>CSA:6,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -4313,35 +4313,35 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CS:7,FRR:5,CLAN:4,WOB:7,CGS:6,BAN:2,DC:5</availability>
+			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
+		<model name='CRB-30'>
+			<availability>CS:8,FRR:3,WOB:6</availability>
+		</model>
 		<model name='CRB-45'>
 			<availability>WOB:5</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CS:7,FRR:5,CLAN:4,WOB:7,CGS:6,BAN:2,DC:5</availability>
 		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
-		</model>
-		<model name='CRB-30'>
-			<availability>CS:8,FRR:3,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
 		<availability>CDS:4,CBS:4,CJF:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN.IS:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN.IS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:4,CBS:8</availability>
@@ -4349,21 +4349,21 @@
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:4,CDS:3,CBS:6</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
@@ -4371,23 +4371,23 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,WOB:8,CIR:4,CGS:5,CWIE:7,DC.GHO:3,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
-		<model name='CRK-5004-1'>
-			<availability>CS:6,FRR:4</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:8,FRR:4</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>WOB:8,CIR:6</availability>
+		<model name='CRK-5003-1'>
+			<availability>CS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
+		</model>
+		<model name='CRK-5004-1'>
+			<availability>CS:6,FRR:4</availability>
 		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:4-,NIOPS:0</availability>
 		</model>
-		<model name='CRK-5003-1'>
-			<availability>CS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-3'>
-			<availability>CS:8,FRR:4</availability>
+		<model name='CRK-5005-1'>
+			<availability>WOB:8,CIR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -4410,33 +4410,37 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CSR:5,CDS:4,CW:4,CBS:5,CSV:8,CLAN:3,CNC:4,CCO:3,CJF:4,CWIE:4,CGB:4</availability>
-		<model name='A'>
-			<availability>General:5</availability>
+		<model name='U'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='U'>
-			<availability>CLAN:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>MERC:2,DC:3</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>MERC:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>DC:5</availability>
@@ -4445,13 +4449,30 @@
 			<roles>recon,spotter</roles>
 			<availability>IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:7,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
+		<model name='CRD-7W'>
+			<availability>DTA:5,FWL:4,WOB:4,MERC:4,RCM:5</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='CRD-3D'>
+			<availability>FVC:2-,FS:2-</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:1-,DC:2-</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:6,FS:2,MERC:4</availability>
+		</model>
+		<model name='CRD-7L'>
+			<availability>CC:6,WOB:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='CRD-8S'>
 			<availability>LA:5,FS:4</availability>
 		</model>
@@ -4459,44 +4480,23 @@
 			<roles>raider</roles>
 			<availability>CC:2-</availability>
 		</model>
-		<model name='CRD-7L'>
-			<availability>CC:6,WOB:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>HL:2-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:4,CS:4,FWL:8,IS:2,WOB:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:1-,DC:2-</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,FWL:4,WOB:4,MERC:4,RCM:5</availability>
-		</model>
-		<model name='CRD-4K'>
-			<availability>LA:2,FRR:8,MERC:2,FS:2,DC:6</availability>
 		</model>
 		<model name='CRD-4BR'>
 			<availability>MERC:5</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:6,FS:2,MERC:4</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:5,WOB:4,MERC:5,DC:6</availability>
+		<model name='CRD-4K'>
+			<availability>LA:2,FRR:8,MERC:2,FS:2,DC:6</availability>
 		</model>
 		<model name='CRD-2R'>
 			<availability>CLAN:4,FWL:4,IS:2,WOB:5,MERC:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FVC:2-,FS:2-</availability>
+		<model name='CRD-5M'>
+			<availability>CC:4,CS:4,FWL:8,IS:2,WOB:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='CRD-5K'>
+			<availability>FRR:5,WOB:4,MERC:5,DC:6</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4504,26 +4504,34 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>CS:8,MOC:2,FRR:8,IS:2,MERC:4,CDP:2,TC:2</availability>
-		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:1-</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:6,DC:6</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:8,IS:6,WOB:6,MH:2,FS:7,CDP:4,DC:3,TC:4</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:2-,General:4-,IS:2-,FS:2-,MERC:2-,DC:2-,TC:2-</availability>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:1,DC:1</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:4,IS:2+,MERC:4,DC:4</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:6,DC:6</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:2-,General:4-,IS:2-,FS:2-,MERC:2-,DC:2-,TC:2-</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:1-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>CS:8,MOC:2,FRR:8,IS:2,MERC:4,CDP:2,TC:2</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -4532,28 +4540,20 @@
 		<model name='CP-11-H'>
 			<availability>FVC:4,HL:2,PIR:6,MH:6,CIR:6,CDP:6,TC:6,Periphery:4</availability>
 		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:1,DC:1</availability>
-		</model>
 		<model name='CP-10-HQ'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
 			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:2,CWIE:2</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4566,25 +4566,25 @@
 			<roles>recon,escort</roles>
 			<availability>CS:4,General:4,NIOPS:4,WOB:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>TC:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4596,35 +4596,35 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>DC:8</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='DAI-01r'>
 			<availability>General:3</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -4644,14 +4644,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>FRR:6,DC:7</availability>
-		<model name='DMO-4K'>
-			<availability>FRR:4,DC:7</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:5</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:4,DC:6</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:5</availability>
+		<model name='DMO-4K'>
+			<availability>FRR:4,DC:7</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -4660,27 +4660,26 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CGS:5,CCO:6</availability>
@@ -4688,8 +4687,9 @@
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4715,14 +4715,14 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>CS:4,LA:5,MH:2,FS:6,MERC:4,CIR:4</availability>
-		<model name='DRT-6T'>
-			<availability>CS:8,LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='DRT-3S'>
 			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:2</availability>
+		</model>
+		<model name='DRT-6T'>
+			<availability>CS:8,LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='DRT-4S'>
 			<availability>LA:4,MH:2,FS:5,MERC:4,CIR:4</availability>
@@ -4730,11 +4730,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:4,FS:7</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:5,General:5</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
 		</model>
@@ -4746,25 +4749,15 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:2</availability>
+			<availability>FVC:5,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:5,CCC:3,MERC.WD:3,CDS:3,CLAN:3,IS:3+,CCO:2,CJF:3,BAN:3,CGB:6</availability>
-		<model name='H'>
-			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:3,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
@@ -4772,18 +4765,25 @@
 		<model name='K'>
 			<availability>General:2,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:3,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
@@ -4800,15 +4800,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4823,11 +4823,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:4,MERC:3</availability>
-		<model name='DFN-3S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -4845,18 +4845,6 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,IS:7,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,FVC:8,LA:5,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:3,IS:4,Periphery.Deep:6,Periphery:5</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,MOC:6,CS:8,LA:8,FRR:6,IS:6,FWL:8,WOB:8,FS:8,TC:6,CWIE:4,DC:8</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,FWL:4,DC:4</availability>
@@ -4864,8 +4852,20 @@
 		<model name='(MRM)'>
 			<availability>FVC:3,DC:6,Periphery:3</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,MOC:6,CS:8,LA:8,FRR:6,IS:6,FWL:8,WOB:8,FS:8,TC:6,CWIE:4,DC:8</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:3,IS:4,Periphery.Deep:6,Periphery:5</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(Defensive)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 	</chassis>
@@ -4875,11 +4875,11 @@
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>LA:3,CWIE:3</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:2,CWIE:2</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>LA:3,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -4901,26 +4901,20 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CS:4,CHH:6,CLAN:4,NIOPS:4,WOB:4</availability>
-		</model>
 		<model name='CX-2'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<availability>CS:4,CHH:6,CLAN:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:2,FRR:3,IS:2,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:2,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
-		<model name='DV-8D'>
-			<availability>FS:4,MERC:4</availability>
-		</model>
-		<model name='DV-6M'>
-			<availability>HL:3-,CLAN:4,IS:3-,Periphery.Deep:8,Periphery:5-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>FS:5,MERC:2</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='DV-6Mr'>
 			<availability>General:2</availability>
@@ -4928,18 +4922,20 @@
 		<model name='DV-1S'>
 			<availability>IS:3-</availability>
 		</model>
+		<model name='DV-8D'>
+			<availability>FS:4,MERC:4</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>HL:3-,CLAN:4,IS:3-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Deva' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-DVA-OS Caelestis'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-DVA-OD Luminos'>
+		<model name='C-DVA-OC Comminus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OB Infernus'>
+		<model name='C-DVA-OD Luminos'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
@@ -4947,21 +4943,25 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OA Dominus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-DVA-OU Exanimus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-DVA-OC Comminus'>
+		<model name='C-DVA-OB Infernus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-DVA-O Invictus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='C-DVA-OS Caelestis'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-DVA-OU Exanimus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-DVA-OA Dominus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -4975,35 +4975,35 @@
 		<model name='DVS-3'>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,LA:2-,FS:2-,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:5</availability>
+		<model name='(Stealth)' mechanized='true'>
+			<availability>WOB:4</availability>
+		</model>
 		<model name='(Standard)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>WOB.SD:8</availability>
 		</model>
-		<model name='(Stealth)' mechanized='true'>
-			<availability>WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Close Support)'>
-			<roles>spotter</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4,CGS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8,CJF:2</availability>
+		</model>
+		<model name='(Close Support)'>
+			<roles>spotter</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau Assault Interceptor' unitType='Dropship'>
@@ -5015,26 +5015,26 @@
 	</chassis>
 	<chassis name='Dragon Fire' unitType='Mek'>
 		<availability>LA:6,FRR:4,WOB:6,MERC:6,DC:5</availability>
-		<model name='DGR-6FC'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='DGR-4F'>
 			<availability>LA:4,WOB:3,MERC:4,DC:4</availability>
 		</model>
 		<model name='DGR-3F'>
 			<availability>General:8,WOB:0</availability>
 		</model>
+		<model name='DGR-6FC'>
+			<availability>WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:1,FRR:6,MERC:3,DC:5</availability>
-		<model name='DRG-7N'>
-			<availability>LA:2,MERC:5,DC:5</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:1-,DC:1-,Periphery:3</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>FRR:5,MERC:5,DC:5,Periphery:3</availability>
+		</model>
+		<model name='DRG-7N'>
+			<availability>LA:2,MERC:5,DC:5</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>FRR:2,MERC:2,DC:2</availability>
@@ -5042,16 +5042,16 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:4,CHH:4,CSV:3,IS:2+,CGB:6</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='Z'>
 			<roles>spotter</roles>
 			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
@@ -5059,45 +5059,45 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:7,CHH:7,CCC:7,CSR:7,CDS:8,CBS:7,General:6,CGS:7,CJF:8,CWIE:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
+		</model>
 		<model name='I'>
+			<availability>General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
-		<model name='(Standard)'>
-			<availability>CC:3-,General:4-</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>LA:2,WOB:2,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:4-,General:2</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>WOB:2</availability>
+		<model name='(Standard)'>
+			<availability>CC:3-,General:4-</availability>
 		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,WOB:6,FS:6</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:2,WOB:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5109,11 +5109,11 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,TC:4</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:6</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle Frigate' unitType='Warship'>
@@ -5125,34 +5125,34 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6b'>
-			<availability>RCM:4</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:1,FS:1</availability>
+		<model name='EGL-R11'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:1-,FS:1-</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1-,General:5-,FS:1-</availability>
+		</model>
+		<model name='EGL-R6b'>
+			<availability>RCM:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:1-,FS:1-</availability>
 		</model>
-		<model name='EGL-R11'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
-		<model name='EGL-R6'>
-			<availability>LA:1-,General:5-,FS:1-</availability>
+		<model name='EGL-R4'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,FWL.MM:7,FWL:6,MH:4,FWL.FO:7,MERC:4</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
 		<model name='EGL-3M'>
 			<availability>DTA:3,FWL:3</availability>
@@ -5181,59 +5181,32 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:3,MERC:2+</availability>
-		<model name='EST-OD'>
-			<availability>General:3</availability>
-		</model>
 		<model name='EST-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='EST-OD'>
+			<availability>General:3</availability>
+		</model>
+		<model name='EST-OC'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,MERC.WD:6,CW:6,CLAN:6,CNC:6+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:3,CLAN:2</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:3,CLAN:2</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -5241,8 +5214,35 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:3,CLAN:2</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:3,CLAN:2</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5253,34 +5253,30 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='EMP-7L'>
-			<availability>CC:5</availability>
+		<model name='EMP-6D'>
+			<availability>FS:8</availability>
 		</model>
 		<model name='EMP-6ME &apos;Mercury Elite&apos;'>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='EMP-6A'>
-			<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
-		</model>
 		<model name='EMP-6M'>
 			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='EMP-7L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='EMP-6L'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='EMP-6S'>
 			<availability>LA:7</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>FS:8</availability>
+		<model name='EMP-6A'>
+			<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>CS:3-,LA:5-,FS:3-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:5,General:2,MERC:5</availability>
@@ -5292,11 +5288,24 @@
 		<model name='END-6Sr'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,FS:7,MERC:5</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6G'>
+			<availability>FS:2,MERC:4</availability>
+		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-7C3BS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6T'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:2</availability>
@@ -5304,34 +5313,21 @@
 		<model name='ENF-6Ma'>
 			<availability>FVC:2,FS:2</availability>
 		</model>
-		<model name='ENF-6T'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='ENF-6G'>
-			<availability>FS:2,MERC:4</availability>
-		</model>
-		<model name='ENF-7C3BS'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:2,LA:2,Periphery.HR:2,MH:2,DC:1</availability>
-		<model name='ENF-5D'>
-			<availability>FVC:8,LA:2,FS:8,MERC:5,CDP:5,TC:5</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>FVC:4-,General:2-,FS:4-,TC:4-</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>FVC:8,LA:2,FS:8,MERC:5,CDP:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -5340,25 +5336,33 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
 		<availability>CSA:4,CHH:5,CSR:4,CSV:4,CSL:5,CJF:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X) &apos;Sholef&apos;'>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGS:3+,CGB:3+,CWIE:4+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -5368,10 +5372,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -5379,22 +5379,22 @@
 	</chassis>
 	<chassis name='Erinyes' unitType='ProtoMek'>
 		<availability>CJF:2</availability>
-		<model name='2'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CJF:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CSR:1,CDS:2,CSV:1,FWL:1,WOB:2,CGS:1,CCO:1,DC:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CS:4,CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CS:4,CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -5403,20 +5403,16 @@
 			<roles>troop_carrier</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>WOB:5,FS:4,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:2,FS:6</availability>
 		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>WOB:5,FS:4,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,CIR:2+,DC:4</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,WOB:5,CGS:6,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:1,NIOPS:8,WOB:8</availability>
@@ -5429,6 +5425,10 @@
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,WOB:5,CGS:6,BAN:2</availability>
+		</model>
 		<model name='EXC-CS'>
 			<roles>fire_support</roles>
 			<availability>CS:8,WOB:8,DC:8</availability>
@@ -5436,25 +5436,25 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3,WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4D'>
-			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
-		</model>
 		<model name='EXT-5F'>
 			<availability>CS:6</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
 		</model>
 		<model name='EXT-5E'>
 			<availability>CS:8,WOB:8</availability>
@@ -5462,16 +5462,16 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:7,CC:3</availability>
+		<model name='EYL-45B'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='EYL-4A'>
 			<availability>MOC:1</availability>
 		</model>
 		<model name='EYL-35A'>
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
-		</model>
-		<model name='EYL-45B'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
 		</model>
 		<model name='EYL-45A'>
 			<roles>spotter</roles>
@@ -5480,39 +5480,39 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
 		<availability>LA:4,WOB:3</availability>
-		<model name='FNR-5WB'>
-			<availability>WOB:8</availability>
+		<model name='FNR-5'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='FNR-5B'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='FNR-5'>
-			<availability>LA:4</availability>
+		<model name='FNR-5WB'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
@@ -5520,12 +5520,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5536,32 +5536,32 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>MERC.KH:1,WOB:2,MERC:3</availability>
-		<model name='FLC-5P'>
-			<availability>WOB:8,MERC:6</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4P'>
-			<availability>MERC.WD:2</availability>
-		</model>
 		<model name='FLC-6C'>
 			<availability>MERC.WD:6+</availability>
+		</model>
+		<model name='FLC-4P'>
+			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
+		<model name='FLC-5P'>
+			<availability>WOB:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>CS:4,LA:8,FS:8,MERC:3</availability>
-		<model name='FLC-9R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FLC-8R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='FLC-9R'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5573,107 +5573,107 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Upgrade)'>
+		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='&apos;Longshot&apos;' mechanized='false'>
-			<availability>General:3</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='&apos;Longshot&apos;' mechanized='false'>
+			<availability>General:3</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:3+,CHH:3,MERC.WD:6,CW:6,CSV:3,CLAN:1,IS:3+,CJF:4,CWIE:6,CGB:3</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:7,CW:6,CSV:6,CNC:6,General:4,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:3,CSV:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:7,CW:6,CSV:6,CNC:6,General:4,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:4,HL:4,LA:5,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3,FS:6</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='&apos;Fermi&apos;'>
 			<roles>apc</roles>
 			<availability>FS:3</availability>
-		</model>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:5</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -5685,59 +5685,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5745,39 +5697,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,SOC:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -5792,13 +5796,13 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CSA:7,CLAN:6,IS:3</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CLAN:6</availability>
@@ -5807,19 +5811,15 @@
 			<roles>urban</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,FS:7,MERC:5</availability>
-		<model name='ALM-10D'>
-			<availability>LA:3,FS:3,MERC:3</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,LA:2,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-10D'>
+			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='ALM-8D'>
 			<roles>recon,raider</roles>
@@ -5845,14 +5845,8 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:2,CLAN:2,WOB:5,BAN:1</availability>
-		<model name='FFL-4D'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
@@ -5860,26 +5854,40 @@
 		<model name='FFL-4DA'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='C'>
+			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
+		</model>
+		<model name='FFL-4D'>
+			<availability>MERC.WD:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-S2'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='FS9-B'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
+		<model name='FS9-S1'>
 			<roles>recon</roles>
-			<availability>LA.SR:1-</availability>
+			<availability>LA:5,General:4,FS:4</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,CIR:7,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S2'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:3,CS:3,MOC:4,LA:6,FRR:4,General:4,FS:4,TC:3</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA.SR:1-</availability>
+		</model>
+		<model name='FS9-B'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:3,Periphery:3</availability>
@@ -5887,64 +5895,53 @@
 		<model name='FS9-S3'>
 			<availability>LA:4,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:3,CS:3,MOC:4,LA:6,FRR:4,General:4,FS:4,TC:3</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:5,General:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5,CC:4,FVC:4+,LA:5,IS:4,WOB:5,FS:5,MERC:4,DC:7</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:1+,DC:1+</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:1+,DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:3</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -5954,73 +5951,76 @@
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:2,CSV:4,FRR:4,CLAN:3,WOB:5,CGS:2,CS:5,DC.GHO:5,Periphery.R:1,CDS:2,LA:4,CBS:2,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
-		<model name='FLS-9C'>
-			<availability>CS:6</availability>
-		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:2-,LA:2-</availability>
+		<model name='FLS-9M'>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,CS:4,LA:8,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
 		</model>
+		<model name='FLS-9C'>
+			<availability>CS:6</availability>
+		</model>
 		<model name='FLS-C'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='FLS-9M'>
-			<availability>FWL:6</availability>
 		</model>
 		<model name='FLS-9B'>
 			<availability>WOB:6</availability>
 		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:2-,LA:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,RCM:3,Periphery:4,TC:4</availability>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,RCM:4-,Periphery:6-,TC:4-</availability>
-		</model>
-		<model name='FLE-20'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:1</availability>
 		</model>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,RCM:4-,Periphery:6-,TC:4-</availability>
+		</model>
 		<model name='FLE-17'>
 			<availability>CC:8,FWL:5,WOB:5,MERC:5,RCM:6,Periphery:5</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6031,8 +6031,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -6044,20 +6044,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -6107,13 +6107,13 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
@@ -6122,29 +6122,29 @@
 			<roles>apc,spotter</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:4,WOB:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>WOB:8,FS:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:4,WOB:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:6,DTA:8,FWL:7,WOB:6,RCM:8</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:3-,General:8,FWL:2-,WOB:4-</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:6,DTA:8,FWL:7,WOB:6,RCM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -6153,24 +6153,24 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:4,CW:4,CLAN:2</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,CLAN:4,CGS:6,CCO:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6184,12 +6184,12 @@
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
 		</model>
 		<model name='GAL-104'>
 			<availability>WOB:5</availability>
@@ -6197,13 +6197,13 @@
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,FRR:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='GAL-103'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -6211,49 +6211,49 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,MERC:5</availability>
 		</model>
+		<model name='GAL-4GLSA'>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,MERC:5</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-,CWIE:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-,CWIE:8</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,MERC:5</availability>
-		</model>
-		<model name='GAL-4GLSA'>
-			<availability>MERC.WD:4</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='GRM-01A2'>
-			<availability>FS:3</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
+		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='GRM-01A2'>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
@@ -6264,32 +6264,32 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:1,CSR:1,CDS:5,CLAN:5,CNC:5,IS:2+,CJF:4,BAN:4,CWIE:2,CGB:9</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='B'>
+			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
 		<model name='P'>
 			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -6340,20 +6340,20 @@
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6365,24 +6365,16 @@
 	</chassis>
 	<chassis name='Goblin Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FVC:6,LA:2,WOB:3,FS:4,MERC:4</availability>
-		<model name='(Sealed)'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CS:2-,CC:1,FVC:2,LA:2-,FS.CH:2-,FRR:1,WOB:1-,FS:2-,TC:3-,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FVC:5,FS:5</availability>
@@ -6391,12 +6383,17 @@
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,FVC:4,LA:2,FRR:2,NIOPS:2,WOB:2,FS:4,DC:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CGB:6</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>CGB:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
@@ -6407,40 +6404,43 @@
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:3,HL:2,IS:1,FS:3,MERC:4,TC:3,Periphery:3,CS:1,OA:2,FVC:2,LA:5,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-4S'>
+		<model name='GOL-5W'>
 			<roles>fire_support</roles>
-			<availability>LA:5</availability>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,FWL:8,WOB:8,MERC:6</availability>
 		</model>
-		<model name='GOL-5W'>
+		<model name='GOL-6H'>
 			<roles>fire_support</roles>
-			<availability>WOB:6</availability>
+			<availability>Periphery.HR:4,Periphery.CM:4,Periphery.MW:4,Periphery.ME:4,MH:4,Periphery:3</availability>
 		</model>
 		<model name='GOL-5D'>
 			<roles>fire_support</roles>
 			<availability>FS:8</availability>
 		</model>
-		<model name='GOL-6H'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>Periphery.HR:4,Periphery.CM:4,Periphery.MW:4,Periphery.ME:4,MH:4,Periphery:3</availability>
+			<availability>LA:5</availability>
 		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>CC:3-,LA:4-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
-		<model name='GOL-2H'>
-			<roles>fire_support</roles>
-			<availability>Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,Periphery.ME:4,MH:4,Periphery:3</availability>
-		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,Periphery.ME:4,MH:4,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
@@ -6449,21 +6449,18 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CSV:8,CJF:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CJF:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:6,CBS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CJF:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CSV:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:4,CLAN:1</availability>
-		<model name='2'>
-			<availability>CSV:2,General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSV:2,General:8</availability>
 		</model>
@@ -6473,20 +6470,23 @@
 		<model name='4'>
 			<availability>CSV:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CSV:2,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,DTA:7,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5-</availability>
-		<model name='GTHA-500b'>
-			<availability>CLAN:4,FWL:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-400'>
-			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:4,FWL:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>DTA:6,FWL:5,WOB:5</availability>
+		</model>
+		<model name='GTHA-400'>
+			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader II' unitType='Mek'>
@@ -6500,26 +6500,29 @@
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
 		<availability>FWL:3,WOB:2</availability>
-		<model name='GRN-D-01'>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
 		<model name='GRN-D-02'>
 			<availability>FWL:2,WOB:2</availability>
+		</model>
+		<model name='GRN-D-01'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:6,WOB:5,DC:8</availability>
-		<model name='DRG-1G'>
-			<availability>FRR:4-,DC:4-</availability>
-		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:6,CNC:8,WOB:8,MERC:4,DC:5</availability>
 		</model>
+		<model name='DRG-7K'>
+			<availability>MERC:3,DC:5</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>FRR:4-,DC:4-</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>FRR:6,DC:6</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='DRG-9KC'>
 			<roles>spotter</roles>
@@ -6527,9 +6530,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>MERC:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -6546,12 +6546,6 @@
 		<model name='GHR-7K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='GHR-5J'>
-			<availability>CS:2-,IS:5,WOB:2-,Periphery:3</availability>
-		</model>
-		<model name='GHR-6K'>
-			<availability>FRR:5,MERC:3,FS:3,DC:5</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
@@ -6560,6 +6554,12 @@
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:3,DC:3</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>CS:2-,IS:5,WOB:2-,Periphery:3</availability>
+		</model>
+		<model name='GHR-6K'>
+			<availability>FRR:5,MERC:3,FS:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -6574,14 +6574,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -6598,17 +6598,14 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:3</availability>
@@ -6617,26 +6614,32 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:3</availability>
+		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:6,CDS:3,CSR:2,CSV:6,CSL:6,CCO:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -6644,26 +6647,23 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,CNC:7,CLAN:3,CCO:6,CJF:3,CWIE:4,CGB:3,DC:4</availability>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,CLAN:3</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,CLAN:3,CCO:8</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CNC:4,CLAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:2-,CNC:4</availability>
+		</model>
 		<model name='6'>
 			<availability>CNC:5,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:2-,CNC:4</availability>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,CLAN:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
@@ -6671,67 +6671,51 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-1S'>
-			<availability>LA:3-,MERC:3-</availability>
-		</model>
-		<model name='GRF-6CS'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CC:2,CLAN:6,FWL:3,WOB:5,FS:2,MERC:3,RCM:4,BAN:4,DC:2</availability>
+		<model name='GRF-1N'>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:3-,MERC:3-,TC:3-</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,FWL:5,WOB:5,MERC:5</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>DTA:5,LA:6,FWL:6,IS:6,FS:5,RCM:6,DC:3</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CS:5,FRR:4,WOB:4,CGB:4</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:6,LA:4,FRR:4,FS:6,MERC:4,DC:5</availability>
+		<model name='GRF-6S'>
+			<availability>LA:5,FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CNC:5,DC:5</availability>
 		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,FWL:5,WOB:5,MERC:5</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:6,LA:4,FRR:4,FS:6,MERC:4,DC:5</availability>
+		</model>
+		<model name='GRF-1S'>
+			<availability>LA:3-,MERC:3-</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>DTA:5,LA:6,FWL:6,IS:6,FS:5,RCM:6,DC:3</availability>
+		</model>
+		<model name='GRF-6CS'>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CS:5,FRR:4,WOB:4,CGB:4</availability>
+		</model>
 		<model name='GRF-5L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:5,FRR:3,FS:4,MERC:4,DC:4</availability>
+		<model name='GRF-2N'>
+			<availability>CC:2,CLAN:6,FWL:3,WOB:5,FS:2,MERC:3,RCM:4,BAN:4,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Grigori' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:7,WOB:2+</availability>
-		<model name='C-GRG-OS Caelestis'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-GRG-OC Comminus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-GRG-OB Infernus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OA Dominus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-GRG-OD Luminos'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-GRG-OE Eminus'>
+		<model name='C-GRG-OC Comminus'>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
@@ -6744,9 +6728,31 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C-GRG-OD Luminos'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OE Eminus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OA Dominus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OS Caelestis'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,WOB:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR30'>
+			<availability>WOB:6+,MERC:3</availability>
+		</model>
+		<model name='GRM-R-PR29'>
+			<availability>CS:8,MERC:8,DC:8</availability>
+		</model>
 		<model name='GRM-R (Einar)'>
 			<roles>spotter</roles>
 			<availability>CS:1</availability>
@@ -6754,12 +6760,6 @@
 		<model name='GRM-R-PR31'>
 			<roles>fire_support</roles>
 			<availability>WOB:6+,MERC:4</availability>
-		</model>
-		<model name='GRM-R-PR30'>
-			<availability>WOB:6+,MERC:3</availability>
-		</model>
-		<model name='GRM-R-PR29'>
-			<availability>CS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -6778,11 +6778,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CC:1,FWL:1</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3</availability>
@@ -6790,38 +6790,38 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CHH:3-,CW:3,CLAN:2-,CNC:3-,CCO:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4,CCO:6,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:3,CSR:3,FRR:2,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:4,FWL:5,NIOPS:7,DC:2</availability>
-		<model name='GLT-4L'>
+		<model name='GLT-6WB'>
 			<roles>raider</roles>
-			<availability>IS:2-,FWL:4-,Periphery.Deep:8,NIOPS:0,MERC:4-,Periphery:2-</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='GLT-8D'>
 			<roles>raider</roles>
 			<availability>FS:7</availability>
 		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>IS:2-,FWL:4-,Periphery.Deep:8,NIOPS:0,MERC:4-,Periphery:2-</availability>
+		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,FWL:8,FS:5,MERC:4</availability>
-		</model>
-		<model name='GLT-6WB2'>
-			<roles>raider</roles>
-			<availability>WOB:5</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
 			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
 		</model>
-		<model name='GLT-6WB'>
+		<model name='GLT-6WB2'>
 			<roles>raider</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -6836,21 +6836,21 @@
 	</chassis>
 	<chassis name='Gurkha' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='GUR-2G'>
+		<model name='GUR-4G'>
 			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='GUR-8G'>
-			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:3</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='GUR-6G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='GUR-4G'>
+		<model name='GUR-8G'>
 			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:4</availability>
+			<availability>WOB:3</availability>
+		</model>
+		<model name='GUR-2G'>
+			<deployedWith>Vanquisher</deployedWith>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6862,27 +6862,27 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,CBS:3,LA:4,CNC:5,DC:4</availability>
-		<model name='HKO-1C'>
-			<roles>fire_support</roles>
-			<availability>LA:7,DC:7</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>LA:3+,CLAN:6,DC:3+</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='HKO-1C'>
+			<roles>fire_support</roles>
+			<availability>LA:7,DC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:7,OA:3,CBS:6,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>OA:6,CSR:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>OA:6,CSR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -6894,49 +6894,43 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>MOC:3,CC:3,FWL:6,MH:3,WOB:6,MERC:5</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,WOB:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>FS:4,MERC:2</availability>
-		<model name='HMH-6D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='HMH-3D'>
 			<availability>General:4-,MERC:4-</availability>
-		</model>
-		<model name='HMH-5D'>
-			<availability>General:3,MERC:4</availability>
 		</model>
 		<model name='HMH-6E'>
 			<availability>General:4,MERC:4</availability>
 		</model>
+		<model name='HMH-5D'>
+			<availability>General:3,MERC:4</availability>
+		</model>
+		<model name='HMH-6D'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:2</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,NIOPS:8,WOB:4</availability>
-		</model>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HF'>
 			<availability>WOB:6</availability>
 		</model>
@@ -6946,33 +6940,39 @@
 		<model name='HMR-HDb'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
 		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
+		</model>
+		<model name='HMR-HE'>
+			<availability>CS:8,NIOPS:8,WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,CSV:5,CNC:5,CLAN:2,IS:3+,CJF:4,CCO:3,CGB:3</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -6991,13 +6991,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5-,CC:5-,HL:3-,FRR:5-,Periphery.Deep:4,IS:4-,WOB:4-,MERC:5-,Periphery:4-,CS:4-,DTA:5,FWL.pm:6-,LA:4-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,RCM:5,DC:5-</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:4-</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:1</availability>
@@ -7009,45 +7009,45 @@
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:3,CHH:6,CBS:2,CSV:6,CSL:6</availability>
-		<model name='(Standard)'>
-			<availability>CSA:4,CHH:4,CBS:4,CSL:4,CJF:4</availability>
+		<model name='3'>
+			<availability>CSA:6,CHH:2</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8,CBS:8,CSV:8,CSL:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:6,CHH:2</availability>
-		</model>
 		<model name='4'>
 			<availability>CHH:5,CSL:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:4,CHH:4,CBS:4,CSL:4,CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:4,WOB:5,MERC:3,DC:7</availability>
-		<model name='HTM-26T'>
-			<availability>DC:2-</availability>
-		</model>
-		<model name='HTM-28T'>
-			<availability>WOB:6,DC:4</availability>
+		<model name='HTM-27T'>
+			<availability>FRR:7,MERC:5,DC:6</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>WOB:6,DC:3</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:7,MERC:5,DC:6</availability>
+		<model name='HTM-28T'>
+			<availability>WOB:6,DC:4</availability>
+		</model>
+		<model name='HTM-26T'>
+			<availability>DC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>FRR:2,DC:3</availability>
+		<model name='HTM-27U'>
+			<availability>General:3-</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaeru' unitType='Mek'>
@@ -7079,14 +7079,11 @@
 		<model name='HCT-6S'>
 			<availability>LA:6,MERC:6</availability>
 		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:2-</availability>
+		<model name='HCT-5K'>
+			<availability>WOB:8,DC:8</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:5,LA:5,FRR:4,FS:5,MERC:4,DC:2,Periphery:2</availability>
 		</model>
 		<model name='HCT-5DD'>
 			<availability>FS:5,MERC:5</availability>
@@ -7095,11 +7092,14 @@
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:4-,MERC:2-,FS:2-,Periphery:2-</availability>
 		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:5,LA:5,FRR:4,FS:5,MERC:4,DC:2,Periphery:2</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:2-</availability>
+		</model>
 		<model name='HCT-6D'>
 			<availability>FS:5,MERC:6</availability>
-		</model>
-		<model name='HCT-5K'>
-			<availability>WOB:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
@@ -7117,18 +7117,14 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:5</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OD'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='HA1-OA'>
 			<availability>General:7</availability>
@@ -7136,14 +7132,18 @@
 		<model name='HA1-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HA1-OD'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,CS:3,DTA:5,LA:3,FRR:3,IS:3,FWL:5,WOB:3,FS:4,RCM:4,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -7171,25 +7171,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7201,11 +7201,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -7229,23 +7229,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>FS:3,MERC:1</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>FS:3,MERC:1</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7256,6 +7256,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7264,20 +7272,20 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8,WOB:4</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7287,14 +7295,6 @@
 			<roles>apc,support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8,WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:2,CSR:2,CSV:2,CNC:2,CSL:4,CWIE:5</availability>
@@ -7302,12 +7302,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:3</availability>
@@ -7315,13 +7315,13 @@
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:2,MOC:2,MERC:2</availability>
-		<model name='HEP-1H'>
-			<roles>artillery</roles>
-			<availability>CC:3-,MOC:3-,MERC:3-</availability>
-		</model>
 		<model name='HEP-4H'>
 			<roles>artillery</roles>
 			<availability>MERC:8</availability>
+		</model>
+		<model name='HEP-1H'>
+			<roles>artillery</roles>
+			<availability>CC:3-,MOC:3-,MERC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -7329,11 +7329,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,CS:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 		<model name='HEL-6X'>
 			<availability>WOB:8</availability>
@@ -7341,8 +7341,8 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:2,CNC:3,NIOPS:6,WOB:6,FS:2,DC:2</availability>
-		<model name='HCT-212'>
-			<availability>LA:8,FS:8</availability>
+		<model name='HCT-214'>
+			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='HCT-215'>
 			<availability>CS:4</availability>
@@ -7351,14 +7351,17 @@
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,WOB:8,DC:8</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		<model name='HCT-212'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213S'>
 			<availability>LA:2,FS:1</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:1,FS:2</availability>
 		</model>
 		<model name='HCT-313'>
 			<availability>OA:8,FVC:6,CSR:8,CDP:6</availability>
@@ -7370,31 +7373,28 @@
 		<model name='HCT-213'>
 			<availability>General:4</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:1,FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:4</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:2,CHH:3,CDS:3,DC.AL:2,CLAN:2,CNC:6,CJF:3</availability>
-		<model name='5'>
-			<availability>CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
+			<availability>CNC:5</availability>
+		</model>
+		<model name='5'>
 			<availability>CNC:5</availability>
 		</model>
 		<model name='2'>
@@ -7406,25 +7406,25 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CBS:2,SOC:5,CSV:4,CLAN:2,CNC:5,CSL:5,CGS:4,CCO:5,CJF:2</availability>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:4,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
@@ -7432,16 +7432,16 @@
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>FS:6,MERC:4</availability>
+		<model name='HSN-8E'>
+			<roles>fire_support</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='HSN-10G'>
 			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='HSN-8E'>
-			<roles>fire_support</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
@@ -7450,25 +7450,25 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7489,135 +7489,138 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>MOC:1-,CC:4,LA:4,FRR:2-,PIR:4,FWL:8,WOB:4,MH:4,MERC:4,FS:5,DC:2-</availability>
-		<model name='HER-4K &apos;Hermes III&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
 		<model name='HER-5C'>
 			<roles>recon</roles>
 			<availability>WOB:10</availability>
 		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
-		</model>
-		<model name='HER-2S'>
+		<model name='HER-4K &apos;Hermes III&apos;'>
 			<roles>recon</roles>
-			<availability>HL:2-,IS:3-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
-		</model>
-		<model name='HER-5S'>
-			<roles>recon</roles>
-			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:3,WOB:8,FS:6,MERC:6,DC:6</availability>
+			<availability>FWL:3</availability>
 		</model>
 		<model name='HER-5Sr'>
 			<roles>recon</roles>
 			<availability>MOC:3,IS:3</availability>
 		</model>
+		<model name='HER-5S'>
+			<roles>recon</roles>
+			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:3,WOB:8,FS:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:2-,IS:3-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:1,FRR:3,FWL:7,NIOPS:3,WOB:3,CGB:1,DC:6</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:4-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:6,WOB:5</availability>
-		</model>
-		<model name='HER-4M'>
-			<roles>recon</roles>
-			<availability>FWL:5,WOB:6</availability>
-		</model>
-		<model name='HER-4WB'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>DC:7</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>CS:3,FRR:3,FWL:5,WOB:3</availability>
 		</model>
+		<model name='HER-4WB'>
+			<roles>recon</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='HER-4M'>
+			<roles>recon</roles>
+			<availability>FWL:5,WOB:6</availability>
+		</model>
 		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:5</availability>
 		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:7</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:4-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CGB:2</availability>
-		<model name='(Standard)'>
-			<availability>General:6-</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:5,CDP:4,TC:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:5,CDP:4,TC:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CC:2,IS:2,Periphery:2</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
 		<availability>LA:2,IS:2</availability>
+		<model name='(Cunnington)'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>LA:6,General:8</availability>
 		</model>
-		<model name='(Cunnington)'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>MERC.WD:2,CHH:4,CDS:4,CW:6,CLAN:2,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CW:4</availability>
+		<model name='(Standard)'>
+			<availability>CDS:5,CW:5,CLAN:4,CNC:5,IS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4,CW:2,CJF:4,CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:5,CW:5,CLAN:4,CNC:5,IS:8</availability>
+		<model name='2'>
+			<availability>CW:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:1,CC:2,CS:9,LA:6,CLAN:5,IS:1,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6,DC:1</availability>
+		<model name='HGN-736'>
+			<availability>CS:8,WOB:6</availability>
+		</model>
+		<model name='HGN-733'>
+			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		</model>
 		<model name='HGN-733C'>
 			<availability>CC:1,:0,LA:1</availability>
 		</model>
-		<model name='HGN-734'>
-			<availability>LA:6,MERC:6</availability>
-		</model>
-		<model name='HGN-736'>
-			<availability>CS:8,WOB:6</availability>
+		<model name='HGN-738'>
+			<availability>LA:5</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CS:5,LA:3,CLAN:4,WOB:5,FS:3,BAN:2</availability>
@@ -7625,29 +7628,26 @@
 		<model name='HGN-694'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='HGN-641-X-2'>
-			<availability>CS:1</availability>
+		<model name='HGN-732'>
+			<availability>MOC:6,CC:3,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:3,NIOPS:3,MERC.SI:8,MH:6</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		<model name='HGN-641-X-2'>
+			<availability>CS:1</availability>
 		</model>
-		<model name='HGN-732'>
-			<availability>MOC:6,CC:3,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:3,NIOPS:3,MERC.SI:8,MH:6</availability>
-		</model>
-		<model name='HGN-738'>
-			<availability>LA:5</availability>
+		<model name='HGN-734'>
+			<availability>LA:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:3</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7673,11 +7673,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7691,34 +7691,34 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:1,MERC.WD:2,CLAN:1,CGS:1</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:2,CLAN:1</availability>
 		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:4,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
-		<model name='HNT-161'>
-			<availability>MERC.WD:2-</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>FVC:2-,IS:1-</availability>
 		</model>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:3-</availability>
+		<model name='HNT-161'>
+			<availability>MERC.WD:2-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -7753,14 +7753,14 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:5,CDS:7,CSR:6,CW:6,CSV:5,CLAN:2,IS:3,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='2'>
-			<availability>CSA:8,CBS:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:4,CSR:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:4,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:8,CBS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:8,CCO:8</availability>
@@ -7768,70 +7768,66 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:3,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6S'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='HBK-4J'>
-			<availability>CC:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>FWL:5,WOB:5,MERC:4</availability>
-		</model>
-		<model name='HBK-4H'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5H'>
-			<availability>MH:6,Periphery:3</availability>
-		</model>
 		<model name='HBK-4SP'>
 			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:1-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-5M'>
 			<availability>CS:4,CC:1,MOC:1,FRR:1,FWL:1,WOB:4,MERC:1,CDP:1,TC:1</availability>
 		</model>
+		<model name='HBK-4J'>
+			<availability>CC:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>MH:6,Periphery:3</availability>
+		</model>
+		<model name='HBK-5SS'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='HBK-5S'>
 			<availability>LA:5,FRR:3,MERC:3,FS:2</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-5P'>
+			<availability>FWL:5,WOB:5,MERC:4</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6N'>
 			<availability>FWL:4,MERC:5</availability>
 		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:4</availability>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:4-</availability>
+			<availability>General:2-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>LA:8,FS:6,RCM:4,MERC:4</availability>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -7841,12 +7837,16 @@
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
-			<availability>General:2-</availability>
+			<availability>LA:8,FS:6,RCM:4,MERC:4</availability>
 		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:4-</availability>
 		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:2,FS:2</availability>
@@ -7854,18 +7854,18 @@
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,FWL:3,MERC:5,TC:3</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
@@ -7883,54 +7883,54 @@
 		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HSCL-1-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='HSCL-1-OD'>
 			<availability>General:4</availability>
 		</model>
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:4,LA:3,CSV:5,FRR:2,CLAN:4,NIOPS:4,WOB:4,MERC:3,DC:1</availability>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		</model>
+		<model name='HSR-300-D'>
+			<availability>DC:2-</availability>
+		</model>
 		<model name='HSR-500-D'>
 			<availability>CS:4,WOB:8</availability>
+		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:1-</availability>
+		</model>
+		<model name='HSR-900-D'>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='HSR-950-D'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:4,General:8,CLAN:6,NIOPS:4,MERC.SI:4,WOB:4,BAN:8</availability>
 		</model>
-		<model name='HSR-900-D'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='HSR-300-D'>
-			<availability>DC:2-</availability>
-		</model>
-		<model name='HSR-950-D'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -7938,13 +7938,13 @@
 		<model name='2'>
 			<availability>CHH:6,CSL:6</availability>
 		</model>
-		<model name='4'>
-			<roles>anti_infantry</roles>
-			<availability>CBS:4</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5</availability>
+		</model>
+		<model name='4'>
+			<roles>anti_infantry</roles>
+			<availability>CBS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CHH:6,CBS:6,CSL:6</availability>
@@ -7959,44 +7959,44 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:8,LA:3,FWL:3,IS:8,WOB:3,MH:8,FS:1,DC:2,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
 		<availability>FWL.pm:2,FWL:2,WOB:2</availability>
-		<model name='ICR-1S'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='ICR-2S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='ICR-1S'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus' unitType='Mek'>
@@ -8021,10 +8021,10 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
+		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
 		</model>
-		<model name='IMP-3E'>
+		<model name='IMP-4E'>
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
@@ -8044,43 +8044,43 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,CNC:2,CWIE:2</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CW:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:1,MERC:2,TC:2</availability>
-		<model name='&apos;Waddle&apos;' mechanized='true'>
-			<roles>recon</roles>
-			<availability>LA:6,FS:6,TC:6</availability>
-		</model>
 		<model name='(Special Ops)' mechanized='true'>
 			<roles>specops</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='&apos;Waddle&apos;' mechanized='true'>
+			<roles>recon</roles>
+			<availability>LA:6,FS:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
 		<availability>WOB:7</availability>
-		<model name='INI-02'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='INI-04'>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='INI-02'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Inquisitor' unitType='Mek'>
@@ -8102,27 +8102,27 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>DTA:8,FWL:8,RCM:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>DTA:8,FWL:8,RCM:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -8134,41 +8134,46 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,DC:1</availability>
-		<model name='IRN-SD3'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:4</availability>
-		</model>
-		<model name='IRN-SD1b'>
-			<availability>CSR:6,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CX-19'>
 			<availability>CS:2</availability>
 		</model>
+		<model name='IRN-SD3'>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='IRN-SD1b'>
+			<availability>CSR:6,CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CLAN:4,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSR:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8178,11 +8183,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8199,9 +8199,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:4-,FS.AH:4-,Periphery.Deep:5,IS:4-,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,DTA:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,RCM:2-,DC:4-</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -8211,17 +8215,13 @@
 			<roles>recon,raider</roles>
 			<availability>DC:8,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
@@ -8259,39 +8259,29 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>MOC:5,CC:2,DTA:6,FVC:2,Periphery.MW:4,Periphery.ME:4,IS:1,FWL:6,WOB:6,MH:5,FS:2,MERC:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>HL:6,General:2,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>DTA:5,LA:5,FWL:5,MERC:5,FS:6</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>HL:6,General:2,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>WOB:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
 		<model name='JKR-9W'>
 			<availability>WOB:5</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:4,CW:5,General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CSR:6,CW:4,CLAN:2</availability>
@@ -8299,8 +8289,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:4,CW:5,General:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8314,21 +8314,6 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:4-,FRR:5,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:3-,FRR:2-,IS:3-,FS:3-,Periphery:6</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:5,MERC:6</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:1,PIR:2,MH:5,Periphery:1</availability>
@@ -8337,24 +8322,59 @@
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
+		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:3,LA:3,FRR:3,FS:3,MERC:3,CDP:2,DC:3</availability>
 		</model>
-		<model name='JM7-C3BS'>
+		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:5</availability>
+			<availability>FS:5,MERC:6</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:3-,FRR:2-,IS:3-,FS:3-,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,HL:3,IS:2,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:2,LA:2,Periphery.HR:5</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:5,LA:6,Periphery.HR:5,PIR:5,FS:5,MERC:6,CDP:5,TC:5</availability>
@@ -8363,83 +8383,67 @@
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,FS:3,MERC:3</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,FS:2,MERC:2,CDP:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
+		<model name='X'>
+			<availability>CSR:2,General:1,CJF:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:5,General:2,CJF:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='X'>
-			<availability>CSR:2,General:1,CJF:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='E'>
+			<availability>CSR:5,General:2,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:5,CSV:6,CNC:8,CLAN:2,CGS:5,CCO:5,DC:3</availability>
-		<model name='3'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CLAN:2,CNC:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:6,CNC:8,IS:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:4,CLAN:2,CNC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:2-,DC:8</availability>
-		<model name='JR7-C4'>
-			<roles>raider</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>MERC:3,DC:4</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='JR7-C4'>
+			<roles>raider</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -8449,17 +8453,9 @@
 			<roles>raider</roles>
 			<availability>MERC:5,FS:5,DC:6</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:5,TC:4</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8467,6 +8463,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -8479,11 +8479,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:5,MOC:4,TC:4</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -8505,26 +8505,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -8542,25 +8542,41 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='KBO-7A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='KBO-7B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='KBO-7A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 		<model name='C' mechanized='true'>
+			<availability>DC:2</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
 			<availability>DC:2</availability>
 		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
@@ -8571,46 +8587,30 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -8621,12 +8621,9 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:3,PIR:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:6,MERC:6</availability>
+		<model name='(BA)'>
+			<roles>apc</roles>
+			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
 		</model>
 		<model name='(Periphery)'>
 			<availability>MOC:5,CC:3,OA:5,FVC:3,HL:3,PIR:7,MH:6,CIR:6,Periphery:5,TC:5</availability>
@@ -8635,13 +8632,20 @@
 			<roles>cargo</roles>
 			<availability>HL:3,IS:8,Periphery:5</availability>
 		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
+		<model name='(AC)'>
+			<availability>MH:6,MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,FRR:2,DC:6</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:4-</availability>
 		</model>
@@ -8651,13 +8655,16 @@
 		<model name='CRK-5003-C'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>CS:5,MERC.WD:4,CW:1,LA:4,FRR:3,CLAN:3,WOB:4,FS:4,DC:3</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -8665,39 +8672,29 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:3,FRR:4,CLAN:3,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:5,LA:3,FWL:3,NIOPS:6,CGB:4,DC:3</availability>
-		<model name='KGC-001'>
-			<availability>CS:8,FVC:8,LA:6,IS:6,WOB:5,MH:6,CIR:6,MERC:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CS:5,FRR:4,CLAN:4,WOB:4,CGS:6,BAN:2,DC:4</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:6,FS:6,MERC:6</availability>
 		</model>
-		<model name='KGC-0000'>
-			<availability>IS:4-,CIR:5</availability>
-		</model>
-		<model name='KGC-008B'>
-			<availability>WOB.PM:8</availability>
+		<model name='KGC-008'>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
+		</model>
+		<model name='KGC-001'>
+			<availability>CS:8,FVC:8,LA:6,IS:6,WOB:5,MH:6,CIR:6,MERC:6</availability>
 		</model>
 		<model name='KGC-005r'>
 			<availability>CS:2,WOB:2</availability>
@@ -8705,29 +8702,32 @@
 		<model name='KGC-005'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='KGC-008'>
-			<availability>WOB:8</availability>
+		<model name='KGC-0000'>
+			<availability>IS:4-,CIR:5</availability>
+		</model>
+		<model name='KGC-008B'>
+			<availability>WOB.PM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CSR:3,CLAN:2,CNC:3,IS:1+,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='X'>
+			<availability>CGB:2</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8735,29 +8735,29 @@
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='X'>
-			<availability>CGB:2</availability>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:6,CHH:1,CDS:1,CSV:1,FRR:4,NIOPS:7,WOB:7,FS:3,MERC:5,DC:4</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:7</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:4,CS:4,DC.SL:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:4-,MERC:4-,DC:2-</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:7</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:4,WOB:4,MERC:5,DC:5</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:7</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:7</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:4-,MERC:4-,DC:2-</availability>
 		</model>
 		<model name='KTO-21'>
 			<availability>CS:6,WOB:5</availability>
@@ -8765,23 +8765,23 @@
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5,CGS:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8793,13 +8793,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
@@ -8807,16 +8807,20 @@
 		<model name='[GL]' mechanized='true'>
 			<availability>FRR:4</availability>
 		</model>
+		<model name='(CS) [SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:8</availability>
+		</model>
 		<model name='(CS) [GL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:6</availability>
 		</model>
+		<model name='(CS) [GL]' mechanized='true'>
+			<availability>CS:4</availability>
+		</model>
 		<model name='[SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>FRR:8</availability>
-		</model>
-		<model name='X-C3' mechanized='true'>
-			<availability>CS:2</availability>
 		</model>
 		<model name='[SL/Flamer]' mechanized='true'>
 			<availability>FRR:6</availability>
@@ -8824,18 +8828,14 @@
 		<model name='(CS) [GL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='(CS) [GL]' mechanized='true'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='(CS) [SL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='(CS) [SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='[GL/Flamer]' mechanized='true'>
 			<availability>FRR:6</availability>
+		</model>
+		<model name='X-C3' mechanized='true'>
+			<availability>CS:2</availability>
 		</model>
 		<model name='[GL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
@@ -8844,8 +8844,8 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:2,CCC:3,CSR:6,CNC:2,CLAN:2,CGS:4,CCO:3,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -8854,11 +8854,11 @@
 		<model name='2'>
 			<availability>CGB:5</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -8867,16 +8867,16 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:5</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
@@ -8887,56 +8887,32 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,WOB:4,MERC:4</availability>
-		<model name='KSC-4I'>
-			<availability>MERC:3</availability>
-		</model>
-		<model name='KSC-5I'>
-			<availability>WOB:8,MERC:6</availability>
-		</model>
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8</availability>
 		</model>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
+		<model name='KSC-4I'>
 			<availability>MERC:3</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>MERC:3</availability>
 		</model>
+		<model name='KSC-5I'>
+			<availability>WOB:8,MERC:6</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:6,CSV:7,CLAN:2,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:2</availability>
-		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
-		</model>
 		<model name='Z'>
 			<roles>recon</roles>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -8946,37 +8922,61 @@
 			<roles>recon</roles>
 			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
 		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
+		<model name='KTO-3A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='KTO-2A'>
 			<availability>General:2</availability>
 		</model>
-		<model name='KTO-3A'>
-			<availability>General:8</availability>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:4,CLAN:1,CJF:4</availability>
-		<model name='4'>
-			<availability>CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CSV:4,CLAN:2,CJF:2</availability>
+		</model>
+		<model name='4'>
+			<availability>CJF:6</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CSV:4,CLAN:2,CJF:3</availability>
-		</model>
-		<model name='2'>
-			<availability>CSV:4,CLAN:2,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
@@ -9018,13 +9018,13 @@
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>CC:8,CS:8,MOC:8,LA:8,FRR:8,FWL:8,IS:8,FS:8,CIR:6,DC:8,TC:7,Periphery:5</availability>
-		</model>
 		<model name='(WoB)'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>CC:8,CS:8,MOC:8,LA:8,FRR:8,FWL:8,IS:8,FS:8,CIR:6,DC:8,TC:7,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -9035,18 +9035,12 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,FRR:3,CLAN:4,NIOPS:6,WOB:6,CGS:5,BAN:7,DC:5</availability>
-		<model name='LNC25-06'>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='LNC25-04'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,FRR:3-,DC:3-</availability>
-		</model>
 		<model name='LNC25-03'>
 			<availability>DC:2-</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
@@ -9055,21 +9049,27 @@
 		<model name='LNC25-08'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
+		<model name='LNC25-04'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,FRR:3-,DC:3-</availability>
+		</model>
+		<model name='LNC25-06'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>DTA:5,FWL:5,WOB:3,RCM:5</availability>
-		<model name='LX-2A'>
-			<availability>DTA:5,FWL:5,RCM:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LX-2A'>
+			<availability>DTA:5,FWL:5,RCM:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
@@ -9077,15 +9077,15 @@
 		<model name='LHU-3L'>
 			<availability>CC:5,MOC:6,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='LHU-3C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9097,65 +9097,65 @@
 	</chassis>
 	<chassis name='Legacy' unitType='Mek'>
 		<availability>WOB:6</availability>
+		<model name='LGC-05'>
+			<availability>WOB:2</availability>
+		</model>
 		<model name='LGC-02'>
 			<roles>fire_support</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGC-04-WVR'>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='LGC-01'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='LGC-05'>
-			<availability>WOB:2</availability>
 		</model>
 		<model name='LGC-03'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='LGC-04-WVR'>
+			<availability>WOB:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>FS:4</availability>
-		<model name='LGN-2F'>
+		<model name='LGN-2XU'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LGN-1X'>
 			<availability>FS.CH:4,FS:1</availability>
 		</model>
-		<model name='LGN-2XU'>
+		<model name='LGN-2F'>
 			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,DTA:8,LA:8,FWL:8,WOB:8,FS:8,RCM:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
+		<model name='(2537)'>
 			<roles>mech_carrier</roles>
-			<availability>DTA:8,LA:8,FWL:8,FS:8,RCM:8</availability>
+			<availability>General:4-</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FWL:3,WOB:6</availability>
 		</model>
-		<model name='(2537)'>
+		<model name='(3056)'>
 			<roles>mech_carrier</roles>
-			<availability>General:4-</availability>
+			<availability>DTA:8,LA:8,FWL:8,FS:8,RCM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -9187,30 +9187,30 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:2,FWL:6,IS:2</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1</availability>
-		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,DC:2,Periphery:4</availability>
 		</model>
 		<model name='Comet'>
 			<availability>FVC:5,FS:5,MERC:1</availability>
 		</model>
+		<model name='Owl III'>
+			<availability>LA:4,MERC:2</availability>
+		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,HL:4,LA:4</availability>
-		</model>
-		<model name='Suzume (&apos;Sparrow&apos;)'>
-			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
 		<model name='Andurien'>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:2,FWL:6,IS:2</availability>
+		<model name='Suzume (&apos;Sparrow&apos;)'>
+			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Owl III'>
-			<availability>LA:4,MERC:2</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9221,21 +9221,21 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:2,CLAN:4,NIOPS:2,WOB:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6,WOB:4</availability>
+		<model name='(RL)'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='(ERML)'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(RL)'>
-			<availability>WOB:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6,WOB:4</availability>
+		</model>
+		<model name='(ERSL)'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='CX-3'>
 			<availability>CS:8</availability>
@@ -9243,73 +9243,73 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:5-</availability>
+		<model name='LTN-G16D'>
+			<availability>FS:5,MERC:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:4,MOC:4,CLAN:3,MERC:3</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>FS:5,MERC:4</availability>
+		<model name='LTN-G16O'>
+			<availability>OA:5,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:5,MOC:5,MERC:4</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>OA:5,FVC:4,CDP:4</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGH-5W'>
+		<model name='LGH-4W'>
 			<roles>recon</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='LGH-7W'>
-			<roles>recon</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='LGH-4Y'>
 			<roles>recon</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGH-4W'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='LGH-6W'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
 		</model>
+		<model name='LGH-7W'>
+			<roles>recon</roles>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='LGH-5W'>
+			<roles>recon</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:2,CCC:4,CSR:5,CW:5,SOC:4,CSV:4,CSL:2,CCO:4,CJF:4,CWIE:6</availability>
-		<model name='B'>
-			<availability>CDS:4,General:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -9320,25 +9320,25 @@
 		<model name='KW1-LH3'>
 			<availability>General:2,WOB:3,FS:3</availability>
 		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='KW1-LH2'>
 			<availability>General:6,WOB:2,FS:2</availability>
 		</model>
 		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
 			<availability>WOB:5,FS:7</availability>
 		</model>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CS:6,CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,WOB:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -9347,10 +9347,6 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CW:6</availability>
-		<model name='2'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8</availability>
 		</model>
@@ -9358,23 +9354,15 @@
 			<roles>anti_infantry</roles>
 			<availability>CW:2</availability>
 		</model>
+		<model name='2'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:3,CHH:6,CW:7,LA:2,CLAN:2,IS:2,CJF:6,DC:3,CGB:6</availability>
-		<model name='3'>
-			<availability>General:1</availability>
-		</model>
-		<model name='6'>
-			<availability>CW:4,CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:4,General:2</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
@@ -9382,16 +9370,32 @@
 		<model name='5'>
 			<availability>CHH:4,CW:4,CCO:4,CGB:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:1</availability>
+		</model>
+		<model name='6'>
+			<availability>CW:4,CGB:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
+		<model name='7'>
+			<availability>CHH:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:2-,HL:5,CLAN:2-,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:3-,Periphery:5</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>FWL:3,WOB:3</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:4,CC:4,FVC:2,TC:5</availability>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:4-,MERC:4-</availability>
 		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
@@ -9401,122 +9405,118 @@
 			<roles>recon</roles>
 			<availability>CC:4,CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-1E'>
 			<roles>recon</roles>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:4,PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
+			<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
 		</model>
 		<model name='LCT-1V2'>
 			<roles>recon</roles>
 			<availability>PIR:4,MH:4</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3,DTA:5,FWL:6,IS:3,MERC:6,RCM:5</availability>
+		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:3-,General:4-,FS:4-</availability>
-		</model>
-		<model name='LCT-5V'>
-			<roles>recon</roles>
-			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
-		</model>
-		<model name='LCT-1E'>
-			<roles>recon</roles>
-			<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
 		</model>
 		<model name='LCT-3S'>
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,MERC:6</availability>
 		</model>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:4,CC:4,FVC:2,TC:5</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-6M'>
+			<roles>recon</roles>
+			<availability>FWL:3,WOB:3</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
+		</model>
 		<model name='LCT-5W'>
 			<roles>recon,spotter</roles>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:3,DTA:5,FWL:6,IS:3,MERC:6,RCM:5</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:4-,MERC:4-</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CDS:2,CW:4,CBS:4,CSV:4,CLAN:2,IS:3+,CJF:2,BAN:5,CWIE:5,CGB:2</availability>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CCC:1,CHH:3,CSR:3,CSV:2,WOB:1,CCO:2,CGS:2,CS:5,CSA:4,MERC.WD:2,CDS:2,CW:1,CNC:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
-		</model>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:4-</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>LA:3,FRR:3,FWL:3,IS:2,FS:4,MERC:3</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:3-,OA:3-,General:3-,TC:3-,Periphery:3-</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:5,LA:3,FWL:3,IS:3,MH:4,FS:3,MERC:3,CDP:2,TC:2</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>WOB:3,FS:4</availability>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:4-</availability>
+		</model>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:2,FWL:3,FS:4,MERC:4,RCM:4,DC:4</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
+		<model name='LGB-13NAIS'>
+			<availability>WOB:3,FS:4</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>LA:3,FRR:3,FWL:3,IS:2,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -9524,32 +9524,32 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:5</availability>
-		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[Flamer] (WoB)' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(Magnetic) (WOB)' mechanized='true'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[David] (WoB)' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
+		<model name='[Flamer] (WoB)' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Magnetic) (WOB)' mechanized='true'>
-			<availability>WOB:6</availability>
+		<model name='[David] (WoB)' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -9563,14 +9563,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:3,FS:3,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:2,FVC:2,LA:8,Periphery.MW:3</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:2,FS:2,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:6-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:3-,FS:3-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:2,FS:2,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -9579,13 +9579,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:2-</availability>
@@ -9600,24 +9600,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,CLAN:1,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -9625,13 +9625,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,WOB:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='W1'>
 			<roles>missile_artillery,escort</roles>
@@ -9663,17 +9663,30 @@
 		<model name='MSK-6S'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='MSK-9H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MSK-5S'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='MSK-9H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:1,MERC.WD:8,CDS:5,CW:7,CBS:3,CLAN:4,CCO:5,CJF:5,BAN:2,CWIE:8</availability>
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CSV:3,CNC:3,General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
@@ -9682,39 +9695,26 @@
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CSV:3,CNC:3,General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:3,CNC:6,FS:3,CWIE:4,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -9740,37 +9740,28 @@
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FRR:1,NIOPS:5,WOB:5,WOB.PM:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(UCSV)'>
 			<roles>apc,urban</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>DTA:8,FWL:8,WOB:3,RCM:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(XL)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Malak' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-MK-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-OB Infernus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-MK-OS Caelestis'>
 			<availability>General:5</availability>
 		</model>
@@ -9779,6 +9770,15 @@
 		</model>
 		<model name='C-MK-O Invictus'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C-MK-OA Dominus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-MK-OB Infernus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-MK-OD Luminos'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-MK-OC Comminus'>
 			<roles>spotter</roles>
@@ -9794,33 +9794,33 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSV:6,CLAN:2,IS:2+,BAN:5,CWIE:8,MERC.WD:8,CDS:8,CW:8,CBS:5,CNC:4,CJF:8,CGB:2</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1</availability>
-		</model>
-		<model name='G'>
-			<availability>General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CSV:7,CNC:6,General:5,CJF:2,CGB:4</availability>
+		<model name='G'>
+			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		<model name='B'>
+			<availability>CDS:4,CSV:7,CNC:6,General:5,CJF:2,CGB:4</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -9831,6 +9831,9 @@
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:5,FS:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
@@ -9838,79 +9841,91 @@
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,FWL:6,NIOPS:7,DC:9</availability>
-		<model name='(LB-X)'>
-			<availability>LA:6,WOB:6,FS:6</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>FS:6,DC:8</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,LA:8,FS:8,MERC:8</availability>
+		<model name='(HPPC)'>
+			<availability>FS:3,DC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,LA:2-,General:4-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
+		<model name='(LB-X)'>
+			<availability>LA:6,WOB:6,FS:6</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
 		</model>
-		<model name='(HPPC)'>
-			<availability>FS:3,DC:3</availability>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,LA:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,CS:2,LA:3,FRR:3,FWL:4,IS:3,WOB:2,FS:5,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>WOB:4,FS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>WOB:4,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:7,MERC.WD:6,CSR:5,CW:6,LA:2,CLAN:2,CNC:6,CJF:7,CWIE:6,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,CLAN:2,CJF:4,CGB:4</availability>
+		<model name='4'>
+			<availability>CNC:5,CGB:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CW:2,LA:8,CJF:4,CWIE:5,CGB:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,CLAN:2,CJF:4,CGB:4</availability>
+		</model>
 		<model name='6'>
 			<availability>CW:4,CJF:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CLAN:2,CJF:5,CGB:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:5,CCC:3,CDS:1,CSR:1,CGS:3,CJF:3,CWIE:1,CGB:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CNC:5,CGB:4</availability>
 		</model>
 		<model name='8'>
 			<availability>CLAN:1,CJF:5,CGB:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:5,CCC:3,CDS:1,CSR:1,CGS:3,CJF:3,CWIE:1,CGB:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:4,CLAN:2,CJF:5,CGB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,PIR:4,CNC:2,FWL:5,MH:4,DC:5</availability>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='MAD-5W'>
+			<availability>CC:6,CS:4,WOB:8</availability>
+		</model>
+		<model name='MAD-4H'>
+			<availability>PIR:8,MH:8,TC:8</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:6,CNC:8,FWL:4,FS:8,MERC:6,DC:5</availability>
@@ -9918,82 +9933,67 @@
 		<model name='MAD-4A'>
 			<availability>MERC:2</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
-		</model>
-		<model name='MAD-5W'>
-			<availability>CC:6,CS:4,WOB:8</availability>
-		</model>
-		<model name='MAD-4K'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='MAD-4H'>
-			<availability>PIR:8,MH:8,TC:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:3,CGB:2</availability>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:5,FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:3-,MH:3-,FS:3-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:5,FRR:6,WOB:4,FS:4,MERC:4,DC:8</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:4,MERC:4</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:5,FRR:6,WOB:4,FS:4,MERC:4,DC:8</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>CS:6,MOC:2,FWL:8,IS:2,WOB:7,MERC:4</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>CS:2-,HL:2-,IS:3-,Periphery.Deep:8,WOB:2-,Periphery:4-,TC:4-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:5,FRR:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3L'>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:1,CGS:1,BAN:1,TC:3</availability>
-		</model>
-		<model name='MAD-1R'>
-			<availability>CS:4-,NIOPS:4-,WOB:4-,MERC:0,BAN:1</availability>
-		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
+		<model name='MAD-7D'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='MAD-9W'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-9S'>
+			<availability>LA:5,FRR:4,MERC:3</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>CS:2-,HL:2-,IS:3-,Periphery.Deep:8,WOB:2-,Periphery:4-,TC:4-</availability>
+		</model>
+		<model name='MAD-3L'>
+			<availability>CC:1-</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>CS:6,MOC:2,FWL:8,IS:2,WOB:7,MERC:4</availability>
+		</model>
+		<model name='MAD-1R'>
+			<availability>CS:4-,NIOPS:4-,WOB:4-,MERC:0,BAN:1</availability>
 		</model>
 		<model name='MAD-5L'>
 			<availability>CC:5,MOC:4,WOB:3,CIR:3,TC:2</availability>
 		</model>
+		<model name='MAD-6L'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:1,CGS:1,BAN:1,TC:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FVC:3-,MH:3-,FS:3-</availability>
+		</model>
 		<model name='MAD-5S'>
 			<availability>FVC:4,LA:5,FRR:3,FS:4,MERC:4</availability>
 		</model>
-		<model name='MAD-7D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:5,FWL:4,WOB:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -10009,17 +10009,17 @@
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CSA:4,CHH:4,CCC:3,CSL:4,CGS:3,CCO:3,CGB:3</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CGB:3</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CSA:4,CHH:4,CCC:3,CSL:4,CGS:3,CCO:3,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10033,11 +10033,11 @@
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MHL-6MC'>
-			<availability>MOC:3</availability>
-		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,TC:4</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
@@ -10052,11 +10052,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CSV:1,CLAN:1,IS:2+,MERC:2+,CGS:7,BAN:3,CWIE:1,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
@@ -10064,8 +10061,14 @@
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
@@ -10073,58 +10076,55 @@
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:2,CSV:5,CLAN.IS:2,CJF:5</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>LA:2,FRR:5,MERC:4,FS:2,DC:7</availability>
+		<model name='MAL-3R'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='MAL-C'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='MAL-1K'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='MAL-1R'>
 			<availability>FRR:8,MERC:6,DC:2</availability>
 		</model>
 		<model name='MAL-2R'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MAL-C'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='MAL-3R'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='MAL-1K'>
-			<availability>DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:4,CLAN:2,MH:4,FS:1,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(Intermediate)'>
-			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:5</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:5</availability>
+		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
 		</model>
 		<model name='(Basic)'>
 			<roles>apc</roles>
@@ -10133,8 +10133,8 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
@@ -10142,76 +10142,76 @@
 		<model name='(LB-X)'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:5</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:2,CC:2,FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:2,LA:4,FWL:2,NIOPS:2-,DC:2</availability>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>IS:2-,Periphery:2</availability>
 		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>FRR:3,IS:2,MERC:3,DC:4</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>FRR:3,IS:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:5,FRR:5,FWL:5,IS:4,DC:5</availability>
-		</model>
-		<model name='(C3S)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>DC:1</availability>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>DC:1</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:2-,Periphery:2</availability>
+			<availability>CC:5,FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CSR:1,WOB:1,CGS:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -10248,39 +10248,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -10292,33 +10289,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10353,23 +10353,19 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10377,13 +10373,17 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mercer' unitType='Dropship'>
@@ -10405,13 +10405,13 @@
 			<roles>recon</roles>
 			<availability>CS:4,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6</availability>
 		</model>
-		<model name='MCY-97'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='MCY-102'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='MCY-97'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
 		</model>
 		<model name='MCY-104'>
 			<roles>recon,spotter</roles>
@@ -10433,14 +10433,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,CSR:4,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:4-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>OA:6,FVC:4,CSR:6,MERC:4</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10450,27 +10450,27 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Targeting Computer)'>
 			<roles>urban</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:3,CBS:4,CSV:4,CSL:8,CGS:6</availability>
-		<model name='4'>
-			<availability>CBS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8,CGS:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -10489,11 +10489,11 @@
 	</chassis>
 	<chassis name='Mithras Light Tank' unitType='Tank'>
 		<availability>CSA:6,CCC:6,CBS:6,SOC:6,CSV:6,CLAN:2,CSL:4,CGS:6,CCO:6</availability>
-		<model name='(ERLL)'>
-			<availability>CSL:4,CGS:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(ERLL)'>
+			<availability>CSL:4,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mjolnir Battlecruiser' unitType='Warship'>
@@ -10511,13 +10511,9 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -10527,11 +10523,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -10575,10 +10575,6 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>CS:5,LA:4+</availability>
-		<model name='MON-268'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,MERC:8</availability>
@@ -10586,6 +10582,10 @@
 		<model name='MON-266'>
 			<roles>recon</roles>
 			<availability>CS:8,LA:2</availability>
+		</model>
+		<model name='MON-268'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
@@ -10611,11 +10611,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -10626,21 +10626,21 @@
 	</chassis>
 	<chassis name='Morningstar City Command Vehicle' unitType='Tank'>
 		<availability>CC:3,WOB:4,FS:6,MERC:4</availability>
-		<model name='(HPG)'>
-			<roles>apc,urban</roles>
-			<availability>WOB:6</availability>
+		<model name='(Standard)'>
+			<roles>urban,spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>urban</roles>
 			<availability>CC:2,WOB:2,FS:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>urban,spotter</roles>
 			<availability>CC:4,WOB:4,FS:4</availability>
+		</model>
+		<model name='(HPG)'>
+			<roles>apc,urban</roles>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
@@ -10669,7 +10669,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -10682,17 +10685,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -10724,32 +10724,32 @@
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='(Armored Pocket Warship)'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='(2737)'>
 			<roles>cargo,civilian</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Armored Pocket Warship)'>
+			<availability>WOB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>FS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,OA:2,LA:5,WOB:4,FS:4,MERC:4,CIR:4,TC:2,Periphery:2,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Type 2'>
 			<availability>CC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Naga' unitType='Mek' omni='Clan'>
@@ -10757,6 +10757,14 @@
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
@@ -10766,24 +10774,16 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>WOB:4,DC:6</availability>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3A'>
 			<roles>fire_support,spotter</roles>
@@ -10810,23 +10810,23 @@
 	</chassis>
 	<chassis name='Nephilim Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:2</availability>
-		<model name='(Narc)' mechanized='false'>
+		<model name='(Support)' mechanized='false'>
 			<availability>General:3</availability>
-		</model>
-		<model name='(Gauss)' mechanized='false'>
-			<availability>General:6</availability>
 		</model>
 		<model name='(Seeker) [MG]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Capture Team)[HMG]' mechanized='false'>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Narc)' mechanized='false'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Support)' mechanized='false'>
-			<availability>General:3</availability>
-		</model>
-		<model name='(Capture Team)[HMG]' mechanized='false'>
-			<availability>General:3</availability>
+		<model name='(Gauss)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -10834,11 +10834,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10869,29 +10869,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CGS:3,CJF:5</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -10910,12 +10910,12 @@
 		<model name='Mk. XXX' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
+		<model name='Mk. XXII' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
 		<model name='Mk. XXI' mechanized='true'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk. XXII' mechanized='true'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightlord Battleship' unitType='Warship'>
@@ -10927,18 +10927,18 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CHH:2,CW:2,CLAN:1,NIOPS:3,WOB:7,CWIE:2,CGB:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8,WOB:2</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>WOB:4</availability>
 		</model>
 		<model name='(Light PPC)'>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,WOB:2</availability>
+		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -10947,32 +10947,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,LA:8,WOB:3,FS:7,MERC:5,CIR:2</availability>
+		<model name='NGS-6T'>
+			<availability>LA:5,WOB:8,MERC:5,FS:5</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:5,General:8,Periphery.Deep:6,FS:5,MERC:5,Periphery:8</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>LA:5,WOB:8,MERC:5,FS:5</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:6,MERC:2</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,CS:3,LA:6,CLAN:1,NIOPS:3,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -10983,57 +10983,57 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='NJT-4'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='NJT-3'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:7,DC.SL:2,FRR:4,WOB:3,MERC:2,DC:6,CGB:3</availability>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>MERC:5,DC:6</availability>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:6,WOB:8,MERC:6,DC:6,CGB:4</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>MERC:5,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:2,CNC:8</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,CNC:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,CNC:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11045,12 +11045,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,CNC:9,CLAN:3,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -11058,20 +11052,26 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support,anti_infantry</roles>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support,anti_infantry</roles>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
@@ -11090,13 +11090,13 @@
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>CS:2,DC:3</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -11147,36 +11147,36 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
-		<model name='(Fusion)'>
-			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:7,MOC:6,IS:6,FWL:7</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:8,CNC:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:2,LA:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:4,IS:4</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:7,MOC:6,IS:6,FWL:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:8,CNC:8,IS:8</availability>
+		<model name='(MML)'>
+			<availability>MOC:4,IS:4</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:5,CSL:5,CGS:3,CCO:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
@@ -11190,38 +11190,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:3,CW:2,LA:2,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
+		<model name='ON1-M'>
+			<availability>CS:6,MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,WOB:6,MH:6,DC:6</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:1,MERC:2,RCM:4,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>HL:2-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>CS:6,MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,WOB:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>MOC:3,CC:3,FWL:4,WOB:4,MERC:2,FS:2</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2-</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>MOC:2,FWL:4,IS:2,MH:2,WOB:4,MERC:3</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:2-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2-</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:7</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:3,CC:3,FWL:4,WOB:4,MERC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11235,11 +11235,11 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,LA:2,FS:6,MERC:4</availability>
-		<model name='OSR-3D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='OSR-4D'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='OSR-3D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11247,48 +11247,48 @@
 		<model name='OSP-26'>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
+		<model name='OSR-4L'>
+			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='OSR-2L'>
+			<availability>IS:1-</availability>
+		</model>
+		<model name='OSR-2C'>
+			<roles>urban</roles>
+			<availability>HL:2-,IS:2-,Periphery.Deep:8,MERC:4-,BAN:1,Periphery:4-</availability>
+		</model>
+		<model name='OSR-2D'>
+			<availability>CS:8,HL:2,IS:4,Periphery:4</availability>
+		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:2-</availability>
+		</model>
+		<model name='OSR-5W'>
+			<roles>urban</roles>
+			<availability>WOB:3</availability>
+		</model>
 		<model name='OSR-3C'>
 			<availability>FVC:2-,IS:1-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-4K'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='OSR-2C'>
-			<roles>urban</roles>
-			<availability>HL:2-,IS:2-,Periphery.Deep:8,MERC:4-,BAN:1,Periphery:4-</availability>
-		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2</availability>
 		</model>
-		<model name='OSR-2L'>
-			<availability>IS:1-</availability>
-		</model>
-		<model name='OSR-2D'>
-			<availability>CS:8,HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='OSR-4C'>
 			<availability>CIR:8,TC:6,Periphery:2</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:2-</availability>
-		</model>
-		<model name='OSR-4L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='OSR-5W'>
-			<roles>urban</roles>
-			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -11297,25 +11297,25 @@
 			<roles>recon,spotter</roles>
 			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
-		<model name='OTT-7J'>
-			<roles>recon</roles>
-			<availability>General:4-,BAN:1</availability>
-		</model>
-		<model name='OTT-9S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,MERC:4</availability>
-		</model>
 		<model name='OTT-10CS'>
 			<roles>recon</roles>
 			<availability>CS:6,WOB:4</availability>
+		</model>
+		<model name='OTT-9CS'>
+			<roles>recon,spotter</roles>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='OTT-7J'>
+			<roles>recon</roles>
+			<availability>General:4-,BAN:1</availability>
 		</model>
 		<model name='OTT-7Jb'>
 			<roles>recon</roles>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='OTT-9CS'>
+		<model name='OTT-9S'>
 			<roles>recon,spotter</roles>
-			<availability>CS:5,WOB:4</availability>
+			<availability>LA:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -11326,26 +11326,26 @@
 		<model name='OTL-8D'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='OTL-4D'>
-			<availability>IS:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4,MERC:1,DC:1</availability>
+		<model name='OTL-8M'>
+			<availability>DTA:5,FWL:4,WOB:3,MERC:3</availability>
 		</model>
 		<model name='OTL-5M'>
 			<availability>CS:4,FWL:5,WOB:6,MERC:4</availability>
 		</model>
-		<model name='OTL-8M'>
-			<availability>DTA:5,FWL:4,WOB:3,MERC:3</availability>
+		<model name='OTL-4F'>
+			<availability>FVC:1-,FS:1-</availability>
 		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:5,MERC:4</availability>
+		<model name='OTL-6D'>
+			<availability>FS:4,MERC:1,DC:1</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>IS:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
 		</model>
-		<model name='OTL-4F'>
-			<availability>FVC:1-,FS:1-</availability>
+		<model name='OTL-9R'>
+			<availability>DTA:5,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -11359,11 +11359,11 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:6,CW:4,CSL:6</availability>
-		<model name='(3070)'>
+		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(3063)'>
+		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:6</availability>
 		</model>
@@ -11377,24 +11377,32 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:6,IS:2,FS:6</availability>
-		</model>
 		<model name='A3A'>
 			<availability>LA:1,FS:1</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:6,IS:2,FS:6</availability>
 		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:4,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:3,CS:3,CNC:4,FWL:3,WOB:3,FS:3,MERC:3,DC:5</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2+,CLAN:6</availability>
+		</model>
+		<model name='OW-1F'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -11403,27 +11411,19 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1A'>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2+,CLAN:6</availability>
 		</model>
 		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='OW-1F'>
+		<model name='OW-1'>
 			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
-		<model name='OW-1B'>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -11436,17 +11436,17 @@
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,MERC.KH:1,CDS:3,CSR:2,CSV:3,CNC:3,CLAN:2,CCO:3,CWIE:7</availability>
-		<model name='2'>
-			<availability>CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -11455,43 +11455,43 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,MOC:5</availability>
-		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4</availability>
 		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
 		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:5,CS:4,NIOPS:4,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>WOB:3</availability>
-		<model name='(LTC)'>
-			<roles>artillery</roles>
-			<availability>LA:3,WOB:3,FS:3,DC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LTC)'>
+			<roles>artillery</roles>
+			<availability>LA:3,WOB:3,FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Palmoni Assault Infantry Fighting Vehicle' unitType='Tank'>
@@ -11503,25 +11503,17 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,FS.DMM:5,CNC:3,FWL:1,NIOPS:2,DC:9</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,MERC:4-,Periphery:4-,DC:4-</availability>
 		</model>
-		<model name='PNT-14S'>
+		<model name='PNT-C'>
 			<roles>fire_support</roles>
-			<availability>WOB:8</availability>
+			<availability>FS.RR:4,FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
-		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
@@ -11535,17 +11527,25 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
+		<model name='PNT-CA'>
 			<roles>fire_support</roles>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,MERC:4-,Periphery:4-,DC:4-</availability>
+			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='PNT-14S'>
+			<roles>fire_support</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>FRR:3,DC:3</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:4,FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
+			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -11561,42 +11561,42 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,CS:6,HL:3,LA:7,FRR:4,CNC:5,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,DC:6</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>WOB:3,FS:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:6,FS:6</availability>
-		</model>
-		<model name='(Cell)'>
-			<availability>General:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>WOB:2,FS:2</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>WOB:3,FS:4</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:4,FS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:5-,CC:2-,HL:4-,FRR:2-,IS:4-,Periphery.Deep:9,WOB:4-,FS:5-,CIR:3-,Periphery:5-,TC:5-,CS:4-,OA:2-,CDS:2,LA:4-,FWL:4-,DC:2-</availability>
-		<model name='(Standard)'>
+		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
@@ -11605,9 +11605,9 @@
 		<model name='(LRM)'>
 			<availability>IS:2-,Periphery:3</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -11618,10 +11618,6 @@
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>FWL:4</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:6,FWL.RH:8</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:8</availability>
@@ -11629,6 +11625,10 @@
 		<model name='PKM-2E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:6,FWL.RH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -11655,9 +11655,17 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:1,CC:2,FRR:2,IS:2,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:2,CS:5-,OA:1,LA:6,FWL:2,DC:6</availability>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,WOB:4,FS:4,DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
@@ -11667,43 +11675,35 @@
 			<roles>recon</roles>
 			<availability>WOB:4,DC:5</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,FS:4,DC:4</availability>
-		</model>
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,FS:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pentagon' unitType='Dropship'>
@@ -11714,44 +11714,53 @@
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:2,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='5'>
-			<availability>CGS:9</availability>
+		<model name='3'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1</availability>
 		</model>
+		<model name='5'>
+			<availability>CGS:9</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='4'>
 			<availability>CSR:8,CBS:7,CGS:6</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:1-,LA:2-,FRR:1-,FWL:1-,IS:1-,FS:2-,MERC:1-,DC:2-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,FWL:6,WOB:5</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2,WOB:6</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
@@ -11759,32 +11768,23 @@
 		<model name='P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2,WOB:6</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:6,WOB:6</availability>
+		<model name='(WoB-A)' mechanized='true'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(A)' mechanized='true'>
 			<availability>FWL:8</availability>
-		</model>
-		<model name='(WoB-C)' mechanized='true'>
-			<availability>WOB:5</availability>
 		</model>
 		<model name='(C)' mechanized='true'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='(WoB-A)' mechanized='true'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='(WoB-C)' mechanized='true'>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='(B)' mechanized='true'>
 			<availability>FWL:1</availability>
@@ -11792,18 +11792,18 @@
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CSR:6,CW:8,CSL:7,CGS:8,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSA:7,General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>CSA:7,General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -11813,114 +11813,114 @@
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CSR:5,CDS:5,CBS:3,CSV:5,CLAN:3,CCO:5</availability>
-		<model name='(Standard)'>
-			<availability>CCC:3,CSR:3,CDS:4,CSV:3,CLAN:2,CNC:4,CCO:4,DC:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:5,CSV:8,CLAN:2</availability>
+		<model name='6'>
+			<availability>CDS:5,CGB:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:6,CLAN:2</availability>
 		</model>
-		<model name='6'>
-			<availability>CDS:5,CGB:5</availability>
+		<model name='4'>
+			<availability>CDS:5,CSV:8,CLAN:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:3,CSR:3,CDS:4,CSV:3,CLAN:2,CNC:4,CCO:4,DC:2</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CSR:5,CDS:2,CSV:5,CNC:2,CCO:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='PHX-HK1'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>IS:2+</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK1RB'>
-			<availability>WOB:1</availability>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
 		</model>
 		<model name='PHX-HK2'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='PHX-HK2M'>
-			<availability>IS:2,FWL:4</availability>
+		<model name='PHX-HK1RB'>
+			<availability>WOB:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:5,CLAN:1,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:1</availability>
+		<model name='PXH-3PL'>
+			<availability>WOB:4,FS:5,MERC:4</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>LA:5,MERC:4</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:6,MOC:4,MH:4,WOB:4,CIR:3,TC:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FVC:2-,PIR:3-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:4,WOB:4,BAN:1</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:1-,DC:2-</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:6,MERC:5</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>DTA:8,FWL:8,IS:4,RCM:8</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='PXH-7CS'>
 			<availability>CS:4</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>WOB:4,FS:5,MERC:4</availability>
+		<model name='PXH-5L'>
+			<availability>CC:3,MOC:3</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>General:3-,BAN:6,Periphery:3-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>LA:5,MERC:4</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:1-,DC:2-</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,FWL:8,IS:4,RCM:8</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:3,FWL:3,WOB:4,RCM:3,CGS:5</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>FVC:2-,PIR:3-,FS:2-,MERC:2-</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:6,MOC:4,MH:4,WOB:4,CIR:3,TC:4</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:4,WOB:4,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -11928,47 +11928,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:4,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:2-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>CC:6,MOC:6,FS:6,MERC:6,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,IS:4,Periphery.Deep:4,Periphery:6</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>CC:6,MOC:6,FS:6,MERC:6,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,CS:4,MOC:3,MERC.WD:4,MERC.KH:4,CNC:6,CLAN:1,NIOPS:4,FS:2,MERC:4,TC:2</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -11976,11 +11976,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -12017,12 +12017,12 @@
 		<model name='(Streak)'>
 			<availability>HL:2,IS:5,TC:6,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>HL:3,FWL:5,IS:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:2</availability>
@@ -12044,11 +12044,11 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
@@ -12059,42 +12059,42 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CS:1,CHH:1,CCC:2,CSR:5,CDS:5,CSV:2,NIOPS:1,CGS:3,CCO:2,CWIE:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CGS:7,CCO:6,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,General:2,CGB:3</availability>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,General:2,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -12114,22 +12114,22 @@
 	</chassis>
 	<chassis name='Preta' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-PRT-OE Eminus'>
-			<availability>General:7</availability>
+		<model name='C-PRT-OU Exanimus'>
+			<availability>General:2</availability>
 		</model>
-		<model name='C-PRT-OD Luminos'>
+		<model name='C-PRT-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-PRT-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-PRT-OU Exanimus'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C-PRT-OS Caelestis'>
 			<availability>General:4</availability>
 		</model>
-		<model name='C-PRT-OA Dominus'>
+		<model name='C-PRT-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-PRT-OC Comminus'>
@@ -12142,20 +12142,20 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:4,CSL:6,CCO:6</availability>
-		<model name='2'>
-			<availability>CHH:2,CCO:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CHH:8,CBS:8,CSL:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:8,CBS:8,CSL:8,CCO:8</availability>
+		<model name='4'>
+			<availability>CCO:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:2,CCO:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12173,10 +12173,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:4,Periphery:7</availability>
@@ -12185,9 +12181,9 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
-			<availability>IS:4,Periphery:4</availability>
+		<model name='(Support)'>
+			<roles>apc</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(WoB)'>
 			<roles>apc</roles>
@@ -12197,35 +12193,39 @@
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8,General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:7,CLAN:7,IS:2+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CGB:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CGB:3</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12233,11 +12233,11 @@
 		<model name='PAT-005'>
 			<availability>CS:4,CHH:2,CW:2,FRR:8,NIOPS:8,WOB:8,CWIE:2</availability>
 		</model>
-		<model name='PAT-007'>
-			<availability>CS:7,WOB:6</availability>
-		</model>
 		<model name='PAT-008'>
 			<availability>WOB:5+</availability>
+		</model>
+		<model name='PAT-007'>
+			<availability>CS:7,WOB:6</availability>
 		</model>
 		<model name='PAT-005b'>
 			<availability>CLAN:8,BAN:2</availability>
@@ -12248,6 +12248,9 @@
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
 		</model>
+		<model name='[Narc]' mechanized='true'>
+			<availability>CS:4,WOB:4,Periphery:4</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5,Periphery:5</availability>
@@ -12255,13 +12258,13 @@
 		<model name='[Laser]' mechanized='true'>
 			<availability>CS:7,WOB:7,Periphery:7</availability>
 		</model>
-		<model name='[Narc]' mechanized='true'>
-			<availability>CS:4,WOB:4,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Purifier Battle Armor Terra' unitType='BattleArmor'>
 		<availability>WOB:4</availability>
 		<model name='[MRR]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[ERSL]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[AP Gauss]' mechanized='true'>
@@ -12270,17 +12273,14 @@
 		<model name='[SPL]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[ERSL]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>HL:3,Periphery:5</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>HL:3,Periphery:5</availability>
@@ -12291,17 +12291,17 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:5,MERC:5,DC:6</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:4,FWL:6</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
 		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
+		</model>
 		<model name='QKD-8K'>
 			<availability>FRR:5,MERC:3,DC:7</availability>
-		</model>
-		<model name='QKD-C'>
-			<availability>FRR:8,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
@@ -12309,11 +12309,11 @@
 		<model name='QKD-4H'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
+		<model name='QKD-C'>
+			<availability>FRR:8,MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:4,FWL:6</availability>
+		<model name='QKD-5K'>
+			<availability>FRR:5,MERC:5,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -12325,40 +12325,37 @@
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='(Standard)'>
-			<availability>CCC:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin II' unitType='Mek'>
 		<availability>WOB:6+</availability>
-		<model name='RJN-200-C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='RJN-200-B'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
@@ -12366,40 +12363,43 @@
 		<model name='RJN-200-A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='RJN-200-C'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
 		<availability>CS:5,WOB:1</availability>
-		<model name='RJN101-C'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RJN101-A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RJN101-C'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,FS:5,MERC:3</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
-		</model>
-		<model name='MDG-1Ar'>
-			<availability>FS:3,MERC:3</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1Ar'>
+			<availability>FS:3,MERC:3</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>CS:4,LA:3,FWL:3,MH:4,MERC:4,FS:3,DC:3</availability>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='VV1'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='VV1 (MG)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
@@ -12408,20 +12408,20 @@
 			<roles>ground_support</roles>
 			<availability>CS:3</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
+		<model name='RPR-300'>
+			<availability>LA:5</availability>
 		</model>
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:2</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:2-</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='RPR-300'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -12437,54 +12437,40 @@
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3,FS:4,DC:6</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:2+</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:2+</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='RTX1-OA'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:4,FS:2,MERC:5,TC:4,DC:2</availability>
-		<model name='RVN-4X'>
-			<availability>CC:2</availability>
-		</model>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FWL:4,FS:1,MERC:3,DC:1,TC:3</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:3</availability>
-		</model>
-		<model name='RVN-SR &apos;Shattered Raven&apos;'>
-			<availability>FS.CMM:2</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,TC:2</availability>
@@ -12493,25 +12479,39 @@
 			<roles>spotter</roles>
 			<availability>CC:4,MOC:3,FWL:2,FS:1,MERC:3,DC:3,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:7,MOC:7,TC:7</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='RVN-SS &apos;Shattered Raven&apos;'>
 			<roles>spotter</roles>
 			<availability>FS.CMM:2</availability>
 		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:7,TC:7</availability>
+		</model>
+		<model name='RVN-4X'>
+			<availability>CC:2</availability>
+		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,FWL:4,FS:1,MERC:3,DC:1,TC:3</availability>
+		</model>
+		<model name='RVN-SR &apos;Shattered Raven&apos;'>
+			<availability>FS.CMM:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>LA:6,FRR:5,MERC:4,FS:4</availability>
-		<model name='RZK-10T'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -12523,11 +12523,6 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='RDS-2A'>
-			<roles>spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='RDS-2B'>
 			<roles>recon,spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
@@ -12537,15 +12532,20 @@
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:4</availability>
 		</model>
+		<model name='RDS-2A'>
+			<roles>spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -12559,6 +12559,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
@@ -12567,27 +12575,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:4,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,RCM:8,DC:4</availability>
-		<model name='F-700a'>
-			<availability>CC:7,DTA:6,FWL:7,WOB:7,FS:5,MERC:7,RCM:6</availability>
+		<model name='F-100'>
+			<availability>CC:2-,FVC:4-,HL:2-,LA:1,FRR:1,FWL:4-,Periphery.Deep:8,MERC:4-,DC:1,Periphery:4-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>DTA:8,FWL:5,WOB:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>FRR:3-,DC:3-</availability>
@@ -12598,32 +12601,29 @@
 		<model name='F-700'>
 			<availability>CC:8,DTA:8,FWL:8,WOB:8,MERC:8,RCM:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>DTA:8,FWL:5,WOB:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:2-,FVC:4-,HL:2-,LA:1,FRR:1,FWL:4-,Periphery.Deep:8,MERC:4-,DC:1,Periphery:4-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,DTA:6,FWL:7,WOB:7,FS:5,MERC:7,RCM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:2,CNC:5,IS:2,CGB:5</availability>
-		<model name='5'>
-			<availability>CSA:5,CDS:3,SOC:4,IS:2,CLAN.HW:4</availability>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,CBS:4,CCO:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2,CNC:5,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CDS:3,CLAN:2,CNC:3</availability>
+		</model>
+		<model name='5'>
+			<availability>CSA:5,CDS:3,SOC:4,IS:2,CLAN.HW:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,CDS:4,CBS:5,CCO:4</availability>
 		</model>
 		<model name='6'>
 			<availability>CSA:5,CHH:3,CDS:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,CBS:4,CCO:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:2,CNC:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -12635,26 +12635,18 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CJF:4</availability>
-		<model name='RFL-6D'>
-			<availability>FS:3</availability>
+		<model name='RFL-5D'>
+			<availability>FVC:5,LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='RFL-7M'>
 			<availability>DTA:6,FRR:4,FWL:6,WOB:5,RCM:6,DC:4</availability>
-		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:1</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FVC:1-,FS:1-,MERC:1-</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:5,LA:4,FS:4,MERC:4</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:3,MERC:2</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:2</availability>
@@ -12663,23 +12655,31 @@
 			<roles>fire_support</roles>
 			<availability>CC:3-,MOC:3-,PIR:3-,FWL:2-,MH:3-,FS:3-,MERC:2-,RCM:3-</availability>
 		</model>
-		<model name='RFL-8D'>
-			<availability>LA:2,FS:5</availability>
-		</model>
-		<model name='RFL-9T'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='RFL-8X'>
-			<availability>MERC:4</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:3,MERC:2</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>CC:4,MOC:4,FWL:4,IS:2,MERC:4,DC:4</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:1,CLAN:8,FS:1,BAN:2,DC:1</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='RFL-8X'>
+			<availability>MERC:4</availability>
+		</model>
+		<model name='RFL-6D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='RFL-8D'>
+			<availability>LA:2,FS:5</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:1</availability>
+		</model>
+		<model name='RFL-9T'>
+			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riot Police' unitType='Infantry'>
@@ -12691,45 +12691,45 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CS:6,CHH:4,FVC:4,CSR:1,LA:5,FRR:5,CLAN:2,NIOPS:6,WOB:6,FS:5,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5,FS:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,FS:2</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CSR:7,CBS:7,SOC:8,CSV:4,CNC:7,CSL:4,CGS:6,CCO:8,CWIE:8</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSR:8,CBS:8,CSV:6,CNC:6,CSL:6,CCO:8,CGS:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:6,CBS:6,CSV:5,CNC:4,CCO:4,CWIE:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:5,CCO:4</availability>
@@ -12743,43 +12743,40 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
 		</model>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='RGU-133F'>
 			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:1</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>OA:5,FVC:3,LA:6,FRR:4,FS:4,MERC:3,CWIE:6,TC:6</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:3,FS:3,CWIE:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:4,TC:0,CWIE:0</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
 		<availability>FWL:3-,FS:2,MERC:2</availability>
-		<model name='NH-3X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='NH-2'>
 			<availability>General:8</availability>
 		</model>
@@ -12791,6 +12788,9 @@
 		</model>
 		<model name='NH-1B'>
 			<availability>MERC:6-,FS:6-</availability>
+		</model>
+		<model name='NH-3X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -12810,12 +12810,12 @@
 			<roles>recon</roles>
 			<availability>LA:6</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -12828,6 +12828,14 @@
 	</chassis>
 	<chassis name='Rusalka' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6</availability>
+		<model name='S-RSL-OE Eminus'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-RSL-OD Luminos'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='S-RSL-OB Infernus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
@@ -12836,15 +12844,7 @@
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-RSL-OE Eminus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='S-RSL-OA Dominus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='S-RSL-OD Luminos'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
@@ -12855,23 +12855,23 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:7,CSV:6,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:7,CBS:8,CNC:4,CJF:7,DC:3+</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
+		<model name='F'>
+			<availability>General:2,CJF:5</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:2,CJF:5</availability>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:1</availability>
@@ -12879,8 +12879,8 @@
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:6,CNC:4,General:5,CCO:7,CJF:4,CWIE:6</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CWIE:5,CGB:6</availability>
@@ -12894,20 +12894,20 @@
 		<model name='3'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CGB:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CGB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
 		<availability>CNC:6,DC:4</availability>
-		<model name='SM1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Telos)'>
 			<availability>CNC:2</availability>
+		</model>
+		<model name='SM1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1A Tank Destroyer' unitType='Tank'>
@@ -12932,13 +12932,13 @@
 			<roles>sr_fire_support,spotter</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:6,Periphery:3</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:8,LA:8,FWL:8,IS:6,FS:8,DC:6,Periphery:6</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:6,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -12955,14 +12955,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
-		<model name='SB-27'>
-			<availability>General:5-</availability>
+		<model name='SB-28'>
+			<availability>CS:6,LA:8,NIOPS:6,WOB:6,FS:5,MERC:5</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>MERC:5,DC:8</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>CS:6,LA:8,NIOPS:6,WOB:6,FS:5,MERC:5</availability>
+		<model name='SB-27'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,CLAN:4,FS:8,MERC:5</availability>
@@ -12970,17 +12970,11 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='E'>
-			<availability>CSR:5,General:2,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -12989,11 +12983,17 @@
 		<model name='D'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>CSR:3,General:1,CJF:3</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='E'>
+			<availability>CSR:5,General:2,CJF:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -13008,50 +13008,50 @@
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:4,CW:4,FRR:6,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
-		<model name='S-4X'>
-			<availability>DC:1</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8,DC:4</availability>
-		</model>
-		<model name='S-3'>
-			<availability>DC:2-</availability>
-		</model>
-		<model name='S-8'>
-			<availability>DC:4</availability>
 		</model>
 		<model name='S-4'>
 			<availability>FRR:6,FS:5,DC:6</availability>
 		</model>
+		<model name='S-8'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='S-3'>
+			<availability>DC:2-</availability>
+		</model>
 		<model name='S-7'>
 			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='S-4X'>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:5,CS:5-,LA:6,FWL:6,CJF:4,DC:9</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:6,DC:7</availability>
+		</model>
 		<model name='(LB-X)'>
 			<availability>IS:6,DC:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:6,DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CSR:6,CW:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CSR:6,CW:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -13060,10 +13060,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:5,LA:7,FS:5,MERC:5</availability>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -13071,6 +13067,10 @@
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
@@ -13087,21 +13087,21 @@
 			<roles>ground_support</roles>
 			<availability>OA:4,FRR:4-,DC:4</availability>
 		</model>
-		<model name='SL-27'>
-			<availability>IS:6,DC:2</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:4-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,FWL:6-,DC:8-</availability>
-		<model name='(MRM)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sasquatch' unitType='Mek'>
@@ -13122,14 +13122,6 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:4,CBS:5,CSV:4,CNC:2,CGS:6,CCO:7,CWIE:7</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='4'>
 			<roles>recon,raider,spotter</roles>
 			<availability>CSR:4,CNC:4</availability>
@@ -13138,26 +13130,34 @@
 			<roles>recon,raider</roles>
 			<availability>CGS:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CW:5,SOC:7,CCO:8</availability>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
 		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -13166,12 +13166,12 @@
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
 		<availability>LA:5,FS:4,MERC:3,DC:3</availability>
+		<model name='(Interdictor)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(Interdictor)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savior Repair Vehicle' unitType='Tank'>
@@ -13183,10 +13183,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:5,MERC:3</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -13194,6 +13190,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -13213,33 +13213,33 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,FRR:4,FWL:4,WOB:4,FS:4,MERC:4,MERC.NH:4,DC:4</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -13250,33 +13250,33 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:4,CC:2,HL:4,FRR:3,IS:4,Periphery.Deep:5,WOB:4,MERC:4,FS:4,CIR:5,Periphery:5,TC:4,CS:3,OA:5,LA:4,FWL:3,DC:2</availability>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
+		<model name='(Armor)'>
+			<availability>CNC:6,IS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>CNC:6,IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,FWL:3-,DC:6-</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:6-</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6-</availability>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:6,DC:8</availability>
@@ -13284,45 +13284,45 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,FRR:8,IS:7,Periphery.Deep:7,FWL:6,FS:6,CJF:4,Periphery:7,DC:6</availability>
-		<model name='(LRM)'>
-			<availability>General:3-</availability>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
-			<availability>General:5-</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:4,MOC:3,LA:4,FWL:4,IS:3,MH:3,WOB:4,FS:4,MERC:4,DC:4,TC:3</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>General:5-</availability>
 		</model>
 		<model name='(ML)'>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
+		<model name='(LAC)'>
+			<availability>CC:4,MOC:3,LA:4,FWL:4,IS:3,MH:3,WOB:4,FS:4,MERC:4,DC:4,TC:3</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2-,CS:2-,HL:2-,LA:3,FRR:2-,Periphery.Deep:4-,FWL:2-,NIOPS:2-,WOB:2-,MERC:2-,Periphery:3-,DC:2-</availability>
-		<model name='SCP-1N'>
-			<availability>HL:2-,FRR:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
-		</model>
-		<model name='SCP-12C'>
-			<availability>WOB:4</availability>
+		<model name='SCP-12S'>
+			<availability>LA:4,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>HL:2-,FRR:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>IS:6,Periphery:2</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,MERC:2</availability>
-		</model>
 		<model name='SCP-1TB'>
 			<availability>MERC:4</availability>
+		</model>
+		<model name='SCP-12C'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -13352,39 +13352,39 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:5,CW:5,CSV:5,CLAN:4,CNC:5,CGS:4,CJF:7,CCO:5,CWIE:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Se&apos;irim Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:7</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Capture Team)' mechanized='true'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -13401,20 +13401,17 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,CS:3,HL:2,LA:6,FRR:3,IS:4,FWL:4,WOB:3,FS:5,CIR:3,Periphery:3,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:8,FWL:4,IS:4,FS:8</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:2,CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,FVC:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:3-,DC:1</availability>
 		</model>
@@ -13423,6 +13420,9 @@
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,FVC:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 		<model name='STN-5WB'>
 			<availability>WOB:8</availability>
@@ -13443,14 +13443,11 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-SRP-O Invictus'>
-			<availability>General:8</availability>
+		<model name='C-SRP-OS Caelestis'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C-SRP-O (Havalah)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C-SRP-OS Caelestis'>
-			<availability>General:4</availability>
 		</model>
 		<model name='C-SRP-OC Comminus'>
 			<availability>General:7</availability>
@@ -13460,6 +13457,9 @@
 		</model>
 		<model name='C-SRP-OD Luminos'>
 			<availability>General:7</availability>
+		</model>
+		<model name='C-SRP-O Invictus'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C-SRP-OB Infernus'>
 			<availability>General:7</availability>
@@ -13471,22 +13471,26 @@
 			<roles>interceptor</roles>
 			<availability>LA:3-,Periphery.Deep:8,FS:2-,Periphery:3-</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:4-,HL:4,FRR:4-,Periphery.Deep:4,FWL:4-,WOB:4-,Periphery:6,TC:4-,DC:4-</availability>
-		</model>
 		<model name='SYD-Z3A'>
 			<availability>LA:6,FRR:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='SYD-45X &apos;Starling&apos;'>
 			<availability>LA:1</availability>
 		</model>
+		<model name='SYD-Z1'>
+			<roles>interceptor</roles>
+			<availability>OA:4-,HL:4,FRR:4-,Periphery.Deep:4,FWL:4-,WOB:4-,Periphery:6,TC:4-,DC:4-</availability>
+		</model>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
+		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,OA:4,LA:6,FRR:2,MERC:5</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2-,FS:1-</availability>
 		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -13495,21 +13499,17 @@
 		<model name='SYD-Z2B'>
 			<availability>OA:4,LA:4,FS:2,MERC:2</availability>
 		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2-,FS:1-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6,MOC:4</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -13521,14 +13521,14 @@
 		<model name='S-HA-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='S-HA-O Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='S-HA-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-HA-OB Infernus'>
 			<availability>General:7</availability>
-		</model>
-		<model name='S-HA-O Invictus'>
-			<availability>General:8</availability>
 		</model>
 		<model name='S-HA-OD Luminos'>
 			<availability>General:7</availability>
@@ -13545,16 +13545,12 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:4,CDS:5,CW:2,CSV:5,CNC:7,CLAN.IS:2,CSL:4,CJF:5,CWIE:2</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:3,CCO:7</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSR:8,CW:3,General:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
 		<model name='J'>
 			<availability>General:5</availability>
@@ -13562,18 +13558,28 @@
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
+		<model name='A'>
 			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
+			<availability>CSR:3,CW:3,General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,FRR:3,CLAN:4,IS:1,FS:3,MERC:3,CWIE:6,DTA:3,CS:3,CDS:6,LA:3,CNC:6,FWL:3,RCM:3,CJF:2,DC:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:2</availability>
+		<model name='6'>
+			<availability>CHH:5</availability>
+		</model>
+		<model name='5'>
+			<availability>CS:6,CDS:6,LA:6,FRR:5,FWL:6,IS:4,FS:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5</availability>
@@ -13581,38 +13587,26 @@
 		<model name='3'>
 			<availability>CSA:4,CDS:5,CNC:5</availability>
 		</model>
-		<model name='5'>
-			<availability>CS:6,CDS:6,LA:6,FRR:5,FWL:6,IS:4,FS:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:2,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:3</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:2-,MERC:2-,DC:4-</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,CLAN:4,FWL:4,MERC:4,BAN:2</availability>
 		</model>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,LA:6,FS:6</availability>
+		<model name='SHD-3K'>
+			<availability>FRR:3,DC:4</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:3-,MOC:3-,FWL:3-,MERC:3-</availability>
 		</model>
-		<model name='SHD-2D'>
-			<availability>FVC:2-,FS:2-</availability>
-		</model>
-		<model name='SHD-11CS'>
-			<availability>CS:6,WOB:5</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,CLAN:4,FWL:4,MERC:4,BAN:2</availability>
-		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:6,IS:2,MERC:6,DC:6</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,WOB:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:2-,MERC:2-,DC:4-</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CCC:8,LA:3,CSV:8,FS:3,CGS:8,DC:3</availability>
@@ -13620,17 +13614,23 @@
 		<model name='SHD-7M'>
 			<availability>CC:4,MOC:3,DTA:5,FVC:2,FWL:5,MERC:3,RCM:5,CDP:2,TC:3</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>WOB:4,FS:4</availability>
+		<model name='SHD-2H'>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
 		</model>
 		<model name='SHD-7CS'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,WOB:4,FS:5,MERC:4</availability>
+		<model name='SHD-9D'>
+			<availability>WOB:4,FS:4</availability>
 		</model>
-		<model name='SHD-3K'>
-			<availability>FRR:3,DC:4</availability>
+		<model name='SHD-11CS'>
+			<availability>CS:6,WOB:5</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,LA:6,FS:6</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FVC:2-,FS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -13638,11 +13638,11 @@
 		<model name='(Flamer)'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:3,CSR:3,CDS:3,CW:3,CNC:3,CJF:3,CGB:4,CWIE:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shedu Assault Battle Armor' unitType='BattleArmor'>
@@ -13654,26 +13654,26 @@
 		<model name='(Capture Team)' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(PPC)' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(PPC)' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>OA:3,FRR:4,MERC:3,DC:4</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='SL-17AC'>
 			<availability>DC:1-</availability>
@@ -13682,6 +13682,9 @@
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>FWL:4,WOB:4,FWL.KIS:6,FWL.FWG:5</availability>
 		<model name='SHV-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
@@ -13693,21 +13696,18 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,CNC:5,CJF:3,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:5,DC:5</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
+		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -13718,12 +13718,12 @@
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:6,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
-		<model name='SL-22'>
-			<availability>FRR:8,DC:8</availability>
-		</model>
 		<model name='SL-21L'>
 			<roles>raider,ground_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='SL-22'>
+			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='SL-21'>
 			<availability>HL:4,LA:4,Periphery.Deep:6,MERC:5,DC:5,Periphery:6</availability>
@@ -13731,14 +13731,14 @@
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
 		<availability>CS:3,CLAN:1,NIOPS:3,WOB:3</availability>
-		<model name='ST-8A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ST-8C'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='ST-9C'>
 			<availability>CS:4,WOB:4</availability>
+		</model>
+		<model name='ST-8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shugenja' unitType='Mek'>
@@ -13766,23 +13766,23 @@
 	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CSA:4,CCC:4,CCO:4</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:4,CCC:4,CCO:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,FWL:3,WOB:4,MERC:3</availability>
-		<model name='SRC-5C'>
-			<availability>DTA:5,FWL:5,WOB:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>DTA:5,FWL:5,WOB:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>DTA:4,FWL:4,WOB:4</availability>
@@ -13790,51 +13790,51 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:5-</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
 			<availability>IS.pm:4</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
+		<model name='SL-15'>
+			<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,CSR:6,FRR:8,FS:6,MERC:6,CDP:4,DC:8,TC:4</availability>
 		</model>
-		<model name='SL-15B'>
-			<availability>FRR:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>FRR:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
+		<model name='SL-15B'>
+			<availability>FRR:1,MERC:1,DC:1</availability>
 		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
 		</model>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:3,FS:3</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snake' unitType='Mek'>
@@ -13858,11 +13858,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -13894,31 +13894,31 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>CS:6,WOB:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3</availability>
+		<model name='SPR-H5K'>
+			<roles>interceptor</roles>
+			<availability>OA:1,FRR:2-,DC:2-</availability>
+		</model>
+		<model name='SPR-7D'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
+		<model name='SPR-DH'>
+			<availability>OA:3-,FVC:3-,MERC:3-</availability>
+		</model>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:2,FRR:5,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:4-,General:2-,Periphery.Deep:8,FS:4-,MERC:4-,CDP:4-,TC:4-</availability>
-		</model>
-		<model name='SPR-7D'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-H5K'>
-			<roles>interceptor</roles>
-			<availability>OA:1,FRR:2-,DC:2-</availability>
-		</model>
-		<model name='SPR-DH'>
-			<availability>OA:3-,FVC:3-,MERC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -13944,25 +13944,35 @@
 		<model name='SPR-5S'>
 			<availability>CS:4,CC:4,LA:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,CS:4,LA:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8,CIR:8</availability>
 		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,CS:4,LA:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:2,CC:2,FWL:8,MH:2,MERC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:3-,DC:3-</availability>
 		</model>
-		<model name='SDR-7Kr'>
-			<availability>MERC:2,DC:2</availability>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:2-</availability>
 		</model>
 		<model name='SDR-7K'>
 			<availability>MERC:4,DC:5</availability>
@@ -13973,18 +13983,8 @@
 		<model name='SDR-7KC'>
 			<availability>MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:2-</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>MERC:3,DC:4</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:2,CC:2,FWL:8,MH:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
@@ -13998,17 +13998,17 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:7,FRR:7,IS:6,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(C3i)'>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
 			<roles>recon</roles>
-			<availability>CS:5,WOB:6</availability>
+			<availability>FRR:5,IS:4,DC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -14018,9 +14018,9 @@
 			<roles>spotter</roles>
 			<availability>LA:3,FWL:3,MERC:3,FS:3,DC:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
+		<model name='(C3i)'>
+			<roles>recon</roles>
+			<availability>CS:5,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14031,14 +14031,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,FWL:8,NIOPS:5,DC:5</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
+		</model>
 		<model name='STK-8S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-6M'>
+			<availability>CC:3,MOC:3,FWL:6,WOB:6,MERC:6,RCM:6</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:1</availability>
@@ -14046,20 +14049,17 @@
 		<model name='STK-7D'>
 			<availability>FS:4,MERC:2</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CC:2,MOC:2,CLAN:8,FWL:3,MERC:3,RCM:3,BAN:2</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
-		</model>
-		<model name='STK-6M'>
-			<availability>CC:3,MOC:3,FWL:6,WOB:6,MERC:6,RCM:6</availability>
+		<model name='STK-3F'>
+			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,CSV:3,MERC:4,FS:5,CJF:3,TC:4</availability>
@@ -14067,12 +14067,12 @@
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -14098,12 +14098,12 @@
 	</chassis>
 	<chassis name='Starslayer' unitType='Mek'>
 		<availability>MOC:4,CC:4,LA:6,FRR:4,FS:4,MERC:4</availability>
+		<model name='STY-3Dr'>
+			<availability>LA:4,MERC:2</availability>
+		</model>
 		<model name='STY-3D'>
 			<roles>raider</roles>
 			<availability>MOC:6,LA:6,MERC:6</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>LA:4,MERC:2</availability>
 		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
@@ -14112,6 +14112,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>CS:4,LA:4,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>LA:2,FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:2,FS:4,MERC:2</availability>
@@ -14120,17 +14124,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>LA:2,FS:6,MERC:4</availability>
+			<availability>LA:2,FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>LA:2,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
@@ -14146,47 +14146,43 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>HL:2-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='STG-5G'>
-			<roles>recon</roles>
-			<availability>CC:3,FWL:2,MERC:2,TC:3</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,TC:3</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:5,FS:3</availability>
 		</model>
-		<model name='STG-3Gb'>
+		<model name='STG-6L'>
 			<roles>recon</roles>
-			<availability>CLAN:8,FWL:4,WOB:4,RCM:6,BAN:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:3,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
+			<availability>CC:5,MOC:4</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
-		<model name='STG-6L'>
+		<model name='STG-5G'>
 			<roles>recon</roles>
-			<availability>CC:5,MOC:4</availability>
+			<availability>CC:3,FWL:2,MERC:2,TC:3</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,TC:3</availability>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>CLAN:8,FWL:4,WOB:4,RCM:6,BAN:2</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>HL:2-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -14200,9 +14196,22 @@
 			<roles>recon</roles>
 			<availability>LA:4,MERC:2</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:3,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,DTA:6,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
+		<model name='F-94'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='F-90'>
+			<availability>CS:3-,LA:2-,IS:4-,FS:3-,Periphery:4-</availability>
+		</model>
+		<model name='F-92'>
+			<availability>FWL:6,IS:4</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:4</availability>
@@ -14210,29 +14219,17 @@
 		<model name='F-95'>
 			<availability>CC:2,DTA:6,LA:2,FWL:5,MERC:2,RCM:6</availability>
 		</model>
-		<model name='F-94'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='F-92'>
-			<availability>FWL:6,IS:4</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:3-,LA:2-,IS:4-,FS:3-,Periphery:4-</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -14240,11 +14237,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14256,62 +14256,68 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4,FWL:4,FS:4,MERC:4,DC:7</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:2+</availability>
-		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:2+</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striga' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='S-STR-OB Infernus'>
+		<model name='S-STR-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OE Eminus'>
+		<model name='S-STR-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OD Luminos'>
+		<model name='S-STR-OA Dominus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-STR-OE Eminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-STR-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,FS:2,DC:1</availability>
 		</model>
@@ -14323,23 +14329,17 @@
 			<roles>fire_support</roles>
 			<availability>FVC:4-,IS:3-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
+		<model name='(SRM)'>
+			<availability>FVC:4-,IS:3-</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,FS.DMM:8,FS:3</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>FVC:4-,IS:3-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,LA:6,FS:7,DC:5</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:3</availability>
-		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,LA:6,FS:7,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
@@ -14359,31 +14359,24 @@
 		<model name='STU-K5'>
 			<availability>FVC:4-,HL:2-,IS:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,FS:3,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:2,LA:2,FS.DMM:2-</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:1,TC:1,Periphery:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,FS:6,MERC:6</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,FS:3,BAN:2</availability>
+		</model>
+		<model name='STU-D7'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:1,TC:1,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:3,CDS:3,HL:2,LA:6,CNC:4,WOB:3,MERC:2,FS:4,CWIE:4</availability>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:5,WOB:0</availability>
-		</model>
 		<model name='(WoB)'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
@@ -14391,9 +14384,20 @@
 		<model name='(Heavy Gauss)'>
 			<availability>LA:6,CNC:6,CWIE:6</availability>
 		</model>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:5,WOB:0</availability>
+		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,WOB:4</availability>
+		<model name='(WOB)'>
+			<roles>recon,fire_support</roles>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
@@ -14401,10 +14405,6 @@
 		<model name='(Standard)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(WOB)'>
-			<roles>recon,fire_support</roles>
-			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Suffren Destroyer' unitType='Warship'>
@@ -14419,12 +14419,6 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
 		</model>
@@ -14433,6 +14427,12 @@
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:6,General:2,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
@@ -14443,8 +14443,12 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,FS:5,MERC:3,DC:7</availability>
-		<model name='SD1-OX'>
-			<availability>General:2</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OE'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
@@ -14453,36 +14457,32 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:2+,CLAN:6,DC:2+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
+		<model name='SD1-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CDS:4,CW:5,CNC:9,CLAN:1,CGB:3,CWIE:5</availability>
-		<model name='2'>
-			<availability>CNC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CNC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -14512,15 +14512,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -14528,19 +14528,15 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CSR:4,CDS:2</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
@@ -14549,15 +14545,19 @@
 			<roles>recon</roles>
 			<availability>CSR:2</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>WOB:3,DC:5</availability>
+		<model name='TSH-8S'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -14574,54 +14574,54 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:4,MERC:3</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(RL)'>
+		<model name='2'>
 			<availability>MOC:4</availability>
 		</model>
-		<model name='2'>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(RL)'>
 			<availability>MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,CS:3,DTA:6,FVC:2,IS:2,FWL:6,WOB:4,MERC:4,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>CC:5,FVC:5,FWL:5,IS:6,MERC:5,DC:5</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:6,FVC:4,IS:4,MERC:5,DC:6</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,General:2,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>DTA:6,FVC:4,FWL:6,IS:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,General:2,FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>CC:5,FVC:5,FWL:5,IS:6,MERC:5,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:4,CNC:4,DC:5</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OE'>
+			<availability>General:4</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OE'>
-			<availability>General:4</availability>
 		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
@@ -14636,103 +14636,103 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>DTA:8,FWL.MM:8,FWL:8,WOB:6,MERC:4</availability>
-		<model name='TMP-3M'>
-			<availability>HL:6,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:4,WOB:4,MERC:4</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>DTA:6,FWL:5,WOB:5</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>HL:6,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>DTA:6,FWL:5,WOB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:4</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
+		<model name='TLR1-OF'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OF'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tengu Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:5</availability>
-		<model name='(Support)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(RL)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Plasma)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(VSP)' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='(Support)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='(ML)' mechanized='true'>
+		<model name='(VSP)' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(C3i)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(RL)' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(ML)' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>CS:6,WOB:5,DC:4</availability>
-		<model name='TSN-X-4'>
+		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
-			<availability>CS:1</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='TSN-1Cr'>
+		<model name='TSN-X-4'>
 			<roles>recon,spotter</roles>
-			<availability>CS:4,DC:4</availability>
+			<availability>CS:1</availability>
 		</model>
 		<model name='TSN-1C'>
 			<roles>recon,spotter</roles>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='TSN-C3M'>
+		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
-			<availability>DC:4</availability>
+			<availability>CS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -14760,11 +14760,15 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CSR:4,CLAN:4,IS:2+,CCO:4,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:4,CW:4,CNC:4,CJF:6,CGB:4</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
@@ -14772,35 +14776,35 @@
 		<model name='D'>
 			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>raider</roles>
+			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
-		<model name='Prime'>
-			<roles>raider</roles>
-			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='HH'>
 			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,WOB:3,BAN:5</availability>
+		<model name='(Clan)'>
+			<roles>artillery</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='(C3i)'>
 			<roles>artillery</roles>
 			<availability>CS:6,WOB:8</availability>
@@ -14809,68 +14813,64 @@
 			<roles>artillery</roles>
 			<availability>CS:4,NIOPS:8,WOB:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<roles>artillery</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+		<model name='THE-N1'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='THE-N'>
+			<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>HL:6,Periphery.Deep:6,DC:2-,Periphery:8</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:1-</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
-		</model>
 		<model name='THE-N2'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:2,CLAN:1</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:4-,FVC:4-,HL:3-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:5-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:4-,FVC:4-,HL:3-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:3,CSV:6,CLAN:4,IS:3,WOB:7,FS:3,CWIE:5,DC.GHO:5,CS:8,DTA:2,OA:4,FVC:2,CDS:3,CW:5,CBS:3,LA:2,CNC:3,FWL:5,NIOPS:8,RCM:2,CJF:5,CGB:5</availability>
+		<model name='THG-12E'>
+			<availability>CS:6,WOB:3</availability>
+		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:4,OA:5,FRR:6,CLAN:6,IS:8,FWL:8,NIOPS:4,WOB:4,FS:8,BAN:8,DC:8</availability>
 		</model>
 		<model name='THG-11Eb'>
 			<availability>CLAN:4,FWL:5,WOB:5,MERC:5,BAN:2</availability>
 		</model>
-		<model name='THG-10E'>
-			<availability>FWL:4-,MERC:4-</availability>
-		</model>
-		<model name='THG-12E'>
-			<availability>CS:6,WOB:3</availability>
-		</model>
 		<model name='THG-13K'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='THG-10E'>
+			<availability>FWL:4-,MERC:4-</availability>
 		</model>
 		<model name='THG-12K'>
 			<availability>WOB:4,DC:6</availability>
@@ -14878,10 +14878,6 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>HL:3,IS:4,Periphery.Deep:8,Periphery:4</availability>
-		<model name='TAV-2'>
-			<roles>artillery</roles>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:5,WOB:6</availability>
@@ -14889,6 +14885,10 @@
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='TAV-2'>
+			<roles>artillery</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
@@ -14899,15 +14899,15 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,CLAN:1,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:5</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4</availability>
@@ -14915,27 +14915,27 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5,CGS:3,CGB:2</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6,CGS:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,MERC:4,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
 		<model name='THR-1L'>
 			<availability>General:8</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
@@ -14946,13 +14946,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -14961,66 +14961,66 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:6,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,LA:6,NIOPS:3-,MH:4,DC:6</availability>
-		<model name='TDR-1C'>
-			<availability>CC:3-,MOC:3-,LA:3-,MERC:3-,TC:3-</availability>
-		</model>
-		<model name='TDR-60-RLA'>
-			<availability>MERC:2,DC:2</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,MERC.ELH:8,MERC:4,FS:4</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,MERC:6,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:5,LA:6,FS:4,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,FWL:2,WOB:4,MERC:4,FS:2</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:4-,HL:2-,LA:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CS:6,CC:5,FWL:8,IS:2,WOB:6,MERC:5</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,DTA:4,CC:3,PIR:2,FWL:4,MH:3,WOB:3</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:4-,MERC:1-</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CCC:6,LA:1,CSV:6,FS:1,CGS:6,DC:1</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>CLAN:1,TC:4</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
-		</model>
-		<model name='TDR-9Nr'>
-			<availability>WOB:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='TDR-17S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,MERC:6,FS:2</availability>
+		<model name='TDR-60-RLA'>
+			<availability>MERC:2,DC:2</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,FWL:2,WOB:4,MERC:4,FS:2</availability>
+		</model>
+		<model name='TDR-9M'>
+			<availability>MOC:3,DTA:4,CC:3,PIR:2,FWL:4,MH:3,WOB:3</availability>
 		</model>
 		<model name='TDR-9NAIS'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>CC:4-,HL:2-,LA:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,MERC.ELH:8,MERC:4,FS:4</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:4-,MERC:1-</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:3-,MOC:3-,LA:3-,MERC:3-,TC:3-</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CLAN:1,TC:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CCC:6,LA:1,CSV:6,FS:1,CGS:6,DC:1</availability>
+		</model>
+		<model name='TDR-9Nr'>
+			<availability>WOB:2,FS:2,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:7,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
@@ -15057,15 +15057,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,FRR:6,CNC:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>FRR:5-,DC:5-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,CNC:8,DC:5</availability>
 		</model>
@@ -15073,18 +15064,26 @@
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>FRR:5-,DC:5-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>FRR:3-,DC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:2,NIOPS:2,WOB:2</availability>
+		<model name='CX-11'>
+			<availability>CS:2</availability>
 		</model>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
+		<model name='THK-63CS'>
+			<availability>CS:8,WOB:6</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -15096,18 +15095,16 @@
 		<model name='THK-63b'>
 			<availability>CLAN:2,BAN:2</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>CS:8,WOB:6</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
-		<model name='CX-11'>
-			<availability>CS:2</availability>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:2,NIOPS:2,WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CW:2</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -15116,6 +15113,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -15127,25 +15127,18 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2,MH:1</availability>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
 		</model>
 		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G14' mechanized='true'>
-			<availability>WOB:3</availability>
-		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,WOB:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
-		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
 		</model>
 		<model name='G17' mechanized='true'>
 			<availability>WOB:4</availability>
@@ -15155,6 +15148,13 @@
 		</model>
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='G14' mechanized='true'>
+			<availability>WOB:3</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -15166,11 +15166,11 @@
 	</chassis>
 	<chassis name='Toyama' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='TYM-1C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='TYM-1A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TYM-1C'>
+			<availability>General:4</availability>
 		</model>
 		<model name='TYM-1B'>
 			<availability>General:6</availability>
@@ -15194,17 +15194,17 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,RCM:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:3-,FWL:2</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
 		<model name='TR-13'>
 			<availability>CC:3-,HL:2-,IS:2-,MERC:3-,Periphery:4-</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:3-,FWL:2</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>CC:7,MOC:5,MERC:5,RCM:8,TC:5</availability>
@@ -15212,12 +15212,12 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
+		<model name='TR-12'>
+			<availability>CC:6,MOC:2</availability>
+		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:2</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:6,MOC:2</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>CC:5,MOC:5,General:6,TC:5</availability>
@@ -15232,13 +15232,12 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:3,CC:3,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:3,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,CS:2-,MOC:6-,LA:2-,FWL:2-,IS:4-,NIOPS:2-,WOB:2-,FS:2-,MERC:4-,DC:2-,Periphery:6-</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:2-,IS:2-,Periphery.Deep:4,FWL:2-,MERC:2-,CDP:2,Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='TBT-3C'>
+		<model name='TBT-9K'>
 			<roles>fire_support</roles>
-			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:4</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
@@ -15248,61 +15247,59 @@
 			<roles>fire_support</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='TBT-9K'>
+		<model name='TBT-3C'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:4</availability>
 		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:2-,IS:2-,Periphery.Deep:4,FWL:2-,MERC:2-,CDP:2,Periphery:2-,TC:2-</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,CS:2-,MOC:6-,LA:2-,FWL:2-,IS:4-,NIOPS:2-,WOB:2-,FS:2-,MERC:4-,DC:2-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
-		<model name='TRN-3V'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
 		</model>
+		<model name='TRN-3V'>
+			<availability>WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MOC:6,MH:4,TC:6</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:5,TC:5</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:5</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:4</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:5</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:5,TC:5</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:5,TC:5</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Triton' unitType='ProtoMek'>
 		<availability>CGS:5</availability>
-		<model name='3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
@@ -15313,16 +15310,19 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,HL:8,CBS:5,CLAN:2,IS:9,Periphery.Deep:8,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>IS:2,DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -15352,9 +15352,6 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:4+</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CW:3</availability>
 		</model>
@@ -15364,16 +15361,19 @@
 		<model name='2'>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Turhan Urban Combat Vehicle' unitType='Tank'>
 		<availability>CS:4,WOB:4,DC:3</availability>
-		<model name='(Original)'>
-			<roles>apc,urban</roles>
-			<availability>DC:4-</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>apc,urban,spotter</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>apc,urban</roles>
+			<availability>DC:4-</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc,urban</roles>
@@ -15382,60 +15382,60 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>SOC:4,CNC:4,CJF:7,CLAN.HW:4</availability>
-		<model name='Z'>
-			<roles>spotter</roles>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
 		</model>
 		<model name='X'>
 			<roles>fire_support</roles>
 			<availability>CJF:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
+		<model name='Z'>
+			<roles>spotter</roles>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -15444,13 +15444,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -15462,75 +15462,75 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,FRR:2,CGB:5,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>FRR:8,CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>FRR:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CHH:3,CSR:6,CSV:4,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:2,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
-		<model name='F'>
-			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CSR:6,CBS:6,General:5,CCO:4</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CSR:6,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:4,CW:4,CGS:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6,CGS:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -15542,13 +15542,13 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:2,LA.SR:4</availability>
-		<model name='(3071)'>
-			<roles>troop_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(3071)'>
+			<roles>troop_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -15557,12 +15557,12 @@
 			<roles>mech_carrier</roles>
 			<availability>CS:8,LA:8,IS:6,WOB:8,FS:8</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>WOB:5</availability>
+		</model>
 		<model name='(2708)'>
 			<roles>mech_carrier</roles>
 			<availability>General:4,BAN:4</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -15578,6 +15578,31 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:5,IS:2,Periphery:2</availability>
+		</model>
+		<model name='UM-R60L'>
+			<roles>urban</roles>
+			<availability>CC:3-,FVC:2,Periphery:3</availability>
+		</model>
+		<model name='UM-R68'>
+			<roles>urban</roles>
+			<availability>CC:6,FS:6,DC:6</availability>
+		</model>
+		<model name='UM-R70'>
+			<roles>urban</roles>
+			<availability>CC:2,MOC:2,FS.CMM:6,FS:4</availability>
+		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>CC:4-,HL:2-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
 		<model name='UM-R80'>
 			<roles>urban,spotter</roles>
 			<availability>CC:3,MOC:3,FWL:2,WOB:3,MERC:2</availability>
@@ -15586,38 +15611,9 @@
 			<roles>urban</roles>
 			<availability>FWL:6,IS:5,Periphery:5</availability>
 		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:6,FS:6,DC:6</availability>
-		</model>
-		<model name='UM-R60L'>
-			<roles>urban</roles>
-			<availability>CC:3-,FVC:2,Periphery:3</availability>
-		</model>
-		<model name='UM-R60'>
-			<roles>urban</roles>
-			<availability>CC:4-,HL:2-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='UM-R70'>
-			<roles>urban</roles>
-			<availability>CC:2,MOC:2,FS.CMM:6,FS:4</availability>
-		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:5,IS:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CGB:6</availability>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -15626,6 +15622,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -15655,37 +15655,37 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,WOB:4,FS:9,MERC:4,CDP:3,TC:3</availability>
-		<model name='VLK-QF'>
+		<model name='VLK-QD3'>
 			<roles>recon,fire_support</roles>
-			<availability>LA:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4</availability>
+			<availability>WOB:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='VLK-QW5'>
 			<roles>recon,fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VLK-QD'>
+		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:5,LA:6,FS:8,MERC:6</availability>
+			<availability>FVC:4-,FS:4-,MERC:4-,CDP:4-,TC:4-</availability>
+		</model>
+		<model name='VLK-QS5'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:3,FS:3</availability>
 		</model>
-		<model name='VLK-QA'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4-,FS:4-,MERC:4-,CDP:4-,TC:4-</availability>
+			<availability>LA:2-,FS:2-,MERC:2-</availability>
+		</model>
+		<model name='VLK-QD'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:5,LA:6,FS:8,MERC:6</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:3,WOB:3,FS:3,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='VLK-QD3'>
-			<roles>recon,fire_support</roles>
-			<availability>WOB:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -15700,24 +15700,24 @@
 		<model name='D'>
 			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -15738,55 +15738,55 @@
 		<model name='VQR-7U'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='VQR-2B'>
+		<model name='VQR-7V'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='VQR-7V'>
+		<model name='VQR-2B'>
 			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:2</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Liao)'>
-			<availability>CC:4-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:7,MOC:8,FVC:4+,Periphery.CM:4+,Periphery.HR:4+,PIR:4+,MH:4+,CDP:4+,TC:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,DTA:5,RCM:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:6</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:2-,General:2-</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:2-,General:4-</availability>
 		</model>
+		<model name='(Liao)'>
+			<availability>CC:4-</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,DTA:5,RCM:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:7,MOC:8,FVC:4+,Periphery.CM:4+,Periphery.HR:4+,PIR:4+,MH:4+,CDP:4+,TC:8</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='(Cell)'>
 			<availability>CC:3,LA:3,FWL:3,WOB:4,FS:3,MERC:4,DC:3</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:6</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>asf_carrier</roles>
 			<availability>IS:2,FS:8</availability>
+		</model>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -15806,73 +15806,73 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:2,LA:2,CWIE:2</availability>
-		<model name='VR5-R'>
-			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
+		<model name='VR5-R'>
+			<deployedWith>Wolfhound</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='VTR-9B'>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,HL:2,FRR:8,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>FS:2,MERC:2</availability>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,MERC:2</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:2</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
+		<model name='VTR-9Ka'>
+			<availability>FS:2,MERC:2</availability>
 		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,HL:2,FRR:8,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>FS:2,MERC:1</availability>
 		</model>
+		<model name='VTR-9D'>
+			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='VTR-9A1'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:2-,CIR:2-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-9D'>
-			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
 		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,MERC:2</availability>
+		<model name='VTR-9S'>
+			<availability>LA:2-,CIR:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CS:6,FRR:7,WOB:4,CGB:5</availability>
-		<model name='VKG-2G'>
-			<availability>CS:5,FRR:6,CGB:6</availability>
-		</model>
 		<model name='VKG-3W'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='VKG-2F'>
-			<roles>fire_support</roles>
-			<availability>General:8,WOB:2</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
 			<availability>CS:4</availability>
+		</model>
+		<model name='VKG-2G'>
+			<availability>CS:5,FRR:6,CGB:6</availability>
+		</model>
+		<model name='VKG-2F'>
+			<roles>fire_support</roles>
+			<availability>General:8,WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -15888,14 +15888,11 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,FRR:1,MERC:4,TC:6</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
+		</model>
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>FRR:8,TC:2</availability>
-		</model>
-		<model name='VND-5L'>
-			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:6,MOC:5,TC:4</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:4</availability>
@@ -15903,14 +15900,17 @@
 		<model name='VND-3L'>
 			<availability>CC:7,MOC:4,General:4,TC:4</availability>
 		</model>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
+		<model name='VND-4L'>
+			<availability>CC:6,MOC:5,TC:4</availability>
 		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-5L'>
+			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -15921,11 +15921,11 @@
 		<model name='2'>
 			<availability>CSV:6,CLAN:4</availability>
 		</model>
-		<model name='4'>
-			<availability>CSR:4,CSV:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CSV:8</availability>
+		</model>
+		<model name='4'>
+			<availability>CSR:4,CSV:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
@@ -15933,26 +15933,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:6,General:2,CJF:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CLAN:2,CGS:5,CJF:5</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
+		<model name='5'>
+			<availability>CHH:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:3,CJF:5</availability>
@@ -15963,18 +15963,18 @@
 		<model name='3'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:5</availability>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:4,DC:5+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CNC:8</availability>
@@ -15993,20 +15993,20 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:1,FRR:4,PIR:2,WOB:6,MERC:1,FS:2,DC:3</availability>
-		<model name='VNL-K100'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='VNL-K75N'>
-			<availability>LA:8,FRR:6,FWL:8,FS:8,DC:8</availability>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,FRR:6,FWL:8,FS:8,DC:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:1,DC:1</availability>
-		</model>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -16014,38 +16014,38 @@
 		<model name='VLC-5N'>
 			<availability>General:2</availability>
 		</model>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>General:3,FS:8,CDP:3</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:3,CS:3,MOC:5,LA:6,FRR:4,IS:4,FWL:6,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>WOB:6,RCM:4</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:3-,General:4-,FS:2-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:4,PIR:2,IS:2,FS:4-,CIR:2,Periphery:2,TC:2</availability>
-		</model>
-		<model name='VT-5M'>
-			<roles>anti_infantry</roles>
-			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='VT-6C'>
 			<roles>anti_infantry</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='VT-5M'>
+			<roles>anti_infantry</roles>
+			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>FVC:3-,General:4-,FS:2-</availability>
+		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:4,FRR:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>WOB:6,RCM:4</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -16057,29 +16057,29 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
+		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:5,CLAN:3,General:1,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -16103,8 +16103,12 @@
 		<model name='(Standard)'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CDS:4,CLAN:2,IS:3</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CLAN:1,IS:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:2,CDS:5,CLAN:2</availability>
 		</model>
 		<model name='6'>
 			<availability>CSR:5,CGB:5</availability>
@@ -16112,28 +16116,29 @@
 		<model name='4'>
 			<availability>CSA:5,CHH:2,CDS:6,CSR:2,CNC:5,CCO:5,CWIE:5,CGB:5</availability>
 		</model>
-		<model name='3'>
-			<availability>CCC:2,CDS:5,CLAN:2</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CLAN:1,IS:3</availability>
+		<model name='5'>
+			<availability>CDS:4,CLAN:2,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
+		<model name='WHM-9D'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='WHM-6L'>
 			<availability>CC:2-</availability>
 		</model>
-		<model name='WHM-9S'>
-			<availability>LA:5,WOB:3,MERC:4,CIR:3</availability>
+		<model name='WHM-6K'>
+			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-,DC:1-</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>FWL:3,WOB:4</availability>
+		<model name='WHM-8K'>
+			<availability>DC:5</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:8</availability>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
+		</model>
+		<model name='WHM-6D'>
+			<availability>FVC:2-,FS:2-</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:4,PIR:3,IS:3,FS:4,MERC:3,TC:4</availability>
@@ -16141,175 +16146,173 @@
 		<model name='WHM-6R'>
 			<availability>HL:2-,General:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='WHM-6K'>
-			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-,DC:1-</availability>
-		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FVC:2-,FS:2-</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:6,CC:3,FVC:3,FRR:2,FWL:8,WOB:7,MERC:4,DC:2,Periphery:3</availability>
-		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
-		</model>
-		<model name='WHM-9D'>
-			<availability>FS:5</availability>
-		</model>
 		<model name='WHM-10T'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='C'>
-			<availability>LA:1+,FS:1+,DC:1+</availability>
+		<model name='WHM-8M'>
+			<availability>FWL:3,WOB:4</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2,TC:4</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CS:6,CC:3,FVC:3,FRR:2,FWL:8,WOB:7,MERC:4,DC:2,Periphery:3</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:5,WOB:3,MERC:4,CIR:3</availability>
+		</model>
+		<model name='WHM-4L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:5,FS:4</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+		<model name='H-9'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='H-7'>
 			<availability>HL:2-,IS:4-,Periphery:4-</availability>
+		</model>
+		<model name='H-7A'>
+			<availability>IS:3-,Periphery:3-</availability>
+		</model>
+		<model name='H-8'>
+			<availability>HL:4,LA:5,FS.CH:8,FRR:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='H-10'>
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-8'>
-			<availability>HL:4,LA:5,FS.CH:8,FRR:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='H-7A'>
-			<availability>IS:3-,Periphery:3-</availability>
-		</model>
 		<model name='H-7C'>
 			<availability>IS:2-,Periphery:2-</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-110'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,CIR:4,Periphery:6</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,TC:3</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:3,MOC:3,WOB:4,TC:4</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:2-</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,FRR:3,FS:3,MERC:3</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:2-,DC:2-</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:3-</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:5,LA:6,FS:5,MERC:3</availability>
 		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:3,MOC:3,WOB:4,TC:4</availability>
+		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,TC:3</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:3-</availability>
+		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='WSP-1L'>
+		<model name='WSP-1W'>
 			<roles>recon</roles>
-			<availability>CC:2-</availability>
+			<availability>MERC.WD:2-</availability>
 		</model>
-		<model name='WSP-1D'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>FVC:2,FS:2-</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-1'>
 			<roles>recon</roles>
 			<availability>CC:3-,MOC:3-,FWL:3-,RCM:3-</availability>
 		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:5,FRR:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:2-</availability>
+		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:3,PIR:3,WOB:3,TC:3</availability>
 		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FVC:2,FS:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:7,FS:8,MERC:4,CDP:5,DC:4</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:2,CSV:2,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='White Flame' unitType='Mek'>
 		<availability>WOB.SD:6,WOB:4</availability>
-		<model name='WHF-3B'>
-			<availability>WOB:8</availability>
+		<model name='WHF-4C'>
+			<roles>spotter</roles>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='WHF-3C'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='WHF-4C'>
-			<roles>spotter</roles>
-			<availability>WOB:3</availability>
+		<model name='WHF-3B'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='White Tip Submarine' unitType='Naval'>
@@ -16320,8 +16323,8 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:2,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:4</availability>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:3,Periphery.HR:3,PIR:5,Periphery.ME:3,MH:5</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -16334,26 +16337,23 @@
 			<roles>fire_support</roles>
 			<availability>CS:8,OA:6,MH:6,FS:2,MERC:3,CDP:6,DC:2,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:3,Periphery.HR:3,PIR:5,Periphery.ME:3,MH:5</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:3,LA:3,CNC:2-,FWL:3,MERC:3,DC:6</availability>
-		<model name='WGT-2LAW'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WGT-4NC &apos;Dezgra&apos;'>
-			<availability>CNC:8</availability>
+		<model name='WGT-2LAWC3'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAWC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-4NC &apos;Dezgra&apos;'>
+			<availability>CNC:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>LA:6,FWL:6,MERC:6,DC:7</availability>
@@ -16363,6 +16363,9 @@
 		</model>
 		<model name='WGT-3SC'>
 			<availability>CC:8,LA:4,FWL:4,MERC:4</availability>
+		</model>
+		<model name='WGT-2LAW'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -16374,42 +16377,42 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>FRR:3,WOB:3,MERC:3,DC:5</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>WOB:6</availability>
-		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
 		<model name='WFT-C'>
 			<availability>FRR:4,DC:4</availability>
 		</model>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,FRR:5,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,MERC.WD:5,FVC:3,LA:7,FWL:3,MH:4</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:1,CWIE:2</availability>
-		</model>
-		<model name='WLF-1'>
-			<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
 		</model>
 		<model name='WLF-3M'>
 			<availability>DTA:8,FWL:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
+		<model name='WLF-1'>
+			<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:2</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:1,CWIE:2</availability>
+		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,FRR:6,FS:2,MERC:6</availability>
 		</model>
 		<model name='WLF-1A'>
 			<availability>MERC.KH:1</availability>
@@ -16417,20 +16420,17 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='WVR-7M'>
+		<model name='WVR-7K'>
 			<roles>recon</roles>
-			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
+			<availability>FRR:8,MERC:6,DC:6</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:5,MERC:4</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:5,CNC:6,MERC:3,DC:4</availability>
-		</model>
-		<model name='WVR-7K'>
+		<model name='WVR-6R'>
 			<roles>recon</roles>
-			<availability>FRR:8,MERC:6,DC:6</availability>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='WVR-8D'>
 			<availability>FS:5</availability>
@@ -16438,35 +16438,38 @@
 		<model name='WVR-9W'>
 			<availability>CS:3,WOB:5</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:5,PIR:4,Periphery.ME:5,FWL:3-,MH:4</availability>
+		<model name='WVR-8K'>
+			<availability>FRR:5,CNC:6,MERC:3,DC:4</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='WVR-8C'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='WVR-9M'>
-			<availability>FWL:4</availability>
+			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:6,LA:6,WOB:4,FS:6</availability>
 		</model>
-		<model name='WVR-9K'>
-			<availability>DC:2</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:5,PIR:4,Periphery.ME:5,FWL:3-,MH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -16493,14 +16496,6 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:3,FRR:5,CLAN:2,IS:3,WOB:4-,FS:7,MERC:5,DC.GHO:5,CS:5,DTA:3,FVC:3,NIOPS:5,RCM:3,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:3,CS:4,FRR:8,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
-		</model>
-		<model name='WVE-10N'>
-			<roles>urban</roles>
-			<availability>CS:5,WOB:4</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CGS:1</availability>
@@ -16509,9 +16504,17 @@
 			<roles>urban</roles>
 			<availability>CS:8,WOB:8</availability>
 		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:3,CS:4,FRR:8,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
+		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
 			<availability>IS:2-,DC:2-,Periphery:2-</availability>
+		</model>
+		<model name='WVE-10N'>
+			<roles>urban</roles>
+			<availability>CS:5,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -16523,14 +16526,14 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:5,LA:3,MERC:3,DC:2,TC:2</availability>
+		<model name='XNT-4O'>
+			<availability>CC:5,MOC:5,LA:5</availability>
+		</model>
 		<model name='XNT-2O'>
 			<availability>General:3-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:4,MOC:4,LA:4,MERC:4</availability>
-		</model>
-		<model name='XNT-4O'>
-			<availability>CC:5,MOC:5,LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -16542,24 +16545,18 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CSR:6,CLAN:5</availability>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>CS:6,FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>CS:4,IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -16567,8 +16564,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>CS:4,IS:3,FS:5</availability>
+		</model>
 		<model name='(PPC)'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -16596,18 +16599,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:4</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zechetinu Corvette' unitType='Warship'>
@@ -16626,61 +16629,52 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:7,DC.GHO:2,FRR:5,CLAN:4,NIOPS:7,WOB:7,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
+		<model name='(C3i)'>
 			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:3-,CLAN:1,NIOPS:3-,WOB:3-</availability>
-		</model>
 		<model name='ZRO-CX-3'>
 			<availability>CS:2</availability>
 		</model>
 		<model name='ZRO-115'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
+		<model name='ZRO-114'>
+			<availability>CS:3-,CLAN:1,NIOPS:3-,WOB:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:2,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:5,LA:8,FRR:6,PIR:6,MH:2,FS:2,MERC:6,CDP:6,TC:6</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>FVC:2-,LA:2-,FS:2-</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,WOB:8</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,FS:5,MERC:4</availability>
@@ -16688,20 +16682,29 @@
 		<model name='ZEU-6S'>
 			<availability>HL:4,General:2-,Periphery.Deep:4,Periphery:6</availability>
 		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:5,LA:8,FRR:6,PIR:6,MH:2,FS:2,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,WOB:8</availability>
+		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:6,HL:2,IS:2,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:4</availability>
-		<model name='(LB-X)'>
-			<availability>WOB:6</availability>
+		<model name='(Liao)'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='(WoB)'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(Liao)'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='(LB-X)'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
@@ -16709,11 +16712,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CW:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>

--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -1321,50 +1321,50 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,CS:8,MOC:6,LA:8,FRR:8,CGB.FRR:8,FWL:8,IS:6,WOB:8,FS:8,TC:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>HL:3,General:5,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,CS:8,MOC:6,LA:8,FRR:8,CGB.FRR:8,FWL:8,IS:6,WOB:8,FS:8,TC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>PR:4,DoO:4,WOB:4,DO:4,DGM:4,DTA:4,SC:4,MCM:4,PG:4,FWL:4,TP:4,RCM:4,DA:4,RFS:4</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
-		<model name='(WoB) [TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:5,WOB:5</availability>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='(WoB) [David]' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(WoB) [TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:5,WOB:5</availability>
 		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
-		<model name='(WoB) [David]' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1380,13 +1380,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:2,CS:3,CCC:2,MERC.WD:1,CSR:3,CDS:1,CBS:1,CNC:5,FWL:1,CGS:2,CJF:5,CWIE:2</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aerie PA(L)' unitType='BattleArmor'>
@@ -1409,11 +1409,11 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CSL:5,CJF:5</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
@@ -1431,17 +1431,17 @@
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
 		<availability>CS:7,CLAN:1,FWL:1,NIOPS:4,WOB:7,DC:1</availability>
-		<model name='AHB-643'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='AHB-443b'>
-			<availability>CLAN:1,WOB:4</availability>
-		</model>
 		<model name='AHB-MD'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='AHB-643'>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='AHB-443b'>
+			<availability>CLAN:1,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Rescue PA(L)' unitType='BattleArmor'>
@@ -1466,6 +1466,16 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
@@ -1473,51 +1483,41 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>CNC:4,WOB:4,DC:6</availability>
-		<model name='AKU-2XK'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>WOB:6,DC:5</availability>
 		</model>
-		<model name='AKU-2XC'>
+		<model name='AKU-2X'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='AKU-1XJ'>
 			<availability>CNC:5,WOB:4,DC:5</availability>
 		</model>
-		<model name='AKU-2X'>
+		<model name='AKU-2XC'>
 			<availability>DC:2</availability>
+		</model>
+		<model name='AKU-2XK'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:2,CS:7,CDS:4,LA:6,CNC:4,NIOPS:7,WOB:7,FS:5,MERC:3,CWIE:6,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>DTA:5,SC:5,DoO:5,MCM:5,ROS:4,FWL:4,WOB:3,DO:5,DGM:5,FWL.KIS:7,TP:5,MERC:2</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,WOB:6,DO:6,DGM:6,TP:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
 		<model name='ALB-3Ur'>
 			<availability>ROS:3,FWL:3,WOB:3,MERC:3</availability>
@@ -1525,11 +1525,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CGB:4</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:2</availability>
@@ -1537,12 +1537,12 @@
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CSA:6,CHH:6,CSR:2,CBS:6,CLAN:2,CGS:4</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,CGB:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,CGB:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1553,23 +1553,23 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:3,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
-		<model name='C 2'>
-			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
+		<model name='ANH-4A'>
+			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,ROS:2,MERC:2,CWIE:5</availability>
+		</model>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5,CHH:3,LA:4,ROS:4,MERC:4,CWIE:3</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:1-</availability>
 		</model>
-		<model name='ANH-4A'>
-			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,ROS:2,MERC:2,CWIE:5</availability>
+		<model name='C'>
+			<availability>CLAN:8,IS:2,BAN:3</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,IS:2,BAN:3</availability>
-		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5,CHH:3,LA:4,ROS:4,MERC:4,CWIE:3</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1588,11 +1588,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:4,MOC:6,PIR:2,TC:3</availability>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
+		</model>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
@@ -1601,34 +1601,30 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:1,PR:6,DoO:6,WOB:2,DO:6,DGM:6,MERC:3,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,TP:6,DA:6,RFS:6</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,DoO:5,FWL:6,WOB:6,DO:5,TP:5,DA:5</availability>
+		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>PR:5,DoO:5,WOB:4,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:2,TP:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='ANV-5M'>
-			<availability>DTA:5,DoO:5,FWL:6,WOB:6,DO:5,TP:5,DA:5</availability>
+		<model name='ANV-3R'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='ANV-5Q'>
+			<availability>DTA:4,SC:4,PR:4,MCM:4,PG:4,FWL:2,WOB:4,DGM:4,RFS:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>CC:5,ROS:6,FWL:4,WOB:4,MERC:5</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-5Q'>
-			<availability>DTA:4,SC:4,PR:4,MCM:4,PG:4,FWL:2,WOB:4,DGM:4,RFS:4</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>CC:5,ROS:6,FWL:4,WOB:4,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,SC:8,LA:1,MCM:8,ROS:4,FWL:8,MH:2,DGM:8,MERC:4,FS:1,DC:6</availability>
 		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1640,9 +1636,17 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
 		<availability>FWL:4,WOB:4</availability>
+		<model name='W1'>
+			<roles>missile_artillery,escort</roles>
+			<availability>WOB:6</availability>
+		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6</availability>
@@ -1651,21 +1655,17 @@
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='W1'>
-			<roles>missile_artillery,escort</roles>
-			<availability>WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,CNC:4,MERC:2</availability>
+		<model name='2'>
+			<availability>General:4</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1676,20 +1676,20 @@
 	</chassis>
 	<chassis name='Arcadia' unitType='Dropship'>
 		<availability>CSR:2,CBS:6</availability>
+		<model name='(3080)'>
+			<availability>CSR:5</availability>
+		</model>
 		<model name='(3066)'>
 			<roles>assault</roles>
 			<availability>CBS:8</availability>
 		</model>
-		<model name='(3080)'>
-			<availability>CSR:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Arcas' unitType='Mek'>
 		<availability>CGB:5</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CGB:3</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
@@ -1698,11 +1698,21 @@
 	</chassis>
 	<chassis name='Archangel' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
+		<model name='C-ANG-OE Eminus'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C-ANG-OD Luminos'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-ANG-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OS Caelestis'>
 			<availability>General:4</availability>
+		</model>
+		<model name='C-ANG-OA Dominus'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OC Comminus'>
 			<availability>General:7</availability>
@@ -1710,55 +1720,9 @@
 		<model name='C-ANG-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-ANG-OE Eminus'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OB Infernus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:3-,Periphery.Deep:5,WOB:2-,FS:3-,Periphery:4,CS:4-,LA:6,CGB.FRR:4,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
-		<model name='ARC-9W'>
-			<roles>fire_support</roles>
-			<availability>ROS:4,WOB:4</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,BAN:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:4,MERC:4</availability>
-		</model>
-		<model name='ARC-2W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:1-</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FRR:3,CGB.FRR:3,ROS:4,MERC:3</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,WOB:4</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:1-</availability>
-		</model>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:3,TC:4,Periphery:3</availability>
-		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>CNC:2,DC:4</availability>
@@ -1767,83 +1731,119 @@
 			<roles>fire_support</roles>
 			<availability>LA:4,ROS:4,FWL:3,WOB:4,MERC:3,DC:3</availability>
 		</model>
-		<model name='C'>
+		<model name='ARC-6W'>
 			<roles>fire_support</roles>
-			<availability>CSA:6,CCC:6,CW:1,LA:2+,FS:2+,CGS:6,CWIE:1,DC:2+</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:6,FS:1</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6,CWIE:1</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:8,CGB.FRR:8,MERC:4,DC:1</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:1-,LA:3-,FRR:2-,CGB.FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
-		</model>
-		<model name='ARC-4M'>
-			<roles>fire_support</roles>
-			<availability>CS:6,CC:5,FVC:3,LA:1,PIR:4,FWL:6,WOB:6,MERC:5,FS:1,DC:5</availability>
+			<availability>FVC:3,TC:4,Periphery:3</availability>
 		</model>
 		<model name='ARC-2K'>
 			<roles>fire_support</roles>
 			<availability>FRR:1-,CGB.FRR:2-,DC:3-</availability>
 		</model>
+		<model name='ARC-9W'>
+			<roles>fire_support</roles>
+			<availability>ROS:4,WOB:4</availability>
+		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:6,FS:1</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:1-</availability>
+		</model>
+		<model name='ARC-4M'>
+			<roles>fire_support</roles>
+			<availability>CS:6,CC:5,FVC:3,LA:1,PIR:4,FWL:6,WOB:6,MERC:5,FS:1,DC:5</availability>
+		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>CC:1,MOC:3,DoO:5,FRR:3,WOB:3,DO:5,DGM:5,MERC:3,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,FWL:2,TP:5,DC:1</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:1-,LA:3-,FRR:2-,CGB.FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:4,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:1-</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,CGB.FRR:8,MERC:4,DC:1</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6,CWIE:1</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:4,MERC:4</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,WOB:4</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FRR:3,CGB.FRR:3,ROS:4,MERC:3</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CCC:6,CW:1,LA:2+,FS:2+,CGS:6,CWIE:1,DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>CNC:4,CWIE:6,CGB:3</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2,MERC.WD:2,CWIE:4</availability>
-		<model name='A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:3</availability>
 		</model>
 		<model name='J'>
 			<availability>General:8</availability>
@@ -1851,11 +1851,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Attack Craft' unitType='Small Craft'>
@@ -1867,11 +1867,11 @@
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CW:8,CLAN:6,CCO:7,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CW:5,CJF:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CW:5,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
@@ -1879,38 +1879,22 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:3</availability>
 		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1918,33 +1902,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1964,25 +1964,25 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
-		<model name='ASN-23'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:3,PIR:2,MH:4,MERC:4,FS:4,RCM:4,DA:4,CDP:6,TC:6</availability>
-		</model>
 		<model name='ASN-30'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
 		<model name='ASN-21'>
 			<availability>General:1-</availability>
 		</model>
+		<model name='ASN-23'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:3,PIR:2,MH:4,MERC:4,FS:4,RCM:4,DA:4,CDP:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
 		<availability>ROS:5,WOB:5,DC:5</availability>
-		<model name='(3082)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(3062)'>
 			<roles>troop_carrier</roles>
 			<availability>WOB:8,DC:8</availability>
+		</model>
+		<model name='(3082)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1994,17 +1994,20 @@
 	</chassis>
 	<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CBS:4,CLAN:8</availability>
-		<model name='(Proto AC)'>
-			<roles>recon</roles>
-			<availability>CBS:3,CSL:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(Proto AC)'>
+			<roles>recon</roles>
+			<availability>CBS:3,CSL:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Asura Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:7</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>WOB:4</availability>
 		</model>
@@ -2012,79 +2015,92 @@
 			<roles>anti_infantry</roles>
 			<availability>WOB:5</availability>
 		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CSR:3,CDS:5,CW:5,CSL:8,CGS:5,CJF:3,CCO:2,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:3,CLAN:1,WOB:3</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:2,FRR:6,CLAN:4,IS:2,WOB:4-,FS:4,Periphery:1,TC:1,CS:4-,OA:1,LA:4,CGB.FRR:6,FWL:2,NIOPS:4-,DC:9</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:3,ROS:4,MERC:3</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CC:1,MOC:3,FRR:5,WOB:3,MERC:4,CDP:3,TC:3,CS:3,OA:3,CGB.FRR:5,CNC:5,FWL:1,DC:7</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:5,ROS:4,MERC:2</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1-,MERC:0,DC:1-</availability>
 		</model>
 		<model name='AS7-K3'>
 			<availability>LA:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:3</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1-,MERC:0,DC:1-</availability>
-		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:3,FS:4,DC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,CGB.FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:3</availability>
 		</model>
 		<model name='AS7-D'>
 			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,CGB.FRR:2,MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:5,ROS:4,MERC:2</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:3,ROS:3,MERC:2</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:3,ROS:4,MERC:3</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:5,CGB.FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:3,ROS:3,MERC:2</availability>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
+		<model name='AS7-C'>
+			<availability>FRR:2,CGB.FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>CC:1,MOC:3,FRR:5,WOB:3,MERC:4,CDP:3,TC:3,CS:3,OA:3,CGB.FRR:5,CNC:5,FWL:1,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -2094,25 +2110,9 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -2127,62 +2127,62 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:4,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSR:5,CDS:9,General:7,CGS:8,CCO:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5,CCO:6</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5,CCO:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSR:5,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CS:6,CNC:4,IS:4,DC:6</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OR'>
-			<availability>General:2+,CLAN:6,DC:2+</availability>
-		</model>
 		<model name='AV1-OE'>
 			<availability>General:6</availability>
 		</model>
+		<model name='AV1-OR'>
+			<availability>General:2+,CLAN:6,DC:2+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -2198,17 +2198,11 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-8R'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='AWS-10KM'>
-			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4,DC:4</availability>
-		</model>
 		<model name='AWS-8T'>
 			<availability>IS:1-,CIR:4</availability>
 		</model>
-		<model name='AWS-8Q'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='AWS-9Ma'>
+			<availability>DTA:4,SC:4,LA:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,TP:4,FS:4</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:4,PIR:4,FWL:6,IS:5,MH:4,TC:4,Periphery:2</availability>
@@ -2216,17 +2210,23 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:4,HL:2,FWL:6,IS:4,MH:4,TC:4,Periphery:4</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:4,SC:4,LA:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,TP:4,FS:4</availability>
+		<model name='AWS-10KM'>
+			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4,DC:4</availability>
+		</model>
+		<model name='AWS-8R'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>FRR:6,CGB.FRR:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>FRR:4,CGB.FRR:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -2240,86 +2240,82 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:3,FRR:2,CGB.FRR:2,ROS:4,FS:2,MERC:1</availability>
+		<model name='AXM-4D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:4,ROS:4,FS:5</availability>
+		</model>
 		<model name='AXM-6T'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:5,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-4D'>
-			<availability>FS:4</availability>
+		<model name='AXM-1N'>
+			<availability>FVC:5,LA:5,FRR:5,CGB.FRR:5,MERC:5,FS:5</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>FVC:1,LA:3,FS:1</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:5,LA:5,FRR:5,CGB.FRR:5,MERC:5,FS:5</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:4,ROS:4,FS:5</availability>
+		<model name='AXM-3S'>
+			<availability>LA:5,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CSR:3,CJF:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:3</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>CSR:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>CSR:3</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:2,MERC.WD:3,CW:3,CSL:2</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:3</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -2331,11 +2327,7 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -2343,15 +2335,23 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>OA:5,IS:5,CLAN.IS:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,IS:8</availability>
+		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>General:2</availability>
@@ -2362,41 +2362,53 @@
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:3+</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:3,ROS:3,FWL:3,WOB:3,FS:3,MERC:8</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:4</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1,CSL:3</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2404,33 +2416,21 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank'>
@@ -2438,14 +2438,6 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
@@ -2457,14 +2449,6 @@
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>apc</roles>
@@ -2474,57 +2458,73 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='I'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:7-,CC:1-,PR:3-,HL:8-,FRR:2-,Periphery.Deep:9-,IS:1-,DGM:3-,FS:1-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,SC:3-,OA:7-,FVC:3-,LA:5-,MCM:3-,CGB.FRR:3-,PG:3-,FWL:3-,MH:7-,RFS:3-,DC:1-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:5-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:3</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6,WOB:9</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>SC:2-,PR:2-,MCM:2-,PG:2-,FWL:1-,DGM:2-,RFS:2-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>HL:1-,General:1-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:5,FRR:3,CGB.FRR:3,MH:2,FS:6,MERC:5</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:5-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6,WOB:9</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>OA:1-,LA:3-,IS:1-,FS:1-,MERC:2-,CIR:3,CDP:2,TC:2-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:5,FRR:3,CGB.FRR:3,MH:2,FS:6,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>HL:1-,General:1-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,FRR:4,CGB.FRR:4,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BGS-2T'>
 			<availability>LA:5,MERC:5</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:6</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2540,40 +2540,40 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:4,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CSR:5,CNC:8,General:7</availability>
-		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:3,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CSR:5,CNC:8,General:7</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>CSR:2,General:1</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:3,CNC:3,CLAN:2</availability>
+		</model>
+		<model name='Z'>
+			<availability>CCO:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2584,11 +2584,8 @@
 		<model name='H'>
 			<availability>CSA:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2596,12 +2593,19 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:5</availability>
+		<model name='BTL-C-2OC'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='BTL-C-2OE'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
@@ -2610,9 +2614,12 @@
 			<roles>ew_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='BTL-C-2OC'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='BTL-C-2OF'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='BTL-C-2OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='BTL-C-2OB'>
 			<roles>fire_support</roles>
@@ -2620,13 +2627,6 @@
 		</model>
 		<model name='BTL-C-2O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='BTL-C-2OF'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='BTL-C-2OD'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2649,11 +2649,11 @@
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
 		<availability>LA:3-,FS:5,MERC:3-</availability>
-		<model name='BKX-7K'>
-			<availability>FS:3-,MERC:5-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='BKX-7K'>
+			<availability>FS:3-,MERC:5-</availability>
 		</model>
 		<model name='BKX-1X'>
 			<availability>LA:8-,FS:3-</availability>
@@ -2661,32 +2661,27 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,CGB.FRR:4,ROS:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1,WOB:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,WOB:5,BAN:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>SC:2,MCM:2,CLAN:1,WOB:1,DGM:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:3-</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:4,WOB:5,MERC:4,CJF:1</availability>
+		<model name='C'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>CS:1,DC.GHO:1,WOB:1</availability>
 		</model>
-		<model name='BLR-1S'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='BLR-10S'>
 			<availability>LA:5,ROS:3,FS:3</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
+		<model name='BLR-4S'>
+			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:4,WOB:5,MERC:4,CJF:1</availability>
+		</model>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-1S'>
+			<availability>LA:2-</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,WOB:5,BAN:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:4,FS:1</availability>
@@ -2694,35 +2689,40 @@
 		<model name='BLR-1G'>
 			<availability>HL:1-,IS:3-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:4-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:6,FVC:5,ROS:5,PIR:5,FWL:5,IS:1,WOB:7,MH:5,MERC:6</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:5,ROS:3,FS:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:7</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>DTA:4,DoO:4,ROS:4,FWL:2,WOB:4,DO:4,TP:4,DA:4,MERC:3</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:3</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:3-</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1,WOB:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>SC:2,MCM:2,CLAN:1,WOB:1,DGM:2</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:2,WOB:3,DO:5,DGM:5,TP:5</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>FRR:4,CGB.FRR:4,ROS:3,WOB:3,DC:4</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:6,FVC:5,ROS:5,PIR:5,FWL:5,IS:1,WOB:7,MH:5,MERC:6</availability>
-		</model>
-		<model name='BLR-4L'>
-			<availability>CC:3</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2734,12 +2734,12 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CGS:6,CCO:4,CJF:7,CWIE:4,CGB:6,DC:1+</availability>
-		<model name='Z'>
-			<availability>CCO:2</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8,CGS:7</availability>
+		</model>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CGS:8,CJF:6</availability>
@@ -2747,24 +2747,16 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>CSA:7,CCC:7,General:6,CGS:3</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>CS:5,ROS:5,NIOPS:5,WOB:8</availability>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -2772,25 +2764,36 @@
 		<model name='(Sealed)'>
 			<availability>CS:8,ROS:8,WOB:4</availability>
 		</model>
+		<model name='(C3i)'>
+			<roles>spotter</roles>
+			<availability>WOB:7</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,CSR:2,CLAN:1,CGS:5</availability>
-		<model name='6'>
+		<model name='4'>
 			<availability>General:1</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
+			<availability>General:1</availability>
+		</model>
+		<model name='6'>
 			<availability>General:1</availability>
 		</model>
 		<model name='2'>
@@ -2799,27 +2802,24 @@
 		<model name='3'>
 			<availability>CHH:7</availability>
 		</model>
-		<model name='5'>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSR:2,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:4,Periphery:4,CS:4-,OA:4,CDS:5,LA:3,CGB.FRR:4,PIR:3,CNC:4,FWL:2,DC:5</availability>
-		<model name='(Kurita)'>
-			<availability>CLAN:5,IS:5,DC:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>FVC:3,CDS:3,General:8,DC:3</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:1</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>FVC:3,CDS:3,General:8,DC:3</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:5,IS:5,DC:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2840,13 +2840,13 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CS:6,FRR:6,CGB.FRR:6,ROS:6,CNC:4,CGB:4</availability>
-		<model name='BEO-12'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='BEO-14'>
 			<roles>recon</roles>
 			<availability>CS:4</availability>
+		</model>
+		<model name='BEO-12'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='BEO-X-7a'>
 			<roles>recon,spotter</roles>
@@ -2855,14 +2855,14 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>PR:4,LA:7,FRR:3,CGB.FRR:3,ROS:4,PG:4,FS:3,MERC:2,RFS:4</availability>
-		<model name='BRZ-A3'>
-			<availability>PR:8,LA:5,FRR:8,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>PR:4,LA:5,ROS:5,PG:4,MERC:5,RFS:4</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:3</availability>
+		<model name='BRZ-A3'>
+			<availability>PR:8,LA:5,FRR:8,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2870,63 +2870,69 @@
 		<model name='BSN-3K'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BSN-4K'>
-			<roles>spotter</roles>
+		<model name='BSN-5KC'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='BSN-5KC'>
+		<model name='BSN-4K'>
+			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:3,CSR:2,CW:2,IS:3+,CGS:1,CCO:1,CJF:3,BAN:4,CWIE:3,CGB:3</availability>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:1</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:1</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:6,FRR:6,CGB.FRR:6,FS:4,MERC:4,DC:7</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
@@ -2936,14 +2942,8 @@
 		<model name='BHKU-OR'>
 			<availability>General:2+,DC:2+</availability>
 		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2954,8 +2954,14 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:4,PR:5,DoO:5,FRR:4,CLAN:5,DO:5,FS:5,CDP:3,CWIE:6,DC.GHO:3,SC:5,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,RFS:5,CGB:6,CSR:4,WOB:7,DGM:5,FWL.OH:3,MERC:4,CGS:6,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:6,LA:4,MCM:5,ROS:6,PG:5,CNC:6,TP:5,RCM:5,DA:5,CJF:4,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>DoO:6,CLAN:5,DO:6,MERC:4,FS:4,CGS:6,BAN:2,DTA:6,CS:6,LA:4,ROS:6,FWL:6,TP:6,DA:6,DC:4</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:6,FS:6</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:1-,TC:1-</availability>
+		</model>
+		<model name='BL-7-KNT'>
+			<availability>:0,LA:2-,FRR:2-,FWL:1-,MERC:2-,FS:2-,CIR:6,DC:2-</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>CS:8,ROS:8,WOB:8</availability>
@@ -2963,44 +2969,38 @@
 		<model name='BL-6-KNT'>
 			<availability>FRR:6,CLAN:6,WOB:4,BAN:6,TC:5,Periphery:5,DC.GHO:4,CS:4,OA:5,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
 		</model>
-		<model name='BL-7-KNT'>
-			<availability>:0,LA:2-,FRR:2-,FWL:1-,MERC:2-,FS:2-,CIR:6,DC:2-</availability>
-		</model>
-		<model name='BL-12-KNT'>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:1-,TC:1-</availability>
+		<model name='BL-6b-KNT'>
+			<availability>DoO:6,CLAN:5,DO:6,MERC:4,FS:4,CGS:6,BAN:2,DTA:6,CS:6,LA:4,ROS:6,FWL:6,TP:6,DA:6,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CJF:7,CCO:4</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>CJF:2</availability>
+		<model name='E'>
+			<availability>CLAN:6,CCO:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:6,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='X'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -3016,76 +3016,73 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:5,MERC:3,MERC.NH:5</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:4-,MOC:4,OA:4,FVC:6,HL:3,IS:1,FS:6,MERC:4,TC:4,Periphery:4</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:7,MERC:5</availability>
+		</model>
 		<model name='BJ-1'>
 			<availability>General:1-,Periphery.Deep:8,Periphery:3</availability>
-		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:1,CS:4,FVC:5,LA:4,PIR:2,WOB:4,FS:5,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:7,MERC:5</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,CS:3,MOC:4,FVC:3,ROS:4,FWL:5,IS:3,WOB:5,FS:5,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:2+,DC:2+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
+		<model name='BJ2-OX'>
+			<availability>General:1</availability>
 		</model>
-		<model name='BJ2-OU'>
-			<availability>General:2</availability>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:1</availability>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:2+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
+		</model>
+		<model name='BJ2-OU'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>SC:4,PR:4,LA:6,MCM:4,PG:4,FWL:2,DGM:4,RFS:4</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:3,WOB:5,MERC:5,TC:3</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>CC:2,General:3,WOB:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3093,20 +3090,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>CC:2,General:3,WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CBS:4,CSL:5</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>CSA:7,General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -3118,26 +3118,26 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CBS:10</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CBS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:5</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -3155,11 +3155,11 @@
 	</chassis>
 	<chassis name='Blue Flame' unitType='Mek'>
 		<availability>WOB.SD:5,WOB:3</availability>
-		<model name='BLF-21'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLF-40'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLF-21'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3177,16 +3177,16 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank' unitType='Tank' omni='IS'>
 		<availability>WOB:4</availability>
-		<model name='Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='Dominus'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Comminus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='Infernus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3200,6 +3200,10 @@
 			<roles>fire_support</roles>
 			<availability>IS:1-,Periphery.Deep:8,Periphery:1-</availability>
 		</model>
+		<model name='BMB-14K'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
 		<model name='BMB-14C'>
 			<roles>fire_support</roles>
 			<availability>CS:6,WOB:6</availability>
@@ -3207,10 +3211,6 @@
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>OA:8</availability>
-		</model>
-		<model name='BMB-14K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3222,19 +3222,19 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4,CDS:1,CGS:2</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
+			<availability>CHH:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
@@ -3256,15 +3256,6 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2,CIR:2,TC:2</availability>
-		<model name='LDT-X3'>
-			<availability>PIR:3</availability>
-		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:3</availability>
-		</model>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-5'>
 			<availability>PIR:6</availability>
 		</model>
@@ -3273,6 +3264,15 @@
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X3'>
+			<availability>PIR:3</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LDT-X4'>
+			<availability>PIR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -3292,17 +3292,17 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(PPC)'>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:4,MOC:3,FS:2</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3339,25 +3339,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:2-,CC:3-,HL:3-,FRR:2-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,CGB.FRR:2-,ROS:3-,FWL:1-,DC:3-</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:3,General:8,FS:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:3,General:8,FS:3,MERC:3,DC:3</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3393,17 +3393,17 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,FS:5,MERC:3</availability>
-		<model name='BSW-S2r'>
-			<availability>General:2</availability>
-		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:2</availability>
+		</model>
+		<model name='BSW-X2'>
+			<availability>LA:4,General:1,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BSW-X2'>
-			<availability>LA:4,General:1,MERC:4</availability>
+		<model name='BSW-S2r'>
+			<availability>General:2</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>General:1,MERC:5</availability>
@@ -3411,17 +3411,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>CS:4,FVC:6,LA:4,FS:6,MERC:4</availability>
-		<model name='CES-4R'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>CS:8,FVC:8,FS:4,MERC:4</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3437,22 +3437,22 @@
 	</chassis>
 	<chassis name='Canis' unitType='Mek'>
 		<availability>CDS:3,CCO:6,CJF:3</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CSR:2,CDS:3,CW:1,CNC:5,CCO:1,CGS:1,CJF:1,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3464,119 +3464,119 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:1,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
-		<model name='CTF-2X'>
-			<availability>CC:2-,MOC:2,FVC:2,MERC:1,TC:2</availability>
+		<model name='CTF-3LL'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:5,LA:2,FS:5</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4</availability>
+		<model name='CTF-1X'>
+			<availability>General:3-,Periphery:4-</availability>
 		</model>
 		<model name='CTF-4L'>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>General:3-,Periphery:4-</availability>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:2-,MOC:2,FVC:2,MERC:1,TC:2</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,DoO:2,FRR:5,DO:2,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,CGB.FRR:5,FWL:1,NIOPS:4,MH:5,TP:2,DA:2,RCM:2,DC:6</availability>
-		<model name='CPLT-C4C'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FS:1,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
-			<roles>fire_support</roles>
-			<availability>WOB:4,DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:6,CGB.FRR:6,DC:8</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:4,CS:3,MOC:3,FWL:2,WOB:3,MERC:2,FS:2,CDP:3,TC:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C6'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:2,MERC:2,TC:2</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CC:3,FVC:2,CLAN:6,IS:1,MERC:2,Periphery:1,DC:3</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CPLT-C5A'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:1-</availability>
+		</model>
+		<model name='CPLT-C6'>
+			<roles>fire_support</roles>
+			<availability>CC:4,MOC:2,MERC:2,TC:2</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FVC:2,CLAN:6,IS:1,MERC:2,Periphery:1,DC:3</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:6,CGB.FRR:6,DC:8</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,DoO:2,DO:2,TP:2,MERC:2,DA:2,RCM:2</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4C'>
 			<roles>fire_support</roles>
-			<availability>CC:1-</availability>
+			<availability>CC:3,MOC:3,FS:1,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>WOB:4,DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:4,CS:3,MOC:3,FWL:2,WOB:3,MERC:2,FS:2,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CSR:3,CDS:5,CW:1,CLAN:1,CNC:5,CGS:6,CJF:1,CGB:1,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='X'>
-			<availability>CHH:1,CW:1</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<availability>CHH:1,CW:1</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:2</availability>
@@ -3584,49 +3584,49 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
-		<model name='(SRM)'>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:1,CBS:5+</availability>
-		<model name='4'>
-			<availability>CBS:4</availability>
+		<model name='(Standard)'>
+			<availability>CSR:5,CBS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CSR:3,CBS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSR:5,CBS:8</availability>
+		<model name='4'>
+			<availability>CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -3638,11 +3638,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:3,CBS:4,CNC:6,CSL:5,CJF:4</availability>
-		<model name='3'>
-			<availability>CSR:3,CBS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CNC:8,CSL:5,CJF:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CSR:3,CBS:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:5</availability>
@@ -3650,30 +3650,24 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='Commando'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='Commando'>
-			<availability>LA:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:2-,Periphery.HR:3,FS:3-,MERC:2-,Periphery.OS:3,Periphery:3</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8,WOB:8</availability>
@@ -3681,32 +3675,23 @@
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>LA:2-,Periphery.HR:3,FS:3-,MERC:2-,Periphery.OS:3,Periphery:3</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>DoO:2,FRR:1,DO:2,Periphery.OS:4,FS:8,CDP:3,SC:2,CGB.FRR:1,FWL:2,NIOPS:2-,MH:4,CC:2,IS:1,WOB:2-,DGM:2,MERC:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,TP:2,DC:1</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='CN9-A'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:3-,Periphery.Deep:8,FS:2-,MERC:2-,Periphery:3-</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:3,MERC:6,CIR:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:2,ROS:3,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-AH'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,FS:2-,MERC:2-</availability>
+		<model name='CN10-B'>
+			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
 		</model>
 		<model name='CN9-H'>
 			<availability>MH:6</availability>
@@ -3714,17 +3699,32 @@
 		<model name='CN9-D4D'>
 			<availability>DTA:2,SC:2,DoO:2,MCM:2,ROS:3,FWL:1,DO:2,DGM:2,TP:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:2</availability>
+		<model name='CN9-A'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:3-,Periphery.Deep:8,FS:2-,MERC:2-,Periphery:3-</availability>
 		</model>
 		<model name='CN9-D3'>
 			<availability>FVC:2,ROS:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='CN10-B'>
-			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
+		<model name='CN9-D'>
+			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:3,MERC:6,CIR:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:2-,FS:2-,MERC:2-</availability>
 		</model>
 		<model name='CN9-Da'>
 			<availability>SC:1,FVC:2,DoO:1,MCM:1,ROS:1,FWL:2,DO:1,DGM:1,TP:1,FS:1,MERC:1,Periphery:2</availability>
+		</model>
+		<model name='CN9-AH'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:2-,FS:2-,MERC:2-</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -3735,11 +3735,11 @@
 		<model name='MR-V2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-6B'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3762,11 +3762,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3778,18 +3778,18 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='XII'>
+			<availability>LA:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='X'>
+			<availability>General:8</availability>
+		</model>
 		<model name='XIVs'>
 			<availability>LA:2,FS:2,DC:2</availability>
-		</model>
-		<model name='XII'>
-			<availability>LA:5,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -3797,6 +3797,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -3806,73 +3810,65 @@
 			<roles>training</roles>
 			<availability>General:2-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CHH:2,PR:2,DoO:2,FRR:4,DO:2,FS:3,DC.GHO:5,SC:2,CGB.FRR:4,FWL:3,NIOPS:5,RFS:2,CGB:3,CC:4,IS:3,WOB:5,DGM:2,MERC:2,CS:5,DTA:2,FVC:2,LA:3,MCM:2,ROS:4,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		</model>
 		<model name='CHP-3P'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='CHP-2N'>
-			<availability>IS:1-,NIOPS:0</availability>
-		</model>
-		<model name='CHP-3N'>
-			<availability>CS:6,ROS:6,WOB:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:1,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:1,CHH:2,WOB:4,FS:1,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:1,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-2N'>
+			<availability>IS:1-,NIOPS:0</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:1,MERC:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>CS:6,ROS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CS:4,FRR:3+,CGB.FRR:3+,ROS:4,IS:3+,NIOPS:4,WOB:6,MERC:2+,BAN:4,Periphery:2+</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>General:4,WOB:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4,WOB:4</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>missile_artillery</roles>
+			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:3-,MOC:2-,FRR:4-,MERC:2-,TC:2-,Periphery:2,OA:2-,FVC:2,LA:3-,CGB.FRR:4-,ROS:2-,FWL:1-,DC:4-</availability>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:3,ROS:3,MERC:4,DC:4</availability>
+		<model name='CGR-3Kr'>
+			<availability>FRR:1,CGB.FRR:2,ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='CGR-3K'>
 			<availability>CC:1-,FRR:3-,CGB.FRR:3-,MERC:3-,DC:3-</availability>
 		</model>
-		<model name='CGR-3Kr'>
-			<availability>FRR:1,CGB.FRR:2,ROS:2,MERC:2,DC:2</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:2,MERC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FVC:4-,OA:4-</availability>
@@ -3881,53 +3877,57 @@
 			<roles>recon</roles>
 			<availability>CC:1-,MOC:1-,OA:1-,LA:1-,FRR:1-,CGB.FRR:1-,FWL:1-,DC:1-,Periphery:1-</availability>
 		</model>
-		<model name='CGR-1A5'>
-			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:3,ROS:3,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:2,MERC:4</availability>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:3,ROS:3,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1L'>
 			<availability>CC:3-,FVC:4,HL:1,Periphery:4</availability>
 		</model>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:3,ROS:3,MERC:4,DC:4</availability>
+		</model>
+		<model name='CGR-1A5'>
+			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>PR:8,HL:2,DoO:10,FRR:3,DO:10,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,RFS:8,MOC:5,CC:3,WOB:6,DGM:10,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,FVC:2,LA:1-,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10,DC:1-</availability>
-		<model name='F-13'>
-			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,TP:4,MERC:4</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:2-,WOB:2-</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,DTA:2,SC:2,MCM:2,PG:2,FWL:2,TP:2,DA:2,RCM:2,RFS:2</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2-,FVC:1,FWL:2-,MERC:2-,Periphery:1</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:3-,PR:2-,HL:1-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,General:1-,FWL:3-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>CC:2,MOC:2,PR:8,DoO:8,FRR:6,WOB:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:2,PG:8,PIR:2,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 		<model name='OF-17A-R'>
 			<roles>recon</roles>
 			<availability>SC:4,MCM:4,ROS:3,DGM:4</availability>
 		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,DTA:2,SC:2,MCM:2,PG:2,FWL:2,TP:2,DA:2,RCM:2,RFS:2</availability>
+		</model>
+		<model name='F-12-S'>
+			<availability>FWL:2-,WOB:2-</availability>
+		</model>
 		<model name='F-14-S'>
 			<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2-,FVC:1,FWL:2-,MERC:2-,Periphery:1</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:2,MOC:2,PR:8,DoO:8,FRR:6,WOB:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:2,PG:8,PIR:2,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='F-13'>
+			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,TP:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,CDS:2,LA:1,ROS:5,CNC:3,NIOPS:5,WOB:5,FS:1,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
 		</model>
@@ -3935,13 +3935,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:4</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:4,LA:4,WOB:4,FS:4,RCM:4,DC:4</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3952,63 +3952,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>PR:4,DoO:4,WOB:4,DO:4,FS:2,MERC:5,DTA:4,FVC:4,LA:6,ROS:4,PG:4,FWL:4,MH:3,TP:4,DA:4,RFS:4,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,HL:1-,LA:3-,IS:1-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:4,FS:1-,CDP:4,TC:4,Periphery:1-</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,FRR:6,CGB.FRR:6,ROS:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:4,FS:1-,CDP:4,TC:4,Periphery:1-</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,FRR:6,CGB.FRR:6,ROS:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:1-,LA:3-,IS:1-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CSA:5,CSR:4,CBS:7,CNC:4,CWIE:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,IS:1,WOB:4-,DGM:6,FS:1,MERC:3,CDP:3,Periphery:3,CS:4-,SC:6,LA:1,MCM:6,PG:6,FWL:6,RFS:6,DC:3</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,FRR:6,CGB.FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6,Periphery:2</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:5,IS:4,WOB:5</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>SC:4,PR:5,MCM:4,PG:5,FWL:7,WOB:6,DGM:4,RFS:5</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,FRR:6,CGB.FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -4035,20 +4035,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -4065,23 +4065,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -4089,14 +4089,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -4113,32 +4113,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -4146,11 +4146,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4159,14 +4159,14 @@
 			<roles>marine</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>CDS:7,CW:4,CNC:7,CGB:4,CWIE:7</availability>
+		<model name='(Volk)' mechanized='true'>
+			<availability>CW:6</availability>
 		</model>
 		<model name='(Rache)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Volk)' mechanized='true'>
-			<availability>CW:6</availability>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>CDS:7,CW:4,CNC:7,CGB:4,CWIE:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -4174,20 +4174,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4210,20 +4210,23 @@
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>CSR:2,CDS:1,CW:5,CBS:2,CLAN:1,CNC:5,CJF:1,CGB:5</availability>
-		<model name='2'>
-			<availability>CSR:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,PR:3,FRR:1,IS:1,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,CGB.FRR:1,PG:3,ROS:3,FWL:1,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3,DC:1</availability>
-		<model name='CLNT-2-4T'>
-			<availability>CC:1,FS:1</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:5,LA:3,General:6</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
@@ -4232,14 +4235,11 @@
 			<roles>spotter</roles>
 			<availability>LA:8,General:4,MERC:8</availability>
 		</model>
+		<model name='CLNT-2-4T'>
+			<availability>CC:1,FS:1</availability>
+		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:8,MOC:3,TC:7</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -4297,13 +4297,29 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>MOC:4+,FVC:3,LA:8,FRR:6,CGB.FRR:6,MH:4+,FS:2,MERC:5,CDP:4+,TC:4+</availability>
+			<availability>LA:2-,MERC:1-,Periphery:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
 		</model>
 		<model name='COM-4H'>
 			<roles>recon</roles>
 			<availability>PIR:8,MH:10</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,WOB:8,MERC:6</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>MOC:4+,FVC:3,LA:8,FRR:6,CGB.FRR:6,MH:4+,FS:2,MERC:5,CDP:4+,TC:4+</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>ROS:8,WOB:10</availability>
 		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
@@ -4313,61 +4329,45 @@
 			<roles>recon</roles>
 			<availability>HL:2,LA:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>ROS:8,WOB:10</availability>
-		</model>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
-		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:2-,MERC:1-,Periphery:1</availability>
-		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:1-,LA:1-,General:3-,Periphery.Deep:8,TC:3-,Periphery:4-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:7,WOB:8,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:4-,FVC:4-,General:3-,FS:4-,Periphery:3-</availability>
-		</model>
 		<model name='(Davion)'>
 			<availability>FS:2-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:7</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
 		</model>
 		<model name='(Upgrade) (Standard)'>
 			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,IS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:4-,FVC:4-,General:3-,FS:4-,Periphery:3-</availability>
 		</model>
 		<model name='(Liao)'>
 			<availability>CC:5-</availability>
 		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>CGB.FRR:4,IS:5,Periphery.Deep:6,WOB:4,CIR:6,Periphery:6,CGB:2</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:5,IS:3,DC:6</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Confederate C' unitType='Dropship'>
@@ -4379,13 +4379,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -4408,12 +4408,12 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:4</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
@@ -4448,53 +4448,53 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='CRX-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-OR'>
 			<availability>OA:2,CLAN:8</availability>
+		</model>
+		<model name='CRX-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:5,CCC:4,CLAN.IS:3,CSL:4,CCO:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>CSA:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FRR:6,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
+		<model name='CSR-V12'>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
 		</model>
 		<model name='CSR-12D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FRR:6,FS:6,MERC:6</availability>
+		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,FS:3,BAN:2</availability>
 		</model>
-		<model name='CSR-V20'>
-			<availability>LA:1,FS.AH:2-,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
-		</model>
 		<model name='CSR-V12M &apos;Regulus&apos;'>
 			<availability>FWL:1</availability>
+		</model>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='CSR-V20'>
+			<availability>LA:1,FS.AH:2-,Periphery:1</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FVC:5,ROS:4,FS:5</availability>
@@ -4521,11 +4521,11 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -4533,16 +4533,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CW:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -4550,8 +4549,9 @@
 		<model name='H'>
 			<availability>CSA:6,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -4569,35 +4569,35 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,CGB.FRR:4,ROS:5,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CS:7,FRR:5,CGB.FRR:5,ROS:7,CLAN:4,WOB:7,CGS:6,BAN:2,DC:5</availability>
+			<availability>DC.GHO:5-,CS:3,FRR:3,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
+		<model name='CRB-30'>
+			<availability>CS:8,FRR:2,CGB.FRR:2,WOB:6</availability>
+		</model>
 		<model name='CRB-45'>
 			<availability>WOB:5</availability>
+		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CS:7,FRR:5,CGB.FRR:5,ROS:7,CLAN:4,WOB:7,CGS:6,BAN:2,DC:5</availability>
 		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,CS:3,FRR:3,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
-		</model>
-		<model name='CRB-30'>
-			<availability>CS:8,FRR:2,CGB.FRR:2,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
 		<availability>CDS:4,CBS:4,CJF:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN.IS:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN.IS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:4,CBS:8</availability>
@@ -4605,21 +4605,21 @@
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:2,CDS:3,CBS:6</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
@@ -4627,23 +4627,23 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:6,CSR:4,FRR:6,CLAN:5,WOB:8,CIR:4,CGS:4,CWIE:6,DC.GHO:3,CS:9,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:5,NIOPS:9,CJF:4,CGB:6</availability>
-		<model name='CRK-5004-1'>
-			<availability>CS:6,FRR:4,CGB.FRR:4,ROS:6</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:8,FRR:4,CGB.FRR:4,ROS:8</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>ROS:8,WOB:8,CIR:6</availability>
+		<model name='CRK-5003-1'>
+			<availability>CS:4,ROS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
+		</model>
+		<model name='CRK-5004-1'>
+			<availability>CS:6,FRR:4,CGB.FRR:4,ROS:6</availability>
 		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:3-,NIOPS:0</availability>
 		</model>
-		<model name='CRK-5003-1'>
-			<availability>CS:4,ROS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-3'>
-			<availability>CS:8,FRR:4,CGB.FRR:4,ROS:8</availability>
+		<model name='CRK-5005-1'>
+			<availability>ROS:8,WOB:8,CIR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -4666,33 +4666,37 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:3,CDS:4,CW:3,CBS:5,CLAN:3,CNC:4,CCO:3,CJF:3,CWIE:4,CGB:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
+		<model name='U'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='U'>
-			<availability>CLAN:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>MERC:2,DC:3</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>MERC:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>DC:5</availability>
@@ -4701,13 +4705,30 @@
 			<roles>recon,spotter</roles>
 			<availability>IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:7,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
+		<model name='CRD-7W'>
+			<availability>DTA:5,SC:5,MCM:5,ROS:4,FWL:2,WOB:4,DGM:5,MERC:4,RCM:5</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='CRD-3D'>
+			<availability>FVC:1-,FS:1-</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:6,FS:1,MERC:4</availability>
+		</model>
+		<model name='CRD-7L'>
+			<availability>CC:6,WOB:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='CRD-8S'>
 			<availability>LA:5,FS:4</availability>
 		</model>
@@ -4715,44 +4736,23 @@
 			<roles>raider</roles>
 			<availability>CC:1-</availability>
 		</model>
-		<model name='CRD-7L'>
-			<availability>CC:6,WOB:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:4,CS:4,FWL:8,IS:1,WOB:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,SC:5,MCM:5,ROS:4,FWL:2,WOB:4,DGM:5,MERC:4,RCM:5</availability>
-		</model>
-		<model name='CRD-4K'>
-			<availability>LA:1,FRR:7,CGB.FRR:7,MERC:1,FS:1,DC:6</availability>
 		</model>
 		<model name='CRD-4BR'>
 			<availability>MERC:5</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:6,FS:1,MERC:4</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:5,CGB.FRR:5,WOB:4,MERC:5,DC:6</availability>
+		<model name='CRD-4K'>
+			<availability>LA:1,FRR:7,CGB.FRR:7,MERC:1,FS:1,DC:6</availability>
 		</model>
 		<model name='CRD-2R'>
 			<availability>ROS:5,CLAN:4,FWL:4,IS:2,WOB:5,MERC:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FVC:1-,FS:1-</availability>
+		<model name='CRD-5M'>
+			<availability>CC:4,CS:4,FWL:8,IS:1,WOB:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:4,WOB:4,MERC:4</availability>
+		<model name='CRD-5K'>
+			<availability>FRR:5,CGB.FRR:5,WOB:4,MERC:5,DC:6</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4760,26 +4760,34 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,CGB.FRR:5,ROS:3,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>CS:8,MOC:3,FRR:8,CGB.FRR:8,IS:3,MERC:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:1-</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:7,DC:7</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:7,IS:6,WOB:6,MH:3,FS:7,CDP:4,DC:3,TC:4</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:1-,General:4-,IS:1-,FS:1-,MERC:1-,DC:1-,TC:1-</availability>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:1,DC:1</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:5,IS:2+,MERC:5,DC:5</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:7,DC:7</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:1-,General:4-,IS:1-,FS:1-,MERC:1-,DC:1-,TC:1-</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:1-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>CS:8,MOC:3,FRR:8,CGB.FRR:8,IS:3,MERC:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -4788,28 +4796,20 @@
 		<model name='CP-11-H'>
 			<availability>FVC:5,HL:3,PIR:6,MH:6,CIR:6,CDP:6,TC:6,Periphery:5</availability>
 		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:1,DC:1</availability>
-		</model>
 		<model name='CP-10-HQ'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
 			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:3,CWIE:2</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4822,25 +4822,25 @@
 			<roles>recon,escort</roles>
 			<availability>CS:4,General:4,NIOPS:4,WOB:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>TC:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4852,35 +4852,35 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='DAI-01r'>
 			<availability>General:3</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -4900,14 +4900,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>FRR:6,CGB.FRR:6,ROS:5,DC:7</availability>
-		<model name='DMO-4K'>
-			<availability>FRR:2,CGB.FRR:2,DC:7</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:5</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:4,CGB.FRR:4,DC:6</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:5</availability>
+		<model name='DMO-4K'>
+			<availability>FRR:2,CGB.FRR:2,DC:7</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -4916,27 +4916,26 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:2+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CGS:5,CCO:6</availability>
@@ -4944,8 +4943,9 @@
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4971,14 +4971,14 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>CS:4,LA:5,ROS:4,MH:2,FS:6,MERC:4,CIR:4</availability>
-		<model name='DRT-6T'>
-			<availability>CS:8,LA:4,ROS:8,FS:4,MERC:4</availability>
-		</model>
 		<model name='DRT-3S'>
 			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:2</availability>
+		</model>
+		<model name='DRT-6T'>
+			<availability>CS:8,LA:4,ROS:8,FS:4,MERC:4</availability>
 		</model>
 		<model name='DRT-4S'>
 			<availability>LA:4,MH:3,FS:5,MERC:4,CIR:4</availability>
@@ -4986,11 +4986,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:4,FS:7</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:5,General:5</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
 		</model>
@@ -5002,25 +5005,15 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:2</availability>
+			<availability>FVC:5,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:5,CCC:3,MERC.WD:3,CDS:3,CLAN:3,IS:3+,CCO:2,CJF:3,BAN:3,CGB:6</availability>
-		<model name='H'>
-			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
@@ -5028,18 +5021,25 @@
 		<model name='K'>
 			<availability>General:2,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
@@ -5059,15 +5059,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5082,11 +5082,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:4,MERC:3</availability>
-		<model name='DFN-3S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -5104,18 +5104,6 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,FS:9,CWIE:6,OA:9,CGB.FRR:7,FWL:8,NIOPS:6,MOC:10,CC:7,IS:7,WOB:6,CIR:9,Periphery:10,TC:9,CS:6,FVC:8,LA:5,ROS:8,CNC:5,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:3,IS:3,Periphery.Deep:6,Periphery:5</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,MOC:7,FRR:6,IS:7,WOB:8,FS:8,TC:7,CWIE:4,CS:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,DC:8</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
@@ -5123,8 +5111,20 @@
 		<model name='(MRM)'>
 			<availability>FVC:3,DC:7,Periphery:3</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,MOC:7,FRR:6,IS:7,WOB:8,FS:8,TC:7,CWIE:4,CS:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,DC:8</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:3,IS:3,Periphery.Deep:6,Periphery:5</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
+		</model>
+		<model name='(Defensive)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 	</chassis>
@@ -5134,11 +5134,11 @@
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>LA:3,CWIE:3</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:2,CWIE:2</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>LA:3,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5167,26 +5167,20 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CS:4,CHH:6,ROS:4,CLAN:4,NIOPS:4,WOB:4</availability>
-		</model>
 		<model name='CX-2'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<availability>CS:4,CHH:6,ROS:4,CLAN:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:2,DoO:3,FRR:3,IS:2,Periphery.Deep:5,DO:3,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:1,FVC:5,LA:3,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:3</availability>
-		<model name='DV-8D'>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='DV-6M'>
-			<availability>HL:2-,CLAN:4,IS:2-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:4,FS:5,MERC:3</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='DV-6Mr'>
 			<availability>General:2</availability>
@@ -5194,18 +5188,20 @@
 		<model name='DV-1S'>
 			<availability>IS:3-</availability>
 		</model>
+		<model name='DV-8D'>
+			<availability>ROS:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>HL:2-,CLAN:4,IS:2-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Deva' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-DVA-OS Caelestis'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-DVA-OD Luminos'>
+		<model name='C-DVA-OC Comminus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OB Infernus'>
+		<model name='C-DVA-OD Luminos'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
@@ -5213,21 +5209,25 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OA Dominus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-DVA-OU Exanimus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-DVA-OC Comminus'>
+		<model name='C-DVA-OB Infernus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-DVA-O Invictus'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='C-DVA-OS Caelestis'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-DVA-OU Exanimus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-DVA-OA Dominus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -5241,11 +5241,11 @@
 		<model name='DVS-3'>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,LA:1-,FS:1-,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5256,10 +5256,13 @@
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:5,PIR:1,WOB:1</availability>
-		<model name='(Reflective)&apos;Terrorizer&apos; (Flamer)' mechanized='true'>
+		<model name='(Reflective)&apos;Terrorizer&apos; (SL)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Reflective)&apos;Terrorizer&apos; (SL)' mechanized='true'>
+		<model name='(Stealth)' mechanized='true'>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='(Reflective)&apos;Terrorizer&apos; (Flamer)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
@@ -5269,22 +5272,19 @@
 		<model name='(Reflective)&apos;Terrorizer&apos; (MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Stealth)' mechanized='true'>
-			<availability>WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Close Support)'>
-			<roles>spotter</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4,CGS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8,CJF:2</availability>
+		</model>
+		<model name='(Close Support)'>
+			<roles>spotter</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau Assault Interceptor' unitType='Dropship'>
@@ -5296,26 +5296,26 @@
 	</chassis>
 	<chassis name='Dragon Fire' unitType='Mek'>
 		<availability>LA:6,FRR:4,CGB.FRR:4,WOB:6,MERC:6,DC:5</availability>
-		<model name='DGR-6FC'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='DGR-4F'>
 			<availability>LA:4,WOB:3,MERC:4,DC:4</availability>
 		</model>
 		<model name='DGR-3F'>
 			<availability>General:8,WOB:0</availability>
 		</model>
+		<model name='DGR-6FC'>
+			<availability>WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:1,FRR:6,CGB.FRR:6,MERC:3,DC:5</availability>
-		<model name='DRG-7N'>
-			<availability>LA:1,MERC:5,DC:5</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:1-,CGB.FRR:1-,DC:1-,Periphery:3</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>FRR:5,CGB.FRR:5,MERC:5,DC:5,Periphery:3</availability>
+		</model>
+		<model name='DRG-7N'>
+			<availability>LA:1,MERC:5,DC:5</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>FRR:2,CGB.FRR:2,MERC:2,DC:2</availability>
@@ -5323,16 +5323,16 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:4,CHH:4,ROS:3+,IS:1+,CGB:6</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='Z'>
 			<roles>spotter</roles>
 			<availability>CCO:2</availability>
+		</model>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
@@ -5340,26 +5340,26 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:7,CHH:7,CCC:7,CSR:4,CDS:8,CBS:7,General:6,CGS:7,CJF:8,CWIE:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
+		</model>
 		<model name='I'>
+			<availability>General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5372,20 +5372,20 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:3-,Periphery:3-,CS:3,FVC:4-,LA:7,ROS:3,FWL:3-,CC.MAC:3-,DC:3-</availability>
-		<model name='(Standard)'>
-			<availability>CC:3-,General:3-</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>LA:2,ROS:2,WOB:2,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CC:3-,General:2</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>WOB:2</availability>
+		<model name='(Standard)'>
+			<availability>CC:3-,General:3-</availability>
 		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,WOB:7,FS:7</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:2,ROS:2,WOB:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5397,11 +5397,11 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,TC:4</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:6</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle Frigate' unitType='Warship'>
@@ -5413,34 +5413,34 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6b'>
-			<availability>SC:4,DoO:4,MCM:4,DO:4,DGM:4,TP:4,RCM:4</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:1,FS:1</availability>
+		<model name='EGL-R11'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:1-,FS:1-</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1-,General:5-,FS:1-</availability>
+		</model>
+		<model name='EGL-R6b'>
+			<availability>SC:4,DoO:4,MCM:4,DO:4,DGM:4,TP:4,RCM:4</availability>
 		</model>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:1-,FS:1-</availability>
 		</model>
-		<model name='EGL-R11'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
-		<model name='EGL-R6'>
-			<availability>LA:1-,General:5-,FS:1-</availability>
+		<model name='EGL-R4'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,PR:6,DGM:7,MERC:4,DTA:6,SC:7,FWL.MM:7,MCM:7,PG:6,FWL:6,MH:4,FWL.FO:7,DA:5,RFS:6</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
 		<model name='EGL-3M'>
 			<availability>DTA:3,SC:3,MCM:3,FWL:3,DGM:3</availability>
@@ -5452,13 +5452,13 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='MEB-9'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='MEB-11'>
 			<roles>recon</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='MEB-9'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eidolon' unitType='Mek'>
@@ -5472,11 +5472,11 @@
 		<model name='EFT-7X'>
 			<availability>IS:8,MH:4</availability>
 		</model>
-		<model name='EFT-4J'>
-			<availability>LA:3-,MERC:2-</availability>
-		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='EFT-4J'>
+			<availability>LA:3-,MERC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5487,19 +5487,19 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:4,MERC:2+</availability>
-		<model name='EST-OD'>
-			<availability>General:3</availability>
-		</model>
 		<model name='EST-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='EST-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='EST-OC'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:3</availability>
 		</model>
-		<model name='EST-OA'>
+		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -5515,41 +5515,14 @@
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,MERC.WD:6,CW:6,CLAN:6,CNC:6+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -5557,8 +5530,35 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5569,34 +5569,30 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='EMP-7L'>
-			<availability>CC:5</availability>
+		<model name='EMP-6D'>
+			<availability>FS:8</availability>
 		</model>
 		<model name='EMP-6ME &apos;Mercury Elite&apos;'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='EMP-6A'>
-			<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
-		</model>
 		<model name='EMP-6M'>
 			<availability>FWL:2,WOB:4</availability>
+		</model>
+		<model name='EMP-7L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='EMP-6L'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='EMP-6S'>
 			<availability>LA:7</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>FS:8</availability>
+		<model name='EMP-6A'>
+			<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>CS:3-,LA:5-,FS:3-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:5,General:1,MERC:5</availability>
@@ -5608,11 +5604,24 @@
 		<model name='END-6Sr'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,FS:7,MERC:5</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6G'>
+			<availability>FS:2,MERC:4</availability>
+		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-7C3BS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6T'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:2</availability>
@@ -5620,34 +5629,21 @@
 		<model name='ENF-6Ma'>
 			<availability>FVC:2,FS:2</availability>
 		</model>
-		<model name='ENF-6T'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='ENF-6G'>
-			<availability>FS:2,MERC:4</availability>
-		</model>
-		<model name='ENF-7C3BS'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:1,LA:1,Periphery.HR:2,MH:2,DC:1</availability>
-		<model name='ENF-5D'>
-			<availability>FVC:8,LA:1,FS:8,MERC:5,CDP:5,TC:5</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>FVC:4-,General:2-,FS:3-,TC:3-</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>FVC:8,LA:1,FS:8,MERC:5,CDP:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -5656,25 +5652,33 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
 		<availability>CSA:4,CHH:5,CSR:2,CSL:5,CJF:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X) &apos;Sholef&apos;'>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGS:3+,CGB:3+,CWIE:4+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -5684,10 +5688,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -5695,22 +5695,22 @@
 	</chassis>
 	<chassis name='Erinyes' unitType='ProtoMek'>
 		<availability>CJF:1</availability>
-		<model name='2'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CJF:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CSR:1,CDS:2,FWL:1,WOB:2,CGS:1,CCO:1,DC:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CS:4,CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CS:4,CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -5719,20 +5719,16 @@
 			<roles>troop_carrier</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>WOB:5,FS:4,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:2,FS:6</availability>
 		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>WOB:5,FS:4,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,ROS:4,CLAN:1,NIOPS:5,WOB:5,CIR:2+,DC:4</availability>
-		<model name='EXC-B2b'>
-			<roles>fire_support</roles>
-			<availability>ROS:6,CLAN:4,WOB:5,CGS:6,BAN:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,CLAN:1,NIOPS:5,WOB:8</availability>
@@ -5745,6 +5741,10 @@
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='EXC-B2b'>
+			<roles>fire_support</roles>
+			<availability>ROS:6,CLAN:4,WOB:5,CGS:6,BAN:2</availability>
+		</model>
 		<model name='EXC-CS'>
 			<roles>fire_support</roles>
 			<availability>CS:8,ROS:6,WOB:8,DC:8</availability>
@@ -5752,28 +5752,28 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>CS:3,FWL:1,IS:1,NIOPS:3,WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:1,NIOPS:2,WOB:4,DC:1</availability>
-		<model name='EXT-4D'>
-			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
-		</model>
 		<model name='EXT-5F'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='EXT-6CS'>
-			<availability>CS:1</availability>
-		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
+		</model>
+		<model name='EXT-4D'>
+			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
+		</model>
+		<model name='EXT-6CS'>
+			<availability>CS:1</availability>
 		</model>
 		<model name='EXT-5E'>
 			<availability>CS:8,WOB:8</availability>
@@ -5781,16 +5781,16 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:7,CC:3</availability>
+		<model name='EYL-45B'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='EYL-4A'>
 			<availability>MOC:1</availability>
 		</model>
 		<model name='EYL-35A'>
 			<roles>spotter</roles>
 			<availability>CC:1</availability>
-		</model>
-		<model name='EYL-45B'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
 		</model>
 		<model name='EYL-45A'>
 			<roles>spotter</roles>
@@ -5799,36 +5799,39 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
 		<availability>LA:4,WOB:3</availability>
-		<model name='FNR-5WB'>
-			<availability>WOB:8</availability>
+		<model name='FNR-5'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='FNR-5B'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='FNR-5WB'>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='FNR-6U'>
 			<roles>marine</roles>
@@ -5837,21 +5840,18 @@
 		<model name='FNR-5X'>
 			<availability>General:2</availability>
 		</model>
-		<model name='FNR-5'>
-			<availability>LA:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
 		<availability>ROS:6,FWL:7,IS:4,WOB:6,MERC:5</availability>
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>SC:6,MCM:6,WOB:8,DGM:6</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5862,32 +5862,32 @@
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
 		<availability>MERC.KH:1,WOB:2,MERC:2</availability>
-		<model name='FLC-5P'>
-			<availability>WOB:8,MERC:6</availability>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4P'>
-			<availability>MERC.WD:2</availability>
-		</model>
 		<model name='FLC-6C'>
 			<availability>MERC.WD:6+</availability>
+		</model>
+		<model name='FLC-4P'>
+			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
+		<model name='FLC-5P'>
+			<availability>WOB:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>CS:4,LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-9R'>
-			<availability>General:5</availability>
-		</model>
 		<model name='FLC-8R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='FLC-9R'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5899,11 +5899,11 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Upgrade)'>
+		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
@@ -5917,96 +5917,96 @@
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='&apos;Longshot&apos;' mechanized='false'>
-			<availability>General:3</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='&apos;Longshot&apos;' mechanized='false'>
+			<availability>General:3</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:3+,CHH:3,MERC.WD:6,CW:6,IS:2+,CJF:4,CWIE:6,CGB:3</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:4,HL:4,LA:5,ROS:3,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3,FS:6</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='&apos;Fermi&apos;'>
 			<roles>apc</roles>
 			<availability>FS:3</availability>
-		</model>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:5</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -6018,59 +6018,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6078,39 +6030,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -6125,13 +6129,13 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CSA:7,CLAN:6,IS:3</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CLAN:6</availability>
@@ -6140,19 +6144,15 @@
 			<roles>urban</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-10D'>
-			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,LA:1,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-10D'>
+			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='ALM-8D'>
 			<roles>recon,raider</roles>
@@ -6178,14 +6178,8 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:1,CLAN:1,WOB:5,BAN:1</availability>
-		<model name='FFL-4D'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
@@ -6193,26 +6187,40 @@
 		<model name='FFL-4DA'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='C'>
+			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
+		</model>
+		<model name='FFL-4D'>
+			<availability>MERC.WD:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-S2'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='FS9-B'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
+		<model name='FS9-S1'>
 			<roles>recon</roles>
-			<availability>LA.SR:1-</availability>
+			<availability>LA:5,General:4,FS:4</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,CIR:7,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S2'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:3,CS:3,MOC:4,LA:5,FRR:4,CGB.FRR:4,General:4,FS:4,TC:3</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:1-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA.SR:1-</availability>
+		</model>
+		<model name='FS9-B'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:3,Periphery:3</availability>
@@ -6220,64 +6228,53 @@
 		<model name='FS9-S3'>
 			<availability>LA:4,ROS:3,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:3,CS:3,MOC:4,LA:5,FRR:4,CGB.FRR:4,General:4,FS:4,TC:3</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:5,General:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5,CC:4,FVC:4+,LA:5,IS:4,WOB:5,FS:5,MERC:4,DC:7</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:1+,DC:1+</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:1+,DC:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:3</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -6287,73 +6284,76 @@
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:2,FRR:4,CLAN:3,WOB:5,DGM:5,CGS:2,CS:5,DC.GHO:5,SC:5,Periphery.R:1,CDS:2,LA:4,CBS:2,MCM:5,CGB.FRR:4,ROS:4,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
-		<model name='FLS-9C'>
-			<availability>CS:6</availability>
-		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:1-,LA:1-</availability>
+		<model name='FLS-9M'>
+			<availability>SC:8,MCM:8,FWL:6,DGM:8</availability>
 		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,CS:4,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
 		</model>
+		<model name='FLS-9C'>
+			<availability>CS:6</availability>
+		</model>
 		<model name='FLS-C'>
 			<availability>DC:1</availability>
-		</model>
-		<model name='FLS-9M'>
-			<availability>SC:8,MCM:8,FWL:6,DGM:8</availability>
 		</model>
 		<model name='FLS-9B'>
 			<availability>WOB:6</availability>
 		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:1-,LA:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,PR:3,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4,MERC.WD:4,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:2,DA:3,RCM:3,RFS:3</availability>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
-		</model>
-		<model name='FLE-20'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:1</availability>
 		</model>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
+		</model>
 		<model name='FLE-17'>
 			<availability>CC:7,PR:6,ROS:8,PG:6,FWL:5,MERC:5,RCM:6,DA:6,RFS:6,Periphery:5</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6364,8 +6364,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -6377,20 +6377,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -6440,10 +6440,6 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:3,FS:3,MERC:3</availability>
@@ -6452,6 +6448,10 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CS:5,CHH:4,CW:3,ROS:5,CLAN:1,WOB:5,FS:5,CJF:3,CGB:4</availability>
@@ -6459,29 +6459,29 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:3,CLAN:4,WOB:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>ROS:5,FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>CS:8,ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:8,WOB:8,FS:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>ROS:3,CLAN:4,WOB:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>CS:8,ROS:4</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>ROS:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:7,PR:8,DoO:8,WOB:6,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:7,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:3-,General:8,FWL:1-,WOB:4-</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:7,PR:8,DoO:8,WOB:6,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:7,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -6490,24 +6490,24 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:2,CW:4,CLAN:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,ROS:8,CLAN:2,CGS:6,CCO:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6521,21 +6521,21 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>LA:3,ROS:3,WOB:5,FS:3,MERC:2</availability>
-		<model name='GLT-7-0'>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='GLT-8-0'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='GLT-7-0'>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,CGB.FRR:5,FWL:7,DC:4</availability>
 		</model>
 		<model name='GAL-104'>
 			<availability>WOB:5</availability>
@@ -6543,13 +6543,13 @@
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,FRR:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='GAL-103'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,CGB.FRR:5,FWL:7,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -6557,49 +6557,49 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:5</availability>
 		</model>
+		<model name='GAL-4GLSA'>
+			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:5</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-,CWIE:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-,CWIE:8</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:5</availability>
-		</model>
-		<model name='GAL-4GLSA'>
-			<availability>MERC.WD:2</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='GRM-01A2'>
-			<availability>FS:3</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
+		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='GRM-01A2'>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,ROS:4,FS:8</availability>
+		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
@@ -6613,32 +6613,32 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:1,CSR:1,CDS:5,CLAN:5,CNC:5,IS:1+,CJF:4,BAN:4,CWIE:1,CGB:9</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='B'>
+			<availability>General:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
+		</model>
 		<model name='P'>
 			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -6678,6 +6678,10 @@
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
 		<availability>FS:5</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='(Light Gauss)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
@@ -6686,27 +6690,23 @@
 			<roles>fire_support</roles>
 			<availability>FS:8</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6718,24 +6718,16 @@
 	</chassis>
 	<chassis name='Goblin Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FVC:6,LA:2,WOB:3,FS:4,MERC:4</availability>
-		<model name='(Sealed)'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CS:2-,CC:1,FVC:2,LA:2-,FS.CH:1-,FRR:1,WOB:1-,FS:2-,TC:3-,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>FRR:4,CGB.FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FVC:5,FS:5</availability>
@@ -6744,12 +6736,17 @@
 			<roles>apc,urban</roles>
 			<availability>CC:2,CS:2,FVC:4,LA:2,FRR:2,CGB.FRR:2,NIOPS:2,WOB:2,FS:4,DC:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>FRR:4,CGB.FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CGB:6</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>CGB:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
@@ -6760,48 +6757,51 @@
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:3,HL:2,IS:1,FS:3,MERC:4,TC:3,Periphery:3,CS:1,OA:2,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-4S'>
+		<model name='GOL-5W'>
 			<roles>fire_support</roles>
-			<availability>LA:5</availability>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,FWL:8,WOB:8,MERC:6</availability>
 		</model>
-		<model name='GOL-5W'>
+		<model name='GOL-6H'>
 			<roles>fire_support</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='GOL-6M'>
-			<roles>fire_support</roles>
-			<availability>ROS:3,FWL:3,MERC:2</availability>
+			<availability>Periphery.HR:4,Periphery.CM:4,Periphery.MW:4,Periphery.ME:4,MH:5,Periphery:3</availability>
 		</model>
 		<model name='GOL-3L'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3</availability>
 		</model>
+		<model name='GOL-6M'>
+			<roles>fire_support</roles>
+			<availability>ROS:3,FWL:3,MERC:2</availability>
+		</model>
 		<model name='GOL-5D'>
 			<roles>fire_support</roles>
 			<availability>FS:8</availability>
 		</model>
-		<model name='GOL-6H'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>Periphery.HR:4,Periphery.CM:4,Periphery.MW:4,Periphery.ME:4,MH:5,Periphery:3</availability>
+			<availability>LA:5</availability>
 		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>CC:3-,LA:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
-		<model name='GOL-2H'>
-			<roles>fire_support</roles>
-			<availability>Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,Periphery.ME:4,MH:5,Periphery:3</availability>
-		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,Periphery.ME:4,MH:5,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
@@ -6810,38 +6810,38 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CJF:5,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:3,CBS:5,CNC:5,CJF:3</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:3,CBS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:3,CBS:5,CNC:5,CJF:3</availability>
+		<model name='2'>
+			<availability>CSA:8,CJF:5,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CLAN:1</availability>
-		<model name='2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DoO:7,CLAN:4,WOB:9,DO:7,DGM:7,MERC:4-,CS:8,DTA:7,SC:7,CDS:5,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,TP:7</availability>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:5,MERC:4,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:4,ROS:6,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-400'>
-			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:5,MERC:4,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,FWL:3,WOB:5,DO:6,DGM:6,TP:6</availability>
+		</model>
+		<model name='GTHA-400'>
+			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader II' unitType='Mek'>
@@ -6855,26 +6855,29 @@
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
 		<availability>FWL:2,WOB:2</availability>
-		<model name='GRN-D-01'>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
 		<model name='GRN-D-02'>
 			<availability>FWL:2,WOB:2</availability>
+		</model>
+		<model name='GRN-D-01'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CGB.FRR:6,CNC:6,WOB:5,DC:8</availability>
-		<model name='DRG-1G'>
-			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
-		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:6,CGB.FRR:6,ROS:6,CNC:8,WOB:8,MERC:5,DC:5</availability>
 		</model>
+		<model name='DRG-7K'>
+			<availability>ROS:6,MERC:3,DC:5</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>FRR:3,CGB.FRR:3,ROS:4,DC:6</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='DRG-9KC'>
 			<roles>spotter</roles>
@@ -6882,9 +6885,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>ROS:6,MERC:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -6898,26 +6898,26 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:5,TC:6</availability>
+		<model name='GHR-7P'>
+			<availability>LA:4,MERC:3</availability>
+		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:5</availability>
 		</model>
-		<model name='GHR-5J'>
-			<availability>CS:2-,IS:5,WOB:2-,Periphery:3</availability>
-		</model>
-		<model name='GHR-6K'>
-			<availability>FRR:5,CGB.FRR:5,ROS:4,MERC:3,FS:3,DC:5</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='GHR-7P'>
-			<availability>LA:4,MERC:3</availability>
 		</model>
 		<model name='GHR-5N'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:3,DC:3</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>CS:2-,IS:5,WOB:2-,Periphery:3</availability>
+		</model>
+		<model name='GHR-6K'>
+			<availability>FRR:5,CGB.FRR:5,ROS:4,MERC:3,FS:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -6932,14 +6932,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -6964,17 +6964,14 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:3</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:3</availability>
@@ -6983,26 +6980,32 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:3</availability>
+		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:6,CDS:3,CSR:1,CSL:6,CCO:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -7010,32 +7013,29 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,LA:2,CLAN:2,CNC:7,CCO:6,CJF:3,CWIE:4,CGB:3,DC:4</availability>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,CLAN:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,CLAN:2,CCO:8</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CNC:3,CLAN:1</availability>
 		</model>
-		<model name='6'>
-			<availability>ROS:4,CNC:5,DC:5</availability>
+		<model name='7'>
+			<availability>ROS:4,CNC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:6,CLAN:1-,CNC:4</availability>
 		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:4</availability>
+		<model name='6'>
+			<availability>ROS:4,CNC:5,DC:5</availability>
 		</model>
 		<model name='8'>
 			<availability>CW:4,LA:4,ROS:4,CJF:4,CWIE:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,CLAN:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
@@ -7043,70 +7043,54 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-1S'>
-			<availability>LA:3-,MERC:3-</availability>
-		</model>
-		<model name='GRF-6CS'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CC:3,DoO:4,CLAN:6,WOB:5,DO:4,DGM:4,FS:3,MERC:3,BAN:4,SC:4,MCM:4,FWL:2,TP:4,RCM:4,DC:3</availability>
+		<model name='GRF-1N'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:3-,MERC:3-,TC:3-</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,FWL:3,WOB:5,DO:6,DGM:6,TP:6,MERC:5</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>PR:6,DoO:5,IS:6,DO:5,DGM:5,FS:5,DTA:5,SC:5,LA:6,MCM:5,PG:6,FWL:6,TP:5,RCM:6,DA:6,RFS:6,DC:3</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CS:5,ROS:5,FRR:4,CGB.FRR:4,CNC:2,FWL:2,WOB:4,FS:2,CGB:4,DC:2</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:6,LA:4,FRR:4,CGB.FRR:4,ROS:4,FS:6,MERC:4,DC:5</availability>
+		<model name='GRF-6S'>
+			<availability>LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CNC:5,DC:5</availability>
 		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,FWL:3,WOB:5,DO:6,DGM:6,TP:6,MERC:5</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:6,LA:4,FRR:4,CGB.FRR:4,ROS:4,FS:6,MERC:4,DC:5</availability>
+		</model>
+		<model name='GRF-1S'>
+			<availability>LA:3-,MERC:3-</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>PR:6,DoO:5,IS:6,DO:5,DGM:5,FS:5,DTA:5,SC:5,LA:6,MCM:5,PG:6,FWL:6,TP:5,RCM:6,DA:6,RFS:6,DC:3</availability>
+		</model>
 		<model name='GRF-4N'>
 			<availability>TC:3</availability>
+		</model>
+		<model name='GRF-6CS'>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CS:5,ROS:5,FRR:4,CGB.FRR:4,CNC:2,FWL:2,WOB:4,FS:2,CGB:4,DC:2</availability>
 		</model>
 		<model name='GRF-5L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
+		<model name='GRF-2N'>
+			<availability>CC:3,DoO:4,CLAN:6,WOB:5,DO:4,DGM:4,FS:3,MERC:3,BAN:4,SC:4,MCM:4,FWL:2,TP:4,RCM:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Grigori' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:7,WOB:2+</availability>
-		<model name='C-GRG-OS Caelestis'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-GRG-OC Comminus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-GRG-OB Infernus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OA Dominus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-GRG-OD Luminos'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-GRG-OE Eminus'>
+		<model name='C-GRG-OC Comminus'>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
@@ -7119,9 +7103,31 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C-GRG-OD Luminos'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OE Eminus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OA Dominus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-GRG-OS Caelestis'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,ROS:6,WOB:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR30'>
+			<availability>ROS:4,WOB:6+,MERC:3</availability>
+		</model>
+		<model name='GRM-R-PR29'>
+			<availability>CS:8,MERC:8,DC:8</availability>
+		</model>
 		<model name='GRM-R (Einar)'>
 			<roles>spotter</roles>
 			<availability>CS:1</availability>
@@ -7129,12 +7135,6 @@
 		<model name='GRM-R-PR31'>
 			<roles>fire_support</roles>
 			<availability>WOB:6+,MERC:4</availability>
-		</model>
-		<model name='GRM-R-PR30'>
-			<availability>ROS:4,WOB:6+,MERC:3</availability>
-		</model>
-		<model name='GRM-R-PR29'>
-			<availability>CS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -7153,11 +7153,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CC:1,FWL:1,Periphery:1</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3</availability>
@@ -7165,42 +7165,42 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CHH:3-,CW:3,CLAN:1-,CNC:3-,CCO:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4,CCO:6,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:3,CSR:2,FRR:1,IS:1,WOB:7,DGM:5,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:3,SC:5,MCM:5,CGB.FRR:1,ROS:6,FWL:5,NIOPS:7,DC:1</availability>
-		<model name='GLT-6WB3'>
+		<model name='GLT-6WB'>
 			<roles>raider</roles>
-			<availability>SC:6,MCM:6,ROS:3,DGM:6,MERC:3</availability>
-		</model>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>IS:1-,FWL:3-,Periphery.Deep:8,NIOPS:0,MERC:3-,Periphery:2-</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='GLT-8D'>
 			<roles>raider</roles>
 			<availability>FS:7</availability>
 		</model>
+		<model name='GLT-4L'>
+			<roles>raider</roles>
+			<availability>IS:1-,FWL:3-,Periphery.Deep:8,NIOPS:0,MERC:3-,Periphery:2-</availability>
+		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:5,MERC:4</availability>
 		</model>
-		<model name='GLT-6WB2'>
+		<model name='GLT-6WB3'>
 			<roles>raider</roles>
-			<availability>WOB:5</availability>
+			<availability>SC:6,MCM:6,ROS:3,DGM:6,MERC:3</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
 			<availability>CS:8,ROS:6,FRR:8,CGB.FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
 		</model>
-		<model name='GLT-6WB'>
+		<model name='GLT-6WB2'>
 			<roles>raider</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -7209,31 +7209,31 @@
 			<roles>spotter</roles>
 			<availability>LA:5,WOB:4,FS:4,DC:4</availability>
 		</model>
-		<model name='GUN-1ERD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GUN-2ERDr'>
 			<roles>spotter</roles>
 			<availability>FS:3,DC:3</availability>
 		</model>
+		<model name='GUN-1ERD'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gurkha' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='GUR-2G'>
+		<model name='GUR-4G'>
 			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='GUR-8G'>
-			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:3</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='GUR-6G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='GUR-4G'>
+		<model name='GUR-8G'>
 			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:4</availability>
+			<availability>WOB:3</availability>
+		</model>
+		<model name='GUR-2G'>
+			<deployedWith>Vanquisher</deployedWith>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
@@ -7251,27 +7251,27 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,CBS:3,LA:4,CNC:5,DC:4</availability>
-		<model name='HKO-1C'>
-			<roles>fire_support</roles>
-			<availability>LA:7,DC:7</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>LA:3+,CLAN:6,DC:3+</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='HKO-1C'>
+			<roles>fire_support</roles>
+			<availability>LA:7,DC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:7,OA:3,CBS:6,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>OA:7,CSR:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>OA:7,CSR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -7283,49 +7283,43 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>MOC:3,CC:3,FWL:6,MH:3,WOB:6,MERC:5</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,WOB:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,WOB:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>FS:4,MERC:2</availability>
-		<model name='HMH-6D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='HMH-3D'>
 			<availability>General:3-,MERC:3-</availability>
-		</model>
-		<model name='HMH-5D'>
-			<availability>General:3,MERC:4</availability>
 		</model>
 		<model name='HMH-6E'>
 			<availability>General:4,MERC:4</availability>
 		</model>
+		<model name='HMH-5D'>
+			<availability>General:3,MERC:4</availability>
+		</model>
+		<model name='HMH-6D'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,ROS:6,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:1</availability>
-		<model name='HMR-HE'>
-			<availability>CS:8,ROS:4,NIOPS:8,WOB:4</availability>
-		</model>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HF'>
 			<availability>WOB:6</availability>
 		</model>
@@ -7335,33 +7329,39 @@
 		<model name='HMR-HDb'>
 			<availability>CSR:3,ROS:4,CLAN:4,BAN:2</availability>
 		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
+		</model>
+		<model name='HMR-HE'>
+			<availability>CS:8,ROS:4,NIOPS:8,WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,CNC:5,CLAN:1,IS:2+,CJF:4,CCO:3,CGB:3</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7380,13 +7380,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>PR:5,HL:3-,DoO:5,FRR:5-,Periphery.Deep:4,DO:5,SC:5,FWL.pm:6-,CGB.FRR:5-,Periphery.CM:5-,Periphery.MW:5-,FWL:6-,MH:4-,RFS:5,MOC:4-,CC:4-,IS:4-,WOB:4-,DGM:5,MERC:4-,Periphery:3-,CS:4-,DTA:5,LA:4-,MCM:5,PG:5,Periphery.ME:5-,TP:5,DA:5,RCM:5,DC:4-</availability>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:3-</availability>
+		</model>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:1</availability>
@@ -7398,45 +7398,45 @@
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:3,CHH:6,CBS:2,CSL:6</availability>
-		<model name='(Standard)'>
-			<availability>CSA:4,CHH:4,CBS:4,CSL:4,CJF:2</availability>
+		<model name='3'>
+			<availability>CSA:6,CHH:1</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8,CBS:8,CSL:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:6,CHH:1</availability>
-		</model>
 		<model name='4'>
 			<availability>CHH:5,CSL:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:4,CHH:4,CBS:4,CSL:4,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:4,CGB.FRR:4,ROS:5,WOB:5,MERC:3,DC:7</availability>
-		<model name='HTM-26T'>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='HTM-28T'>
-			<availability>ROS:4,WOB:6,DC:4</availability>
+		<model name='HTM-27T'>
+			<availability>FRR:7,CGB.FRR:7,MERC:5,DC:6</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:5,WOB:6,DC:3</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:7,CGB.FRR:7,MERC:5,DC:6</availability>
+		<model name='HTM-28T'>
+			<availability>ROS:4,WOB:6,DC:4</availability>
+		</model>
+		<model name='HTM-26T'>
+			<availability>DC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>FRR:2,CGB.FRR:2,DC:3</availability>
+		<model name='HTM-27U'>
+			<availability>General:3-</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaeru' unitType='Mek'>
@@ -7468,33 +7468,33 @@
 		<model name='HCT-6S'>
 			<availability>LA:6,MERC:6</availability>
 		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:1-</availability>
+		<model name='HCT-5K'>
+			<availability>WOB:8,DC:8</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='HCT-6M'>
-			<availability>DTA:8,SC:8,MCM:8,FWL:8,DGM:8</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:5,LA:5,FRR:4,CGB.FRR:4,FS:5,MERC:4,DC:2,Periphery:2</availability>
-		</model>
 		<model name='HCT-5DD'>
 			<availability>ROS:6,FS:5,MERC:5</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:5</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:3-,MERC:2-,FS:1-,Periphery:2-</availability>
 		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:5,LA:5,FRR:4,CGB.FRR:4,FS:5,MERC:4,DC:2,Periphery:2</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:1-</availability>
+		</model>
 		<model name='HCT-6D'>
 			<availability>ROS:5,FS:5,MERC:6</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>WOB:8,DC:8</availability>
+		<model name='HCT-6M'>
+			<availability>DTA:8,SC:8,MCM:8,FWL:8,DGM:8</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
@@ -7512,18 +7512,14 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:5</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OD'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='HA1-OA'>
 			<availability>General:7</availability>
@@ -7531,14 +7527,18 @@
 		<model name='HA1-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HA1-OD'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,PR:5,DoO:5,FRR:3,IS:3,WOB:3,DO:5,DGM:5,FS:4,CS:3,DTA:5,SC:5,LA:3,MCM:5,CGB.FRR:3,PG:5,FWL:5,TP:5,RCM:4,DA:3,RFS:5,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -7566,25 +7566,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7596,11 +7596,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -7624,23 +7624,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>ROS:2,FS:3,MERC:1</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>ROS:2,FS:3,MERC:1</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7651,6 +7651,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7659,20 +7667,20 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8,WOB:4</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7682,14 +7690,6 @@
 			<roles>apc,support</roles>
 			<availability>ROS:4,WOB:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8,WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:2,CSR:1,CNC:2,CSL:4,CWIE:5</availability>
@@ -7697,12 +7697,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:3</availability>
@@ -7710,13 +7710,13 @@
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:2,MOC:2,MERC:2</availability>
-		<model name='HEP-1H'>
-			<roles>artillery</roles>
-			<availability>CC:3-,MOC:3-,MERC:3-</availability>
-		</model>
 		<model name='HEP-4H'>
 			<roles>artillery</roles>
 			<availability>MERC:8</availability>
+		</model>
+		<model name='HEP-1H'>
+			<roles>artillery</roles>
+			<availability>CC:3-,MOC:3-,MERC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -7724,11 +7724,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,CS:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 		<model name='HEL-6X'>
 			<availability>WOB:8</availability>
@@ -7736,8 +7736,8 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:1,ROS:4,CNC:2,NIOPS:6,WOB:6,FS:1,DC:1</availability>
-		<model name='HCT-212'>
-			<availability>LA:5,FS:5</availability>
+		<model name='HCT-214'>
+			<availability>CS:8,NIOPS:5,WOB:8</availability>
 		</model>
 		<model name='HCT-215'>
 			<availability>CS:4,ROS:4</availability>
@@ -7746,13 +7746,16 @@
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:3,WOB:8,DC:5</availability>
 		</model>
-		<model name='HCT-214'>
-			<availability>CS:8,NIOPS:5,WOB:8</availability>
+		<model name='HCT-212'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:2,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213S'>
+			<availability>LA:1,FS:1</availability>
+		</model>
+		<model name='HCT-213D'>
 			<availability>LA:1,FS:1</availability>
 		</model>
 		<model name='HCT-313'>
@@ -7765,32 +7768,29 @@
 		<model name='HCT-213'>
 			<availability>General:4</availability>
 		</model>
-		<model name='HCT-213D'>
-			<availability>LA:1,FS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:4</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:2,CHH:3,CDS:3,DC.AL:2,CLAN:1,CNC:6,CJF:3</availability>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
@@ -7801,25 +7801,25 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CBS:2,CLAN:1,CNC:5,CSL:5,CGS:4,CCO:5,CJF:2</availability>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:4,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
@@ -7827,7 +7827,7 @@
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>FS:6,MERC:4</availability>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
@@ -7835,12 +7835,12 @@
 			<roles>spotter</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
@@ -7861,25 +7861,25 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7900,132 +7900,135 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>MOC:2-,CC:4,DoO:4,FRR:2-,WOB:4,DO:4,DGM:4,MERC:4,FS:5,SC:4,LA:4,MCM:4,ROS:2,PIR:4,FWL:8,MH:4,TP:4,DC:2-</availability>
-		<model name='HER-4K &apos;Hermes III&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>SC:4,DoO:4,MCM:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
 		<model name='HER-5C'>
 			<roles>recon</roles>
 			<availability>WOB:10</availability>
 		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
-		</model>
-		<model name='HER-2S'>
+		<model name='HER-4K &apos;Hermes III&apos;'>
 			<roles>recon</roles>
-			<availability>HL:1-,IS:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
-		</model>
-		<model name='HER-5S'>
-			<roles>recon</roles>
-			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:4,WOB:8,FS:6,MERC:6,DC:6</availability>
+			<availability>FWL:3</availability>
 		</model>
 		<model name='HER-5Sr'>
 			<roles>recon</roles>
 			<availability>MOC:3,IS:3</availability>
 		</model>
+		<model name='HER-5S'>
+			<roles>recon</roles>
+			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:4,WOB:8,FS:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='HER-2S'>
+			<roles>recon</roles>
+			<availability>HL:1-,IS:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>SC:4,DoO:4,MCM:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CHH:1,DoO:8,FRR:3,WOB:3,DO:8,DGM:8,CS:3,DC.GHO:5,SC:8,MCM:8,CGB.FRR:3,FWL:7,NIOPS:3,TP:8,CGB:1,DC:6</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:3-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:5,WOB:5</availability>
-		</model>
-		<model name='HER-4M'>
-			<roles>recon</roles>
-			<availability>FWL:3,WOB:6</availability>
-		</model>
-		<model name='HER-4WB'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,TP:6,DC:7</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>CS:3,SC:4,DoO:4,MCM:4,FRR:3,CGB.FRR:3,FWL:5,WOB:3,DO:4,DGM:4,TP:4</availability>
 		</model>
+		<model name='HER-4WB'>
+			<roles>recon</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='HER-4M'>
+			<roles>recon</roles>
+			<availability>FWL:3,WOB:6</availability>
+		</model>
 		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:5</availability>
 		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,TP:6,DC:7</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:3-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CS:2-,CDS:3,Periphery.CM:7,CGB.FRR:2,CNC:3,CGB:2</availability>
-		<model name='(Standard)'>
-			<availability>General:6-</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:5,PR:4,PG:4,DA:4,CDP:4,RFS:4,TC:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:5,PR:4,PG:4,DA:4,CDP:4,RFS:4,TC:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CC:2,IS:2,Periphery:2</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
 		<availability>LA:2,IS:2</availability>
+		<model name='(Cunnington)'>
+			<roles>spotter</roles>
+			<availability>LA:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>LA:6,General:8</availability>
 		</model>
-		<model name='(Cunnington)'>
-			<roles>spotter</roles>
-			<availability>LA:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>MERC.WD:1,CHH:4,CDS:4,CW:6,CLAN:1,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CW:4</availability>
+		<model name='(Standard)'>
+			<availability>CDS:5,CW:5,CLAN:3,CNC:5,IS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:5,CW:2,CJF:5,CGB:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:5,CW:5,CLAN:3,CNC:5,IS:8</availability>
+		<model name='2'>
+			<availability>CW:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:2,CC:3,CS:9,LA:6,CLAN:5,IS:2,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6,DC:2</availability>
-		<model name='HGN-734'>
-			<availability>LA:6,ROS:6,MERC:6</availability>
-		</model>
 		<model name='HGN-736'>
 			<availability>CS:8,WOB:6</availability>
+		</model>
+		<model name='HGN-733'>
+			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		</model>
+		<model name='HGN-738'>
+			<availability>LA:5,ROS:5</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>CS:5,LA:3,CLAN:4,WOB:5,FS:3,BAN:2</availability>
@@ -8033,26 +8036,23 @@
 		<model name='HGN-694'>
 			<availability>LA:1</availability>
 		</model>
-		<model name='HGN-641-X-2'>
-			<availability>CS:1</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
-		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:4,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:5,ROS:5</availability>
+		<model name='HGN-641-X-2'>
+			<availability>CS:1</availability>
+		</model>
+		<model name='HGN-734'>
+			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:3</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8078,11 +8078,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8096,34 +8096,34 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:1,MERC.WD:1,CLAN:1,CGS:1</availability>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:2,CLAN:1</availability>
 		</model>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
-		<model name='HNT-161'>
-			<availability>MERC.WD:1-</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>FVC:2-,IS:1-</availability>
 		</model>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:3-</availability>
+		<model name='HNT-161'>
+			<availability>MERC.WD:1-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -8158,14 +8158,14 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:5,CDS:7,CSR:6,CW:6,CLAN:1,IS:2,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='2'>
-			<availability>CSA:8,CBS:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:5,CSR:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:2,General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:8,CBS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5,CCO:8</availability>
@@ -8173,70 +8173,66 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:5</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6S'>
 			<availability>LA:5,ROS:4,MERC:5</availability>
 		</model>
-		<model name='HBK-4J'>
-			<availability>CC:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:5,FWL:5,WOB:5,MERC:4</availability>
-		</model>
-		<model name='HBK-4H'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5H'>
-			<availability>MH:6,Periphery:3</availability>
-		</model>
 		<model name='HBK-4SP'>
 			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:5,CC:5,CS:5,FRR:5,CGB.FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:1-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-5M'>
 			<availability>CS:4,CC:1,MOC:1,FRR:1,CGB.FRR:1,FWL:1,WOB:4,MERC:1,CDP:1,TC:1</availability>
 		</model>
+		<model name='HBK-4J'>
+			<availability>CC:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>MH:6,Periphery:3</availability>
+		</model>
+		<model name='HBK-5SS'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='HBK-5S'>
 			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:3,MERC:3,FS:2</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-5P'>
+			<availability>ROS:5,FWL:5,WOB:5,MERC:4</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6N'>
 			<availability>ROS:3,FWL:4,MERC:5</availability>
 		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:5,CC:5,CS:5,FRR:5,CGB.FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CGS:5,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:2,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,CGB.FRR:5,ROS:3,FWL:5,DC:4</availability>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(Ammo)'>
 			<roles>fire_support</roles>
-			<availability>General:4-</availability>
+			<availability>General:1-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>PR:5,LA:8,ROS:5,PG:5,FS:6,RCM:5,MERC:5,DA:5,RFS:5</availability>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
@@ -8246,12 +8242,16 @@
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(Ammo)'>
+		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
-			<availability>General:1-</availability>
+			<availability>PR:5,LA:8,ROS:5,PG:5,FS:6,RCM:5,MERC:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:4-</availability>
 		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:2,FS:2</availability>
@@ -8259,18 +8259,18 @@
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,FWL:4,MERC:5,TC:4</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
@@ -8282,13 +8282,16 @@
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>CS:3,FRR:5,CGB.FRR:5,CNC:4,CGB:4</availability>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:2+</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='HSCL-1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:2+</availability>
+		</model>
+		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OD'>
@@ -8297,36 +8300,33 @@
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:3,LA:3,FRR:1,CGB.FRR:2,ROS:3,CLAN:4,NIOPS:4,WOB:4,MERC:3,DC:1</availability>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,ROS:8,WOB:8,MERC:8</availability>
+		</model>
+		<model name='HSR-300-D'>
+			<availability>DC:1-</availability>
+		</model>
 		<model name='HSR-500-D'>
 			<availability>CS:4,WOB:8</availability>
+		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:1-</availability>
+		</model>
+		<model name='HSR-900-D'>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='HSR-950-D'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:4,General:8,CLAN:6,NIOPS:4,MERC.SI:4,WOB:4,BAN:8</availability>
 		</model>
-		<model name='HSR-900-D'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='HSR-300-D'>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='HSR-950-D'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='HSR-200-Db'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,ROS:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8338,14 +8338,14 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:3,CLAN:5</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -8353,13 +8353,13 @@
 		<model name='2'>
 			<availability>CHH:6,CSL:6</availability>
 		</model>
-		<model name='4'>
-			<roles>anti_infantry</roles>
-			<availability>CBS:4</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5</availability>
+		</model>
+		<model name='4'>
+			<roles>anti_infantry</roles>
+			<availability>CBS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CHH:6,CBS:6,CSL:6</availability>
@@ -8374,44 +8374,44 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:8,LA:3,ROS:4,FWL:3,IS:8,WOB:3,MH:8,FS:1,DC:2,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
 		<availability>FWL.pm:2,FWL:2,WOB:2</availability>
-		<model name='ICR-1S'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='ICR-2S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='ICR-1S'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus' unitType='Mek'>
@@ -8436,10 +8436,10 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
+		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
 		</model>
-		<model name='IMP-3E'>
+		<model name='IMP-4E'>
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
@@ -8459,43 +8459,43 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,CNC:1,CWIE:1</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CW:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:1,MERC:2,TC:2</availability>
-		<model name='&apos;Waddle&apos;' mechanized='true'>
-			<roles>recon</roles>
-			<availability>LA:6,FS:6,TC:6</availability>
-		</model>
 		<model name='(Special Ops)' mechanized='true'>
 			<roles>specops</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='&apos;Waddle&apos;' mechanized='true'>
+			<roles>recon</roles>
+			<availability>LA:6,FS:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:3,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
 		<availability>WOB:7</availability>
-		<model name='INI-02'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='INI-04'>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='INI-02'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Inquisitor' unitType='Mek'>
@@ -8506,13 +8506,13 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>WOB:6</availability>
-		<model name='(Standard)'>
-			<roles>assault</roles>
-			<availability>FWL:8,WOB:6</availability>
-		</model>
 		<model name='(SCC)'>
 			<roles>assault</roles>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>assault</roles>
+			<availability>FWL:8,WOB:6</availability>
 		</model>
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
@@ -8521,27 +8521,27 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:3,PG:8,FWL:8,TP:8,DA:8,RCM:8,RFS:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:3,PG:8,FWL:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,CGB.FRR:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631) (LF)'>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
+		<model name='(2631)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -8553,32 +8553,35 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:3,WOB:6,DC:1</availability>
-		<model name='IRN-SD3'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:4</availability>
-		</model>
-		<model name='IRN-SD1b'>
-			<availability>CSR:6,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CX-19'>
 			<availability>CS:2</availability>
 		</model>
+		<model name='IRN-SD3'>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='IRN-SD1b'>
+			<availability>CSR:6,CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CLAN:4,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>CCC:6,CSR:4,CLAN:4,CGB:6</availability>
+		<model name='2'>
+			<availability>CSR:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
@@ -8586,12 +8589,14 @@
 			<roles>recon</roles>
 			<availability>CSR:2</availability>
 		</model>
-		<model name='2'>
-			<availability>CSR:3</availability>
-		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,CIR:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8602,11 +8607,6 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8615,20 +8615,24 @@
 	</chassis>
 	<chassis name='J-37 Ordnance Transport' unitType='Tank'>
 		<availability>General:3,CLAN:3</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>support</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:4-,PR:1-,DC.LV:4-,HL:2-,DoO:2-,FRR:2-,Periphery.Deep:5,DO:2-,FS:3-,SC:2-,OA:2-,CGB.FRR:3-,FWL:2-,NIOPS:2-,RFS:1-,MOC:3-,CC:1-,DC.GR:3-,FS.AH:3-,IS:3-,WOB:3-,DGM:2-,CIR:4-,Periphery:3-,TC:4-,CS:2-,DTA:1-,LA:3-,MCM:2-,PG:1-,TP:2-,RCM:1-,DA:1-,DC:3-</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -8638,17 +8642,13 @@
 			<roles>recon,raider</roles>
 			<availability>DC:8,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
@@ -8659,13 +8659,13 @@
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
 		<availability>CS:3,CC:3,LA:3,CGB.FRR:3,FWL:3,FS:4,MERC:3,CGB:4,DC:3,Periphery:2</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>IS:3,CGB:8,Periphery:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>IS:3,CGB:8,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -8697,39 +8697,29 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>MOC:5,CC:1,IS:1,WOB:6,DGM:6,FS:1,MERC:6,DTA:6,SC:6,FVC:1,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5</availability>
-		<model name='JA-KL-1532'>
-			<availability>HL:6,General:1,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>DTA:5,SC:5,LA:3,MCM:5,ROS:5,FWL:3,DGM:5,MERC:5,FS:3</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>HL:6,General:1,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackrabbit' unitType='Mek'>
 		<availability>WOB:2-</availability>
-		<model name='JKR-9R &apos;Joker&apos;'>
+		<model name='JKR-8T'>
 			<availability>General:8</availability>
 		</model>
 		<model name='JKR-9W'>
 			<availability>WOB:5</availability>
 		</model>
-		<model name='JKR-8T'>
+		<model name='JKR-9R &apos;Joker&apos;'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:2,CW:5,General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CSR:3,CW:4,CLAN:2</availability>
@@ -8737,8 +8727,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:2,CW:5,General:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8752,21 +8752,6 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:4-,FRR:3,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,CGB.FRR:3,Periphery.CM:2,Periphery.HR:3,ROS:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:3-,FRR:1-,CGB.FRR:2-,IS:3-,FS:3-,Periphery:6</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:4,FS:5,MERC:6</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:1,PIR:2,MH:5,Periphery:1</availability>
@@ -8775,24 +8760,59 @@
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
+		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:3,LA:3,ROS:2,FRR:2,CGB.FRR:3,FS:3,MERC:3,CDP:2,DC:3</availability>
 		</model>
-		<model name='JM7-C3BS'>
+		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:5</availability>
+			<availability>ROS:4,FS:5,MERC:6</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,CGB.FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:3-,FRR:1-,CGB.FRR:2-,IS:3-,FS:3-,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,HL:3,IS:1,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:1,LA:2,Periphery.HR:5,ROS:4</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>HL:1-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:5,LA:6,Periphery.HR:5,PIR:5,FS:5,MERC:6,CDP:5,TC:5</availability>
@@ -8801,83 +8821,67 @@
 			<roles>recon</roles>
 			<availability>FS:5</availability>
 		</model>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>HL:1-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
+		<model name='X'>
+			<availability>CSR:1,General:1,CJF:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:3,General:2,CJF:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='X'>
-			<availability>CSR:1,General:1,CJF:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='E'>
+			<availability>CSR:3,General:2,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:5,ROS:4,CNC:8,CLAN:1,CGS:5,CCO:5,DC:3</availability>
-		<model name='3'>
-			<availability>CCC:6,CNC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CLAN:2,CNC:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:6,CNC:8,IS:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CCC:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:4,CLAN:2,CNC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
-		<model name='JR7-C4'>
-			<roles>raider</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:1-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='JR7-C4'>
+			<roles>raider</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:1-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -8887,17 +8891,9 @@
 			<roles>raider</roles>
 			<availability>MERC:5,FS:5,DC:6</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:5,TC:4</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8905,6 +8901,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -8917,11 +8917,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:5,MOC:4,TC:4</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -8943,26 +8943,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -8980,26 +8980,42 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='KBO-7A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='KBO-7B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='KBO-7A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:2,DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 		<model name='C' mechanized='true'>
 			<availability>DC:2</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>ROS:2,DC:2</availability>
 		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
@@ -9009,29 +9025,13 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -9043,36 +9043,36 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>CGB:4</availability>
+		<model name='C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -9084,30 +9084,34 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:3,PIR:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:6,MERC:6</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:4,OA:5,FVC:4,HL:3,PIR:7,MH:6,CIR:6,DA:4,Periphery:5,TC:5</availability>
-		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:2</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>HL:3,IS:8,Periphery:5</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
 		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:4,OA:5,FVC:4,HL:3,PIR:7,MH:6,CIR:6,DA:4,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>HL:3,IS:8,Periphery:5</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>MH:6,MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,FRR:2,CGB.FRR:2,DC:6</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,CGB.FRR:8,DC:3-</availability>
 		</model>
@@ -9117,13 +9121,16 @@
 		<model name='CRK-5003-C'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>CS:5,MERC.WD:4,CW:1,LA:3,FRR:2,CGB.FRR:3,CLAN:3,WOB:4,FS:4,DC:3</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -9131,39 +9138,29 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:3,FRR:4,CLAN:2,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:3,LA:3,CGB.FRR:4,ROS:6,FWL:3,NIOPS:6,CGB:3,DC:3</availability>
-		<model name='KGC-001'>
-			<availability>CS:8,FVC:8,LA:5,IS:5,WOB:5,MH:6,CIR:6,MERC:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CS:5,FRR:4,CGB.FRR:4,CLAN:4,WOB:4,CGS:6,BAN:2,DC:4</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:7,ROS:7,FS:7,MERC:7</availability>
 		</model>
-		<model name='KGC-0000'>
-			<availability>IS:3-,CIR:5</availability>
-		</model>
-		<model name='KGC-008B'>
-			<availability>ROS:4,WOB.PM:8</availability>
+		<model name='KGC-008'>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='KGC-000'>
 			<availability>CS:4,FRR:8,CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
+		</model>
+		<model name='KGC-001'>
+			<availability>CS:8,FVC:8,LA:5,IS:5,WOB:5,MH:6,CIR:6,MERC:6</availability>
 		</model>
 		<model name='KGC-005r'>
 			<availability>CS:2,ROS:2,WOB:2</availability>
@@ -9171,29 +9168,32 @@
 		<model name='KGC-005'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='KGC-008'>
-			<availability>WOB:8</availability>
+		<model name='KGC-0000'>
+			<availability>IS:3-,CIR:5</availability>
+		</model>
+		<model name='KGC-008B'>
+			<availability>ROS:4,WOB.PM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CSR:2,CLAN:1,CNC:3,IS:1+,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='X'>
+			<availability>CGB:1</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -9201,29 +9201,29 @@
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='X'>
-			<availability>CGB:1</availability>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:6,CHH:1,CDS:1,FRR:4,CGB.FRR:4,ROS:6,NIOPS:7,WOB:7,FS:3,MERC:5,DC:4</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:7</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:4,CS:4,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
 		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:3-,MERC:3-,DC:1-</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:7</availability>
+		<model name='KTO-19b'>
+			<availability>ROS:6,CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:4,CGB.FRR:4,WOB:4,MERC:5,DC:5</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>ROS:6,CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:7</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:7</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:3-,MERC:3-,DC:1-</availability>
 		</model>
 		<model name='KTO-21'>
 			<availability>CS:6,WOB:5</availability>
@@ -9231,23 +9231,23 @@
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5,CGS:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9259,13 +9259,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
@@ -9273,16 +9273,20 @@
 		<model name='[GL]' mechanized='true'>
 			<availability>FRR:4,CGB.FRR:4</availability>
 		</model>
+		<model name='(CS) [SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:8</availability>
+		</model>
 		<model name='(CS) [GL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:6</availability>
 		</model>
+		<model name='(CS) [GL]' mechanized='true'>
+			<availability>CS:4</availability>
+		</model>
 		<model name='[SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>FRR:8,CGB.FRR:8</availability>
-		</model>
-		<model name='X-C3' mechanized='true'>
-			<availability>CS:2</availability>
 		</model>
 		<model name='[SL/Flamer]' mechanized='true'>
 			<availability>FRR:6,CGB.FRR:6</availability>
@@ -9290,18 +9294,14 @@
 		<model name='(CS) [GL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='(CS) [GL]' mechanized='true'>
-			<availability>CS:4</availability>
-		</model>
 		<model name='(CS) [SL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='(CS) [SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='[GL/Flamer]' mechanized='true'>
 			<availability>FRR:6,CGB.FRR:6</availability>
+		</model>
+		<model name='X-C3' mechanized='true'>
+			<availability>CS:2</availability>
 		</model>
 		<model name='[GL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
@@ -9310,8 +9310,8 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:1,CCC:3,CSR:3,CNC:1,CLAN:1,CGS:4,CCO:3,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -9320,11 +9320,11 @@
 		<model name='2'>
 			<availability>CGB:5</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -9333,16 +9333,16 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:5</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
@@ -9357,56 +9357,32 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,WOB:4,MERC:4</availability>
-		<model name='KSC-4I'>
-			<availability>MERC:3</availability>
-		</model>
-		<model name='KSC-5I'>
-			<availability>WOB:8,MERC:7</availability>
-		</model>
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8</availability>
 		</model>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
+		<model name='KSC-4I'>
 			<availability>MERC:3</availability>
 		</model>
 		<model name='KSC-4L'>
 			<availability>MERC:3</availability>
 		</model>
+		<model name='KSC-5I'>
+			<availability>WOB:8,MERC:7</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:6,CLAN:1,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:2</availability>
-		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
 		<model name='Z'>
 			<roles>recon</roles>
 			<availability>CCO:2</availability>
 		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -9416,37 +9392,61 @@
 			<roles>recon</roles>
 			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
 		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
+		<model name='KTO-3A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='KTO-2A'>
 			<availability>General:1</availability>
 		</model>
-		<model name='KTO-3A'>
-			<availability>General:8</availability>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:2,ROS:2,CLAN:1,CJF:4</availability>
-		<model name='4'>
-			<availability>ROS:8,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:1,CJF:1</availability>
+		</model>
+		<model name='4'>
+			<availability>ROS:8,CJF:6</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1,CJF:2</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:1,CJF:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
@@ -9488,13 +9488,13 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>CC:8,MOC:8,FRR:8,IS:8,FS:8,CIR:6,TC:7,Periphery:5,CS:8,LA:8,CGB.FRR:8,FWL:8,DC:8</availability>
-		</model>
 		<model name='(WoB)'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>CC:8,MOC:8,FRR:8,IS:8,FS:8,CIR:6,TC:7,Periphery:5,CS:8,LA:8,CGB.FRR:8,FWL:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -9505,18 +9505,12 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,FRR:3,ROS:5,CGB.FRR:3,CLAN:4,NIOPS:6,WOB:6,CGS:5,BAN:7,DC:5</availability>
-		<model name='LNC25-06'>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='LNC25-04'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,FRR:2-,CGB.FRR:3-,DC:3-</availability>
-		</model>
 		<model name='LNC25-03'>
 			<availability>DC:1-</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:4,ROS:4,FRR:6,CGB.FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
 		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
@@ -9525,40 +9519,46 @@
 		<model name='LNC25-08'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:4,ROS:4,FRR:6,CGB.FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
+		<model name='LNC25-04'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,FRR:2-,CGB.FRR:3-,DC:3-</availability>
+		</model>
+		<model name='LNC25-06'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>PR:5,DoO:5,WOB:3,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,DA:5,RCM:5,RFS:5</availability>
-		<model name='LX-2A'>
-			<availability>PR:5,DoO:5,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,RCM:5,DA:5,RFS:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LX-2A'>
+			<availability>PR:5,DoO:5,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:7,MOC:5,FS:3,TC:4</availability>
-		<model name='LHU-4E'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='LHU-3L'>
 			<availability>CC:5,MOC:6,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='LHU-4E'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9570,65 +9570,65 @@
 	</chassis>
 	<chassis name='Legacy' unitType='Mek'>
 		<availability>WOB:6</availability>
+		<model name='LGC-05'>
+			<availability>WOB:2</availability>
+		</model>
 		<model name='LGC-02'>
 			<roles>fire_support</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGC-04-WVR'>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='LGC-01'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='LGC-05'>
-			<availability>WOB:2</availability>
 		</model>
 		<model name='LGC-03'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='LGC-04-WVR'>
+			<availability>WOB:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='LGN-2F'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
-		</model>
 		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='LGN-2XA'>
-			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2D'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
+		<model name='LGN-2F'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='LGN-2XA'>
+			<roles>missile_artillery</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
+		<model name='(2537)'>
 			<roles>mech_carrier</roles>
-			<availability>PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+			<availability>General:3-</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FWL:2,WOB:6</availability>
 		</model>
-		<model name='(2537)'>
+		<model name='(3056)'>
 			<roles>mech_carrier</roles>
-			<availability>General:3-</availability>
+			<availability>PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -9667,30 +9667,30 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:2,FWL:7,IS:2</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1</availability>
-		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,DC:2,Periphery:4</availability>
 		</model>
 		<model name='Comet'>
 			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
 		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:2</availability>
+		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,HL:4,LA:4</availability>
-		</model>
-		<model name='Suzume (&apos;Sparrow&apos;)'>
-			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
 		<model name='Andurien'>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:2,FWL:7,IS:2</availability>
+		<model name='Suzume (&apos;Sparrow&apos;)'>
+			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:2</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9701,21 +9701,21 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:2,CLAN:4,NIOPS:2,WOB:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6,WOB:4</availability>
+		<model name='(RL)'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>ROS:4,WOB:4</availability>
-		</model>
 		<model name='(ERML)'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(RL)'>
-			<availability>WOB:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6,WOB:4</availability>
+		</model>
+		<model name='(ERSL)'>
+			<availability>ROS:4,WOB:4</availability>
 		</model>
 		<model name='CX-3'>
 			<availability>CS:8</availability>
@@ -9723,73 +9723,73 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:5-</availability>
+		<model name='LTN-G16D'>
+			<availability>FS:5,MERC:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:4,MOC:4,CLAN:3,MERC:3</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>FS:5,MERC:4</availability>
+		<model name='LTN-G16O'>
+			<availability>OA:5,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:5,MOC:5,MERC:4</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>OA:5,FVC:4,CDP:4</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGH-5W'>
+		<model name='LGH-4W'>
 			<roles>recon</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='LGH-7W'>
-			<roles>recon</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='LGH-4Y'>
 			<roles>recon</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGH-4W'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='LGH-6W'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
 		</model>
+		<model name='LGH-7W'>
+			<roles>recon</roles>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='LGH-5W'>
+			<roles>recon</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:1,CCC:4,CSR:3,CW:5,CSL:1,CCO:4,CJF:4,CWIE:6</availability>
-		<model name='B'>
-			<availability>CDS:4,General:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -9800,25 +9800,25 @@
 		<model name='KW1-LH3'>
 			<availability>General:2,WOB:3,FS:3</availability>
 		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='KW1-LH2'>
 			<availability>General:6,WOB:2,FS:2</availability>
 		</model>
 		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
 			<availability>WOB:5,FS:7</availability>
 		</model>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CS:6,CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,WOB:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -9827,10 +9827,6 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CW:6</availability>
-		<model name='2'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8</availability>
 		</model>
@@ -9838,26 +9834,15 @@
 			<roles>anti_infantry</roles>
 			<availability>CW:2</availability>
 		</model>
+		<model name='2'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:3,CHH:6,CW:7,LA:1,ROS:3,CLAN:2,IS:1,CJF:6,DC:3,CGB:6</availability>
-		<model name='3'>
-			<availability>General:1</availability>
-		</model>
-		<model name='6'>
-			<availability>CW:4,CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:4,General:1</availability>
-		</model>
-		<model name='8'>
-			<availability>CGB:5</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
@@ -9865,19 +9850,42 @@
 		<model name='5'>
 			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
+		<model name='3'>
+			<availability>General:1</availability>
+		</model>
+		<model name='8'>
+			<availability>CGB:5</availability>
+		</model>
+		<model name='6'>
+			<availability>CW:4,CGB:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
+		<model name='7'>
+			<availability>CHH:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:2-,HL:5,CLAN:2-,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:3-,Periphery:5</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>SC:4,MCM:4,ROS:2,FWL:3,WOB:3,DGM:4</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:4,CC:4,FVC:3,TC:5</availability>
+		<model name='LCT-3V'>
+			<roles>recon</roles>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:3-,MERC:3-</availability>
 		</model>
 		<model name='LCT-5M3'>
 			<availability>SC:3,MCM:3,ROS:3,DGM:3</availability>
+		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>CS:4,LA:3,ROS:4,CLAN:2,IS:2,FS:3,DC:3</availability>
 		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
@@ -9887,130 +9895,122 @@
 			<roles>recon</roles>
 			<availability>CC:4,CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-1E'>
 			<roles>recon</roles>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:4,ROS:4,PIR:4,FWL:5,IS:2,WOB:4,FS:4,MERC:4</availability>
+			<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
 		</model>
 		<model name='LCT-1V2'>
 			<roles>recon</roles>
 			<availability>PIR:4,MH:4</availability>
 		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>CS:4,LA:3,ROS:4,CLAN:2,IS:2,FS:3,DC:3</availability>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:6,DTA:5,SC:5,MCM:5,PG:5,FWL:6,TP:5,RCM:5,DA:5,RFS:5</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:3-,General:3-,FS:3-</availability>
 		</model>
-		<model name='LCT-5V'>
-			<roles>recon</roles>
-			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
-		</model>
-		<model name='LCT-1E'>
-			<roles>recon</roles>
-			<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
-		</model>
 		<model name='LCT-3S'>
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,CGB.FRR:6,MERC:6</availability>
+		</model>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:4,CC:4,FVC:3,TC:5</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,ROS:4,PIR:4,FWL:5,IS:2,WOB:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-6M'>
+			<roles>recon</roles>
+			<availability>SC:4,MCM:4,ROS:2,FWL:3,WOB:3,DGM:4</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
 		</model>
 		<model name='LCT-5W'>
 			<roles>recon,spotter</roles>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:6,DTA:5,SC:5,MCM:5,PG:5,FWL:6,TP:5,RCM:5,DA:5,RFS:5</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:3-,MERC:3-</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CDS:1,CW:4,CBS:4,CLAN:1,IS:2+,CJF:2,BAN:5,CWIE:5,CGB:1</availability>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CS:5,CSA:4,CCC:1,CHH:3,MERC.WD:2,CSR:2,CDS:2,CW:1,CNC:3,WOB:1,CCO:2,CGS:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6</availability>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
-		</model>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:3-</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>LA:3,FRR:3,CGB.FRR:3,FWL:3,IS:2,FS:4,MERC:3</availability>
-		</model>
-		<model name='LGB-12R'>
-			<roles>fire_support</roles>
-			<availability>DTA:3,LA:3,ROS:8,FS:3,DC:2</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:3-,OA:3-,General:3-,TC:3-,Periphery:3-</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:5,LA:3,FWL:3,IS:3,MH:4,FS:3,MERC:3,CDP:2,TC:2</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>WOB:3,FS:4</availability>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:3-</availability>
+		</model>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:3,DoO:4,DO:4,DGM:4,FS:5,MERC:5,SC:4,MCM:4,ROS:5,FWL:2,TP:4,DA:5,RCM:5,DC:5</availability>
 		</model>
-		<model name='LGB-14C'>
+		<model name='LGB-13NAIS'>
+			<availability>WOB:3,FS:4</availability>
+		</model>
+		<model name='LGB-12R'>
 			<roles>fire_support</roles>
-			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
+			<availability>DTA:3,LA:3,ROS:8,FS:3,DC:2</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>LA:3,FRR:3,CGB.FRR:3,FWL:3,IS:2,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -10018,32 +10018,32 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:5</availability>
-		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[Flamer] (WoB)' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='(Magnetic) (WOB)' mechanized='true'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[David] (WoB)' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
+		<model name='[Flamer] (WoB)' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Magnetic) (WOB)' mechanized='true'>
-			<availability>WOB:6</availability>
+		<model name='[David] (WoB)' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -10057,14 +10057,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:3,FS:2,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:2,FS:1,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:3-,FS:3-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:2,FS:1,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -10073,13 +10073,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:2-</availability>
@@ -10094,24 +10094,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,ROS:4,CLAN:1,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -10119,13 +10119,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,WOB:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='W1'>
 			<roles>missile_artillery,escort</roles>
@@ -10157,17 +10157,30 @@
 		<model name='MSK-6S'>
 			<availability>PR:8,PG:8,FWL:8,RFS:8</availability>
 		</model>
-		<model name='MSK-9H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MSK-5S'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='MSK-9H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:1,MERC.WD:7,CDS:5,CW:7,CBS:3,CLAN:3,CCO:5,CJF:5,BAN:2,CWIE:7</availability>
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:3,General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
@@ -10176,42 +10189,29 @@
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:3,General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:3,CNC:6,FS:3,CWIE:4,DC:3</availability>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:3</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -10237,27 +10237,27 @@
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FRR:1,CGB.FRR:1,NIOPS:3,WOB:5,WOB.PM:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(UCSV)'>
 			<roles>apc,urban</roles>
 			<availability>WOB:8</availability>
 		</model>
-	</chassis>
-	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-		<availability>PR:8,DoO:8,WOB:3,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(XL)'>
+	</chassis>
+	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
+		<availability>PR:8,DoO:8,WOB:3,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='(C3)'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(XL)'>
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
@@ -10269,15 +10269,6 @@
 	</chassis>
 	<chassis name='Malak' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-MK-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-OB Infernus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-MK-OS Caelestis'>
 			<availability>General:5</availability>
 		</model>
@@ -10286,6 +10277,15 @@
 		</model>
 		<model name='C-MK-O Invictus'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C-MK-OA Dominus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-MK-OB Infernus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-MK-OD Luminos'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-MK-OC Comminus'>
 			<roles>spotter</roles>
@@ -10301,33 +10301,33 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.WD:7,CDS:7,CW:7,CBS:5,CLAN:1,CNC:3,IS:1+,CJF:7,BAN:5,CWIE:7,CGB:1</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1</availability>
-		</model>
-		<model name='G'>
-			<availability>General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
+		<model name='G'>
+			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
+		<model name='B'>
+			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
@@ -10344,6 +10344,9 @@
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:5,FS:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
@@ -10351,88 +10354,100 @@
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,CGB.FRR:8,ROS:7,FWL:6,NIOPS:7,DC:9</availability>
-		<model name='(LB-X)'>
-			<availability>LA:7,ROS:7,WOB:6,FS:7</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='(HPPC)'>
+			<availability>ROS:4,FS:4,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,LA:2-,General:3-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
+		<model name='(LB-X)'>
+			<availability>LA:7,ROS:7,WOB:6,FS:7</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='(HPPC)'>
-			<availability>ROS:4,FS:4,DC:4</availability>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,CS:2,LA:3,FRR:3,CGB.FRR:3,FWL:4,IS:3,WOB:2,FS:5,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>WOB:4,FS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>WOB:4,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:7,MERC.WD:6,CSR:3,CW:6,LA:1,CLAN:1,CNC:6,CJF:7,CWIE:6,CGB:7</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,CLAN:1,CJF:4,CGB:4</availability>
+		<model name='4'>
+			<availability>CNC:5,CGB:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CW:1,LA:5,CJF:4,CWIE:5,CGB:1</availability>
 		</model>
-		<model name='6'>
-			<availability>CW:4,CJF:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:3,CLAN:1,CJF:5,CGB:5</availability>
-		</model>
 		<model name='7'>
 			<availability>CGB:3</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:5,CCC:3,CDS:1,CSR:1,CGS:3,CJF:3,CWIE:1,CGB:3</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,CLAN:1,CJF:4,CGB:4</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:5,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:4,CJF:3</availability>
 		</model>
 		<model name='8'>
 			<availability>CLAN:1,CJF:5,CGB:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:5,CCC:3,CDS:1,CSR:1,CGS:3,CJF:3,CWIE:1,CGB:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:3,CLAN:1,CJF:5,CGB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,CGB.FRR:5,ROS:6,PIR:4,CNC:1,FWL:5,MH:4,DC:5</availability>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:3</availability>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='MAD-5W'>
+			<availability>CC:3,CS:4,WOB:8</availability>
+		</model>
+		<model name='MAD-4H'>
+			<availability>PIR:7,MH:7,TC:7</availability>
+		</model>
+		<model name='MAD-6M'>
+			<availability>ROS:4,FWL:4,MERC:4</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:7</availability>
 		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='MAD-6M'>
-			<availability>ROS:4,FWL:4,MERC:4</availability>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:3</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:6,CGB.FRR:6,ROS:6,CNC:8,FWL:3,FS:7,MERC:6,DC:4</availability>
@@ -10440,85 +10455,70 @@
 		<model name='MAD-4A'>
 			<availability>MERC:1</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
-		</model>
-		<model name='MAD-5W'>
-			<availability>CC:3,CS:4,WOB:8</availability>
-		</model>
-		<model name='MAD-4K'>
-			<availability>DC:7</availability>
-		</model>
-		<model name='MAD-4H'>
-			<availability>PIR:7,MH:7,TC:7</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:2,DO:5,DGM:5,WOB:4,TP:5,MERC:3,DA:5</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:3-,MH:3-,FS:3-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:5,FRR:6,CGB.FRR:6,WOB:4,FS:4,MERC:4,DC:7</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>PR:4,DoO:4,ROS:4,PG:4,FWL:2,WOB:4,DO:4,TP:4,MERC:4,DA:4,RFS:4</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:5,FRR:6,CGB.FRR:6,WOB:4,FS:4,MERC:4,DC:7</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>CS:6,MOC:3,ROS:4,FWL:8,IS:1,WOB:7,MERC:4</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:1,LA:1+,CNC:1,FS:1+,CJF:1,DC:1+,CGB:1,CWIE:1</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>CS:2-,HL:1-,IS:3-,Periphery.Deep:8,WOB:2-,Periphery:4-,TC:4-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:5,FRR:4,CGB.FRR:4,ROS:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3L'>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>CLAN:1,CGS:1,BAN:1,TC:3</availability>
-		</model>
-		<model name='MAD-1R'>
-			<availability>CS:4-,NIOPS:2-,WOB:4-,MERC:0,BAN:1</availability>
-		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
+		<model name='MAD-7D'>
+			<availability>FS:5</availability>
 		</model>
 		<model name='MAD-9W'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
-		</model>
-		<model name='MAD-5L'>
-			<availability>CC:5,MOC:4,WOB:3,CIR:3,TC:1</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:4,LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4</availability>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
 		</model>
 		<model name='MAD-9W2'>
 			<availability>LA:4,ROS:3,FS:4,MERC:3,DC:4</availability>
 		</model>
-		<model name='MAD-7D'>
-			<availability>FS:5</availability>
+		<model name='MAD-9S'>
+			<availability>LA:5,FRR:4,CGB.FRR:4,ROS:4,MERC:3</availability>
 		</model>
 		<model name='MAD-5T'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>CS:2-,HL:1-,IS:3-,Periphery.Deep:8,WOB:2-,Periphery:4-,TC:4-</availability>
+		</model>
+		<model name='MAD-3L'>
+			<availability>CC:1-</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>CS:6,MOC:3,ROS:4,FWL:8,IS:1,WOB:7,MERC:4</availability>
+		</model>
+		<model name='MAD-1R'>
+			<availability>CS:4-,NIOPS:2-,WOB:4-,MERC:0,BAN:1</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:5,MOC:4,WOB:3,CIR:3,TC:1</availability>
+		</model>
+		<model name='MAD-6L'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>CLAN:1,CGS:1,BAN:1,TC:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:1,LA:1+,CNC:1,FS:1+,CJF:1,DC:1+,CGB:1,CWIE:1</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FVC:3-,MH:3-,FS:3-</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:4,LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4</availability>
+		</model>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:2,DO:5,DGM:5,WOB:4,TP:5,MERC:3,DA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -10534,17 +10534,17 @@
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CSA:4,CHH:4,CCC:3,CSL:4,CGS:3,CCO:3,CGB:3</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CGB:3</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CSA:4,CHH:4,CCC:3,CSL:4,CGS:3,CCO:3,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10558,11 +10558,11 @@
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MHL-6MC'>
-			<availability>MOC:3</availability>
-		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,TC:4</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
@@ -10577,11 +10577,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:2,CLAN:1,IS:1+,MERC:2+,CGS:7,BAN:3,CWIE:1,CSA:3,MERC.WD:3,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
@@ -10589,8 +10586,14 @@
 		<model name='A'>
 			<availability>CDS:8,General:5,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
@@ -10598,58 +10601,55 @@
 		<model name='B'>
 			<availability>CDS:8,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:1,CLAN.IS:1,CJF:5</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>LA:1,FRR:5,CGB.FRR:5,MERC:4,FS:1,DC:7</availability>
+		<model name='MAL-3R'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='MAL-C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='MAL-1K'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='MAL-1R'>
 			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:2</availability>
 		</model>
 		<model name='MAL-2R'>
 			<availability>LA:5,FS:5,MERC:5</availability>
 		</model>
-		<model name='MAL-C'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='MAL-3R'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='MAL-1K'>
-			<availability>DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:4,CLAN:2,MH:4,FS:1,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(Intermediate)'>
-			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:5</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:5</availability>
+		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
 		</model>
 		<model name='(Basic)'>
 			<roles>apc</roles>
@@ -10658,8 +10658,8 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
@@ -10667,76 +10667,76 @@
 		<model name='(LB-X)'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:1,LA:3,CGB.FRR:3,ROS:2,FWL:2,NIOPS:2-,DC:2</availability>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>IS:2-,Periphery:2</availability>
 		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>FRR:3,CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>FRR:3,CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:5,FRR:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
-		</model>
-		<model name='(C3S)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>DC:1</availability>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>DC:1</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:2-,Periphery:2</availability>
+			<availability>CC:5,FRR:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CSR:1,WOB:1,CGS:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -10773,39 +10773,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -10817,33 +10814,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10878,23 +10878,19 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10902,13 +10898,17 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mercer' unitType='Dropship'>
@@ -10930,13 +10930,13 @@
 			<roles>recon</roles>
 			<availability>CS:4,ROS:4,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6</availability>
 		</model>
-		<model name='MCY-97'>
-			<roles>recon</roles>
-			<availability>CS:4,ROS:4</availability>
-		</model>
 		<model name='MCY-102'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='MCY-97'>
+			<roles>recon</roles>
+			<availability>CS:4,ROS:4</availability>
 		</model>
 		<model name='MCY-104'>
 			<roles>recon,spotter</roles>
@@ -10958,14 +10958,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,CSR:2,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:4-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>OA:6,FVC:4,CSR:3,MERC:4</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10974,6 +10974,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,WOB:6</availability>
+		</model>
+		<model name='(Targeting Computer)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Gauss) &apos;Sandblaster&apos;'>
 			<roles>urban</roles>
@@ -10985,25 +10990,20 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Targeting Computer)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:2,CBS:4,CSL:8,CGS:6</availability>
-		<model name='4'>
-			<availability>CBS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='XP'>
-			<availability>CHH:3</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8,CGS:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CBS:4</availability>
+		</model>
+		<model name='XP'>
+			<availability>CHH:3</availability>
 		</model>
 		<model name='P2'>
 			<availability>CHH:4</availability>
@@ -11025,11 +11025,11 @@
 	</chassis>
 	<chassis name='Mithras Light Tank' unitType='Tank'>
 		<availability>CSA:6,CCC:6,CBS:6,CLAN:1,CSL:4,CGS:6,CCO:6</availability>
-		<model name='(ERLL)'>
-			<availability>CSL:5,CGS:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(ERLL)'>
+			<availability>CSL:5,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mjolnir Battlecruiser' unitType='Warship'>
@@ -11041,22 +11041,18 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:4,FS:2,MERC:2</availability>
-		<model name='MLR-B2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MLR-BX'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='MLR-B2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -11066,11 +11062,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -11118,10 +11118,6 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>CS:5,LA:4+</availability>
-		<model name='MON-268'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3,ROS:3</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:8,MERC:8</availability>
@@ -11129,6 +11125,10 @@
 		<model name='MON-266'>
 			<roles>recon</roles>
 			<availability>CS:8,LA:1</availability>
+		</model>
+		<model name='MON-268'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3,ROS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
@@ -11158,11 +11158,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -11173,33 +11173,33 @@
 	</chassis>
 	<chassis name='Morningstar City Command Vehicle' unitType='Tank'>
 		<availability>CC:3,WOB:4,FS:6,MERC:4</availability>
-		<model name='(HPG)'>
-			<roles>apc,urban</roles>
-			<availability>WOB:6</availability>
+		<model name='(Standard)'>
+			<roles>urban,spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>urban</roles>
 			<availability>CC:1,WOB:2,FS:1</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>urban,spotter</roles>
 			<availability>CC:4,WOB:4,FS:4</availability>
 		</model>
+		<model name='(HPG)'>
+			<roles>apc,urban</roles>
+			<availability>WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
 		<availability>CSA:5,CBS:6,CLAN:3,IS:3</availability>
-		<model name='(HAG)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized Heavy Infantry' unitType='Infantry'>
@@ -11219,7 +11219,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -11232,17 +11235,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -11274,39 +11274,39 @@
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='(Armored Pocket Warship)'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='(2737)'>
 			<roles>cargo,civilian</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Armored Pocket Warship)'>
+			<availability>WOB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>FS:6</availability>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:5</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,OA:2,LA:5,WOB:4,FS:4,MERC:4,CIR:4,TC:2,Periphery:2,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:7</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>FS:3,MERC:4</availability>
 		</model>
-		<model name='Type 2'>
-			<availability>CC:7</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Naga' unitType='Mek' omni='Clan'>
@@ -11314,6 +11314,14 @@
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
@@ -11323,24 +11331,16 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>WOB:4,DC:6</availability>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3A'>
 			<roles>fire_support,spotter</roles>
@@ -11370,23 +11370,23 @@
 	</chassis>
 	<chassis name='Nephilim Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:2</availability>
-		<model name='(Narc)' mechanized='false'>
+		<model name='(Support)' mechanized='false'>
 			<availability>General:3</availability>
-		</model>
-		<model name='(Gauss)' mechanized='false'>
-			<availability>General:6</availability>
 		</model>
 		<model name='(Seeker) [MG]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Capture Team)[HMG]' mechanized='false'>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Narc)' mechanized='false'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Support)' mechanized='false'>
-			<availability>General:3</availability>
-		</model>
-		<model name='(Capture Team)[HMG]' mechanized='false'>
-			<availability>General:3</availability>
+		<model name='(Gauss)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -11394,11 +11394,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11429,29 +11429,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CGS:3,CJF:5</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -11470,12 +11470,12 @@
 		<model name='Mk. XXX' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
+		<model name='Mk. XXII' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
 		<model name='Mk. XXI' mechanized='true'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk. XXII' mechanized='true'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightlord Battleship' unitType='Warship'>
@@ -11487,18 +11487,18 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CHH:2,CW:2,ROS:5,CLAN:1,NIOPS:3,WOB:7,CWIE:2,CGB:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8,WOB:2</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,WOB:4</availability>
 		</model>
 		<model name='(Light PPC)'>
 			<availability>WOB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,WOB:2</availability>
+		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -11507,32 +11507,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>PR:4,DoO:4,WOB:3,DO:4,FS:7,MERC:5,CIR:2,Periphery.R:2,LA:8,ROS:5,PG:4,TP:4,RFS:4</availability>
+		<model name='NGS-6T'>
+			<availability>PR:6,LA:5,ROS:6,PG:6,WOB:8,MERC:5,FS:5,RFS:6</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>PR:6,LA:5,ROS:6,PG:6,WOB:8,MERC:5,FS:5,RFS:6</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:6,ROS:6,MERC:2</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,CS:3,LA:6,ROS:5,CLAN:1,NIOPS:3,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -11549,11 +11549,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='NJT-4'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='NJT-3'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11565,51 +11565,51 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:7,DC.SL:2,LA:2,FRR:4,CGB.FRR:4,WOB:3,MERC:2,DC:6,CGB:3</availability>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>MERC:5,DC:7</availability>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:6,CGB.FRR:6,WOB:8,MERC:6,DC:6,CGB:4</availability>
 		</model>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
+		<model name='NDA-2KC'>
+			<availability>MERC:5,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:1,CNC:8</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,CNC:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,CNC:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11621,12 +11621,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -11634,24 +11628,34 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='E'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='E'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>CS:2,MERC:2,DC:3</availability>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DC:3</availability>
+		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -11659,10 +11663,6 @@
 		<model name='NX-90'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='NX-80C'>
-			<roles>recon</roles>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='O-66 &apos;Oppie&apos; Hazardous Materials Recovery Vehicle' unitType='Tank'>
@@ -11674,13 +11674,13 @@
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>CS:2,DC:3</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -11734,39 +11734,39 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,CGB.FRR:4,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
-		<model name='(Fusion)'>
-			<availability>CC:2,FVC:2,LA:2,ROS:2,FWL:2,FS:2</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:7,MOC:6,IS:6,FWL:7</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:7,CNC:8,IS:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:2,LA:2,ROS:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:4,IS:4</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:7,MOC:6,IS:6,FWL:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:7,CNC:8,IS:7</availability>
+		<model name='(Sealed)'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:4,IS:4</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>CC:2,FVC:2,LA:2,ROS:2,FWL:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:5,CSL:5,CGS:3,CCO:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
@@ -11780,38 +11780,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:2,CW:2,LA:2,CGB.FRR:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:4,CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
+		<model name='ON1-M'>
+			<availability>CS:6,MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,WOB:6,MH:6,DC:6</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:4,CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,DoO:4,WOB:4,DO:4,DGM:4,FS:1,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,TP:4,DA:4,RCM:4,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>HL:1-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>CS:6,MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,WOB:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>MOC:3,CC:3,PR:4,WOB:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,RFS:4</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2-</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>MOC:2,FWL:4,IS:2,MH:2,WOB:4,MERC:3</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:1-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2-</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:7</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:3,CC:3,PR:4,WOB:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,RFS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11825,14 +11825,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,LA:1,FS:6,MERC:4</availability>
-		<model name='OSR-5D'>
-			<availability>FS:4</availability>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
+		<model name='OSR-5D'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11840,66 +11840,66 @@
 		<model name='OSP-26'>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,TC:4,Periphery:2,CS:3-,LA:4,CGB.FRR:5,ROS:4,NIOPS:3-,DC:5</availability>
+		<model name='OSR-5C'>
+			<availability>TC:3</availability>
+		</model>
+		<model name='OSR-4L'>
+			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='OSR-2L'>
+			<availability>IS:1-</availability>
+		</model>
+		<model name='OSR-2C'>
+			<roles>urban</roles>
+			<availability>HL:1-,IS:1-,Periphery.Deep:8,MERC:4-,BAN:1,Periphery:4-</availability>
+		</model>
+		<model name='OSR-2D'>
+			<availability>CS:8,HL:2,ROS:6,IS:4,Periphery:4</availability>
+		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='OSR-5W'>
+			<roles>urban</roles>
+			<availability>WOB:3</availability>
+		</model>
 		<model name='OSR-3C'>
 			<availability>FVC:2-,IS:1-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-4K'>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='OSR-5C'>
-			<availability>TC:3</availability>
-		</model>
-		<model name='OSR-2C'>
-			<roles>urban</roles>
-			<availability>HL:1-,IS:1-,Periphery.Deep:8,MERC:4-,BAN:1,Periphery:4-</availability>
-		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2</availability>
 		</model>
-		<model name='OSR-2L'>
-			<availability>IS:1-</availability>
-		</model>
-		<model name='OSR-2D'>
-			<availability>CS:8,HL:2,ROS:6,IS:4,Periphery:4</availability>
-		</model>
 		<model name='OSR-4C'>
 			<availability>CIR:8,TC:6,Periphery:3</availability>
-		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='OSR-4L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='OSR-5W'>
-			<roles>urban</roles>
-			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>CGB:2</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -11908,9 +11908,21 @@
 			<roles>recon,spotter</roles>
 			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
+		<model name='OTT-10CS'>
+			<roles>recon</roles>
+			<availability>CS:6,WOB:4</availability>
+		</model>
+		<model name='OTT-9CS'>
+			<roles>recon,spotter</roles>
+			<availability>CS:5,WOB:4</availability>
+		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:3-,BAN:1</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
@@ -11920,50 +11932,38 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:6,ROS:5,MERC:4</availability>
 		</model>
-		<model name='OTT-10CS'>
-			<roles>recon</roles>
-			<availability>CS:6,WOB:4</availability>
-		</model>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='OTT-9CS'>
-			<roles>recon,spotter</roles>
-			<availability>CS:5,WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>PR:5,DoO:5,IS:1,WOB:6,DO:5,DGM:5,FS:5,MERC:4,Periphery:2,CS:6,DTA:5,SC:5,MCM:5,ROS:4,PG:5,FWL:5,NIOPS:6,TP:5,RFS:5</availability>
 		<model name='OTL-7M'>
 			<availability>DTA:7,SC:6,DoO:6,MCM:6,ROS:6,FWL:6,WOB:4,DO:6,DGM:6,TP:6,MERC:4</availability>
 		</model>
-		<model name='OTL-9M'>
-			<availability>FWL:3</availability>
-		</model>
 		<model name='OTL-8D'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>IS:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4,MERC:1,DC:1</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>CS:4,FWL:5,WOB:6,MERC:4</availability>
 		</model>
 		<model name='OTL-8M'>
 			<availability>DTA:5,SC:5,PR:5,MCM:5,PG:5,FWL:2,WOB:3,DGM:5,MERC:3,RFS:5</availability>
 		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:5,ROS:5,MERC:4</availability>
+		<model name='OTL-5M'>
+			<availability>CS:4,FWL:5,WOB:6,MERC:4</availability>
+		</model>
+		<model name='OTL-9M'>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='OTL-4F'>
+			<availability>FVC:1-,FS:1-</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4,MERC:1,DC:1</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>IS:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
 		</model>
-		<model name='OTL-4F'>
-			<availability>FVC:1-,FS:1-</availability>
+		<model name='OTL-9R'>
+			<availability>DTA:5,ROS:5,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -11977,10 +11977,6 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:7,CW:4,CSL:6</availability>
-		<model name='(3070)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:6</availability>
@@ -11988,6 +11984,10 @@
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
 			<availability>CHH:2</availability>
+		</model>
+		<model name='(3070)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -11999,24 +11999,32 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:6,IS:2,FS:6</availability>
-		</model>
 		<model name='A3A'>
 			<availability>LA:1,FS:1</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:6,IS:2,FS:6</availability>
 		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:4,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:3,CS:3,CNC:4,FWL:3,WOB:3,FS:3,MERC:3,DC:5</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2+,CLAN:6</availability>
+		</model>
+		<model name='OW-1F'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -12024,6 +12032,14 @@
 		<model name='OW-1C'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1'>
 			<roles>recon,spotter</roles>
@@ -12033,45 +12049,29 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2+,CLAN:6</availability>
-		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1F'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
 		<availability>CWIE:6</availability>
-		<model name='2'>
-			<availability>CWIE:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,MERC.KH:1,CDS:3,CSR:1,CNC:3,CLAN:1,CCO:3,CWIE:7</availability>
-		<model name='2'>
-			<availability>CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -12080,47 +12080,47 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,MERC.KH:1,FRR:2,IS:1,Periphery.Deep:6,MERC:2,FS:1,Periphery:3,CGB.FRR:2,PIR:2,General:2,FWL:1,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,MOC:5</availability>
-		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4,SC:3-,MCM:3-,DGM:3-,DA:3-</availability>
 		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
 		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,MERC.KH:1,FRR:2,IS:1,Periphery.Deep:6,MERC:2,FS:1,Periphery:3,CGB.FRR:2,PIR:2,General:2,FWL:1,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4,SC:3-,MCM:3-,DGM:3-,DA:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
 		<availability>CC:5,CS:4,ROS:4,NIOPS:4,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:2,WOB:3</availability>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>LA:3,ROS:3,WOB:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>LA:3,ROS:3,WOB:3,FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Palmoni Assault Infantry Fighting Vehicle' unitType='Tank'>
@@ -12132,6 +12132,9 @@
 	</chassis>
 	<chassis name='Pandion Combat WiGE' unitType='Tank'>
 		<availability>FS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -12140,59 +12143,56 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:7,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,CGB.FRR:7,ROS:4,FS.DMM:5,CNC:2,FWL:1,NIOPS:2,DC:9</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,CGB.FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,MERC:3-,Periphery:4-,DC:3-</availability>
 		</model>
-		<model name='PNT-14S'>
+		<model name='PNT-C'>
 			<roles>fire_support</roles>
-			<availability>WOB:8</availability>
+			<availability>FS.RR:3,FRR:2,CGB.FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:1,CGB.FRR:1,FS.DMM:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,FRR:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FVC:2,FRR:5,CGB.FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
 		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:3,FRR:2,CGB.FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4,FVC:2,FRR:5,CGB.FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
+		</model>
 		<model name='PNT-16K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
+		<model name='PNT-CA'>
 			<roles>fire_support</roles>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,MERC:3-,Periphery:4-,DC:3-</availability>
+			<availability>FS.RR:2,FRR:1,CGB.FRR:1,FS.DMM:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='PNT-14S'>
+			<roles>fire_support</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>FRR:3,CGB.FRR:3,DC:4</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:3,FRR:2,CGB.FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
+			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FRR:2,CGB.FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -12208,42 +12208,42 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,HL:3,FRR:4,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,CS:6,LA:7,CGB.FRR:4,CNC:5,DC:6</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>WOB:3,FS:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:6,FS:6</availability>
-		</model>
-		<model name='(Cell)'>
-			<availability>General:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>WOB:2,FS:2</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>WOB:3,FS:4</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:4,FS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:4-,CC:2-,HL:3-,FRR:1-,IS:3-,Periphery.Deep:9,WOB:4-,FS:4-,CIR:3-,Periphery:4-,TC:4-,CS:4-,OA:2-,CDS:2,LA:3-,CGB.FRR:1-,FWL:3-,DC:2-</availability>
-		<model name='(Standard)'>
+		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
-			<availability>General:5</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
@@ -12252,9 +12252,9 @@
 		<model name='(LRM)'>
 			<availability>IS:2-,Periphery:3</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12265,10 +12265,6 @@
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>PR:4,PG:4,FWL:2,RFS:4</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:7,FWL.RH:8</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:7</availability>
@@ -12276,6 +12272,10 @@
 		<model name='PKM-2E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:7,FWL.RH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -12302,9 +12302,17 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:1,CC:1,FRR:1,IS:1,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:1,CS:5-,OA:1,LA:6,CGB.FRR:1,ROS:6,FWL:2,DC:6</availability>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,WOB:4,FS:4,DC:7</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
@@ -12314,43 +12322,35 @@
 			<roles>recon</roles>
 			<availability>WOB:4,DC:5</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
-		</model>
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:3</availability>
 		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pentagon' unitType='Dropship'>
@@ -12361,44 +12361,57 @@
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:1,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='5'>
-			<availability>CGS:9</availability>
+		<model name='3'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:7</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1</availability>
 		</model>
+		<model name='5'>
+			<availability>CGS:9</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:1</availability>
+		</model>
 		<model name='4'>
 			<availability>CSR:5,CBS:7,CGS:6</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:1-,LA:1-,FRR:1-,CGB.FRR:1-,FWL:1-,IS:1-,FS:1-,MERC:1-,DC:1-</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='(Cargo)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,WOB:5,DO:6,DGM:6,TP:6</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2,WOB:6</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
@@ -12406,36 +12419,23 @@
 		<model name='P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2,WOB:6</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:6,WOB:6</availability>
+		<model name='(WoB-A)' mechanized='true'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(A)' mechanized='true'>
 			<availability>FWL:8</availability>
-		</model>
-		<model name='(WoB-C)' mechanized='true'>
-			<availability>WOB:5</availability>
 		</model>
 		<model name='(C)' mechanized='true'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='(WoB-A)' mechanized='true'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='(WoB-C)' mechanized='true'>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='(B)' mechanized='true'>
 			<availability>FWL:1</availability>
@@ -12450,18 +12450,18 @@
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CSR:3,CW:8,CSL:7,CGS:8,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSA:7,General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>CSA:7,General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -12471,123 +12471,123 @@
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CSR:3,CDS:5,CBS:3,CLAN:3,CCO:5</availability>
-		<model name='(Standard)'>
-			<availability>CCC:2,CSR:2,CDS:4,CLAN:1,CNC:4,CCO:3,DC:2</availability>
-		</model>
 		<model name='7'>
 			<availability>CDS:4,CGB:5,DC:3</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:5,CLAN:1</availability>
+		<model name='6'>
+			<availability>CDS:5,CGB:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:6,CLAN:1</availability>
 		</model>
-		<model name='6'>
-			<availability>CDS:5,CGB:5</availability>
+		<model name='4'>
+			<availability>CDS:5,CLAN:1</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:2,CSR:2,CDS:4,CLAN:1,CNC:4,CCO:3,DC:2</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CSR:3,CDS:2,CNC:2,CCO:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='PHX-HK1'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK1RB'>
-			<availability>WOB:2</availability>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
 		</model>
 		<model name='PHX-HK2'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='PHX-HK2M'>
-			<availability>IS:2,FWL:4</availability>
+		<model name='PHX-HK1RB'>
+			<availability>WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:5,CLAN:1,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:2</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,WOB:4,FS:5,MERC:4</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>LA:5,ROS:4,MERC:4</availability>
-		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:3,WOB:3,TC:3</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:6,MOC:4,MH:4,WOB:4,CIR:3,TC:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FVC:2-,PIR:3-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>SC:5,MCM:5,CLAN:5,FWL:4,WOB:4,DGM:5,BAN:1</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:1-,CGB.FRR:1-,DC:2-</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>FRR:8,CGB.FRR:8,DC:8</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:6,MERC:5</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-4W'>
+			<availability>MOC:3,WOB:3,TC:3</availability>
+		</model>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='PXH-7CS'>
 			<availability>CS:4</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,WOB:4,FS:5,MERC:4</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>CS:3,ROS:2,DC:2</availability>
+		<model name='PXH-5L'>
+			<availability>CC:3,MOC:3</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>General:3-,BAN:6,Periphery:3-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>LA:5,ROS:4,MERC:4</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:1-,CGB.FRR:1-,DC:2-</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>SC:4,DoO:3,MCM:4,CLAN:3,FWL:3,WOB:4,DO:3,DGM:4,TP:3,DA:3,RCM:3,CGS:5</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>FVC:2-,PIR:3-,FS:2-,MERC:2-</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:6,MOC:4,MH:4,WOB:4,CIR:3,TC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>CS:3,ROS:2,DC:2</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>SC:5,MCM:5,CLAN:5,FWL:4,WOB:4,DGM:5,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>FRR:8,CGB.FRR:8,DC:8</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -12595,47 +12595,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:3,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:2-,MERC.WD:5,CDS:6,LA:2-,CGB.FRR:3-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>CC:7,MOC:6,FS:6,MERC:7,DA:7,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,IS:3,Periphery.Deep:2,Periphery:5</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>CC:7,MOC:6,FS:6,MERC:7,DA:7,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,CS:4,MOC:3,MERC.WD:4,MERC.KH:4,CNC:6,CLAN:1,NIOPS:4,FS:1,MERC:4,TC:1</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12643,11 +12643,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -12684,12 +12684,12 @@
 		<model name='(Streak)'>
 			<availability>HL:2,IS:5,TC:6,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>HL:4,IS:6,Periphery.Deep:2,Periphery:6</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>HL:3,FWL:5,IS:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:4,IS:6,Periphery.Deep:2,Periphery:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:2</availability>
@@ -12711,14 +12711,14 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='(HV)'>
 			<availability>CC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
@@ -12729,42 +12729,42 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CS:1,CHH:1,CCC:2,CSR:3,CDS:5,NIOPS:1,CGS:3,CCO:2,CWIE:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CGS:7,CCO:6,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:2,CGB:3</availability>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:2,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -12784,22 +12784,22 @@
 	</chassis>
 	<chassis name='Preta' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-PRT-OE Eminus'>
-			<availability>General:7</availability>
+		<model name='C-PRT-OU Exanimus'>
+			<availability>General:2</availability>
 		</model>
-		<model name='C-PRT-OD Luminos'>
+		<model name='C-PRT-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-PRT-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-PRT-OU Exanimus'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C-PRT-OS Caelestis'>
 			<availability>General:4</availability>
 		</model>
-		<model name='C-PRT-OA Dominus'>
+		<model name='C-PRT-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-PRT-OC Comminus'>
@@ -12812,23 +12812,23 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:4,CSL:6,CCO:6</availability>
-		<model name='(Quad)'>
-			<availability>CHH:4+</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:2,CCO:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CHH:8,CBS:8,CSL:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:8,CBS:8,CSL:8,CCO:8</availability>
+		<model name='4'>
+			<availability>CCO:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:2,CCO:2</availability>
+		</model>
+		<model name='(Quad)'>
+			<availability>CHH:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12846,10 +12846,6 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
-			<roles>apc</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:3,Periphery:7</availability>
@@ -12858,9 +12854,9 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
-			<availability>IS:4,Periphery:4,CGB:4</availability>
+		<model name='(Support)'>
+			<roles>apc</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(WoB)'>
 			<roles>apc</roles>
@@ -12870,35 +12866,39 @@
 			<roles>support</roles>
 			<availability>CS:8,CLAN:8,General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4,CGB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CLAN:7,IS:1+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12906,11 +12906,11 @@
 		<model name='PAT-005'>
 			<availability>CS:2,CHH:2,CW:2,FRR:8,CGB.FRR:8,ROS:2,NIOPS:8,WOB:8,CWIE:2</availability>
 		</model>
-		<model name='PAT-007'>
-			<availability>CS:7,WOB:6</availability>
-		</model>
 		<model name='PAT-008'>
 			<availability>ROS:6,WOB:5+</availability>
+		</model>
+		<model name='PAT-007'>
+			<availability>CS:7,WOB:6</availability>
 		</model>
 		<model name='PAT-005b'>
 			<availability>CLAN:8,BAN:2</availability>
@@ -12924,25 +12924,25 @@
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:5,WOB:5,Periphery:5</availability>
-		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CS:7,WOB:7,Periphery:7</availability>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Narc]' mechanized='true'>
 			<availability>CS:4,WOB:4,Periphery:4</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:5,WOB:5,Periphery:5</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CS:7,WOB:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Purifier Battle Armor Terra' unitType='BattleArmor'>
@@ -12950,13 +12950,13 @@
 		<model name='[MRR]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[ERSL]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='[AP Gauss]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[SPL]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[ERSL]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -12968,11 +12968,11 @@
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>HL:3,Periphery:5</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>HL:3,Periphery:5</availability>
@@ -12983,17 +12983,17 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:5,CGB.FRR:5,MERC:5,DC:6</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:4,FWL:6</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
 		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
+		</model>
 		<model name='QKD-8K'>
 			<availability>FRR:5,CGB.FRR:5,ROS:5,MERC:3,DC:7</availability>
-		</model>
-		<model name='QKD-C'>
-			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4-,OA:4-,HL:1-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
@@ -13001,11 +13001,11 @@
 		<model name='QKD-4H'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
+		<model name='QKD-C'>
+			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:4,FWL:6</availability>
+		<model name='QKD-5K'>
+			<availability>FRR:5,CGB.FRR:5,MERC:5,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -13017,40 +13017,37 @@
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='(Standard)'>
-			<availability>CCC:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin II' unitType='Mek'>
 		<availability>WOB:6+</availability>
-		<model name='RJN-200-C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='RJN-200-B'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
@@ -13058,40 +13055,43 @@
 		<model name='RJN-200-A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='RJN-200-C'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
 		<availability>CS:5,WOB:1</availability>
-		<model name='RJN101-C'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RJN101-A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RJN101-C'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,ROS:3,FS:5,MERC:3</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
-		</model>
-		<model name='MDG-1Ar'>
-			<availability>ROS:8,FS:3,MERC:3</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1Ar'>
+			<availability>ROS:8,FS:3,MERC:3</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>CS:4,LA:3,ROS:4,ROS.pm:4,FWL:3,MH:5,MERC:5,FS:3,DC:3</availability>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='VV1'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='VV1 (MG)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
@@ -13100,14 +13100,14 @@
 			<roles>ground_support</roles>
 			<availability>CS:2</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
-		</model>
-		<model name='RPR-300S'>
-			<availability>LA:3</availability>
+		<model name='RPR-300'>
+			<availability>LA:5</availability>
 		</model>
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:1</availability>
+		</model>
+		<model name='RPR-100'>
+			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
 		</model>
 		<model name='RPR-102'>
 			<availability>LA:1-</availability>
@@ -13115,8 +13115,8 @@
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:5</availability>
+		<model name='RPR-300S'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -13132,54 +13132,40 @@
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3,FS:4,DC:6</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:2+</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:2+</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='RTX1-OA'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:4,FS:2,MERC:5,DA:4,TC:4,DC:2</availability>
-		<model name='RVN-4X'>
-			<availability>CC:1</availability>
-		</model>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FWL:4,FS:1,MERC:3,DC:1,TC:3</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:4</availability>
-		</model>
-		<model name='RVN-SR &apos;Shattered Raven&apos;'>
-			<availability>FS.CMM:1</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
@@ -13188,25 +13174,39 @@
 			<roles>spotter</roles>
 			<availability>CC:4,MOC:3,FWL:1,FS:1,MERC:3,DC:3,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:7,MOC:7,DA:6,TC:7</availability>
+			<availability>CC:4</availability>
 		</model>
 		<model name='RVN-SS &apos;Shattered Raven&apos;'>
 			<roles>spotter</roles>
 			<availability>FS.CMM:1</availability>
 		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:7,DA:6,TC:7</availability>
+		</model>
+		<model name='RVN-4X'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,FWL:4,FS:1,MERC:3,DC:1,TC:3</availability>
+		</model>
+		<model name='RVN-SR &apos;Shattered Raven&apos;'>
+			<availability>FS.CMM:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>LA:6,FRR:5,CGB.FRR:5,MERC:4,FS:4</availability>
-		<model name='RZK-10T'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='RZK-10S'>
 			<availability>LA:3</availability>
@@ -13221,11 +13221,6 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='RDS-2A'>
-			<roles>spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='RDS-2B'>
 			<roles>recon,spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
@@ -13235,15 +13230,20 @@
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:4</availability>
 		</model>
+		<model name='RDS-2A'>
+			<roles>spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -13257,6 +13257,14 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
@@ -13265,27 +13273,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>PR:7,DoO:8,FRR:5,DO:8,FS:3,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,RFS:7,MOC:3,CC:3,WOB:6,DGM:8,MERC:2,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:1,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:4</availability>
-		<model name='F-700a'>
-			<availability>CC:7,PR:6,DoO:6,WOB:7,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,TP:6,DA:6,RCM:6,RFS:6</availability>
+		<model name='F-100'>
+			<availability>CC:1-,FVC:4-,HL:1-,LA:1,FRR:1,CGB.FRR:1,FWL:3-,Periphery.Deep:8,MERC:3-,DC:1,Periphery:4-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>DTA:8,SC:8,DoO:8,MCM:8,ROS:6,FWL:5,WOB:5,DO:8,DGM:8,TP:8,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>FRR:2-,CGB.FRR:2-,DC:2-</availability>
@@ -13296,38 +13299,35 @@
 		<model name='F-700'>
 			<availability>CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>DTA:8,SC:8,DoO:8,MCM:8,ROS:6,FWL:5,WOB:5,DO:8,DGM:8,TP:8,MERC:5,DC:5</availability>
-		</model>
-		<model name='F-100'>
-			<availability>CC:1-,FVC:4-,HL:1-,LA:1,FRR:1,CGB.FRR:1,FWL:3-,Periphery.Deep:8,MERC:3-,DC:1,Periphery:4-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,PR:6,DoO:6,WOB:7,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,TP:6,DA:6,RCM:6,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:3,CLAN:1,CNC:5,IS:2,CGB:5</availability>
-		<model name='8'>
-			<availability>CC:2,DoO:2,DO:2,DGM:2,FS:2,MERC:2,SC:2,CDS:3,LA:2,MCM:2,TP:2,DC:2,CGB:5</availability>
-		</model>
-		<model name='5'>
-			<availability>CSA:5,CDS:3,IS:3,CLAN.HW:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:3,CLAN:2,CNC:3</availability>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,CBS:2,CCO:2</availability>
 		</model>
 		<model name='7'>
 			<availability>CNC:5,DC:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CLAN:1,CNC:5,IS:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:3,CLAN:2,CNC:3</availability>
+		</model>
+		<model name='5'>
+			<availability>CSA:5,CDS:3,IS:3,CLAN.HW:4</availability>
+		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,CDS:2,CBS:5,CCO:2</availability>
 		</model>
+		<model name='8'>
+			<availability>CC:2,DoO:2,DO:2,DGM:2,FS:2,MERC:2,SC:2,CDS:3,LA:2,MCM:2,TP:2,DC:2,CGB:5</availability>
+		</model>
 		<model name='6'>
 			<availability>CSA:5,CHH:3,CDS:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,CBS:2,CCO:2</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:1,CNC:5,IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -13339,26 +13339,18 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:6,HL:3,FRR:7,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:4</availability>
-		<model name='RFL-6D'>
-			<availability>FS:2</availability>
+		<model name='RFL-5D'>
+			<availability>FVC:5,LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='RFL-7M'>
 			<availability>PR:6,DoO:6,FRR:4,WOB:5,DO:6,DGM:6,DTA:6,SC:6,MCM:6,CGB.FRR:4,PG:6,FWL:6,TP:6,DA:6,RCM:6,RFS:6,DC:4</availability>
-		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:1</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FVC:1-,FS:1-,MERC:1-</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:5,LA:4,FS:4,MERC:4</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:3,MERC:2</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:2</availability>
@@ -13367,30 +13359,38 @@
 			<roles>fire_support</roles>
 			<availability>CC:3-,MOC:3-,DoO:3-,PIR:3-,FWL:1-,MH:3-,DO:3-,TP:3-,FS:3-,DA:3-,MERC:1-,RCM:3-</availability>
 		</model>
-		<model name='C 2'>
-			<availability>CJF:3</availability>
-		</model>
-		<model name='RFL-8D'>
-			<availability>LA:1,FS:5</availability>
-		</model>
-		<model name='RFL-9T'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='RFL-8X'>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='RFL-7X'>
-			<roles>fire_support</roles>
-			<availability>ROS:3,MERC:3</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>CC:4,MOC:4,FWL:4,IS:1,MERC:4,DC:4</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:1,CLAN:5,FS:1,BAN:1,DC:1</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CJF:3</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='RFL-8X'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='RFL-6D'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-7X'>
+			<roles>fire_support</roles>
+			<availability>ROS:3,MERC:3</availability>
+		</model>
+		<model name='RFL-8D'>
+			<availability>LA:1,FS:5</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:1</availability>
+		</model>
+		<model name='RFL-9T'>
+			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riot Police' unitType='Infantry'>
@@ -13402,45 +13402,45 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,CSR:1,FRR:5,CLAN:2,WOB:6,FS:5,CS:6,FVC:4,LA:5,CGB.FRR:5,ROS:6,NIOPS:6,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5,ROS:4,FS:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:2</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CSR:4,CBS:7,CNC:7,CSL:4,CGS:6,CCO:8,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSR:5,CBS:8,CNC:6,CSL:6,CCO:8,CGS:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:3,CBS:6,CNC:4,CCO:4,CWIE:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:3,CCO:4</availability>
@@ -13448,53 +13448,50 @@
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CGB:5-</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HR' mechanized='true'>
 			<roles>recon</roles>
 			<availability>CGB:2</availability>
 		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:2,WOB:4</availability>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
 		</model>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:8</availability>
-		</model>
 		<model name='RGU-133F'>
 			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
+		</model>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='RGU-133P'>
 			<availability>CS:1</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>PR:3,FRR:4,FS:4,MERC:3,CWIE:6,TC:6,OA:5,FVC:3,LA:6,CGB.FRR:4,ROS:3,PG:3,RFS:3</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:3,ROS:3,FS:3,CWIE:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:0,General:3,TC:0,CWIE:0</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
 		<availability>FWL:2-,FS:2,MERC:2</availability>
-		<model name='NH-3X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='NH-2'>
 			<availability>General:8</availability>
 		</model>
@@ -13506,6 +13503,9 @@
 		</model>
 		<model name='NH-1B'>
 			<availability>ROS:5-,MERC:5-,FS:5-</availability>
+		</model>
+		<model name='NH-3X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -13525,12 +13525,12 @@
 			<roles>recon</roles>
 			<availability>LA:6</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13543,6 +13543,14 @@
 	</chassis>
 	<chassis name='Rusalka' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6</availability>
+		<model name='S-RSL-OE Eminus'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-RSL-OD Luminos'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='S-RSL-OB Infernus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
@@ -13551,15 +13559,7 @@
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-RSL-OE Eminus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='S-RSL-OA Dominus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='S-RSL-OD Luminos'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
@@ -13570,23 +13570,23 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:4,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:6,CBS:7,CNC:2,CJF:6,DC:3+</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:5,CCC:5,CBS:4,CLAN:3,General:1</availability>
+		<model name='F'>
+			<availability>General:2,CJF:5</availability>
+		</model>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:2,CJF:5</availability>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:5,CCC:5,CBS:4,CLAN:3,General:1</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:1</availability>
@@ -13594,8 +13594,8 @@
 		<model name='E'>
 			<availability>CHH:4,CSR:3,CDS:6,CNC:4,General:5,CCO:7,CJF:4,CWIE:6</availability>
 		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:3,CBS:6,General:5,CWIE:5,CGB:6</availability>
@@ -13609,20 +13609,20 @@
 		<model name='3'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CGB:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CGB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
 		<availability>CNC:6,DC:4</availability>
-		<model name='SM1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Telos)'>
 			<availability>CNC:2</availability>
+		</model>
+		<model name='SM1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1A Tank Destroyer' unitType='Tank'>
@@ -13647,13 +13647,13 @@
 			<roles>sr_fire_support,spotter</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:7,Periphery:3</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:8,LA:8,FWL:8,IS:7,FS:8,DC:6,Periphery:6</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:7,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13670,14 +13670,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
-		<model name='SB-27'>
-			<availability>General:5-</availability>
+		<model name='SB-28'>
+			<availability>CS:6,LA:8,ROS:4,NIOPS:6,WOB:6,FS:5,MERC:5</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>MERC:5,DC:8</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>CS:6,LA:8,ROS:4,NIOPS:6,WOB:6,FS:5,MERC:5</availability>
+		<model name='SB-27'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:5</availability>
@@ -13689,17 +13689,11 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -13708,11 +13702,17 @@
 		<model name='D'>
 			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>CSR:2,General:1,CJF:3</availability>
 		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
+		<model name='E'>
+			<availability>CSR:3,General:2,CJF:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -13727,50 +13727,50 @@
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:4,CW:4,FRR:6,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
-		<model name='S-4X'>
-			<availability>DC:1</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>ROS:4,CLAN:8,DC:4</availability>
-		</model>
-		<model name='S-3'>
-			<availability>DC:2-</availability>
-		</model>
-		<model name='S-8'>
-			<availability>ROS:6,DC:5</availability>
 		</model>
 		<model name='S-4'>
 			<availability>FRR:6,CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
 		</model>
+		<model name='S-8'>
+			<availability>ROS:6,DC:5</availability>
+		</model>
+		<model name='S-3'>
+			<availability>DC:2-</availability>
+		</model>
 		<model name='S-7'>
 			<availability>ROS:6,CNC:5,DC:5</availability>
+		</model>
+		<model name='S-4X'>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:4,CS:5-,LA:6,CGB.FRR:7,FWL:6,CJF:4,DC:9</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:7,DC:7</availability>
+		</model>
 		<model name='(LB-X)'>
 			<availability>IS:6,DC:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:5-,Periphery:5-</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:7,DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CSR:3,CW:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CSR:3,CW:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -13779,10 +13779,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:5,LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -13790,6 +13786,10 @@
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
@@ -13806,21 +13806,21 @@
 			<roles>ground_support</roles>
 			<availability>OA:2,FRR:2-,DC:2</availability>
 		</model>
-		<model name='SL-27'>
-			<availability>IS:6,DC:3</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:3-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,CGB.FRR:6-,ROS:2-,FWL:6-,DC:7-</availability>
-		<model name='(MRM)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa' unitType='Mek'>
@@ -13847,45 +13847,45 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:2,CBS:5,CNC:2,CGS:6,CCO:7,CWIE:4</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='4'>
 			<roles>recon,raider,spotter</roles>
 			<availability>CSR:2,CNC:4</availability>
-		</model>
-		<model name='XP'>
-			<availability>CNC:4</availability>
 		</model>
 		<model name='3'>
 			<roles>recon,raider</roles>
 			<availability>CGS:4,CWIE:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='XP'>
+			<availability>CNC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CW:5,CCO:9</availability>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
 		</model>
+		<model name='Z'>
+			<availability>CCO:2</availability>
+		</model>
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -13894,12 +13894,12 @@
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
 		<availability>LA:5,FS:4,MERC:3,DC:3</availability>
+		<model name='(Interdictor)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>LA:1,FS:1</availability>
-		</model>
-		<model name='(Interdictor)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savior Repair Vehicle' unitType='Tank'>
@@ -13911,10 +13911,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:5,MERC:3</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -13922,6 +13918,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -13941,33 +13941,33 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,DoO:4,FRR:4,CGB.FRR:4,FWL:4,WOB:4,DO:4,TP:4,FS:4,MERC:4,MERC.NH:4,DC:4</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -13978,33 +13978,33 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:2,HL:4,FRR:2,IS:3,Periphery.Deep:5,WOB:4,MERC:3,FS:3,CIR:5,Periphery:5,TC:3,CS:3,OA:3,LA:3,CGB.FRR:3,FWL:3,DC:2</availability>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
+		<model name='(Armor)'>
+			<availability>CNC:6,IS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>CNC:6,IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,CGB.FRR:7-,FWL:3-,DC:6-</availability>
-		<model name='(Missile)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5-</availability>
+		<model name='(Missile)'>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:7,DC:8</availability>
@@ -14012,48 +14012,48 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,FS:6,Periphery:7,FVC:6,LA:6,CGB.FRR:8,FWL:6,CJF:4,DC:6</availability>
-		<model name='(LRM)'>
-			<availability>General:3-</availability>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
-			<availability>General:5-</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:4,MOC:3,LA:4,ROS:4,IS:3,FWL:4,WOB:4,MH:3,FS:4,MERC:4,TC:3,DC:4</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>General:5-</availability>
 		</model>
 		<model name='(ML)'>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
+		<model name='(LAC)'>
+			<availability>CC:4,MOC:3,LA:4,ROS:4,IS:3,FWL:4,WOB:4,MH:3,FS:4,MERC:4,TC:3,DC:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,MERC:2-,Periphery:3-,CS:2-,LA:3,CGB.FRR:2-,FWL:2-,NIOPS:2-,DC:2-</availability>
-		<model name='SCP-1N'>
-			<availability>HL:1-,FRR:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
-		</model>
-		<model name='SCP-12C'>
-			<availability>WOB:4</availability>
+		<model name='SCP-12S'>
+			<availability>LA:4,ROS:2,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>HL:1-,FRR:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>IS:5,Periphery:3</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,ROS:2,MERC:2</availability>
+		<model name='SCP-1TB'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='SCP-12C'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='SCP-10M'>
 			<availability>CS:3,CC:3,FRR:2,CGB.FRR:3,FWL:5,MERC:3,DC:3</availability>
-		</model>
-		<model name='SCP-1TB'>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -14086,33 +14086,30 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:3,CW:5,CLAN:4,CNC:5,CGS:4,CJF:7,CCO:5,CWIE:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Se&apos;irim Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:7</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -14120,17 +14117,20 @@
 		<model name='(Capture Team)' mechanized='true'>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(SRM6)'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:3</availability>
@@ -14144,20 +14144,17 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,FS:5,CIR:3,Periphery:3,CS:3,LA:6,CGB.FRR:3,FWL:4,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:8,FWL:4,IS:4,FS:8</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>CS:8,FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-3M'>
 			<availability>DC.GHO:2-,DC:1</availability>
 		</model>
@@ -14166,6 +14163,9 @@
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>CS:8,FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 		<model name='STN-5WB'>
 			<availability>WOB:8</availability>
@@ -14186,14 +14186,11 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-SRP-O Invictus'>
-			<availability>General:8</availability>
+		<model name='C-SRP-OS Caelestis'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C-SRP-O (Havalah)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C-SRP-OS Caelestis'>
-			<availability>General:4</availability>
 		</model>
 		<model name='C-SRP-OC Comminus'>
 			<availability>General:7</availability>
@@ -14203,6 +14200,9 @@
 		</model>
 		<model name='C-SRP-OD Luminos'>
 			<availability>General:7</availability>
+		</model>
+		<model name='C-SRP-O Invictus'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C-SRP-OB Infernus'>
 			<availability>General:7</availability>
@@ -14214,22 +14214,26 @@
 			<roles>interceptor</roles>
 			<availability>LA:3-,Periphery.Deep:8,FS:1-,Periphery:3-</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:8,FRR:6,CGB.FRR:6,ROS:4,FS:8,MERC:6</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:2-,HL:4,FRR:2-,ROS:2-,Periphery.Deep:2,FWL:2-,WOB:2-,Periphery:6,TC:3-,DC:2-</availability>
-		</model>
 		<model name='SYD-Z3A'>
 			<availability>LA:6,FRR:3,CGB.FRR:3,ROS:2,MERC:3,FS:2</availability>
 		</model>
 		<model name='SYD-45X &apos;Starling&apos;'>
 			<availability>LA:1</availability>
 		</model>
+		<model name='SYD-Z1'>
+			<roles>interceptor</roles>
+			<availability>OA:2-,HL:4,FRR:2-,ROS:2-,Periphery.Deep:2,FWL:2-,WOB:2-,Periphery:6,TC:3-,DC:2-</availability>
+		</model>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>LA:8,FRR:6,CGB.FRR:6,ROS:4,FS:8,MERC:6</availability>
+		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,OA:5,LA:6,FRR:2,CGB.FRR:2,ROS:4,MERC:5</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2-,FS:1-</availability>
 		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14238,21 +14242,17 @@
 		<model name='SYD-Z2B'>
 			<availability>OA:4,LA:4,ROS:4,FS:3,MERC:3</availability>
 		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2-,FS:1-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6,MOC:4</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -14264,14 +14264,14 @@
 		<model name='S-HA-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='S-HA-O Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='S-HA-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-HA-OB Infernus'>
 			<availability>General:7</availability>
-		</model>
-		<model name='S-HA-O Invictus'>
-			<availability>General:8</availability>
 		</model>
 		<model name='S-HA-OD Luminos'>
 			<availability>General:7</availability>
@@ -14288,16 +14288,12 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:2,CDS:5,CW:1,CNC:7,CLAN.IS:1,CSL:4,CJF:5,CWIE:1</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:2,General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:3,CCO:7</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSR:5,CW:3,General:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSR:2,CW:3,General:6</availability>
 		</model>
 		<model name='J'>
 			<availability>General:5</availability>
@@ -14305,69 +14301,61 @@
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
+		<model name='A'>
 			<roles>recon</roles>
-			<availability>CSR:2,General:8</availability>
+			<availability>CSR:2,CW:3,General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSR:5,CW:3,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>PR:3,CHH:6,DoO:3,FRR:3,CLAN:2,DO:3,FS:3,CWIE:6,SC:3,OA:3,CDS:6,CGB.FRR:3,FWL:3,RFS:3,CGB:6,IS:1,DGM:3,MERC:3,DTA:3,CS:3,LA:3,MCM:3,ROS:3,PG:3,CNC:6,TP:3,RCM:3,DA:2,CJF:1,DC:3</availability>
+		<model name='6'>
+			<availability>CHH:5</availability>
+		</model>
+		<model name='5'>
+			<availability>CS:6,CDS:7,LA:7,FRR:5,CGB.FRR:5,FWL:7,IS:5,FS:7,MERC:7,DC:7</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CGB:4</availability>
+		</model>
 		<model name='8'>
 			<availability>CDS:3,LA:3,CNC:4,CWIE:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CGB:4</availability>
+		<model name='4'>
+			<availability>CDS:5,CNC:5</availability>
 		</model>
 		<model name='7'>
 			<availability>OA:2,CSR:2</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:5,CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:4,CDS:5,CNC:5</availability>
-		</model>
-		<model name='5'>
-			<availability>CS:6,CDS:7,LA:7,FRR:5,CGB.FRR:5,FWL:7,IS:5,FS:7,MERC:7,DC:7</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:3</availability>
-		<model name='SHD-2K'>
-			<availability>FRR:1-,CGB.FRR:1-,MERC:2-,DC:3-</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,FWL:2,DGM:4,MERC:4,DA:4,BAN:2</availability>
 		</model>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,LA:3,FS:6</availability>
+		<model name='SHD-3K'>
+			<availability>FRR:3,CGB.FRR:3,DC:5</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:3-,MOC:3-,FWL:3-,MERC:3-</availability>
 		</model>
-		<model name='SHD-2D'>
-			<availability>FVC:1-,FS:1-</availability>
-		</model>
-		<model name='SHD-11CS'>
-			<availability>CS:6,WOB:5</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,FWL:2,DGM:4,MERC:4,DA:4,BAN:2</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>FRR:2,CGB.FRR:5</availability>
-		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,FRR:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:6,IS:1,MERC:6,DC:6</availability>
 		</model>
-		<model name='SHD-8L'>
-			<availability>CC:5</availability>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,WOB:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='SHD-2K'>
+			<availability>FRR:1-,CGB.FRR:1-,MERC:2-,DC:3-</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:5,CCC:5,LA:2,FS:2,CGS:5,DC:2</availability>
@@ -14375,17 +14363,29 @@
 		<model name='SHD-7M'>
 			<availability>CC:4,MOC:3,DoO:5,DO:5,DGM:5,MERC:3,CDP:2,TC:3,DTA:5,SC:5,FVC:2,MCM:5,ROS:4,FWL:3,TP:5,RCM:5</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>WOB:4,FS:4</availability>
+		<model name='SHD-2H'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
 		</model>
 		<model name='SHD-7CS'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,WOB:4,FS:5,MERC:4</availability>
+		<model name='SHD-12C'>
+			<availability>FRR:2,CGB.FRR:5</availability>
 		</model>
-		<model name='SHD-3K'>
-			<availability>FRR:3,CGB.FRR:3,DC:5</availability>
+		<model name='SHD-9D'>
+			<availability>WOB:4,FS:4</availability>
+		</model>
+		<model name='SHD-11CS'>
+			<availability>CS:6,WOB:5</availability>
+		</model>
+		<model name='SHD-8L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,LA:3,FS:6</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FVC:1-,FS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -14393,11 +14393,11 @@
 		<model name='(Flamer)'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:3,CSR:2,CDS:3,CW:3,CNC:3,CJF:3,CGB:5,CWIE:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shedu Assault Battle Armor' unitType='BattleArmor'>
@@ -14409,26 +14409,26 @@
 		<model name='(Capture Team)' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(PPC)' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(PPC)' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>ROS:6,DC:7</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>OA:2,FRR:2,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>ROS:6,DC:7</availability>
 		</model>
 		<model name='SL-17AC'>
 			<availability>DC:1-</availability>
@@ -14445,6 +14445,9 @@
 		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SHV-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
 		</model>
@@ -14454,21 +14457,18 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,CNC:5,CJF:2,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:5,DC:5</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
+		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -14479,12 +14479,12 @@
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:6,CGB.FRR:6,ROS:3,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
-		<model name='SL-22'>
-			<availability>FRR:8,CGB.FRR:8,ROS:8,DC:8</availability>
-		</model>
 		<model name='SL-21L'>
 			<roles>raider,ground_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='SL-22'>
+			<availability>FRR:8,CGB.FRR:8,ROS:8,DC:8</availability>
 		</model>
 		<model name='SL-21'>
 			<availability>HL:4,LA:2,Periphery.Deep:7,MERC:4,DC:4,Periphery:6</availability>
@@ -14492,14 +14492,14 @@
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
 		<availability>CS:3,CLAN:1,NIOPS:3,WOB:3</availability>
-		<model name='ST-8A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ST-8C'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='ST-9C'>
 			<availability>CS:4,WOB:4</availability>
+		</model>
+		<model name='ST-8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shugenja' unitType='Mek'>
@@ -14527,23 +14527,23 @@
 	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CSA:4,CCC:4,CCO:4</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:4,CCC:4,CCO:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,SC:5,DoO:5,MCM:5,FWL:2,WOB:4,DO:5,DGM:5,TP:5,MERC:3</availability>
-		<model name='SRC-5C'>
-			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:5,WOB:5,DO:5,DGM:5,TP:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:5,WOB:5,DO:5,DGM:5,TP:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>DTA:4,SC:4,DoO:4,MCM:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4</availability>
@@ -14551,51 +14551,51 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,CGB.FRR:5-,ROS:3-,FWL:3,NIOPS:3-,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:5-</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
 			<availability>IS.pm:4</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,CGB.FRR:1,DC:1</availability>
+		<model name='SL-15'>
+			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,CSR:3,FRR:8,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,DC:8,TC:4</availability>
 		</model>
-		<model name='SL-15B'>
-			<availability>FRR:1,CGB.FRR:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>FRR:4,CGB.FRR:4,ROS:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
+		<model name='SL-15B'>
+			<availability>FRR:1,CGB.FRR:1,MERC:1,DC:1</availability>
 		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,CGB.FRR:1,DC:1</availability>
 		</model>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,CGB.FRR:1,DC:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:3,ROS:4,FS:3</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>LA:3</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Snake' unitType='Mek'>
@@ -14619,11 +14619,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -14658,31 +14658,31 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>ROS:4,WOB:5</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>CS:6,ROS:6,WOB:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+		<model name='SPR-H5K'>
+			<roles>interceptor</roles>
+			<availability>OA:1,FRR:1-,CGB.FRR:1-,DC:1-</availability>
+		</model>
+		<model name='SPR-7D'>
+			<availability>ROS:5,FS:5,MERC:5</availability>
+		</model>
+		<model name='SPR-DH'>
+			<availability>OA:3-,FVC:3-,MERC:3-</availability>
+		</model>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:3,FRR:5,CGB.FRR:5,ROS:3,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:3-,General:1-,Periphery.Deep:8,FS:3-,MERC:3-,CDP:3-,TC:3-</availability>
-		</model>
-		<model name='SPR-7D'>
-			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-H5K'>
-			<roles>interceptor</roles>
-			<availability>OA:1,FRR:1-,CGB.FRR:1-,DC:1-</availability>
-		</model>
-		<model name='SPR-DH'>
-			<availability>OA:3-,FVC:3-,MERC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -14708,12 +14708,12 @@
 		<model name='SPR-5S'>
 			<availability>CS:4,CC:4,LA:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,CS:4,LA:4,ROS:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8,CIR:8</availability>
-		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,CS:4,LA:4,ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -14727,15 +14727,31 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:2,CC:2,FWL:8,MH:2,MERC:2</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:3,MERC:3</availability>
+		</model>
+		<model name='SDR-8X'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
 		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:1-</availability>
 		</model>
 		<model name='SDR-7K'>
 			<availability>ROS:4,MERC:4,DC:5</availability>
@@ -14746,27 +14762,11 @@
 		<model name='SDR-7KC'>
 			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:1-</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
-		</model>
-		<model name='SDR-8K'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>ROS:3,MERC:3,DC:4</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:3,MERC:3</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:2,CC:2,FWL:8,MH:2,MERC:2</availability>
-		</model>
-		<model name='SDR-8X'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
+		<model name='SDR-8K'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
@@ -14780,17 +14780,17 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:7,FRR:7,CGB.FRR:7,ROS:7,IS:6,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FRR:5,CGB.FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(C3i)'>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
 			<roles>recon</roles>
-			<availability>CS:5,WOB:6</availability>
+			<availability>FRR:5,CGB.FRR:5,IS:4,DC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -14800,9 +14800,9 @@
 			<roles>spotter</roles>
 			<availability>LA:3,FWL:3,MERC:3,FS:3,DC:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
+		<model name='(C3i)'>
+			<roles>recon</roles>
+			<availability>CS:5,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14813,14 +14813,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,CGB.FRR:6,ROS:4,FWL:8,NIOPS:5,DC:5</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
+		</model>
 		<model name='STK-8S'>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-6M'>
+			<availability>CC:4,MOC:4,PR:6,DoO:6,WOB:6,DO:6,MERC:6,ROS:6,PG:6,FWL:6,TP:6,DA:4,RCM:6,RFS:6</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:1</availability>
@@ -14828,20 +14831,17 @@
 		<model name='STK-7D'>
 			<availability>ROS:4,FS:4,MERC:2</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CC:2,MOC:2,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
-		</model>
-		<model name='STK-6M'>
-			<availability>CC:4,MOC:4,PR:6,DoO:6,WOB:6,DO:6,MERC:6,ROS:6,PG:6,FWL:6,TP:6,DA:4,RCM:6,RFS:6</availability>
+		<model name='STK-3F'>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
@@ -14849,12 +14849,12 @@
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -14880,12 +14880,12 @@
 	</chassis>
 	<chassis name='Starslayer' unitType='Mek'>
 		<availability>MOC:4,CC:4,LA:6,FRR:4,CGB.FRR:4,FS:4,MERC:4</availability>
+		<model name='STY-3Dr'>
+			<availability>LA:4,MERC:3</availability>
+		</model>
 		<model name='STY-3D'>
 			<roles>raider</roles>
 			<availability>MOC:6,LA:6,MERC:6</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>LA:4,MERC:3</availability>
 		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
@@ -14894,6 +14894,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>CS:4,LA:4,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>LA:1,FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:1,FS:4,MERC:1</availability>
@@ -14902,17 +14906,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>LA:1,FS:6,MERC:4</availability>
+			<availability>LA:1,FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>LA:1,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
@@ -14928,47 +14928,43 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,CGB.FRR:4,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='STG-5G'>
-			<roles>recon</roles>
-			<availability>CC:3,FWL:2,MERC:2,TC:3</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,TC:3</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:5,ROS:5,MERC:5,FS:3</availability>
 		</model>
-		<model name='STG-3Gb'>
+		<model name='STG-6L'>
 			<roles>recon</roles>
-			<availability>SC:6,DoO:6,MCM:6,CLAN:8,FWL:4,WOB:4,DGM:6,DO:6,TP:6,RCM:6,DA:6,BAN:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:2,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:2</availability>
+			<availability>CC:5,MOC:4,DA:4</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
-		<model name='STG-6L'>
+		<model name='STG-5G'>
 			<roles>recon</roles>
-			<availability>CC:5,MOC:4,DA:4</availability>
+			<availability>CC:3,FWL:2,MERC:2,TC:3</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,TC:3</availability>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>SC:6,DoO:6,MCM:6,CLAN:8,FWL:4,WOB:4,DGM:6,DO:6,TP:6,RCM:6,DA:6,BAN:2</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -14982,9 +14978,22 @@
 			<roles>recon</roles>
 			<availability>LA:4,ROS:4,MERC:2</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:2,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:2,RFS:5,MOC:2,CC:5,IS:3,WOB:3,DGM:6,MERC:5,CIR:2,Periphery:1,TC:2,CS:3,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
+		<model name='F-94'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='F-90'>
+			<availability>CS:2-,LA:2-,IS:4-,FS:2-,Periphery:4-</availability>
+		</model>
+		<model name='F-92'>
+			<availability>FWL:6,IS:4</availability>
+		</model>
 		<model name='F-90S'>
 			<roles>ground_support</roles>
 			<availability>LA:2</availability>
@@ -14992,29 +15001,17 @@
 		<model name='F-95'>
 			<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:3,PG:6,FWL:5,TP:6,RCM:6,DA:6,RFS:6</availability>
 		</model>
-		<model name='F-94'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='F-92'>
-			<availability>FWL:6,IS:4</availability>
-		</model>
-		<model name='F-90'>
-			<availability>CS:2-,LA:2-,IS:4-,FS:2-,Periphery:4-</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -15022,11 +15019,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15038,62 +15038,68 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4,FWL:4,FS:5,MERC:4,DC:7</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:2+</availability>
-		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:2+</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striga' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='S-STR-OB Infernus'>
+		<model name='S-STR-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OE Eminus'>
+		<model name='S-STR-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OD Luminos'>
+		<model name='S-STR-OA Dominus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-STR-OE Eminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-STR-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
 		</model>
@@ -15105,23 +15111,17 @@
 			<roles>fire_support</roles>
 			<availability>FVC:3-,IS:3-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
+		<model name='(SRM)'>
+			<availability>FVC:3-,IS:3-</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,ROS:3,FS.DMM:8,FS:3</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>FVC:3-,IS:3-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,LA:6,ROS:6,FS:7,DC:5</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:3</availability>
-		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,LA:6,ROS:6,FS:7,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
@@ -15141,31 +15141,24 @@
 		<model name='STU-K5'>
 			<availability>FVC:4-,HL:1-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>ROS:5,FS:6</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>ROS:6,CLAN:8,FS:3,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
 			<availability>OA:1,LA:1,FS.DMM:1-</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:1,TC:1,Periphery:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>ROS:6,CLAN:8,FS:3,BAN:2</availability>
+		</model>
+		<model name='STU-D7'>
+			<availability>ROS:5,FS:6</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:1,TC:1,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>PR:4,HL:2,WOB:3,MERC:2,FS:4,CWIE:4,Periphery.R:3,CDS:3,LA:6,ROS:4,PG:4,CNC:4,RFS:4</availability>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:5,WOB:0</availability>
-		</model>
 		<model name='(WoB)'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
@@ -15173,9 +15166,20 @@
 		<model name='(Heavy Gauss)'>
 			<availability>PR:3,LA:6,PG:3,CNC:6,RFS:3,CWIE:6</availability>
 		</model>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:5,WOB:0</availability>
+		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,WOB:4</availability>
+		<model name='(WOB)'>
+			<roles>recon,fire_support</roles>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
@@ -15183,10 +15187,6 @@
 		<model name='(Standard)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(WOB)'>
-			<roles>recon,fire_support</roles>
-			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Suffren Destroyer' unitType='Warship'>
@@ -15201,12 +15201,6 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
 		</model>
@@ -15215,6 +15209,12 @@
 		</model>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,CBS:6,General:2,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
@@ -15225,8 +15225,12 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,FS:5,MERC:3,DC:7</availability>
-		<model name='SD1-OX'>
-			<availability>General:2</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OE'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
@@ -15235,36 +15239,32 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:2+,CLAN:6,DC:2+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
+		<model name='SD1-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CDS:4,CW:5,CNC:9,CLAN:1,CGB:3,CWIE:5</availability>
-		<model name='2'>
-			<availability>CNC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CNC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -15294,15 +15294,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -15310,19 +15310,15 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>CS:4,ROS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:5,CLAN:8</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>CS:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CSR:2,CDS:2</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
@@ -15331,15 +15327,19 @@
 			<roles>recon</roles>
 			<availability>CSR:1</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>WOB:3,DC:5</availability>
+		<model name='TSH-8S'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Taihou Assault Dropship' unitType='Dropship'>
@@ -15363,54 +15363,54 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:4,MERC:3</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(RL)'>
+		<model name='2'>
 			<availability>MOC:4</availability>
 		</model>
-		<model name='2'>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(RL)'>
 			<availability>MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DoO:6,IS:1,WOB:4,DO:6,DGM:6,MERC:4,CS:3,DTA:6,SC:6,FVC:1,MCM:6,ROS:4,FWL:6,TP:6,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>CC:5,FVC:3,ROS:5,FWL:5,IS:3,MERC:5,DC:5</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:7,SC:6,FVC:2,DoO:6,MCM:6,ROS:6,IS:2,DO:6,DGM:6,TP:6,MERC:5,DC:7</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,ROS:5,General:1,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>DoO:6,IS:2,DGM:6,DO:6,MERC:4,DTA:7,SC:6,FVC:2,MCM:6,ROS:5,FWL:7,TP:6,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,ROS:5,General:1,FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>CC:5,FVC:3,ROS:5,FWL:5,IS:3,MERC:5,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:4,CGB.FRR:4,CNC:4,DC:5</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OE'>
+			<availability>General:4</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OE'>
-			<availability>General:4</availability>
 		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
@@ -15425,112 +15425,112 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>PR:8,DoO:8,WOB:6,DO:8,DGM:8,MERC:4,DTA:8,SC:8,FWL.MM:8,MCM:8,ROS:5,PG:8,FWL:8,TP:8,RFS:8</availability>
-		<model name='TMP-3M'>
-			<availability>HL:6,ROS:4,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>SC:4,PR:4,MCM:4,ROS:4,PG:4,FWL:2,WOB:4,DGM:4,MERC:4,RFS:4</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,FWL:3,WOB:5,DO:6,DGM:6,TP:6</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>ROS:2,FWL:2,WOB:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>HL:6,ROS:4,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,FWL:3,WOB:5,DO:6,DGM:6,TP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:5</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OI'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OE'>
+		<model name='TLR1-OF'>
 			<roles>spotter</roles>
-			<availability>General:3</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OF'>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OE'>
 			<roles>spotter</roles>
-			<availability>General:2</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tengu Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:5</availability>
-		<model name='(Support)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(RL)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Plasma)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(VSP)' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='(Support)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='(ML)' mechanized='true'>
+		<model name='(VSP)' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(C3i)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(RL)' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(ML)' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>CS:6,WOB:5,DC:4</availability>
-		<model name='TSN-X-4'>
+		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
-			<availability>CS:1</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='TSN-1Cr'>
+		<model name='TSN-X-4'>
 			<roles>recon,spotter</roles>
-			<availability>CS:4,DC:4</availability>
+			<availability>CS:1</availability>
 		</model>
 		<model name='TSN-1C'>
 			<roles>recon,spotter</roles>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='TSN-C3M'>
+		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
-			<availability>DC:4</availability>
+			<availability>CS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -15538,11 +15538,11 @@
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TNS-6S'>
-			<availability>LA:4,IS:3</availability>
-		</model>
 		<model name='TNS-4T'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='TNS-6S'>
+			<availability>LA:4,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -15561,11 +15561,15 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:2,CLAN:3,IS:1+,CCO:3,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:3,CW:3,CNC:4,CJF:6,CGB:3</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
@@ -15573,38 +15577,38 @@
 		<model name='D'>
 			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,ROS:4,CLAN:5,NIOPS:3,WOB:3,BAN:5</availability>
+		<model name='(Clan)'>
+			<roles>artillery</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='(C3i)'>
 			<roles>artillery</roles>
 			<availability>CS:6,WOB:8</availability>
@@ -15613,68 +15617,64 @@
 			<roles>artillery</roles>
 			<availability>CS:4,ROS:8,NIOPS:8,WOB:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<roles>artillery</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,ROS:6,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+		<model name='THE-N1'>
+			<availability>CS:8,ROS:8,WOB:8</availability>
+		</model>
+		<model name='THE-N'>
+			<availability>CS:5,CLAN:3,NIOPS:3,BAN:3</availability>
+		</model>
 		<model name='THE-S'>
 			<availability>HL:3,Periphery.Deep:3,DC:1-,Periphery:5</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:1-</availability>
 		</model>
-		<model name='THE-N'>
-			<availability>CS:5,CLAN:3,NIOPS:3,BAN:3</availability>
-		</model>
 		<model name='THE-N2'>
 			<availability>ROS:8,WOB:8</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,ROS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:1,CLAN:1</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:3-,FVC:4-,HL:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:5-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:3</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:3-,FVC:4-,HL:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:3,PR:5,DoO:2,CLAN:4,DO:2,FS:3,CWIE:5,DC.GHO:5,SC:5,OA:4,CDS:3,CBS:3,FWL:5,NIOPS:8,MH:2,RFS:5,CGB:5,MOC:2,IS:3,WOB:7,DGM:5,CS:8,DTA:1,FVC:1,CW:5,LA:1,MCM:5,ROS:6,PG:5,CNC:3,TP:2,DA:5,RCM:1,CJF:5</availability>
+		<model name='THG-12E'>
+			<availability>CS:6,WOB:3</availability>
+		</model>
 		<model name='THG-11E'>
 			<availability>FRR:6,CLAN:6,IS:8,WOB:4,FS:8,BAN:8,DC.GHO:8,CS:4,OA:6,CGB.FRR:6,ROS:8,PG:8,FWL:8,NIOPS:4,DC:8</availability>
 		</model>
 		<model name='THG-11Eb'>
 			<availability>SC:5,MCM:5,ROS:5,CLAN:4,FWL:5,WOB:5,DGM:5,MERC:5,BAN:2</availability>
 		</model>
-		<model name='THG-10E'>
-			<availability>SC:3-,MOC:3-,PR:3-,MCM:3-,PG:3-,PIR:3-,FWL:3-,MH:3-,MERC:3-,DA:3-</availability>
-		</model>
-		<model name='THG-12E'>
-			<availability>CS:6,WOB:3</availability>
-		</model>
 		<model name='THG-13K'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='THG-10E'>
+			<availability>SC:3-,MOC:3-,PR:3-,MCM:3-,PG:3-,PIR:3-,FWL:3-,MH:3-,MERC:3-,DA:3-</availability>
 		</model>
 		<model name='THG-12K'>
 			<availability>ROS:5,WOB:4,DC:7</availability>
@@ -15682,10 +15682,6 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>HL:3,IS:4,Periphery.Deep:8,Periphery:4</availability>
-		<model name='TAV-2'>
-			<roles>artillery</roles>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:5,WOB:6</availability>
@@ -15693,6 +15689,10 @@
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='TAV-2'>
+			<roles>artillery</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
@@ -15703,15 +15703,15 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,CLAN:1,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:5</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4</availability>
@@ -15719,30 +15719,30 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5,CGS:2,CGB:1</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6,CGS:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,PR:4,PG:4,MERC:4,DA:4,RFS:4,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-1L'>
-			<availability>General:7</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-C4'>
 			<availability>CC:2,MOC:2,CC.LCC:3</availability>
+		</model>
+		<model name='THR-1L'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
@@ -15753,13 +15753,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:8,FRR:6,CGB.FRR:6,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:8,FRR:6,CGB.FRR:6,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -15768,44 +15768,53 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:6,HL:3,CLAN:1,IS:5,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='TDR-1C'>
-			<availability>CC:3-,MOC:3-,LA:3-,MERC:3-,TC:3-</availability>
-		</model>
-		<model name='TDR-60-RLA'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,MERC.ELH:8,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MERC:6,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:5,LA:6,FS:4,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,WOB:4,MERC:4,FS:2</availability>
-		</model>
-		<model name='TDR-9T'>
-			<availability>TC:3</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:3-,HL:1-,LA:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CS:6,CC:5,FWL:7,IS:1,WOB:6,MERC:5</availability>
+		</model>
+		<model name='TDR-17S'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='TDR-60-RLA'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,WOB:4,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9M'>
 			<availability>MOC:3,CC:3,DoO:4,WOB:3,DO:4,DGM:4,DTA:4,SC:4,MCM:4,PIR:2,FWL:4,MH:3,TP:4,DA:4</availability>
 		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:3-,HL:1-,LA:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,MERC.ELH:8,ROS:6,MERC:4,FS:4</availability>
+		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:3-,MERC:1-</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:6,CCC:6,LA:1,FS:1,CGS:6,DC:1</availability>
+		<model name='TDR-9T'>
+			<availability>TC:3</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:3-,MOC:3-,LA:3-,MERC:3-,TC:3-</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CLAN:1,TC:4</availability>
 		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
+		<model name='C'>
+			<availability>CSA:6,CCC:6,LA:1,FS:1,CGS:6,DC:1</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>WOB:2,FS:2,MERC:2</availability>
@@ -15813,30 +15822,21 @@
 		<model name='TDR-10M'>
 			<availability>ROS:6,FWL:3</availability>
 		</model>
-		<model name='TDR-17S'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MERC:6,FS:2</availability>
-		</model>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:7,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
+		<model name='TSG-9C'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='TSG-9DDC'>
 			<availability>CC.WHO:5</availability>
 		</model>
-		<model name='TSG-9C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
@@ -15876,15 +15876,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,FRR:3,CGB.FRR:3,CNC:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>FRR:5-,CGB.FRR:5-,DC:5-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,CNC:8,DC:5</availability>
 		</model>
@@ -15892,18 +15883,26 @@
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>FRR:5-,CGB.FRR:5-,DC:5-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,ROS:7,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
-		<model name='THK-53'>
-			<roles>escort</roles>
-			<availability>CS:2,NIOPS:1,WOB:2</availability>
+		<model name='CX-11'>
+			<availability>CS:2</availability>
 		</model>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
+		<model name='THK-63CS'>
+			<availability>CS:8,ROS:8,WOB:6</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -15915,18 +15914,16 @@
 		<model name='THK-63b'>
 			<availability>CLAN:1,BAN:1</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>CS:8,ROS:8,WOB:6</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
-		<model name='CX-11'>
-			<availability>CS:2</availability>
+		<model name='THK-53'>
+			<roles>escort</roles>
+			<availability>CS:2,NIOPS:1,WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CW:2</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -15935,6 +15932,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -15946,25 +15946,18 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2,MH:1</availability>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
 		</model>
 		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G14' mechanized='true'>
-			<availability>WOB:3</availability>
-		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,WOB:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
-		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
 		</model>
 		<model name='G17' mechanized='true'>
 			<availability>WOB:4</availability>
@@ -15974,6 +15967,13 @@
 		</model>
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='G14' mechanized='true'>
+			<availability>WOB:3</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -15985,11 +15985,11 @@
 	</chassis>
 	<chassis name='Toyama' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='TYM-1C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='TYM-1A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TYM-1C'>
+			<availability>General:4</availability>
 		</model>
 		<model name='TYM-1B'>
 			<availability>General:6</availability>
@@ -16017,17 +16017,17 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,PIR:1,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:3-,FWL:1</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
 		<model name='TR-13'>
 			<availability>CC:3-,HL:1-,IS:1-,MERC:3-,Periphery:4-</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:3-,FWL:1</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
@@ -16035,16 +16035,16 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
-		<model name='TR-11'>
-			<roles>recon</roles>
-			<availability>General:2</availability>
+		<model name='TR-13G'>
+			<roles>ground_support,assault</roles>
+			<availability>CC:3</availability>
 		</model>
 		<model name='TR-12'>
 			<availability>CC:6,MOC:3</availability>
 		</model>
-		<model name='TR-13G'>
-			<roles>ground_support,assault</roles>
-			<availability>CC:3</availability>
+		<model name='TR-11'>
+			<roles>recon</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>CC:4,MOC:5,General:6,TC:5</availability>
@@ -16068,21 +16068,8 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:3,CC:3,PR:6,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:2,LA:3,CGB.FRR:4,Periphery.MW:5,ROS:4,PG:6,Periphery.ME:5,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,CS:2-,MOC:5-,LA:2-,FWL:2-,IS:3-,NIOPS:2-,WOB:2-,FS:2-,MERC:3-,DC:2-,Periphery:5-</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:5,SC:4,PR:4,MCM:4,ROS:5,PG:4,FWL:2,NIOPS:5,WOB:5,DGM:4,MERC:4,RFS:4</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FRR:4,CGB.FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>SC:4,MCM:4,ROS:4,WOB:4,DGM:4</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:1-,IS:1-,Periphery.Deep:4,FWL:1-,MERC:1-,CDP:2,Periphery:1-,TC:2-</availability>
 		</model>
 		<model name='TBT-9K'>
 			<roles>fire_support</roles>
@@ -16092,57 +16079,67 @@
 			<roles>fire_support</roles>
 			<availability>TC:3</availability>
 		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FRR:4,CGB.FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>SC:4,MCM:4,ROS:4,WOB:4,DGM:4</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:5,SC:4,PR:4,MCM:4,ROS:5,PG:4,FWL:2,NIOPS:5,WOB:5,DGM:4,MERC:4,RFS:4</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:2-</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:1-,IS:1-,Periphery.Deep:4,FWL:1-,MERC:1-,CDP:2,Periphery:1-,TC:2-</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,CS:2-,MOC:5-,LA:2-,FWL:2-,IS:3-,NIOPS:2-,WOB:2-,FS:2-,MERC:3-,DC:2-,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
-		<model name='TRN-3V'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:3,CLAN:4,BAN:2</availability>
 		</model>
+		<model name='TRN-3V'>
+			<availability>WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7,MOC:7,MH:4,TC:7</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:5,TC:5</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:5</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:4</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:5</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:5,TC:5</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:5,TC:5</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Triton' unitType='ProtoMek'>
 		<availability>CGS:5</availability>
-		<model name='3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
@@ -16153,16 +16150,19 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,HL:8,CBS:5,CLAN:2,IS:9,Periphery.Deep:8,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>IS:3,DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -16202,9 +16202,6 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:4+,CWIE:2</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
 		</model>
@@ -16214,16 +16211,19 @@
 		<model name='2'>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Turhan Urban Combat Vehicle' unitType='Tank'>
 		<availability>CS:4,WOB:4,DC:3</availability>
-		<model name='(Original)'>
-			<roles>apc,urban</roles>
-			<availability>DC:3-</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>apc,urban,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>apc,urban</roles>
+			<availability>DC:3-</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc,urban</roles>
@@ -16232,60 +16232,60 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CNC:4,CJF:7,CLAN.HW:4</availability>
-		<model name='Z'>
-			<roles>spotter</roles>
-			<availability>CCO:2</availability>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
 		</model>
 		<model name='X'>
 			<roles>fire_support</roles>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
+		<model name='Z'>
+			<roles>spotter</roles>
+			<availability>CCO:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -16294,13 +16294,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -16312,75 +16312,75 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,FRR:2,CGB.FRR:2,CGB:5,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>FRR:8,CGB.FRR:8,CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>FRR:8,CGB.FRR:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CHH:3,CSR:3,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:1,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
-		<model name='F'>
-			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:4,CW:4,CGS:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6,CGS:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -16392,11 +16392,11 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:2,LA.SR:4</availability>
-		<model name='(3071)'>
+		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(3065)'>
+		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
@@ -16407,12 +16407,12 @@
 			<roles>mech_carrier</roles>
 			<availability>CS:8,LA:8,IS:6,WOB:8,FS:8</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>WOB:5</availability>
+		</model>
 		<model name='(2708)'>
 			<roles>mech_carrier</roles>
 			<availability>General:4,BAN:4</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -16428,6 +16428,31 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:5,IS:2,Periphery:2</availability>
+		</model>
+		<model name='UM-R60L'>
+			<roles>urban</roles>
+			<availability>CC:3-,FVC:2,Periphery:3</availability>
+		</model>
+		<model name='UM-R68'>
+			<roles>urban</roles>
+			<availability>CC:6,FS:6,DC:6</availability>
+		</model>
+		<model name='UM-R70'>
+			<roles>urban</roles>
+			<availability>CC:2,MOC:2,SC:2,MCM:2,FS.CMM:6,DGM:2,FS:4</availability>
+		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>CC:3-,HL:2-,General:1-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
 		<model name='UM-R80'>
 			<roles>urban,spotter</roles>
 			<availability>CC:3,MOC:3,FWL:2,WOB:3,MERC:2</availability>
@@ -16435,31 +16460,6 @@
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:5,Periphery:5</availability>
-		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:6,FS:6,DC:6</availability>
-		</model>
-		<model name='UM-R60L'>
-			<roles>urban</roles>
-			<availability>CC:3-,FVC:2,Periphery:3</availability>
-		</model>
-		<model name='UM-R60'>
-			<roles>urban</roles>
-			<availability>CC:3-,HL:2-,General:1-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='UM-R70'>
-			<roles>urban</roles>
-			<availability>CC:2,MOC:2,SC:2,MCM:2,FS.CMM:6,DGM:2,FS:4</availability>
-		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:5,IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -16475,10 +16475,6 @@
 			<deployedWith>IS</deployedWith>
 			<availability>CGB:2</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -16487,6 +16483,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -16516,41 +16516,41 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,ROS:4,WOB:4,FS:9,MERC:4,CDP:3,TC:3</availability>
-		<model name='VLK-QF'>
+		<model name='VLK-QD3'>
 			<roles>recon,fire_support</roles>
-			<availability>LA:1-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,ROS:4</availability>
+			<availability>ROS:4,WOB:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='VLK-QW5'>
 			<roles>recon,fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VLK-QD'>
+		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:5,LA:6,ROS:6,FS:7,MERC:6</availability>
+			<availability>FVC:4-,FS:3-,MERC:3-,CDP:4-,TC:3-</availability>
+		</model>
+		<model name='VLK-QS5'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:3,FS:3</availability>
 		</model>
-		<model name='VLK-QA'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4-,FS:3-,MERC:3-,CDP:4-,TC:3-</availability>
+			<availability>LA:1-,FS:2-,MERC:2-</availability>
 		</model>
-		<model name='VLK-QD1'>
+		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:3,ROS:4,WOB:3,FS:3,MERC:3,CDP:3,TC:3</availability>
+			<availability>FVC:5,LA:6,ROS:6,FS:7,MERC:6</availability>
 		</model>
 		<model name='VLK-QT2'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
-		<model name='VLK-QD3'>
+		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
-			<availability>ROS:4,WOB:3,FS:3,MERC:3</availability>
+			<availability>FVC:3,ROS:4,WOB:3,FS:3,MERC:3,CDP:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -16565,24 +16565,24 @@
 		<model name='D'>
 			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:3,General:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:3,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -16603,58 +16603,58 @@
 		<model name='VQR-7U'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='VQR-2B'>
+		<model name='VQR-7V'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='VQR-7V'>
+		<model name='VQR-2B'>
 			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:1</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Liao)'>
-			<availability>CC:3-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:7,MOC:8,FVC:4+,Periphery.CM:4+,Periphery.HR:4+,PIR:4+,MH:4+,CDP:4+,TC:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,DTA:5,PR:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:6</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>CC:2-,General:2-</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CC:1-,General:3-</availability>
 		</model>
+		<model name='(Liao)'>
+			<availability>CC:3-</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,DTA:5,PR:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:7,MOC:8,FVC:4+,Periphery.CM:4+,Periphery.HR:4+,PIR:4+,MH:4+,CDP:4+,TC:8</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:2</availability>
+		</model>
 		<model name='(Cell)'>
 			<availability>CC:4,LA:3,FWL:4,WOB:4,FS:3,MERC:4,DC:3</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:6</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
-		<model name='(2682)'>
+		<model name='(3056)'>
 			<roles>asf_carrier</roles>
-			<availability>General:4</availability>
+			<availability>IS:2,FS:8</availability>
 		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:2,CC:2</availability>
 		</model>
-		<model name='(3056)'>
+		<model name='(2682)'>
 			<roles>asf_carrier</roles>
-			<availability>IS:2,FS:8</availability>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -16674,77 +16674,77 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:2,LA:2,ROS:2,CWIE:2</availability>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:2</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,CGB.FRR:6,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='VTR-9B'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,HL:2,FRR:8,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>ROS:3,FS:2,MERC:2</availability>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:2</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:2</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
+		<model name='VTR-9Ka'>
+			<availability>ROS:3,FS:2,MERC:2</availability>
 		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,FRR:6,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,HL:2,FRR:8,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
+		<model name='VTR-9D'>
+			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='VTR-9A1'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:2-,CIR:2-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-9D'>
-			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,FRR:6,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
 		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:2</availability>
+		<model name='VTR-9S'>
+			<availability>LA:2-,CIR:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CS:6,FRR:7,CGB.FRR:7,WOB:4,CGB:5</availability>
-		<model name='VKG-2G'>
-			<availability>CS:5,FRR:6,CGB.FRR:6,CGB:6</availability>
-		</model>
 		<model name='VKG-3W'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='VKG-2F'>
-			<roles>fire_support</roles>
-			<availability>General:8,WOB:2</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
 			<availability>CS:4</availability>
+		</model>
+		<model name='VKG-2G'>
+			<availability>CS:5,FRR:6,CGB.FRR:6,CGB:6</availability>
+		</model>
+		<model name='VKG-2F'>
+			<roles>fire_support</roles>
+			<availability>General:8,WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -16760,14 +16760,11 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,FRR:1,CGB.FRR:1,MERC:4,TC:6</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
+		</model>
 		<model name='VND-1AA &apos;Avenging Angel&apos;'>
 			<availability>FRR:5,CGB.FRR:5,TC:1</availability>
-		</model>
-		<model name='VND-5L'>
-			<availability>CC:4,MOC:3,MERC:3,TC:2</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:7,MOC:5,TC:2</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,CGB.FRR:0,General:3</availability>
@@ -16775,14 +16772,17 @@
 		<model name='VND-3L'>
 			<availability>CC:6,MOC:4,General:4,TC:4</availability>
 		</model>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
+		<model name='VND-4L'>
+			<availability>CC:7,MOC:5,TC:2</availability>
 		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-5L'>
+			<availability>CC:4,MOC:3,MERC:3,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -16802,26 +16802,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:3,General:2,CJF:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CLAN:1,CGS:5,CJF:5</availability>
-		<model name='2'>
-			<availability>CLAN:1</availability>
+		<model name='5'>
+			<availability>CHH:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:2,CJF:5</availability>
@@ -16832,25 +16832,25 @@
 		<model name='3'>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:5</availability>
+		<model name='2'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:4,DC:5+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CNC:8</availability>
-		</model>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -16866,20 +16866,20 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:1,FRR:4,CGB.FRR:4,PIR:2,WOB:6,MERC:1,FS:2,DC:3</availability>
-		<model name='VNL-K100'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='VNL-K75N'>
-			<availability>LA:8,FRR:6,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:1</availability>
 		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,FRR:6,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
+		</model>
+		<model name='VNL-K100'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='VNL-K70'>
 			<availability>FRR:1,CGB.FRR:1,DC:1</availability>
-		</model>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -16887,38 +16887,38 @@
 		<model name='VLC-5N'>
 			<availability>General:1</availability>
 		</model>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>General:3,FS:8,CDP:3</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:3,MOC:5,FRR:4,IS:4,WOB:3,CIR:5,Periphery:5,TC:5,CS:3,LA:6,CGB.FRR:4,FWL:6,NIOPS:3</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>DoO:4,WOB:6,DO:4,TP:4,DA:5,RCM:5</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:3-,General:4-,FS:2-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:3,PIR:2,IS:2,FS:3-,CIR:2,Periphery:2,TC:2</availability>
-		</model>
-		<model name='VT-5M'>
-			<roles>anti_infantry</roles>
-			<availability>FRR:3,CGB.FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='VT-6C'>
 			<roles>anti_infantry</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='VT-5M'>
+			<roles>anti_infantry</roles>
+			<availability>FRR:3,CGB.FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>FVC:3-,General:4-,FS:2-</availability>
+		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:4,FRR:4,CGB.FRR:4,ROS:6,FS:4,MERC:4</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>DoO:4,WOB:6,DO:4,TP:4,DA:5,RCM:5</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -16930,29 +16930,29 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:3,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:5,CLAN:3,General:1,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CNC:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -16982,43 +16982,51 @@
 		<model name='(Standard)'>
 			<availability>CLAN:1</availability>
 		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CLAN:1,IS:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:1,CDS:5,CLAN:1</availability>
+		</model>
+		<model name='6'>
+			<availability>CSR:3,CGB:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:5,CHH:3,CDS:6,CSR:1,CNC:5,CCO:5,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='7'>
+			<availability>CSR:2</availability>
+		</model>
 		<model name='5'>
 			<availability>CDS:4,CLAN:1,IS:3</availability>
 		</model>
 		<model name='8'>
 			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
 		</model>
-		<model name='6'>
-			<availability>CSR:3,CGB:5</availability>
-		</model>
-		<model name='7'>
-			<availability>CSR:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:5,CHH:3,CDS:6,CSR:1,CNC:5,CCO:5,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CCC:1,CDS:5,CLAN:1</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CLAN:1,IS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
+		<model name='WHM-5L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:5</availability>
+		</model>
 		<model name='WHM-6L'>
 			<availability>CC:2-</availability>
 		</model>
-		<model name='WHM-9S'>
-			<availability>LA:5,ROS:4,WOB:3,MERC:4,CIR:3</availability>
+		<model name='WHM-6K'>
+			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-,DC:1-</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>PR:5,PG:5,FWL:3,WOB:4,RFS:5</availability>
+		<model name='WHM-8K'>
+			<availability>DC:5</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
+		</model>
+		<model name='WHM-6D'>
+			<availability>FVC:2-,FS:2-</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:4,PIR:3,IS:3,FS:4,MERC:3,TC:4</availability>
@@ -17026,47 +17034,39 @@
 		<model name='WHM-6R'>
 			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='WHM-6K'>
-			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-,DC:1-</availability>
-		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FVC:2-,FS:2-</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:6,CC:3,FVC:3,FRR:1,CGB.FRR:2,ROS:4,FWL:7,WOB:7,MERC:4,DC:2,Periphery:3</availability>
-		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
-		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:5</availability>
-		</model>
 		<model name='WHM-10T'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='C'>
-			<availability>LA:1+,FS:1+,DC:1+</availability>
+		<model name='WHM-8M'>
+			<availability>PR:5,PG:5,FWL:3,WOB:4,RFS:5</availability>
 		</model>
 		<model name='WHM-6Rb'>
 			<availability>CLAN:4,BAN:2,TC:4</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CS:6,CC:3,FVC:3,FRR:1,CGB.FRR:2,ROS:4,FWL:7,WOB:7,MERC:4,DC:2,Periphery:3</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:5,ROS:4,WOB:3,MERC:4,CIR:3</availability>
+		</model>
+		<model name='WHM-4L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:5,FS:4</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:4</availability>
@@ -17074,137 +17074,140 @@
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,CGB.FRR:5,ROS:6,FWL:5,MH:6,DC:4</availability>
+		<model name='H-9'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='H-7'>
 			<availability>HL:1-,IS:4-,Periphery:4-</availability>
+		</model>
+		<model name='H-7A'>
+			<availability>IS:3-,Periphery:3-</availability>
+		</model>
+		<model name='H-8'>
+			<availability>HL:4,LA:5,FS.CH:8,FRR:6,CGB.FRR:6,ROS:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='H-10'>
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-8'>
-			<availability>HL:4,LA:5,FS.CH:8,FRR:6,CGB.FRR:6,ROS:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='H-7A'>
-			<availability>IS:3-,Periphery:3-</availability>
-		</model>
 		<model name='H-7C'>
 			<availability>IS:2-,Periphery:2-</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-110'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,CIR:4,Periphery:6</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,DA:3,TC:3</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:3,MOC:3,WOB:4,TC:5</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:1-</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:5,FS:3,MERC:3</availability>
-		</model>
 		<model name='WSP-1K'>
 			<roles>recon</roles>
 			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:3-</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:5,LA:6,FS:5,MERC:3</availability>
 		</model>
+		<model name='WSP-3A'>
+			<roles>recon</roles>
+			<availability>OA:2</availability>
+		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:3,MOC:3,WOB:4,TC:5</availability>
+		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,DA:3,TC:3</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:3-</availability>
+		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='WSP-1L'>
+		<model name='WSP-1W'>
 			<roles>recon</roles>
-			<availability>CC:2-</availability>
+			<availability>MERC.WD:1-</availability>
 		</model>
-		<model name='WSP-1D'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>FVC:2,FS:2-</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-1'>
 			<roles>recon</roles>
 			<availability>CC:3-,MOC:3-,FWL:3-,RCM:3-</availability>
 		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:5,FS:3,MERC:3</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:2-</availability>
+		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:3,PIR:3,WOB:3,DA:3,TC:3</availability>
 		</model>
-		<model name='WSP-3A'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>OA:2</availability>
+			<availability>FVC:2,FS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:7,FS:8,MERC:4,CDP:5,DC:4</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CS:1,CSR:1,CJF:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='White Flame' unitType='Mek'>
 		<availability>WOB.SD:6,WOB:4</availability>
-		<model name='WHF-3B'>
-			<availability>WOB:8</availability>
+		<model name='WHF-4C'>
+			<roles>spotter</roles>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='WHF-3C'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='WHF-4C'>
-			<roles>spotter</roles>
-			<availability>WOB:3</availability>
+		<model name='WHF-3B'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='White Tip Submarine' unitType='Naval'>
@@ -17215,8 +17218,8 @@
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:1,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:5</availability>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,MH:5</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -17229,26 +17232,23 @@
 			<roles>fire_support</roles>
 			<availability>CS:8,OA:6,MH:6,FS:1,MERC:3,CDP:6,DC:1,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,MH:5</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:4,LA:4,CNC:2-,FWL:4,MERC:4,DC:7</availability>
-		<model name='WGT-2LAW'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WGT-4NC &apos;Dezgra&apos;'>
-			<availability>CNC:8</availability>
+		<model name='WGT-2LAWC3'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAWC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-4NC &apos;Dezgra&apos;'>
+			<availability>CNC:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>LA:6,FWL:6,MERC:6,DC:7</availability>
@@ -17258,6 +17258,9 @@
 		</model>
 		<model name='WGT-3SC'>
 			<availability>CC:8,LA:4,FWL:4,MERC:4</availability>
+		</model>
+		<model name='WGT-2LAW'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -17269,11 +17272,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>FRR:3,CGB.FRR:3,ROS:3,WOB:3,MERC:3,DC:5-</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>ROS:6,WOB:6</availability>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:6,DC:4</availability>
 		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
@@ -17281,57 +17281,49 @@
 		<model name='WFT-C'>
 			<availability>FRR:4,CGB.FRR:4,DC:4</availability>
 		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:6,DC:4</availability>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>ROS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,DoO:3,FRR:5,DO:3,DGM:3,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:3,LA:7,MCM:3,CGB.FRR:5,ROS:5,FWL:2,MH:4,TP:3</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:1,CWIE:2</availability>
-		</model>
-		<model name='WLF-1'>
-			<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,ROS:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
 		</model>
 		<model name='WLF-3M'>
 			<availability>DTA:8,SC:8,DoO:8,MCM:8,FWL:8,DO:8,DGM:8,TP:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,ROS:4,FRR:6,CGB.FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
-		</model>
 		<model name='WLF-2H'>
 			<availability>LA:2,MERC:1,CWIE:2</availability>
 		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:5,LA:4,ROS:4,MERC:3,FS:3,CWIE:4</availability>
+		<model name='WLF-1'>
+			<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,ROS:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:1</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:1,CWIE:2</availability>
+		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,ROS:4,FRR:6,CGB.FRR:6,FS:2,MERC:6</availability>
 		</model>
 		<model name='WLF-1A'>
 			<availability>MERC.KH:1</availability>
 		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:5,LA:4,ROS:4,MERC:3,FS:3,CWIE:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:3,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CGB.FRR:3,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-9D'>
-			<roles>spotter</roles>
-			<availability>FS:5,MERC:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:5,CGB.FRR:5,ROS:4,CNC:6,MERC:3,DC:3</availability>
-		</model>
 		<model name='WVR-9W2'>
 			<availability>IS:4,DC:5</availability>
 		</model>
@@ -17339,41 +17331,52 @@
 			<roles>recon</roles>
 			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:6</availability>
 		</model>
+		<model name='WVR-9D'>
+			<roles>spotter</roles>
+			<availability>FS:5,MERC:4</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='WVR-8D'>
 			<availability>FS:5</availability>
 		</model>
 		<model name='WVR-9W'>
 			<availability>CS:3,WOB:5</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:5,PIR:4,Periphery.ME:5,FWL:3-,MH:4</availability>
+		<model name='WVR-8K'>
+			<availability>FRR:5,CGB.FRR:5,ROS:4,CNC:6,MERC:3,DC:3</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='WVR-8C'>
 			<availability>ROS:4,DC:5</availability>
 		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='WVR-9M'>
-			<availability>FWL:4</availability>
+			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:6,LA:6,ROS:4,WOB:4,FS:6</availability>
 		</model>
-		<model name='WVR-9K'>
-			<availability>DC:2</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:5,PIR:4,Periphery.ME:5,FWL:3-,MH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -17400,14 +17403,6 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>PR:3,DoO:3,FRR:5,CLAN:2,DO:3,FS:7,DC.GHO:5,SC:3,CGB.FRR:5,NIOPS:5,RFS:3,CC:3,IS:3,WOB:4-,DGM:3,MERC:5,CS:5,DTA:3,FVC:3,MCM:3,PG:3,ROS:5,TP:3,RCM:3,DA:3,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:3,CS:4,FRR:8,CGB.FRR:8,ROS:6,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
-		</model>
-		<model name='WVE-10N'>
-			<roles>urban</roles>
-			<availability>CS:5,WOB:4</availability>
-		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CGS:1</availability>
@@ -17416,9 +17411,17 @@
 			<roles>urban</roles>
 			<availability>CS:8,ROS:8,WOB:8</availability>
 		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:3,CS:4,FRR:8,CGB.FRR:8,ROS:6,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
+		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
 			<availability>IS:2-,DC:2-,Periphery:2-</availability>
+		</model>
+		<model name='WVE-10N'>
+			<roles>urban</roles>
+			<availability>CS:5,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -17430,14 +17433,14 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:5,LA:3,MERC:3,DC:3,TC:3</availability>
+		<model name='XNT-4O'>
+			<availability>CC:5,MOC:5,LA:5</availability>
+		</model>
 		<model name='XNT-2O'>
 			<availability>General:3-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:4,MOC:4,LA:4,MERC:4</availability>
-		</model>
-		<model name='XNT-4O'>
-			<availability>CC:5,MOC:5,LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -17449,24 +17452,18 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CSR:3,CLAN:5</availability>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>CS:6,FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>CS:4,IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -17474,8 +17471,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>CS:4,IS:3,FS:5</availability>
+		</model>
 		<model name='(PPC)'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -17503,18 +17506,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:4</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yurei' unitType='Mek'>
@@ -17539,61 +17542,52 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:7,DC.GHO:2,FRR:5,CGB.FRR:5,CLAN:4,WOB:7,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
+		<model name='(C3i)'>
 			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,CGB.FRR:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,ROS:4,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-114'>
-			<availability>CS:3-,CLAN:1,NIOPS:2-,WOB:3-</availability>
-		</model>
 		<model name='ZRO-CX-3'>
 			<availability>CS:2</availability>
 		</model>
 		<model name='ZRO-115'>
 			<availability>CS:8,ROS:8,WOB:8</availability>
 		</model>
+		<model name='ZRO-114'>
+			<availability>CS:3-,CLAN:1,NIOPS:2-,WOB:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:1,TC:4,Periphery.R:5,LA:10,CGB.FRR:4,ROS:5,PIR:4,MH:4</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:5,LA:8,FRR:6,CGB.FRR:6,PIR:6,MH:3,FS:1,MERC:6,CDP:6,TC:6</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>FVC:2-,LA:2-,FS:2-</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4,WOB:8</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:5,MERC:4</availability>
@@ -17601,20 +17595,29 @@
 		<model name='ZEU-6S'>
 			<availability>HL:3,General:2-,Periphery.Deep:2,Periphery:5</availability>
 		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:5,LA:8,FRR:6,CGB.FRR:6,PIR:6,MH:3,FS:1,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4,WOB:8</availability>
+		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:6,HL:2,IS:3,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:5</availability>
-		<model name='(LB-X)'>
-			<availability>WOB:6</availability>
+		<model name='(Liao)'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='(WoB)'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(Liao)'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='(LB-X)'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
@@ -17622,11 +17625,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CW:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -1138,31 +1138,31 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,LA:8,CGB.FRR:8,FWL:8,IS:6,FS:8,TC:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,General:4,Periphery.Deep:6,Periphery:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,LA:8,CGB.FRR:8,FWL:8,IS:6,FS:8,TC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>PR:4,DoO:4,DO:4,DGM:4,DTA:4,SC:4,MCM:4,PG:4,FWL:4,MSC:3,TP:4,RCM:4,DA:4,RFS:4</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1178,13 +1178,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:2,CCC:2,MERC.WD:1,CDS:1,CSR:3,CBS:1,ROS:1,CNC:5,CJF:5,RA:4,CWIE:2</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>ROS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>ROS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aerie PA(L)' unitType='BattleArmor'>
@@ -1216,11 +1216,11 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CSL:6,CJF:6</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
@@ -1258,6 +1258,16 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
@@ -1265,51 +1275,41 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:3,CNC:4,DC:6</availability>
-		<model name='AKU-2XK'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='AKU-2XC'>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,DC:5</availability>
 		</model>
 		<model name='AKU-2X'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='AKU-2XC'>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='AKU-2XK'>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,CW:2,LA:6,ROS:4,CNC:4,NIOPS:7,FS:5,MERC:2,CWIE:6,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>LA:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>DTA:5,SC:5,DoO:5,MCM:5,ROS:4,FWL:5,DO:5,DGM:5,MSC:4,TP:5,MERC:2</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,MERC:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,DO:6,DGM:6,MSC:6,TP:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,MERC:8</availability>
 		</model>
 		<model name='ALB-3Ur'>
 			<availability>ROS:4,FWL:4,MERC:4</availability>
@@ -1317,11 +1317,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CGB:5</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:2</availability>
@@ -1329,23 +1329,23 @@
 	</chassis>
 	<chassis name='Angerona Scout Suit' unitType='BattleArmor'>
 		<availability>ROS:3+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Recon)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CSA:6,CHH:6,CSR:2,CBS:6,CLAN:2,RA:3</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,CGB:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,CGB:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1356,20 +1356,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:3,CHH:3,CSR:3,MERC:3,CCO:2,CWIE:4,BAN:2,RA:3,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
-		<model name='C 2'>
-			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
-		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:3,ROS:3,MERC:3,CWIE:5</availability>
 		</model>
-		<model name='ANH-2A'>
-			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5,CHH:4,LA:5,ROS:5,MERC:5,CWIE:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,IS:3,BAN:3</availability>
 		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5,CHH:4,LA:5,ROS:5,MERC:5,CWIE:4</availability>
+		<model name='ANH-2A'>
+			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		</model>
+		<model name='C 2'>
+			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1388,11 +1388,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:5,MOC:6,DA:2,TC:3</availability>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
+		</model>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-4C'>
 			<availability>CC:2,MOC:2</availability>
@@ -1404,40 +1404,36 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>PR:6,DoO:6,DO:6,DGM:6,MERC:4,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,MSC:4,TP:6,DA:6,RFS:6</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
+		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,SC:5,PR:5,DoO:5,MCM:5,PG:5,DO:5,DGM:5,MSC:5,TP:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='ANV-5M'>
-			<availability>DTA:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='ANV-5Q'>
+			<availability>DTA:4,SC:4,PR:4,MCM:4,PG:4,DGM:4,MSC:4,RFS:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:4,MERC:4</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>ROS:1,FWL:3,MERC:1</availability>
 		</model>
-		<model name='ANV-5Q'>
-			<availability>DTA:4,SC:4,PR:4,MCM:4,PG:4,DGM:4,MSC:4,RFS:4</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,SC:8,MCM:8,Periphery.MW:1,ROS:4,Periphery.ME:1,FWL:8,MH:3,DGM:8,MSC:6,MERC:4,DC:6</availability>
-		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>CC:2,FWL:4,MERC:2,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>MCM:4,MSC:4</availability>
+		</model>
+		<model name='APL-1R'>
+			<roles>fire_support</roles>
+			<availability>CC:2,FWL:4,MERC:2,DC:3</availability>
 		</model>
 		<model name='APL-2S'>
 			<roles>fire_support</roles>
@@ -1446,6 +1442,10 @@
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -1461,14 +1461,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:3,CNC:5,MERC:3,FS:2,DC:2</availability>
+		<model name='2'>
+			<availability>General:4</availability>
+		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1479,21 +1479,21 @@
 	</chassis>
 	<chassis name='Arcadia' unitType='Dropship'>
 		<availability>CSR:2,CBS:6,RA:3</availability>
+		<model name='(3080)'>
+			<availability>CSR:5,RA:8</availability>
+		</model>
 		<model name='(3066)'>
 			<roles>assault</roles>
 			<availability>CBS:8</availability>
 		</model>
-		<model name='(3080)'>
-			<availability>CSR:5,RA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Arcas' unitType='Mek'>
 		<availability>CDS:2,ROS:2,CGB:6</availability>
-		<model name='2'>
-			<availability>ROS:3,CGB:3</availability>
-		</model>
 		<model name='3'>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='2'>
+			<availability>ROS:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -1501,38 +1501,6 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:2-,Periphery:4,DC:5,CGB:2</availability>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:7,MOC:3</availability>
-		</model>
-		<model name='ARC-9W'>
-			<roles>fire_support</roles>
-			<availability>ROS:5</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
-		</model>
-		<model name='ARC-9KC'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:3,MERC:3</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:2</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:5</availability>
-		</model>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:1,TC:5,Periphery:4</availability>
-		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
@@ -1541,83 +1509,115 @@
 			<roles>fire_support</roles>
 			<availability>LA:5,ROS:4,FWL:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='C'>
+		<model name='ARC-6W'>
 			<roles>fire_support</roles>
-			<availability>CSA:6,CCC:6</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:8,MERC:4,CGB:3</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
-		</model>
-		<model name='ARC-4M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FVC:4,PIR:5,FWL:5,MERC:4,DC:4,Periphery:2</availability>
+			<availability>FVC:4,HL:1,TC:5,Periphery:4</availability>
 		</model>
 		<model name='ARC-2K'>
 			<roles>fire_support</roles>
 			<availability>CGB.FRR:1-,DC:3-</availability>
 		</model>
+		<model name='ARC-9W'>
+			<roles>fire_support</roles>
+			<availability>ROS:5</availability>
+		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3</availability>
+		</model>
+		<model name='ARC-4M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FVC:4,PIR:5,FWL:5,MERC:4,DC:4,Periphery:2</availability>
+		</model>
+		<model name='ARC-9KC'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
+		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>MOC:3,DoO:5,DO:5,DGM:5,MERC:4,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,MSC:5,TP:5</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:8,MERC:4,CGB:3</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:7,MOC:3</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:3,MERC:3</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:2</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CCC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:3,ROS:2,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>MERC.KH:2,CNC:4,CWIE:6,CGB:3</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:1,MERC.WD:2,CWIE:4</availability>
-		<model name='A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:3</availability>
 		</model>
 		<model name='J'>
 			<availability>General:8</availability>
@@ -1625,11 +1625,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Attack Craft' unitType='Small Craft'>
@@ -1641,11 +1641,11 @@
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CW:8,CLAN:6,CCO:7,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
@@ -1653,38 +1653,22 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1692,33 +1676,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1727,13 +1727,13 @@
 			<roles>assault</roles>
 			<availability>FS:5</availability>
 		</model>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Refit)'>
 			<roles>assault</roles>
 			<availability>ROS:4,FS:2</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1742,22 +1742,22 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:2,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
 		<availability>ROS:5,DC:5</availability>
-		<model name='(3082)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(3062)'>
 			<roles>troop_carrier</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(3082)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1769,90 +1769,106 @@
 	</chassis>
 	<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CBS:4,CLAN:8</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Proto AC)'>
 			<roles>recon</roles>
 			<availability>CBS:3,CSL:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CDS:5,CSR:3,CW:5,ROS:3,CSL:8,CJF:3,RA:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:7,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:4,ROS:3,CLAN:1</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:5,Periphery:2,TC:2,RA.OA:1,OA:1,LA:4,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>PR:4,LA:2,PG:4,RFS:4,DC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:3,OA:4,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:7,Periphery:2,TC:3</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1-,MERC:0,DC:1-</availability>
 		</model>
 		<model name='AS7-K3'>
 			<availability>LA:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:4</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1-,MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:3,CNC:4,IS:2,CLAN.IS:3,Periphery:2,CWIE:4</availability>
-		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:3,FS:4,DC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>CGB.FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:4</availability>
 		</model>
 		<model name='AS7-D'>
 			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:3,CNC:4,IS:2,CLAN.IS:3,Periphery:2,CWIE:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:2,ROS:3,MERC:3</availability>
+		</model>
+		<model name='AS7-K4'>
+			<availability>PR:4,LA:2,PG:4,RFS:4,DC:2</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>CGB.FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:2,ROS:3,MERC:3</availability>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		<model name='AS7-C'>
+			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:3,OA:4,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:7,Periphery:2,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -1862,25 +1878,9 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1895,62 +1895,62 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:4,General:6,RA:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,CSR:5,General:7,CCO:8,RA:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5,CCO:6</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5,CCO:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,CSR:5,General:7,CCO:8,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CNC:4,IS:4,DC:6,CGB:3</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OR'>
-			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
 		<model name='AV1-OE'>
 			<availability>General:6</availability>
 		</model>
+		<model name='AV1-OR'>
+			<availability>General:3+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -1966,11 +1966,8 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-10KM'>
-			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4,DC:5</availability>
-		</model>
-		<model name='AWS-8Q'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='AWS-9Ma'>
+			<availability>DoO:3,DO:3,DGM:3,FS:3,MERC:3,DTA:3,SC:3,LA:3,MCM:3,ROS:3,FWL:3,MSC:3,TP:3</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:3,PIR:4,FWL:5,IS:4,MH:3,TC:3,Periphery:3</availability>
@@ -1978,17 +1975,20 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:5,HL:2,FWL:5,IS:5,MH:5,TC:5,Periphery:4</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DoO:3,DO:3,DGM:3,FS:3,MERC:3,DTA:3,SC:3,LA:3,MCM:3,ROS:3,FWL:3,MSC:3,TP:3</availability>
+		<model name='AWS-10KM'>
+			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4,DC:5</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>CDS:4,ROS:4,CGB.FRR:6,FS:4,CWIE:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CGB.FRR:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -2002,86 +2002,82 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:4,CGB.FRR:2,ROS:4,FS:2,MERC:1</availability>
+		<model name='AXM-4D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:5,ROS:4,FS:6,MERC:2</availability>
+		</model>
 		<model name='AXM-6T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-4D'>
-			<availability>FS:5</availability>
+		<model name='AXM-1N'>
+			<availability>FVC:5,LA:5,CGB.FRR:5,MERC:5,FS:5</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>FVC:1,LA:2,FS:1</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:5,LA:5,CGB.FRR:5,MERC:5,FS:5</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:5,ROS:4,FS:6,MERC:2</availability>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CSR:3,CJF:5,RA:4</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:3,RA:6</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>CSR:3,RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>CSR:3,RA:8</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:3,RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:3,CHH:2,CW:3,LA:1,ROS:2,CSL:2</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:4</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:2,MERC:4</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2093,11 +2089,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2105,15 +2097,23 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:6,OA:6,IS:6,CLAN.IS:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,IS:8</availability>
+		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>General:2</availability>
@@ -2124,41 +2124,53 @@
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4+</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:3,HL:1,LA:2,ROS:4,FWL:4,MERC:8,FS:4,DA:3,Periphery:2</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:3</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1,CSL:2</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2166,33 +2178,21 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank'>
@@ -2204,14 +2204,6 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -2224,14 +2216,6 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -2240,52 +2224,65 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='I'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,DGM:2-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,SC:2-,FVC:3-,OA:6-,LA:4-,MCM:2-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:1-,RFS:3-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:5-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:2-,OA:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>SC:2-,PR:2-,MCM:2-,PG:2-,DGM:2-,MSC:2-,RFS:2-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:4,CGB.FRR:3,MH:3,FS:6,MERC:5</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:5-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>RA.OA:1-,OA:1-,LA:2-,MERC:1-,CDP:1,TC:1-,Periphery:2-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:4,CGB.FRR:3,MH:3,FS:6,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:2-,OA:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,CGB.FRR:4,ROS:3,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
@@ -2294,6 +2291,9 @@
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:6</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2309,37 +2309,37 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:4,ROS:2+,CNC:5,CLAN:4,IS:2+,RA:5,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CSR:5,CNC:8,General:7,RA:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:3,CNC:3,CLAN:2,RA:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CSR:5,CNC:8,General:7,RA:8</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>CSR:2,General:1,RA:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:3,CNC:3,CLAN:2,RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2350,11 +2350,8 @@
 		<model name='H'>
 			<availability>CSA:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2362,8 +2359,11 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2386,11 +2386,11 @@
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
 		<availability>LA:2-,ROS:2,FS:6,MERC:4</availability>
-		<model name='BKX-7K'>
-			<availability>FS:3-,MERC:4-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>ROS:8,FS:8,MERC:3</availability>
+		</model>
+		<model name='BKX-7K'>
+			<availability>FS:3-,MERC:4-</availability>
 		</model>
 		<model name='BKX-1X'>
 			<availability>LA:8-,FS:3-</availability>
@@ -2398,32 +2398,24 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:1,LA:1,FWL:1,FS:1,Periphery:1,DC:1</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:2,DoO:3,CLAN:8,DO:3,DGM:3,FS:2,MERC:3,BAN:2,SC:3,MCM:3,MSC:3,TP:3,DC:2</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>SC:2,MCM:2,DGM:2,MSC:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:3-</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
-		</model>
-		<model name='BLR-1S'>
-			<availability>LA:1-</availability>
+		<model name='C'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='BLR-10S'>
 			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
+		<model name='BLR-4S'>
+			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
+		</model>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='BLR-1S'>
+			<availability>LA:1-</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:2,DoO:3,CLAN:8,DO:3,DGM:3,FS:2,MERC:3,BAN:2,SC:3,MCM:3,MSC:3,TP:3,DC:2</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:3</availability>
@@ -2431,35 +2423,43 @@
 		<model name='BLR-1G'>
 			<availability>IS:3-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:3-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:7</availability>
+		<model name='BLR-6X'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>DTA:5,DoO:5,ROS:4,DO:5,TP:5,DA:5,MERC:4</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:3-</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CC:1,LA:1,FWL:1,FS:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>SC:2,MCM:2,DGM:2,MSC:2</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>CGB.FRR:5,ROS:4,DC:5</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
-		</model>
-		<model name='BLR-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2481,12 +2481,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>CSA:7,CCC:7,General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2501,14 +2501,14 @@
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>ROS:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
@@ -2525,18 +2525,18 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:2,HL:3,IS:2,MERC:2,FS:4,Periphery:4,RA.OA:3,OA:3,CDS:5,LA:3,CGB.FRR:3,PIR:2,CNC:4,FWL:2,DC:5</availability>
-		<model name='(Kurita)'>
-			<availability>CLAN:6,IS:6,DC:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,DC:3</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,DC:3</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:6,IS:6,DC:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2564,25 +2564,25 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:4,CGB:5</availability>
-		<model name='BEO-12'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='BEO-14'>
 			<roles>recon</roles>
 			<availability>ROS:3</availability>
 		</model>
+		<model name='BEO-12'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>PR:5,LA:7,CGB.FRR:3,ROS:4,PG:5,FS:3,MERC:3,RFS:5</availability>
-		<model name='BRZ-A3'>
-			<availability>PR:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>PR:4,LA:6,ROS:6,PG:4,MERC:6,RFS:4</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:2</availability>
+		<model name='BRZ-A3'>
+			<availability>PR:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2590,63 +2590,69 @@
 		<model name='BSN-3K'>
 			<availability>General:8</availability>
 		</model>
+		<model name='BSN-5KC'>
+			<availability>ROS:5,DC:5</availability>
+		</model>
 		<model name='BSN-4K'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='BSN-5KC'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:3,CSR:2,CW:2,ROS:2+,IS:2+,CJF:2,RA:1,BAN:3,CWIE:3,CGB:2</availability>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,CGB.FRR:6,IS:4,FS:5,MERC:5,DC:8</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
@@ -2656,14 +2662,8 @@
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
 		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2674,8 +2674,8 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:5,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,SC:6,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,MSC:4,RFS:6,CGB:6,CSR:4,IS:4,DGM:6,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,LA:4,MCM:6,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>ROS:8</availability>
@@ -2683,38 +2683,38 @@
 		<model name='BL-6-KNT'>
 			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:5,Periphery:5,DC.GHO:4,RA.OA:6,OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
 		</model>
-		<model name='BL-12-KNT'>
-			<availability>ROS:6,FS:6</availability>
+		<model name='BL-6b-KNT'>
+			<availability>DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CJF:7,CCO:4</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>CJF:2</availability>
+		<model name='E'>
+			<availability>CLAN:6,CCO:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:6,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='X'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -2730,76 +2730,73 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:3-,MOC:3,RA.OA:4,FVC:5,OA:4,HL:3,FS:5,MERC:3,TC:3,Periphery:4</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:7,MERC:6</availability>
+		</model>
 		<model name='BJ-1'>
 			<availability>Periphery.Deep:8,Periphery:2</availability>
-		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>FVC:4,LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:7,MERC:6</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:3,ROS:4,FWL:5,IS:2,FS:6,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OU'>
+		<model name='BJ2-OX'>
 			<availability>General:2</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OX'>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
+		</model>
+		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>SC:4,PR:4,LA:6,MCM:4,ROS:3,PG:4,DGM:4,MSC:3,MERC:3,RFS:4</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>PR:2,LA:6,ROS:4,PG:2,RFS:2</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -2807,20 +2804,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CBS:4,CSL:5</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>CSA:7,General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -2832,26 +2832,26 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CBS:10</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CBS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:7</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -2882,22 +2882,22 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:1</availability>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='Prime'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
+		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2912,13 +2912,13 @@
 			<roles>fire_support</roles>
 			<availability>Periphery.Deep:8</availability>
 		</model>
-		<model name='BMB-05A'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RA.OA:8,OA:8</availability>
-		</model>
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='BMB-05A'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RA.OA:8,OA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -2930,20 +2930,20 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4</availability>
-		<model name='3'>
-			<availability>CHH:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
@@ -2957,15 +2957,6 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-X3'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-5'>
 			<availability>PIR:5</availability>
 		</model>
@@ -2974,6 +2965,15 @@
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X3'>
+			<availability>PIR:4</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LDT-X4'>
+			<availability>PIR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -2997,17 +2997,17 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(PPC)'>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:4,MOC:4,RA.OA:2,IS:2,FS:3</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3036,25 +3036,25 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:2-,CC:3-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:3-,General:8,FS:3-,MERC:3-,DC:3-</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:3-,General:8,FS:3-,MERC:3-,DC:3-</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3065,11 +3065,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:3,ROS:6,CNC:3,NIOPS:7,CJF:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>ROS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burrock' unitType='Mek'>
@@ -3090,17 +3090,17 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:3,FS:5,MERC:3</availability>
-		<model name='BSW-S2r'>
-			<availability>General:3</availability>
-		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:1</availability>
+		</model>
+		<model name='BSW-X2'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BSW-X2'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='BSW-S2r'>
+			<availability>General:3</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>MERC:4</availability>
@@ -3108,17 +3108,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:5,LA:4,FS:5,MERC:4</availability>
-		<model name='CES-4R'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>FVC:8,FS:4,MERC:4</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3134,11 +3134,11 @@
 	</chassis>
 	<chassis name='Canis' unitType='Mek'>
 		<availability>CDS:4,CCO:6,CJF:4</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carnivore Assault Tank' unitType='Tank'>
@@ -3155,13 +3155,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CDS:3,CSR:2,CW:1,CNC:5,CCO:1,CJF:1,RA:2,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3173,108 +3173,108 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
-		<model name='CTF-2X'>
-			<availability>CC:1-,MOC:1,FVC:1,MERC:1,TC:1</availability>
+		<model name='CTF-3LL'>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:4,MH:2,FS:4,MERC:2</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4,MERC:3</availability>
+		<model name='CTF-1X'>
+			<availability>General:3-,Periphery:4-</availability>
 		</model>
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>General:3-,Periphery:4-</availability>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:1-,MOC:1,FVC:1,MERC:1,TC:1</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,DoO:2,DO:2,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:2,DA:3,RCM:3,DC:6</availability>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:6,DC:8</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:3,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C6'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FVC:2,CLAN:6,MERC:2,Periphery:2,DC:4</availability>
 		</model>
 		<model name='CPLT-C5A'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FVC:2,CLAN:6,MERC:2,Periphery:2,DC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:6,DC:8</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,DoO:3,DO:3,TP:3,MERC:3,DA:3,RCM:3</availability>
 		</model>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:3,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CDS:5,CSR:3,CNC:5,RA:4,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
@@ -3282,58 +3282,58 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
-		<model name='(SRM)'>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:1,CBS:5+,RA:2</availability>
-		<model name='4'>
-			<availability>CBS:4</availability>
+		<model name='(Standard)'>
+			<availability>CSR:5,CBS:8,RA:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CSR:3,CBS:6,RA:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSR:5,CBS:8,RA:8</availability>
+		<model name='4'>
+			<availability>CBS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:3,CBS:4,CNC:6,CSL:5,RA:4</availability>
-		<model name='3'>
-			<availability>CSR:3,CBS:6,RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CNC:8,CSL:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CSR:3,CBS:6,RA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:6</availability>
@@ -3341,30 +3341,24 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='Commando'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='Commando'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:2-,Periphery.HR:2,FS:2-,MERC:2-,Periphery.OS:2,Periphery:2</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
@@ -3372,32 +3366,23 @@
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>LA:2-,Periphery.HR:2,FS:2-,MERC:2-,Periphery.OS:2,Periphery:2</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,DoO:2,DO:2,DGM:2,Periphery.OS:4,FS:8,MERC:2,CDP:3,Periphery:2,DTA:2,SC:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:1,TP:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:1-,FS:1-,MERC:1-</availability>
-		</model>
-		<model name='CN9-A'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:3-,Periphery.Deep:8,FS:1-,MERC:1-,Periphery:3-</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:4,HL:2,FS:3,MERC:5,Periphery:4</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:4</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CDP:2</availability>
 		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-AH'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:1-,FS:1-,MERC:1-</availability>
+		<model name='CN10-B'>
+			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-H'>
 			<availability>MH:6</availability>
@@ -3405,17 +3390,32 @@
 		<model name='CN9-D4D'>
 			<availability>DTA:3,SC:3,DoO:3,MCM:3,ROS:3,DO:3,DGM:3,MSC:3,TP:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:3</availability>
+		<model name='CN9-A'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:3-,Periphery.Deep:8,FS:1-,MERC:1-,Periphery:3-</availability>
 		</model>
 		<model name='CN9-D3'>
 			<availability>FVC:2,ROS:3,FS:3,MERC:3,CDP:2</availability>
 		</model>
-		<model name='CN10-B'>
-			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
+		<model name='CN9-D'>
+			<availability>FVC:4,HL:2,FS:3,MERC:5,Periphery:4</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:1-,FS:1-,MERC:1-</availability>
 		</model>
 		<model name='CN9-Da'>
 			<availability>DoO:3,DO:3,DGM:3,FS:2,MERC:2,Periphery:2,SC:3,FVC:2,MCM:3,ROS:2,FWL:2,MSC:3,TP:3</availability>
+		</model>
+		<model name='CN9-AH'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:1-,FS:1-,MERC:1-</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -3447,11 +3447,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3469,18 +3469,18 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,ROS:3,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='XII'>
+			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='X'>
+			<availability>General:8</availability>
+		</model>
 		<model name='XIVs'>
 			<availability>LA:3,ROS:4,FS:3,DC:3</availability>
-		</model>
-		<model name='XII'>
-			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -3488,6 +3488,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>HL:1,LA:6,IS:4,FS:6,Periphery:2</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -3497,118 +3501,114 @@
 			<roles>training</roles>
 			<availability>General:2-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>HL:1,LA:6,IS:4,FS:6,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,SC:2,CGB.FRR:4,FWL:2,NIOPS:5,MSC:1,RFS:2,CGB:3,CC:4,IS:2,DGM:2,MERC:1,DTA:2,FVC:2,LA:3,MCM:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
-		<model name='CHP-3N'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,LA:4,ROS:2,MERC:4,CGB:2</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>DC.GHO:2-,CHH:2,LA:4,NIOPS:4,MERC.SI:4,MERC:4,BAN:3,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-1N2'>
+			<availability>CC:4,LA:4,ROS:2,MERC:4,CGB:2</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CGB.FRR:3+,ROS:4,IS:3,NIOPS:4,MERC:2,BAN:4,Periphery:2,CGB:1</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>missile_artillery</roles>
+			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:2-,MOC:2-,RA.OA:2-,FVC:2,OA:2-,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:1,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='CGR-3K'>
+			<availability>CGB.FRR:3-,MERC:2-,DC:3-</availability>
+		</model>
 		<model name='CGR-2A2'>
 			<availability>MOC:5,RA.OA:10,FVC:5,OA:10,HL:2,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:2,MERC:3</availability>
+		</model>
+		<model name='CGR-1A9'>
+			<availability>RA.OA:3-,FVC:3-,OA:3-,Periphery:2-</availability>
 		</model>
 		<model name='CGR-SA5'>
 			<roles>urban</roles>
 			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CGR-3K'>
-			<availability>CGB.FRR:3-,MERC:2-,DC:3-</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:1,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
+		<model name='CGR-1L'>
+			<availability>CC:2-,FVC:3,Periphery:3</availability>
 		</model>
 		<model name='CGR-C'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='CGR-1A9'>
-			<availability>RA.OA:3-,FVC:3-,OA:3-,Periphery:2-</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:2,MERC:3</availability>
-		</model>
-		<model name='CGR-1L'>
-			<availability>CC:2-,FVC:3,Periphery:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:2,RA.OA:4,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:7,RFS:8,MOC:5,CC:2,DGM:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
-		<model name='F-13'>
-			<availability>CC:2,DoO:4,DO:4,DGM:4,FS:3,MERC:4,DTA:4,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,Periphery:1,DTA:2,SC:2,FVC:1,MCM:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2-,FVC:2,FWL:2-,MERC:2-,Periphery:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:3-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,FWL:3-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>CC:3,MOC:3,PR:8,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:1,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 		<model name='OF-17A-R'>
 			<roles>recon</roles>
 			<availability>SC:5,MCM:5,ROS:4,DGM:5,MSC:5</availability>
 		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,Periphery:1,DTA:2,SC:2,FVC:1,MCM:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
+		</model>
+		<model name='F-12-S'>
+			<availability>FWL:1-</availability>
+		</model>
 		<model name='F-14-S'>
 			<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2-,FVC:2,FWL:2-,MERC:2-,Periphery:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:3,MOC:3,PR:8,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:1,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='F-13'>
+			<availability>CC:2,DoO:4,DO:4,DGM:4,FS:3,MERC:4,DTA:4,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:2,CDS:3,LA:2,ROS:5,CNC:3,NIOPS:5,FS:2,RCM:2,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>ROS:2</availability>
 		</model>
@@ -3616,13 +3616,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>ROS:2</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:4,CDS:3,LA:4,ROS:3,FS:4,RCM:4,DC:4</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3633,63 +3633,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>PR:4,DoO:4,DO:4,FS:2,MERC:5,DTA:4,FVC:4,LA:6,ROS:4,PG:4,FWL:4,MH:4,TP:4,DA:4,RFS:4,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,OA:2,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:3,CDP:3,TC:3</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:7</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CSA:5,CSR:4,CBS:7,CNC:5,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,SC:5,MCM:5,PG:5,FWL:5,DGM:5,MSC:5,MERC:2,CDP:3,RFS:5,Periphery:3,DC:2</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,CGB.FRR:6,FWL:5,MERC:6,DC:6</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6,Periphery:3</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:4,IS:4</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>SC:6,PR:6,MCM:6,PG:6,FWL:7,DGM:6,MSC:6,RFS:6</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,CGB.FRR:6,FWL:5,MERC:6,DC:6</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -3716,20 +3716,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -3746,23 +3746,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -3770,14 +3770,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -3794,32 +3794,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3827,11 +3827,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3840,14 +3840,14 @@
 			<roles>marine</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>CDS:7,CW:4,CNC:7,CGB:4,CWIE:7</availability>
+		<model name='(Volk)' mechanized='true'>
+			<availability>CW:5</availability>
 		</model>
 		<model name='(Rache)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Volk)' mechanized='true'>
-			<availability>CW:5</availability>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>CDS:7,CW:4,CNC:7,CGB:4,CWIE:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -3855,20 +3855,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3880,10 +3880,6 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='V3'>
-			<roles>assault</roles>
-			<availability>LA:3,FS:3</availability>
-		</model>
 		<model name='Interceptor'>
 			<roles>assault</roles>
 			<availability>LA:1</availability>
@@ -3892,20 +3888,30 @@
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='V3'>
+			<roles>assault</roles>
+			<availability>LA:3,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>CSR:2,CW:5,CBS:2,CNC:5,RA:2,CGB:5</availability>
-		<model name='2'>
-			<availability>CSR:3,RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:3,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,PR:3,HL:1,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
 		<model name='CLNT-2-3U'>
 			<availability>CC:5,LA:2,General:6</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
@@ -3916,12 +3922,6 @@
 		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:8,MOC:4,TC:7</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>Periphery.Deep:8,NIOPS:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -3972,59 +3972,59 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>MOC:4,FVC:3,LA:8,CGB.FRR:6,MH:4,FS:2,MERC:5,CDP:4,TC:4</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:3,Periphery:2</availability>
-		</model>
-		<model name='COM-2Dr'>
-			<roles>recon</roles>
-			<availability>HL:3,LA:5,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>LA:3,ROS:8</availability>
+			<availability>LA:2-,MERC:1-,Periphery:2</availability>
 		</model>
 		<model name='COM-1A'>
 			<roles>recon</roles>
 			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
 		</model>
-		<model name='COM-3A'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:2-,MERC:1-,Periphery:2</availability>
+			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:3,Periphery:2</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,MERC:6</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>MOC:4,FVC:3,LA:8,CGB.FRR:6,MH:4,FS:2,MERC:5,CDP:4,TC:4</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>LA:3,ROS:8</availability>
+		</model>
+		<model name='COM-2Dr'>
+			<roles>recon</roles>
+			<availability>HL:3,LA:5,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>General:3-,Periphery.Deep:8,TC:3-,Periphery:3-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:7,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:4-,FVC:3-,General:2-,FS:4-,Periphery:3-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:7</availability>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CC:1,LA:1,FS:1</availability>
 		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:4-,FVC:3-,General:2-,FS:4-,Periphery:3-</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:5-</availability>
+		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
@@ -4038,13 +4038,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>CGB.FRR:4,IS:5,Periphery.Deep:6,Periphery:6,CGB:2</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:6,IS:3,DC:7</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Confederate C' unitType='Dropship'>
@@ -4056,13 +4056,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,NIOPS:6,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -4085,12 +4085,12 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:5</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
@@ -4119,50 +4119,50 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='CRX-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-OR'>
 			<availability>RA.OA:3,OA:3,CLAN:8</availability>
+		</model>
+		<model name='CRX-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:6,CCC:4,CLAN.IS:3,CSL:4,CCO:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>CSA:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,RA.OA:3,OA:3,LA:4,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
+		<model name='CSR-V12'>
+			<availability>IS:3-,Periphery.Deep:8,BAN:4,Periphery:3-</availability>
 		</model>
 		<model name='CSR-12D'>
 			<availability>FS:5</availability>
 		</model>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		</model>
 		<model name='CSR-V12b'>
 			<availability>ROS:4,CLAN:6,FS:4,MERC:2,BAN:2</availability>
 		</model>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,FS.AH:1-,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>IS:3-,Periphery.Deep:8,BAN:4,Periphery:3-</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
@@ -4189,11 +4189,11 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:1</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -4201,16 +4201,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CW:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -4218,8 +4217,9 @@
 		<model name='H'>
 			<availability>CSA:6,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -4237,29 +4237,29 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:1,CSR:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CBS:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CGB.FRR:6,ROS:8,CLAN:4,FWL:5,MERC:5,BAN:2,DC:6</availability>
+			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CGB.FRR:6,ROS:8,CLAN:4,FWL:5,MERC:5,BAN:2,DC:6</availability>
+		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
 		<availability>CC:2,DGM:3,FS:2,MERC:3,CWIE:5,SC:3,CDS:5,LA:3,CBS:5,MCM:3,ROS:3,CNC:4,MSC:2,CJF:5,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>SC:8,MCM:8,ROS:8,CLAN.IS:8,DGM:8,MSC:8,FS:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>SC:8,MCM:8,ROS:8,CLAN.IS:8,DGM:8,MSC:8,FS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CC:8,CDS:4,CBS:8,CNC:4,MERC:8,DC:8</availability>
@@ -4267,21 +4267,21 @@
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CDS:4,CSR:2,CBS:6,RA:3</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
@@ -4289,23 +4289,23 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:6,CSR:4,CLAN:5,RA:4,CWIE:6,DC.GHO:2,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:4,NIOPS:9,CJF:4,CGB:6</availability>
-		<model name='CRK-5004-1'>
-			<availability>CGB.FRR:4,ROS:6</availability>
+		<model name='CRK-5003-3'>
+			<availability>CGB.FRR:4,ROS:8</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>ROS:8</availability>
+		<model name='CRK-5003-1'>
+			<availability>ROS:4,CLAN:6,NIOPS:4,BAN:8</availability>
+		</model>
+		<model name='CRK-5004-1'>
+			<availability>CGB.FRR:4,ROS:6</availability>
 		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:3-,NIOPS:0</availability>
 		</model>
-		<model name='CRK-5003-1'>
-			<availability>ROS:4,CLAN:6,NIOPS:4,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-3'>
-			<availability>CGB.FRR:4,ROS:8</availability>
+		<model name='CRK-5005-1'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -4325,33 +4325,37 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:3,CDS:3,CW:3,CBS:5,CLAN:2,CNC:3,CCO:4,CJF:3,RA:4,CWIE:3,CGB:3</availability>
-		<model name='A'>
-			<availability>General:5</availability>
+		<model name='U'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='U'>
-			<availability>CLAN:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>CC:2,MOC:2,ROS:3,CNC:2,IS:1,FWL:2,MERC:3,DC:4</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
@@ -4360,51 +4364,47 @@
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>HL:4,CLAN:5,IS:6,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-8S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:3,MOC:3,FWL:8,FS:3,MERC:4,CDP:3,DC:3,TC:3</availability>
-		</model>
 		<model name='CRD-7W'>
 			<availability>DTA:5,SC:5,MCM:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,DGM:5,MSC:5,MERC:3,RCM:5</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>CGB.FRR:6,DC:5</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:5,MERC:5</availability>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:5,MERC:5</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:5,MERC:4</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:7</availability>
+		</model>
 		<model name='CRD-4L'>
 			<availability>CC:3,MOC:3</availability>
 		</model>
-		<model name='CRD-5K'>
-			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
+		<model name='CRD-8S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='CRD-3R'>
+			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:5,MERC:5</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>CGB.FRR:6,DC:5</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>FVC:3,ROS:5,CLAN:4,FWL:5,IS:3,MERC:5,BAN:2</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:5,MERC:5</availability>
+		<model name='CRD-5M'>
+			<availability>CC:3,MOC:3,FWL:8,FS:3,MERC:4,CDP:3,DC:3,TC:3</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4412,23 +4412,31 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>MOC:3,CGB.FRR:8,IS:3,MERC:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:7,DC:7</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>MOC:4,CC:5,LA:5,FWL:6,IS:5,MH:3,FS:6,CDP:4,DC:2,TC:4,Periphery:1</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>General:3-</availability>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:2,DC:2</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:5,MOC:4,IS:3+,MERC:5,DC:5</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:7,DC:7</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>MOC:3,CGB.FRR:8,IS:3,MERC:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -4437,28 +4445,20 @@
 		<model name='CP-11-H'>
 			<availability>FVC:5,HL:3,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:5</availability>
 		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:2,DC:2</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:3,MERC.WD:1,ROS:1,CWIE:3</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4471,25 +4471,25 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,HL:1,ROS:2,General:4,NIOPS:4,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>MOC:3,CDP:3,TC:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:4</availability>
-		<model name='(Gauss)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4501,35 +4501,35 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='DAI-01r'>
 			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -4549,14 +4549,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:5,DC:7,CGB:3</availability>
-		<model name='DMO-4K'>
-			<availability>DC:8</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:4</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>CGB.FRR:4,DC:6</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:4</availability>
+		<model name='DMO-4K'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -4565,27 +4565,26 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,CBS:4,ROS:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CCO:6</availability>
@@ -4593,8 +4592,9 @@
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4613,31 +4613,31 @@
 	</chassis>
 	<chassis name='Dark Crow' unitType='Mek'>
 		<availability>RA:3</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:3,FS:6,MERC:4</availability>
-		<model name='DRT-6T'>
-			<availability>LA:5,ROS:8,FS:5,MERC:5</availability>
-		</model>
 		<model name='DRT-3S'>
 			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='DRT-6T'>
+			<availability>LA:5,ROS:8,FS:5,MERC:5</availability>
 		</model>
 		<model name='DRT-4S'>
 			<availability>LA:3,MH:3,FS:4,MERC:4</availability>
@@ -4645,11 +4645,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:2,FS:7,CDP:3</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:5,General:5,CDP:3</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5,CDP:3</availability>
 		</model>
@@ -4661,25 +4664,15 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2,CDP:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
+			<availability>FVC:5,General:5,CDP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:4,CCC:2,MERC.WD:3,CDS:2,CLAN:2,IS:3+,CCO:1,CJF:3,BAN:3,CGB:6</availability>
-		<model name='H'>
-			<availability>CSA:6,CDS:5,CBS:4,General:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
@@ -4687,27 +4680,34 @@
 		<model name='K'>
 			<availability>General:2,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CDS:5,CBS:4,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
 		<availability>CDS:3,CSR:1,LA:3,ROS:2,CNC:3,IS:1,FS:3,RA:2,CGB:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,IS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -4721,15 +4721,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4,MOC:4,SC:3,MCM:3,DGM:3,MSC:2</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4744,11 +4744,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:5,MERC:4</availability>
-		<model name='DFN-3S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -4772,18 +4772,6 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,OA:9,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:2,IS:3,Periphery.Deep:6,Periphery:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,MOC:7,LA:8,CGB.FRR:6,ROS:8,FWL:8,IS:7,FS:8,DC:8,TC:7,CWIE:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,HL:1,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
@@ -4791,8 +4779,20 @@
 		<model name='(MRM)'>
 			<availability>FVC:4,HL:1,DC:7,Periphery:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,MOC:7,LA:8,CGB.FRR:6,ROS:8,FWL:8,IS:7,FS:8,DC:8,TC:7,CWIE:4</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:2,IS:3,Periphery.Deep:6,Periphery:4</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
+		</model>
+		<model name='(Defensive)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 	</chassis>
@@ -4802,11 +4802,11 @@
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>LA:4,ROS:4,CWIE:4</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:3,CWIE:3</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>LA:4,ROS:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -4842,23 +4842,23 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:1,CC:1,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,OA:1,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
-		<model name='DV-8D'>
-			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
-		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,IS:2-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:5,FS:6,MERC:3</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='DV-6Mr'>
 			<availability>General:2</availability>
 		</model>
 		<model name='DV-1S'>
 			<availability>IS:2-</availability>
+		</model>
+		<model name='DV-8D'>
+			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>CLAN:4,IS:2-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -4872,11 +4872,11 @@
 		<model name='DVS-3'>
 			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -4901,10 +4901,10 @@
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
 		<availability>PIR:1</availability>
-		<model name='(Reflective)&apos;Terrorizer&apos; (Flamer)' mechanized='true'>
+		<model name='(Reflective)&apos;Terrorizer&apos; (SL)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Reflective)&apos;Terrorizer&apos; (SL)' mechanized='true'>
+		<model name='(Reflective)&apos;Terrorizer&apos; (Flamer)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Reflective)&apos;Terrorizer&apos; (MG)' mechanized='true'>
@@ -4923,16 +4923,16 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Close Support)'>
-			<roles>spotter</roles>
-			<availability>CHH:6,CGB:4</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8,CJF:2</availability>
+		</model>
+		<model name='(Close Support)'>
+			<roles>spotter</roles>
+			<availability>CHH:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon Fire' unitType='Mek'>
@@ -4946,14 +4946,14 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,CGB.FRR:6,MERC:3,DC:4</availability>
-		<model name='DRG-7N'>
-			<availability>MERC:6,DC:6</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:2</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>HL:2,CGB.FRR:4,MERC:4,DC:4,Periphery:4</availability>
+		</model>
+		<model name='DRG-7N'>
+			<availability>MERC:6,DC:6</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
@@ -4961,12 +4961,12 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,MERC.WD:3,CHH:4,ROS:3+,CGB:5</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
@@ -4974,26 +4974,26 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:2</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:7,CHH:7,CCC:7,CDS:8,CSR:4,CBS:7,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
+		</model>
 		<model name='I'>
+			<availability>General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5006,17 +5006,17 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:3-,Periphery:2-,FVC:4-,LA:6,ROS:3,FWL:2-,CC.MAC:3-,DC:2-</availability>
-		<model name='(Standard)'>
-			<availability>CC:2-,General:3-</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>LA:3,ROS:3,FS:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CC:3-,General:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:2-,General:3-</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,FS:7</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:3,ROS:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5028,33 +5028,33 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:2,TC:4</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:6,MOC:2</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6b'>
-			<availability>SC:5,DoO:5,MCM:5,DO:5,DGM:5,MSC:5,TP:5,RCM:5</availability>
-		</model>
 		<model name='EGL-R11'>
 			<availability>PR:6,LA:5,ROS:6,PG:6,MERC:5,FS:3,RFS:6</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>General:4-</availability>
 		</model>
+		<model name='EGL-R6b'>
+			<availability>SC:5,DoO:5,MCM:5,DO:5,DGM:5,MSC:5,TP:5,RCM:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,PR:6,DGM:7,MERC:4,DTA:6,SC:7,MCM:7,PG:6,FWL:6,MH:4,MSC:5,DA:5,RFS:6</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
 		<model name='EGL-3M'>
 			<availability>DTA:4,SC:4,MCM:4,FWL:4,DGM:4,MSC:4</availability>
@@ -5066,13 +5066,13 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='MEB-9'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='MEB-11'>
 			<roles>recon</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='MEB-9'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -5080,11 +5080,11 @@
 		<model name='EFT-7X'>
 			<availability>IS:8,MH:5</availability>
 		</model>
-		<model name='EFT-4J'>
-			<availability>LA:1-,MERC:2-,Periphery:8</availability>
-		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='EFT-4J'>
+			<availability>LA:1-,MERC:2-,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5095,19 +5095,19 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:4,ROS:3,MERC:3</availability>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
-		</model>
 		<model name='EST-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='EST-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='EST-OC'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
 		</model>
-		<model name='EST-OA'>
+		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -5123,41 +5123,14 @@
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,MERC.WD:5,CW:5,CLAN:5,CNC:5+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CHH:1,CW:1,CJF:4</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2,RA:4</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2,RA:3</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CHH:1,CW:1,CJF:4</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2,RA:3</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CHH:1,CW:1,CJF:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -5165,43 +5138,66 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2,RA:4</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CHH:1,CW:1,CJF:4</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2,RA:3</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CHH:1,CW:1,CJF:4</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2,RA:3</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4</availability>
-		<model name='X' mechanized='true'>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X' mechanized='true'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:2,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:2,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:4</availability>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 		<model name='EMP-7L'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='EMP-6A'>
-			<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
+		<model name='EMP-6L'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='EMP-6S'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
+		<model name='EMP-6A'>
+			<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>LA:5-,ROS:2-,FS:2-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:5,MERC:5</availability>
@@ -5213,11 +5209,24 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,ROS:3,FS:7,MERC:5</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6G'>
+			<availability>ROS:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-7C3BS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6T'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:1</availability>
@@ -5225,34 +5234,21 @@
 		<model name='ENF-6Ma'>
 			<availability>FVC:3,FS:3,MERC:2</availability>
 		</model>
-		<model name='ENF-6T'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='ENF-6G'>
-			<availability>ROS:4,FS:2,MERC:4</availability>
-		</model>
-		<model name='ENF-7C3BS'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:6,MH:2,FS:6,MERC:3,CDP:2,TC:2</availability>
-		<model name='ENF-5D'>
-			<availability>FVC:8,FS:8,MERC:6,CDP:5,TC:5</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>FVC:3-,General:2-,FS:3-,TC:3-</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>FVC:8,FS:8,MERC:6,CDP:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -5261,28 +5257,36 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
 		<availability>CSA:4,CHH:6,CSR:2,CSL:5,CJF:3,RA:3,CGB:3,CWIE:3</availability>
-		<model name='(ER Pulse)'>
-			<availability>CHH:5</availability>
+		<model name='(LB-X) &apos;Sholef&apos;'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LB-X) &apos;Sholef&apos;'>
-			<availability>CHH:4</availability>
+		<model name='(ER Pulse)'>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGB:3+,CWIE:4+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -5292,10 +5296,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -5303,13 +5303,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CDS:2,CSR:1,ROS:1,CCO:1,RA:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -5318,12 +5318,12 @@
 			<roles>troop_carrier</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:4,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:3,FS:6</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5339,13 +5339,13 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
@@ -5361,27 +5361,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MERC:2</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
-		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5402,12 +5402,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>SC:6,MCM:6,ROS:5,DGM:6,MSC:6</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5418,10 +5418,10 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-9R'>
+		<model name='FLC-8R'>
 			<availability>General:5</availability>
 		</model>
-		<model name='FLC-8R'>
+		<model name='FLC-9R'>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
@@ -5434,13 +5434,13 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Standard)'>
-			<roles>cruiser</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cruiser</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
@@ -5455,62 +5455,62 @@
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='&apos;Longshot&apos;' mechanized='false'>
-			<availability>General:4</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='&apos;Longshot&apos;' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,MERC.KH:3+,CHH:2,CW:5,CJF:3,CWIE:5,CGB:2</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
@@ -5527,36 +5527,36 @@
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:3,HL:4,LA:4,ROS:3,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='&apos;Fermi&apos;'>
 			<roles>apc</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:4</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -5568,59 +5568,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5628,39 +5580,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -5675,19 +5679,15 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CSA:7,CLAN:6,IS:3</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-10D'>
-			<availability>LA:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-10D'>
+			<availability>LA:4,ROS:5,FS:4,MERC:4</availability>
 		</model>
 		<model name='ALM-8D'>
 			<roles>recon,raider</roles>
@@ -5716,11 +5716,19 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-S2'>
-			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		<model name='FS9-S1'>
+			<roles>recon</roles>
+			<availability>LA:4,General:3,FS:3</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S2'>
+			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:2,MOC:3,LA:5,CGB.FRR:3,General:3,FS:3,TC:2</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
@@ -5733,64 +5741,53 @@
 		<model name='FS9-S3'>
 			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:2,MOC:3,LA:5,CGB.FRR:3,General:3,FS:3,TC:2</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:4,General:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:4,LA:5,IS:3,FS:4,MERC:4,DC:7</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:2+,DC:2+</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:2+,DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:4</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -5800,44 +5797,47 @@
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:1,CLAN:2,DGM:5,DC.GHO:5,SC:5,CDS:1,LA:4,CBS:1,MCM:5,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:4,CJF:3,CGB:1,DC:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:5,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
-		</model>
 		<model name='FLS-9M'>
 			<availability>SC:8,MCM:8,FWL:6,DGM:8,MSC:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:5,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,CLAN.IS:4,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,CLAN.IS:4,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -5846,11 +5846,11 @@
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 		</model>
-		<model name='FLE-20'>
-			<availability>CC:4,MOC:1</availability>
-		</model>
 		<model name='FLE-17'>
 			<availability>CC:7,PR:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:4,MOC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -5861,8 +5861,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -5874,20 +5874,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -5916,17 +5916,17 @@
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
 		<availability>ROS:1,FS:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(VSP)'>
+		<model name='(Interdictor)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Interdictor)'>
+		<model name='(VSP)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -5964,10 +5964,6 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,ROS:4,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
@@ -5976,6 +5972,10 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CHH:3,CW:2,ROS:5,FS:5,MERC:2,CJF:2,CGB:3</availability>
@@ -5983,29 +5983,29 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>ROS:5,FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:8,FS:8,MERC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>ROS:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:7,PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:2-,General:8</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:7,PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
@@ -6025,24 +6025,24 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:2,CW:3,ROS:1,RA:2</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,ROS:8,CCO:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6053,28 +6053,28 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:2,LA:4,ROS:4,CNC:2,IS:2,FS:4,MERC:3,CDP:2,CWIE:2,TC:2</availability>
-		<model name='GLT-7-0'>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='GLT-8-0'>
 			<availability>ROS:3,FS:8,MERC:3</availability>
+		</model>
+		<model name='GLT-7-0'>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,RA.OA:3,OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,Periphery:4</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,RA.OA:3,OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -6082,35 +6082,35 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-,CWIE:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:1,MERC:1</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-,CWIE:8</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='GRM-01A2'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
 		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRM-01A2'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Garuda Heavy VTOL' unitType='VTOL'>
@@ -6122,55 +6122,55 @@
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,ROS:5,General:2,FS:8</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
 		<availability>CC:2,MOC:1,DoO:3,IS:1,DO:3,DGM:3,MERC:2,FS:2,TC:1,DTA:2,SC:3,FVC:2,LA:3,MCM:3,PIR:1,FWL:2,MH:1,MSC:2,TP:3,DC:2</availability>
-		<model name='GST-50'>
-			<availability>DTA:5,SC:5,DoO:5,MCM:5,DO:5,DGM:5,MSC:5,TP:5</availability>
-		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
 		</model>
 		<model name='GST-11'>
 			<availability>General:4</availability>
 		</model>
+		<model name='GST-50'>
+			<availability>DTA:5,SC:5,DoO:5,MCM:5,DO:5,DGM:5,MSC:5,TP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CDS:5,CSR:1,ROS:2+,CNC:5,CLAN:5,CJF:4,BAN:4,CGB:9</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='B'>
+			<availability>General:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CGB:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		</model>
 		<model name='P'>
 			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6210,6 +6210,10 @@
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
 		<availability>ROS:3,FS:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>FS:5</availability>
+		</model>
 		<model name='(Light Gauss)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
@@ -6218,27 +6222,23 @@
 			<roles>fire_support</roles>
 			<availability>FS:8</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>FS:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6250,24 +6250,16 @@
 	</chassis>
 	<chassis name='Goblin Infantry Support Vehicle' unitType='Tank'>
 		<availability>FVC:5,LA:2,ROS:3,FS:4,MERC:4</availability>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,FVC:2,LA:1-,FS:2-,TC:2-,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>CGB.FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FVC:5,FS:5</availability>
@@ -6276,12 +6268,17 @@
 			<roles>apc,urban</roles>
 			<availability>CC:2,FVC:4,LA:2,CGB.FRR:2,NIOPS:2,FS:4,DC:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>CGB.FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CGB:7</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>CGB:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
@@ -6292,44 +6289,47 @@
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,HL:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:2,FVC:2,OA:3,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-4S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,MOC:2,FWL:8,MH:2,MERC:6,CDP:4,TC:2</availability>
-		</model>
-		<model name='GOL-6M'>
-			<roles>fire_support</roles>
-			<availability>ROS:4,FWL:4,MERC:3</availability>
-		</model>
-		<model name='GOL-3L'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>HL:1,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='GOL-6M'>
+			<roles>fire_support</roles>
+			<availability>ROS:4,FWL:4,MERC:3</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
+		<model name='GOL-4S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>CC:2-,LA:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
-		<model name='GOL-2H'>
-			<roles>fire_support</roles>
-			<availability>HL:1,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
-		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>HL:1,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
@@ -6338,44 +6338,47 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:3,CBS:5,CNC:5,RA:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:3,CBS:6,RA:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:3,CBS:5,CNC:5,RA:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DoO:7,CLAN:3,DO:7,DGM:7,MERC:3,DTA:7,SC:7,CDS:4,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:5,TP:7</availability>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,HL:3,ROS:6,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,MERC:5,BAN:2,Periphery:5</availability>
 		</model>
-		<model name='GTHA-400'>
-			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>DTA:7,SC:7,DoO:7,MCM:7,ROS:7,DO:7,DGM:7,MSC:7,TP:7</availability>
 		</model>
+		<model name='GTHA-400'>
+			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:6,MERC:2,DC:8,CGB:3</availability>
-		<model name='DRG-1G'>
-			<availability>CGB.FRR:2-,DC:3-</availability>
-		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>CGB.FRR:6,ROS:6,CNC:8,MERC:5,DC:4,CGB:8</availability>
 		</model>
+		<model name='DRG-7K'>
+			<availability>ROS:6,MERC:4,DC:4</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>CGB.FRR:2-,DC:3-</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:5</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='DRG-9KC'>
 			<roles>spotter</roles>
@@ -6383,9 +6386,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>ROS:6,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -6402,26 +6402,26 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,OA:6,HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:5,TC:6</availability>
+		<model name='GHR-7P'>
+			<availability>LA:6,MERC:4</availability>
+		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='GHR-5J'>
-			<availability>HL:1,IS:6,Periphery:4</availability>
-		</model>
-		<model name='GHR-6K'>
-			<availability>CGB.FRR:4,ROS:4,MERC:2,FS:2,DC:4</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='GHR-7P'>
-			<availability>LA:6,MERC:4</availability>
 		</model>
 		<model name='GHR-5N'>
 			<availability>General:1-</availability>
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:3,DC:3</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>HL:1,IS:6,Periphery:4</availability>
+		</model>
+		<model name='GHR-6K'>
+			<availability>CGB.FRR:4,ROS:4,MERC:2,FS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Heavy Suit' unitType='BattleArmor'>
@@ -6442,14 +6442,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -6474,17 +6474,14 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
@@ -6493,26 +6490,32 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:6,CSR:1,CDS:2,CSL:6,CCO:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -6520,32 +6523,29 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,LA:3,CNC:7,IS:3,CCO:6,CJF:3,CWIE:4,DC:4</availability>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,IS:8,CCO:8</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CNC:3</availability>
 		</model>
-		<model name='6'>
-			<availability>ROS:4,CNC:6,DC:6</availability>
+		<model name='7'>
+			<availability>ROS:4,CNC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:6,CNC:4</availability>
 		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:5</availability>
+		<model name='6'>
+			<availability>ROS:4,CNC:6,DC:6</availability>
 		</model>
 		<model name='8'>
 			<availability>CW:5,LA:5,ROS:4,CJF:5,CWIE:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
@@ -6553,54 +6553,54 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-1S'>
-			<availability>LA:2-,MERC:2-</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CC:3,MOC:2,DoO:4,CLAN:6,DO:4,DGM:4,FS:3,MERC:4,BAN:4,SC:4,MCM:4,MH:3,MSC:4,TP:4,RCM:4,DC:3</availability>
+		<model name='GRF-1N'>
+			<availability>General:3-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:2-,MERC:2-,TC:3-</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,DO:6,DGM:6,MSC:6,TP:6,MERC:5</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>MOC:2,PR:6,DoO:5,IS:5,DO:5,DGM:5,FS:4,DTA:5,SC:5,LA:5,MCM:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CC:2,ROS:6,CGB.FRR:5,CNC:2,FWL:3,FS:3,DC:2,CGB:5</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:5,LA:3,CGB.FRR:3,ROS:4,FS:5,MERC:3,DC:4</availability>
+		<model name='GRF-6S'>
+			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CNC:6,DC:6</availability>
 		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,DO:6,DGM:6,MSC:6,TP:6,MERC:5</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:5,LA:3,CGB.FRR:3,ROS:4,FS:5,MERC:3,DC:4</availability>
+		</model>
+		<model name='GRF-1S'>
+			<availability>LA:2-,MERC:2-</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>MOC:2,PR:6,DoO:5,IS:5,DO:5,DGM:5,FS:4,DTA:5,SC:5,LA:5,MCM:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
+		</model>
 		<model name='GRF-4N'>
 			<availability>TC:4</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CC:2,ROS:6,CGB.FRR:5,CNC:2,FWL:3,FS:3,DC:2,CGB:5</availability>
 		</model>
 		<model name='GRF-5L'>
 			<availability>CC:5</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:3-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
+		<model name='GRF-2N'>
+			<availability>CC:3,MOC:2,DoO:4,CLAN:6,DO:4,DGM:4,FS:3,MERC:4,BAN:4,SC:4,MCM:4,MH:3,MSC:4,TP:4,RCM:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:5,MERC:8,DC:8</availability>
+		</model>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -6619,11 +6619,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,MERC:2,RCM:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CC:1,FWL:1,Periphery:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,MERC:2,RCM:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3,MERC:2,RCM:2</availability>
@@ -6631,30 +6631,30 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:2,CHH:2-,CW:4,LA:2,ROS:2,CNC:2-,CCO:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:4,CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4,IS:8,CCO:6,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:2,CSR:2,DGM:5,FS:5,MERC:3,RA:1,Periphery:2,DC.GHO:3,SC:5,MCM:5,ROS:6,FWL:5,NIOPS:7,MSC:5</availability>
-		<model name='GLT-6WB3'>
+		<model name='GLT-8D'>
 			<roles>raider</roles>
-			<availability>SC:6,MCM:6,ROS:3,DGM:6,MSC:6,MERC:3</availability>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>FWL:3-,Periphery.Deep:8,NIOPS:0,MERC:3-,Periphery:2-</availability>
 		</model>
-		<model name='GLT-8D'>
-			<roles>raider</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='GLT-6WB3'>
+			<roles>raider</roles>
+			<availability>SC:6,MCM:6,ROS:3,DGM:6,MSC:6,MERC:3</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -6667,22 +6667,22 @@
 			<roles>spotter</roles>
 			<availability>LA:6,General:3,FS:5,DC:5</availability>
 		</model>
-		<model name='GUN-1ERD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GUN-2ERDr'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
 		</model>
+		<model name='GUN-1ERD'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:5+,ROS:4,FS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6694,9 +6694,9 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CBS:3,CNC:5,IS:3,DC:4,CWIE:3</availability>
-		<model name='HKO-1C'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>LA:6,DC:6</availability>
+			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:3,CDS:3,LA:2+,ROS:4+,CNC:3,DC:2+</availability>
@@ -6704,20 +6704,20 @@
 		<model name='2'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='HKO-1C'>
 			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
+			<availability>LA:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,RA.OA:3,CHH:7,OA:4,LA:1,CBS:6,ROS:2,CLAN:5,FS:1,MERC:1</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:8,OA:7,CDS:4,CSR:3,RA:8,CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:8,OA:7,CDS:4,CSR:3,RA:8,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -6729,79 +6729,79 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>MOC:2,CC:2,FWL:6,MH:2,MERC:5</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,MERC:3</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,MERC:3</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,MERC:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:2,FS:4,MERC:3</availability>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
-		</model>
 		<model name='HMH-3D'>
 			<availability>General:3-,MERC:3-</availability>
-		</model>
-		<model name='HMH-5D'>
-			<availability>General:2,MERC:4</availability>
 		</model>
 		<model name='HMH-6E'>
 			<availability>General:5,MERC:5</availability>
 		</model>
+		<model name='HMH-5D'>
+			<availability>General:2,MERC:4</availability>
+		</model>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
-		<model name='HMR-HE'>
-			<availability>ROS:4,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>CSR:3,ROS:4,CLAN:4,RA:6,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>CSR:3,ROS:4,CLAN:4,RA:6,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>ROS:4,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,ROS:2+,CNC:5,CJF:4,CCO:3,CGB:3</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -6820,56 +6820,56 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,SC:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:4-,Periphery.MW:4-,FWL:5,MH:4,MSC:4,RFS:5,MOC:4,CC:4,IS:3-,DGM:5,MERC:4,Periphery:2-,DTA:5,LA:3,MCM:5,PG:5,Periphery.ME:4-,TP:5,DA:5,RCM:5,DC:3-</availability>
-		<model name='(MML)'>
-			<availability>MOC:2,CC:2,PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:2,SC:4,LA:2,MCM:4,PG:2,MSC:4,TP:4,RCM:2,DA:2,RFS:2</availability>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:3-</availability>
 		</model>
 		<model name='(LRM)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:3-</availability>
+		<model name='(MML)'>
+			<availability>MOC:2,CC:2,PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:2,SC:4,LA:2,MCM:4,PG:2,MSC:4,TP:4,RCM:2,DA:2,RFS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:3,CHH:6,CBS:2,CSL:6</availability>
-		<model name='(Standard)'>
-			<availability>CSA:4,CHH:4,CBS:4,CSL:4</availability>
+		<model name='3'>
+			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8,CBS:8,CSL:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CHH:6,CSL:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:4,CHH:4,CBS:4,CSL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:5,MERC:2,DC:6</availability>
-		<model name='HTM-28T'>
-			<availability>ROS:4,DC:3</availability>
+		<model name='HTM-27T'>
+			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:4</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
+		<model name='HTM-28T'>
+			<availability>ROS:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>CGB.FRR:2,DC:2</availability>
+		<model name='HTM-27U'>
+			<availability>General:2-</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaeru' unitType='Mek'>
@@ -6901,30 +6901,30 @@
 		<model name='HCT-6S'>
 			<availability>LA:7,MERC:6</availability>
 		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:2,FS:1,MERC:1,CDP:2</availability>
 		</model>
-		<model name='HCT-6M'>
-			<availability>DTA:8,SC:8,MCM:8,ROS:2,FWL:8,DGM:8,MSC:8,MERC:2</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:4,LA:4,CGB.FRR:4,FS:4,MERC:4,DC:2,Periphery:3</availability>
-		</model>
 		<model name='HCT-5DD'>
 			<availability>ROS:6,FS:6,MERC:6,CDP:3</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:6,ROS:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:3-,MERC:2-,Periphery:2-</availability>
 		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:4,LA:4,CGB.FRR:4,FS:4,MERC:4,DC:2,Periphery:3</availability>
+		</model>
 		<model name='HCT-6D'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-6M'>
+			<availability>DTA:8,SC:8,MCM:8,ROS:2,FWL:8,DGM:8,MSC:8,MERC:2</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:6,ROS:2,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
@@ -6942,18 +6942,14 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OD'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='HA1-OA'>
 			<availability>General:7</availability>
@@ -6961,14 +6957,18 @@
 		<model name='HA1-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HA1-OD'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,PR:5,DoO:5,IS:3,DO:5,DGM:5,FS:4,DTA:5,SC:5,LA:3,MCM:5,CGB.FRR:3,PG:5,FWL:5,MSC:4,TP:5,RCM:4,DA:3,RFS:5,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -6996,25 +6996,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7026,11 +7026,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,RA.OA:2+,OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -7061,23 +7061,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>ROS:2,FS:3,MERC:2</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,RA.OA:5,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>ROS:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7088,6 +7088,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7096,20 +7104,20 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7119,14 +7127,6 @@
 			<roles>apc,support</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:3,CSR:1,LA:2+,CNC:3,CSL:4,RA:2,CWIE:5</availability>
@@ -7134,12 +7134,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -7147,13 +7147,13 @@
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:3,MOC:3,IS:2,MERC:3</availability>
-		<model name='HEP-1H'>
-			<roles>artillery</roles>
-			<availability>CC:2-,MOC:2-,MERC:2-</availability>
-		</model>
 		<model name='HEP-4H'>
 			<roles>artillery</roles>
 			<availability>General:8,MERC:8</availability>
+		</model>
+		<model name='HEP-1H'>
+			<roles>artillery</roles>
+			<availability>CC:2-,MOC:2-,MERC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -7161,11 +7161,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7185,26 +7185,26 @@
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:3</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:1,CHH:3,CDS:2,ROS:1,DC.AL:1,CNC:6,CJF:3</availability>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
@@ -7215,25 +7215,25 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CBS:2,CNC:5,CSL:5,CCO:5,CJF:2</availability>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:4,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
@@ -7241,7 +7241,7 @@
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:3,ROS:3,FS:6,MERC:4</availability>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
@@ -7249,12 +7249,12 @@
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
@@ -7275,25 +7275,25 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7318,127 +7318,127 @@
 			<roles>recon</roles>
 			<availability>ROS:3-,FWL:2-,MERC:3-</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>SC:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>CC:3,MOC:3,FWL:4,MERC:3</availability>
-		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+			<availability>MOC:4,IS:4,MH:2</availability>
 		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:4,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5Sr'>
+		<model name='HER-2S'>
 			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:2</availability>
+			<availability>FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>SC:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>CC:3,MOC:3,FWL:4,MERC:3</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>DoO:8,DO:8,DGM:8,MERC:3,DC.GHO:6,SC:8,MCM:8,CGB.FRR:3,FWL:7,NIOPS:3,MSC:6,TP:8,DC:6</availability>
-		<model name='HER-3S2'>
-			<roles>recon,spotter</roles>
-			<availability>FWL:2</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:3-,CLAN:6,NIOPS:4,BAN:8</availability>
-		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:5</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:4,DC:8</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>SC:4,DoO:4,MCM:4,CGB.FRR:3,FWL:4,DO:4,DGM:4,MSC:4,TP:4</availability>
 		</model>
+		<model name='HER-3S2'>
+			<roles>recon,spotter</roles>
+			<availability>FWL:2</availability>
+		</model>
 		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:4,DC:8</availability>
+		</model>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>DC.GHO:3-,CLAN:6,NIOPS:4,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:1,Periphery:1,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:5-</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,PR:5,PG:5,DA:5,CDP:5,RFS:5,TC:6</availability>
 		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,PR:5,PG:5,DA:5,CDP:5,RFS:5,TC:6</availability>
-		</model>
-		<model name='(AC10)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CC:1,IS:1,Periphery:1</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
 		<availability>LA:1,IS:1</availability>
+		<model name='(Cunnington)'>
+			<roles>spotter</roles>
+			<availability>LA:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>LA:5,General:8</availability>
 		</model>
-		<model name='(Cunnington)'>
-			<roles>spotter</roles>
-			<availability>LA:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CHH:5,CDS:4,CW:6,LA:2,ROS:3,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CW:4</availability>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:4,CLAN:3,CNC:4,IS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:5,CW:3,ROS:4,CJF:5,CGB:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:4,CLAN:3,CNC:4,IS:8</availability>
+		<model name='2'>
+			<availability>CW:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:2,CC:3,LA:6,CLAN:4,IS:2,FWL:2,NIOPS:9,MH:2,MERC:4,FS:5,CJF:5,DC:2</availability>
-		<model name='HGN-734'>
-			<availability>LA:6,ROS:6,MERC:6</availability>
-		</model>
-		<model name='HGN-732b'>
-			<availability>LA:4,CLAN:4,IS:2,FWL:2,MH:4,FS:4,BAN:2</availability>
-		</model>
 		<model name='HGN-733'>
 			<availability>CC:2-,MOC:2-,:0,LA:2-,DC:2-</availability>
-		</model>
-		<model name='HGN-732'>
-			<availability>MOC:6,CC:4,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
 		</model>
 		<model name='HGN-738'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='HGN-732b'>
+			<availability>LA:4,CLAN:4,IS:2,FWL:2,MH:4,FS:4,BAN:2</availability>
+		</model>
+		<model name='HGN-732'>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
+		</model>
+		<model name='HGN-734'>
+			<availability>LA:6,ROS:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:4</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7446,7 +7446,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7472,11 +7472,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7494,12 +7494,12 @@
 			<roles>recon,urban</roles>
 			<availability>FVC:1-,IS:1-</availability>
 		</model>
+		<model name='HNT-171'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:2-</availability>
-		</model>
-		<model name='HNT-171'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -7534,14 +7534,14 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:4,CDS:7,CSR:5,CW:5,CJF:5,CGB:5,CWIE:4,RA:5</availability>
-		<model name='2'>
-			<availability>CSA:8,CBS:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:5,CSR:6,RA:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:2,General:8,RA:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:8,CBS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5,CCO:8,RA:8</availability>
@@ -7549,76 +7549,57 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:5</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6S'>
 			<availability>LA:5,ROS:5,MERC:5</availability>
 		</model>
+		<model name='HBK-4SP'>
+			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
+		</model>
 		<model name='HBK-4J'>
 			<availability>CC:1-,FWL:1-,MERC:1-,Periphery:1-</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:6,MERC:4</availability>
-		</model>
-		<model name='HBK-4H'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-5H'>
 			<availability>FVC:3,HL:1,MH:6,Periphery:4</availability>
 		</model>
-		<model name='HBK-4SP'>
-			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:1-,Periphery:2-</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:5</availability>
 		</model>
 		<model name='HBK-5S'>
 			<availability>LA:4,CGB.FRR:3,ROS:3,MH:3,MERC:2,FS:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:6,MERC:4</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6N'>
 			<availability>ROS:3,FWL:3,MH:4,MERC:4,DC:2</availability>
 		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:3-</availability>
-		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>PR:6,LA:8,ROS:6,PG:6,FS:6,RCM:5,MERC:5,DA:6,RFS:6</availability>
-		</model>
-		<model name='(LRM10)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='(Ammo)'>
 			<roles>fire_support</roles>
 			<availability>General:1-</availability>
@@ -7629,35 +7610,57 @@
 		<model name='(Amphibious)'>
 			<availability>LA:1,MERC:1</availability>
 		</model>
+		<model name='(LRM10)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>PR:6,LA:8,ROS:6,PG:6,FS:6,RCM:5,MERC:5,DA:6,RFS:6</availability>
+		</model>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:3-</availability>
+		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,FWL:4,MERC:6,TC:4</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>LA:3,CGB.FRR:5,ROS:4,CNC:4,MERC:3,FS:3,CGB:5,DC:3</availability>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:2+</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='HSCL-1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:2+</availability>
+		</model>
+		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OD'>
@@ -7666,18 +7669,15 @@
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:3,LA:2,CGB.FRR:1,ROS:3,CLAN:3,NIOPS:4,MERC:2,DC:1</availability>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,NIOPS:4,MERC.SI:4,BAN:8</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -7689,14 +7689,14 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:3,CLAN:4,RA:4</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -7704,13 +7704,13 @@
 		<model name='2'>
 			<availability>CHH:6,CSL:6</availability>
 		</model>
-		<model name='4'>
-			<roles>anti_infantry</roles>
-			<availability>CBS:4</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5</availability>
+		</model>
+		<model name='4'>
+			<roles>anti_infantry</roles>
+			<availability>CBS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CHH:6,CBS:6,CSL:6</availability>
@@ -7725,8 +7725,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:3,MOC:8,LA:2,ROS:4,FWL:3,IS:8,MH:8,FS:1,DC:1,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -7734,20 +7734,20 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='[SRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
 		<availability>FWL.pm:3,ROS:1,FWL:3,MH:1,MERC:1</availability>
-		<model name='ICR-1S'>
-			<availability>General:4-</availability>
-		</model>
 		<model name='ICR-2S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='ICR-1S'>
+			<availability>General:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus' unitType='Mek'>
@@ -7772,11 +7772,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:6,MERC.KH:8</availability>
-		</model>
 		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-4E'>
+			<availability>MERC.WD:6,MERC.KH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -7795,34 +7795,34 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CW:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
 		<availability>MERC:1,TC:1</availability>
-		<model name='&apos;Waddle&apos;' mechanized='true'>
-			<roles>recon</roles>
-			<availability>LA:6,FS:6,TC:6</availability>
-		</model>
 		<model name='(Special Ops)' mechanized='true'>
 			<roles>specops</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='&apos;Waddle&apos;' mechanized='true'>
+			<roles>recon</roles>
+			<availability>LA:6,FS:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -7831,13 +7831,13 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:2,LA:2,ROS:3,FWL:2,FS:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>assault</roles>
-			<availability>CC:8,ROS:6,FWL:8</availability>
-		</model>
 		<model name='(SCC)'>
 			<roles>assault</roles>
 			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>assault</roles>
+			<availability>CC:8,ROS:6,FWL:8</availability>
 		</model>
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
@@ -7846,39 +7846,39 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>PR:8,DoO:8,IS:1,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>PR:8,DoO:8,IS:1,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,CLAN:9,IS:7,Periphery.Deep:7,FS:9,BAN:6,Periphery:8,TC:8,RA.OA:8,OA:8,LA:9,CGB.FRR:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:4</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Fire)' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -7891,17 +7891,20 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,LA:1,ROS:2,CLAN:4,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CHH:7,CW:3,ROS:3,CJF:4,CWIE:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>CCC:6,CSR:4,CLAN:4,RA:5,CGB:6</availability>
+		<model name='2'>
+			<availability>CSR:3,RA:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
@@ -7909,12 +7912,14 @@
 			<roles>recon</roles>
 			<availability>CSR:2,RA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSR:3,RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,RA.OA:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -7925,11 +7930,6 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -7938,20 +7938,24 @@
 	</chassis>
 	<chassis name='J-37 Ordnance Transport' unitType='Tank'>
 		<availability>General:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>support</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>MOC:3-,DC.LV:4-,DC.GR:3-,FS.AH:3-,IS:3-,Periphery.Deep:5,FS:2-,Periphery:3-,TC:4-,RA.OA:3-,OA:2-,LA:3-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:3-</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -7961,34 +7965,26 @@
 			<roles>recon,raider</roles>
 			<availability>DC:8,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>HL:1,IS:2,TC:3,Periphery:2</availability>
-		<model name='(3082 Upgrade)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>TC:5</availability>
+		</model>
+		<model name='(3082 Upgrade)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
 		<availability>CC:4,LA:4,ROS:3,CGB.FRR:4,IS:3,FWL:4,FS:5,MERC:4,CJF:3,CGB:5,Periphery:2,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>IS:3,CGB:8,Periphery:6</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>ROS:5,FS:3,CJF:8</availability>
@@ -7996,6 +7992,10 @@
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>IS:3,CGB:8,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -8027,27 +8027,17 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>MOC:5,DTA:6,SC:6,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5,DGM:6,MSC:4,MERC:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>HL:6,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>DTA:5,SC:5,MCM:5,ROS:5,DGM:5,MSC:5,MERC:5</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>HL:6,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:2,CW:5,General:2,RA:4</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CSR:3,CW:4,CLAN:2,RA:6</availability>
@@ -8055,8 +8045,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:2,CW:5,General:2,RA:4</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8070,21 +8070,6 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:3-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,OA:2,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:2-,CGB.FRR:1-,IS:2-,FS:2-,Periphery:5</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:4,MERC:6</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
@@ -8093,24 +8078,59 @@
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
+		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,LA:2,ROS:2,CGB.FRR:2,FS:2,MERC:2,CDP:3,DC:2</availability>
 		</model>
-		<model name='JM7-C3BS'>
+		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:6</availability>
+			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>MOC:3,RA.OA:5,FVC:5,OA:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:2-,CGB.FRR:1-,IS:2-,FS:2-,Periphery:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,OA:1,LA:1,Periphery.HR:4,ROS:4</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:4,MERC:6,CDP:6,TC:6</availability>
@@ -8119,83 +8139,67 @@
 			<roles>recon</roles>
 			<availability>FS:5</availability>
 		</model>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
+		<model name='X'>
+			<availability>CSR:1,General:1,CJF:2,RA:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='X'>
-			<availability>CSR:1,General:1,CJF:2,RA:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='E'>
+			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:6,ROS:4,CNC:8,CCO:5,DC:3</availability>
-		<model name='3'>
-			<availability>CCC:6,CNC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CNC:4,CLAN:1</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:7,CNC:8,IS:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CCC:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:4,CNC:4,CLAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:3,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
-		<model name='JR7-C4'>
-			<roles>raider</roles>
-			<availability>DC:3</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>ROS:4,DC:5</availability>
+		</model>
+		<model name='JR7-C4'>
+			<roles>raider</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -8205,17 +8209,9 @@
 			<roles>raider</roles>
 			<availability>MERC:6,FS:6,DC:5</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8223,6 +8219,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -8235,11 +8235,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -8258,26 +8258,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -8295,26 +8295,42 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:2,DC:6</availability>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 		<model name='C' mechanized='true'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>ROS:2,DC:2</availability>
 		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
@@ -8324,29 +8340,13 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -8358,36 +8358,36 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.NSR:6,DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>CGB:5</availability>
+		<model name='C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -8399,30 +8399,34 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:2,PIR:2,IS:3,Periphery.Deep:4,Periphery:3,RA:2</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:5,MERC:5</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:4,RA.OA:5,FVC:4,OA:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
-		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:3</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:8,Periphery.Deep:2,Periphery:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>FWL:5,IS:6</availability>
 		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:4,RA.OA:5,FVC:4,OA:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:8,Periphery.Deep:2,Periphery:6</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>MH:5,MERC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,CGB.FRR:2,DC:6</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>CGB.FRR:8,DC:3-</availability>
 		</model>
@@ -8432,13 +8436,16 @@
 		<model name='CRK-5003-C'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:3,LA:3,CGB.FRR:2,ROS:2,CLAN:3,FS:3,DC:2</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -8446,30 +8453,29 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,FVC:2,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:2,CGB:3,DC:4</availability>
-		<model name='KGC-001'>
-			<availability>FVC:8,LA:5,IS:5,MH:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CGB.FRR:5,ROS:3,CLAN:4,BAN:2,DC:5</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:7,ROS:8,FS:7,MERC:7</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
+		</model>
+		<model name='KGC-001'>
+			<availability>FVC:8,LA:5,IS:5,MH:6</availability>
+		</model>
+		<model name='KGC-005r'>
+			<availability>ROS:3,MERC:2</availability>
 		</model>
 		<model name='KGC-0000'>
 			<availability>IS:3-</availability>
@@ -8477,37 +8483,31 @@
 		<model name='KGC-008B'>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='KGC-000'>
-			<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-005r'>
-			<availability>ROS:3,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CSR:2,ROS:2+,CNC:3,RA:2,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
@@ -8519,44 +8519,44 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,CGB.FRR:4,ROS:6,NIOPS:7,FS:2,MERC:4,DC:4</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:6</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:3,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:3-,MERC:3-</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='KTO-20'>
-			<availability>CGB.FRR:3,MERC:5,DC:4</availability>
 		</model>
 		<model name='KTO-19b'>
 			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
+		<model name='KTO-20'>
+			<availability>CGB.FRR:3,MERC:5,DC:4</availability>
+		</model>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:6</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:3-,MERC:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8568,13 +8568,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
@@ -8599,8 +8599,8 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CCC:3,CSR:3,ROS:3,CCO:3,RA:4,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -8609,11 +8609,11 @@
 		<model name='2'>
 			<availability>ROS:6,CGB:5</availability>
 		</model>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:4,CGB:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -8622,23 +8622,20 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:4</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DoO:5,ROS:4,FWL:4,DO:5,TP:5,MERC:3</availability>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>DoO:4,DO:4,TP:4</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -8646,55 +8643,34 @@
 		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>DoO:4,DO:4,TP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:2,ROS:2,MERC:4</availability>
+		<model name='KSC-5MC'>
+			<availability>MOC:8,CC:8,MERC:2</availability>
+		</model>
 		<model name='KSC-4I'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-4L'>
 			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-5I'>
 			<availability>DTA:8,ROS:8,MERC:7</availability>
 		</model>
-		<model name='KSC-5MC'>
-			<availability>MOC:8,CC:8,MERC:2</availability>
-		</model>
 		<model name='KSC-5X'>
 			<roles>urban</roles>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='KSC-4L'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,MERC.WD:5,CDS:5,CSR:5,CW:5,CBS:6,IS:4+,CCO:1,CJF:4,BAN:6</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -8704,27 +8680,51 @@
 			<roles>recon</roles>
 			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
 		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='KTO-3A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:2,ROS:2,CJF:3,RA:2</availability>
-		<model name='4'>
-			<availability>ROS:8,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<availability>ROS:8,CJF:6</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
@@ -8750,11 +8750,11 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>CGB.FRR:2,CGB:2</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -8792,44 +8792,44 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>ROS:4,CGB.FRR:3,CLAN:4,NIOPS:6,BAN:7,DC:4</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,CGB.FRR:2-,DC:2-</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,CGB.FRR:6,CLAN:8,NIOPS:4,MERC.SI:4,BAN:6,DC:5</availability>
 		</model>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,CGB.FRR:2-,DC:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>PR:6,DoO:6,DO:6,FS:2,SC:6,Periphery.MW:2,Periphery.CM:2,FWL:6,MH:2,MSC:4,RFS:6,CC:2,MOC:2,DGM:6,MERC:2,DTA:6,FVC:2,LA:2,MCM:6,ROS:2,PG:6,Periphery.ME:2,TP:6,DA:6,RCM:6</availability>
-		<model name='LX-2A'>
-			<availability>PR:5,DoO:5,DO:5,DGM:5,MERC:5,DTA:5,SC:5,LA:5,MCM:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LX-2A'>
+			<availability>PR:5,DoO:5,DO:5,DGM:5,MERC:5,DTA:5,SC:5,LA:5,MCM:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-4E'>
-			<availability>CC:4</availability>
-		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:7,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='LHU-4E'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -8841,43 +8841,43 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:3,FS:7,MERC:3</availability>
-		<model name='LGN-2F'>
-			<availability>FS:7</availability>
-		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
-		</model>
 		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='LGN-2XA'>
-			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2D'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
+		<model name='LGN-2F'>
+			<availability>FS:7</availability>
+		</model>
+		<model name='LGN-2XA'>
+			<roles>missile_artillery</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,TC:8,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:3-</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -8916,15 +8916,17 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:3,FWL:7,IS:3</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,General:1,Periphery.ME:3,FWL:2,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:3,HL:5,LA:3</availability>
@@ -8932,11 +8934,9 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:3,FWL:7,IS:3</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,General:1,Periphery.ME:3,FWL:2,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -8947,12 +8947,12 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,NIOPS:2,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='(ERSL)'>
 			<availability>ROS:4</availability>
@@ -8960,50 +8960,50 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:4-</availability>
+		<model name='LTN-G16D'>
+			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:5,MOC:5,CLAN:3,IS:2,MERC:4</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>ROS:6,FS:6,MERC:4</availability>
+		<model name='LTN-G16O'>
+			<availability>RA.OA:6,FVC:4,OA:6,CDP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:4-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:6,MOC:6,SC:4,PR:4,MCM:4,PG:4,DGM:4,MSC:4,MERC:4,DA:6,RFS:4</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>RA.OA:6,FVC:4,OA:6,CDP:4</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,MERC.KH:2+,CSR:3,CW:5,CCO:4,CJF:4,RA:4,CWIE:6</availability>
-		<model name='B'>
-			<availability>CDS:4,General:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -9023,13 +9023,13 @@
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CHH:7,MERC.WD:4,CBS:6,CLAN:4,NIOPS:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -9038,10 +9038,6 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CW:6,CJF:1</availability>
-		<model name='2'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8</availability>
 		</model>
@@ -9049,26 +9045,15 @@
 			<roles>anti_infantry</roles>
 			<availability>CW:2</availability>
 		</model>
+		<model name='2'>
+			<roles>anti_infantry</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,ROS:3,CJF:6,DC:3,CGB:6</availability>
-		<model name='6'>
-			<availability>CW:5,CGB:5</availability>
-		</model>
-		<model name='9'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:3</availability>
-		</model>
-		<model name='8'>
-			<availability>ROS:3,CGB:6,DC:3</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:4,ROS:1</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
@@ -9076,151 +9061,166 @@
 		<model name='5'>
 			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
+		<model name='8'>
+			<availability>ROS:3,CGB:6,DC:3</availability>
+		</model>
+		<model name='6'>
+			<availability>CW:5,CGB:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
+		<model name='7'>
+			<availability>CHH:4,ROS:1</availability>
+		</model>
+		<model name='9'>
+			<availability>CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>HL:5,CLAN:2-,IS:7,NIOPS:2-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>SC:5,MCM:5,ROS:2,FWL:4,DGM:5,MSC:5,MERC:3</availability>
-		</model>
-		<model name='LCT-5M2'>
-			<availability>SC:3,MCM:3,ROS:3,DGM:3,MSC:3</availability>
-		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:4,CC:4,FVC:3,TC:6</availability>
-		</model>
-		<model name='LCT-5M3'>
-			<availability>SC:4,MCM:4,ROS:4,DGM:4,MSC:4</availability>
-		</model>
-		<model name='LCT-1Vb'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:3,CLAN:6,FWL:3,MERC:3,BAN:2</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='LCT-5M'>
+		<model name='LCT-1S'>
 			<roles>recon</roles>
-			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
+			<availability>LA:3-,MERC:3-</availability>
 		</model>
-		<model name='LCT-1V2'>
-			<roles>recon</roles>
-			<availability>PIR:4,MH:4,MERC:2</availability>
+		<model name='LCT-5M3'>
+			<availability>SC:4,MCM:4,ROS:4,DGM:4,MSC:4</availability>
 		</model>
 		<model name='LCT-5W2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,CLAN:2,IS:2,FS:4,DC:4</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:2-,General:3-,FS:3-</availability>
+		<model name='LCT-5M2'>
+			<availability>SC:3,MCM:3,ROS:3,DGM:3,MSC:3</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-1Vb'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
+			<availability>CC:5,MOC:3,CLAN:6,FWL:3,MERC:3,BAN:2</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
-		<model name='LCT-3S'>
+		<model name='LCT-1V2'>
 			<roles>recon</roles>
-			<availability>LA:8,CGB.FRR:6,MERC:6</availability>
+			<availability>PIR:4,MH:4,MERC:2</availability>
 		</model>
 		<model name='LCT-3M'>
 			<roles>recon</roles>
 			<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:3-,MERC:3-</availability>
+			<availability>LA:2-,General:3-,FS:3-</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-3S'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>LA:8,CGB.FRR:6,MERC:6</availability>
+		</model>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:4,CC:4,FVC:3,TC:6</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-6M'>
+			<roles>recon</roles>
+			<availability>SC:5,MCM:5,ROS:2,FWL:4,DGM:5,MSC:5,MERC:3</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CW:4,CBS:4,IS:2+,CJF:1,BAN:5,CWIE:4</availability>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CSA:4,CCC:1,CHH:3,MERC.WD:2,CDS:2,CSR:2,CW:1,ROS:1,CNC:3,CCO:2,RA:2</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:2</availability>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:2</availability>
-		</model>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:3-</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>LA:4,CGB.FRR:4,FWL:4,IS:3,FS:5,MERC:4,CGB:3</availability>
-		</model>
-		<model name='LGB-12R'>
-			<roles>fire_support</roles>
-			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:3</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:2-,OA:2-,General:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:3,TC:3</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:3-</availability>
+		</model>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:2</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:3,DoO:6,DO:6,DGM:6,FS:5,MERC:5,SC:6,MCM:6,ROS:6,MSC:6,TP:6,DA:6,RCM:5,DC:5</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGB-12R'>
+			<roles>fire_support</roles>
+			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:3</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>LA:4,CGB.FRR:4,FWL:4,IS:3,FS:5,MERC:4,CGB:3</availability>
+		</model>
 		<model name='LGB-14C2'>
 			<roles>fire_support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -9228,17 +9228,17 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
@@ -9252,14 +9252,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,OA:1,HL:4,LA:7,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:3,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:2-,FS:2-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:3,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -9268,13 +9268,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:2-</availability>
@@ -9293,24 +9293,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>ROS:5,MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -9318,13 +9318,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -9352,17 +9352,30 @@
 		<model name='MSK-6S'>
 			<availability>PR:8,PG:8,FWL:8,RFS:8</availability>
 		</model>
-		<model name='MSK-9H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MSK-5S'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='MSK-9H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2+,CLAN:3,MERC:1+,CCO:4,BAN:2,CWIE:7,CSA:4,MERC.WD:7,CDS:4,CW:6,CBS:3,ROS:1+,CJF:4</availability>
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:3,General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>CHH:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
@@ -9371,33 +9384,20 @@
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:3,General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:4,CNC:6,CLAN:3,IS:3,FS:4,CWIE:4,DC:4</availability>
-		<model name='Enhanced'>
-			<availability>CGB.FRR:5,CLAN:5,CNC:3,CWIE:3</availability>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -9408,8 +9408,8 @@
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
+		<model name='Enhanced'>
+			<availability>CGB.FRR:5,CLAN:5,CNC:3,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -9429,18 +9429,18 @@
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,Periphery.MM:2,PR:8,DoO:8,DO:8,DGM:8,MERC:2,DTA:8,SC:8,LA:2,MCM:8,ROS:2,Periphery.CM:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Malaika' unitType='Aero'>
@@ -9458,58 +9458,61 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:7,CDS:7,CW:7,CBS:5,CNC:3,CJF:7,BAN:5,CWIE:7</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1</availability>
-		</model>
-		<model name='G'>
-			<availability>General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:3,CCO:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='G'>
+			<availability>General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3,CCO:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:3,PR:2,LA:2,ROS:2,PG:2,MERC:2,RFS:2,CWIE:5</availability>
-		<model name='MNL-4S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:5,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:2</availability>
 		</model>
+		<model name='MNL-4S'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
 		<availability>ROS:4</availability>
-		<model name='(Support)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Support)'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:6,ROS:3,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
@@ -9517,162 +9520,159 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:4,RA.OA:6,OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
-		<model name='(LB-X)'>
-			<availability>LA:7,ROS:8,FS:7</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='(HPPC)'>
+			<availability>CC:2,MOC:2,DTA:3,LA:2,ROS:5,FS:4,MERC:2,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:2,LA:1-,General:3-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
+		<model name='(LB-X)'>
+			<availability>LA:7,ROS:8,FS:7</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='(HPPC)'>
-			<availability>CC:2,MOC:2,DTA:3,LA:2,ROS:5,FS:4,MERC:2,DC:4</availability>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,LA:3,CGB.FRR:3,FWL:4,IS:3,FS:5,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:6,CW:5,CNC:5,CJF:6,RA:4,CWIE:5,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,CJF:4,CGB:4</availability>
+		<model name='4'>
+			<availability>CNC:6,RA:3,CGB:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:4,CWIE:6</availability>
 		</model>
-		<model name='6'>
-			<availability>CW:5,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:3,CJF:5,CGB:5</availability>
-		</model>
 		<model name='7'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,CJF:4,CGB:4</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:6,RA:3,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:5,CJF:4</availability>
 		</model>
 		<model name='8'>
 			<availability>CJF:4,CGB:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:3,CJF:5,CGB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:2,FS:6,MERC:6,TC:4,MERC.WD:6,LA:3,CGB.FRR:5,ROS:6,PIR:4,FWL:6,MH:4,DC:6</availability>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='MAD-5A'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='MAD-6M'>
-			<availability>ROS:4,FWL:5,MERC:5</availability>
+		<model name='C'>
+			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='MAD-4L'>
 			<availability>CC:5,MOC:5</availability>
 		</model>
-		<model name='MAD-4S'>
-			<availability>LA:8,CGB.FRR:5,ROS:6,CNC:8,FWL:3,FS:7,MERC:7,DC:3</availability>
+		<model name='MAD-4H'>
+			<availability>PIR:7,MH:7,TC:7</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
+		<model name='MAD-6M'>
+			<availability>ROS:4,FWL:5,MERC:5</availability>
 		</model>
 		<model name='MAD-4K'>
 			<availability>DC:7</availability>
 		</model>
-		<model name='MAD-4H'>
-			<availability>PIR:7,MH:7,TC:7</availability>
+		<model name='MAD-5A'>
+			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:5</availability>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='MAD-4S'>
+			<availability>LA:8,CGB.FRR:5,ROS:6,CNC:8,FWL:3,FS:7,MERC:7,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:2-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:3,DA:6</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:2-,MH:2-,FS:2-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:7</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>PR:5,DoO:5,ROS:4,PG:5,DO:5,TP:5,MERC:4,DA:5,RFS:5,DC:2</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:7</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>MOC:3,ROS:4,FWL:7,MERC:4</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:5,MOC:4</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>IS:2-,Periphery.Deep:8,Periphery:3-,TC:3-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
+		<model name='MAD-7D'>
+			<availability>FS:5</availability>
 		</model>
 		<model name='MAD-5R'>
 			<availability>FS:4,MERC:3</availability>
 		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		<model name='MAD-9W2'>
+			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
+		</model>
+		<model name='MAD-9S'>
+			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>IS:2-,Periphery.Deep:8,Periphery:3-,TC:3-</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>MOC:3,ROS:4,FWL:7,MERC:4</availability>
 		</model>
 		<model name='MAD-5L'>
 			<availability>CC:6,MOC:5</availability>
 		</model>
+		<model name='MAD-6L'>
+			<availability>CC:5,MOC:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FVC:2-,MH:2-,FS:2-</availability>
+		</model>
 		<model name='MAD-5S'>
 			<availability>FVC:3,LA:5,CGB.FRR:3,FS:3,MERC:4</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:3,DA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -9688,17 +9688,17 @@
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,ROS:4,CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CSA:4,CHH:4,CCC:3,ROS:4,CSL:4,CCO:3,CGB:3</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:4,CDS:4,ROS:4,CGB:4</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CSA:4,CHH:4,CCC:3,ROS:4,CSL:4,CCO:3,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -9712,11 +9712,11 @@
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MHL-6MC'>
-			<availability>MOC:4,CC:2</availability>
-		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,HL:2,PIR:4,MERC:4,TC:4,Periphery:2</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:4,CC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
@@ -9731,11 +9731,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,MERC.WD:3,CSR:2,CDS:5,CW:3,CBS:4,CNC:2,MERC:2+,CJF:4,RA:2,BAN:3,CGB:4</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
@@ -9743,8 +9740,14 @@
 		<model name='A'>
 			<availability>CDS:8,General:5,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
@@ -9752,55 +9755,52 @@
 		<model name='B'>
 			<availability>CDS:8,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CCO:6,CGB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:1,CJF:6</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>CGB.FRR:5,MERC:5,DC:7</availability>
-		<model name='MAL-1R'>
-			<availability>CGB.FRR:8,MERC:6,DC:1</availability>
+		<model name='MAL-3R'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='MAL-C'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='MAL-3R'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='MAL-1K'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='MAL-1R'>
+			<availability>CGB.FRR:8,MERC:6,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(Intermediate)'>
-			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:6</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
+		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
 		</model>
 		<model name='(Basic)'>
 			<roles>apc</roles>
@@ -9809,8 +9809,8 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
@@ -9818,61 +9818,61 @@
 		<model name='(LB-X)'>
 			<availability>FWL:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,OA:1,LA:3,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
+			<availability>IS:1-,Periphery:2-</availability>
 		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2-</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(C3S)'>
+		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
+			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2-</availability>
+			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
@@ -9892,13 +9892,13 @@
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CSR:1,RA:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -9928,39 +9928,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -9972,33 +9969,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10033,23 +10033,19 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10057,13 +10053,17 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mengqin' unitType='Aero'>
@@ -10104,25 +10104,25 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Dropship'>
 		<availability>PR:1,FWL:6</availability>
-		<model name='R1'>
-			<roles>assault</roles>
-			<availability>PR:8,PG:8,RFS:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>assault</roles>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='R1'>
+			<roles>assault</roles>
+			<availability>PR:8,PG:8,RFS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,OA:8,CSR:2,HL:3,MERC:6,RA:4,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:3-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>RA.OA:6,FVC:4,OA:6,CSR:3,MERC:4,CDP:4,RA:6,TC:4</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10131,6 +10131,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Targeting Computer)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Gauss) &apos;Sandblaster&apos;'>
 			<roles>urban</roles>
@@ -10142,25 +10147,20 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Targeting Computer)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:2,CBS:4,CSL:8,RA:2</availability>
-		<model name='4'>
-			<availability>CBS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='XP'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8</availability>
+		</model>
+		<model name='4'>
+			<availability>CBS:4</availability>
+		</model>
+		<model name='XP'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='P2'>
 			<availability>CHH:5</availability>
@@ -10182,11 +10182,11 @@
 	</chassis>
 	<chassis name='Mithras Light Tank' unitType='Tank'>
 		<availability>CSA:6,CCC:6,CBS:6,CSL:4,CCO:6</availability>
-		<model name='(ERLL)'>
-			<availability>CSL:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(ERLL)'>
+			<availability>CSL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mjolnir Battlecruiser' unitType='Warship'>
@@ -10198,22 +10198,18 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:5,ROS:3,FS:3,MERC:3</availability>
-		<model name='MLR-B2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MLR-BX'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='MLR-B2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -10223,11 +10219,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -10268,13 +10268,13 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>LA:4,ROS:4,MERC:3</availability>
-		<model name='MON-268'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3,ROS:3,MERC:3</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
+		<model name='MON-268'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
@@ -10296,11 +10296,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:3,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -10337,14 +10337,14 @@
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
 		<availability>CSA:5,CBS:6,CLAN:4,IS:4</availability>
-		<model name='(HAG)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mortar Carrier' unitType='Tank'>
@@ -10370,7 +10370,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -10383,17 +10386,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -10419,29 +10419,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:3,FS:6</availability>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:6</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:5,RA.OA:2,OA:2,LA:5,ROS:4,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:7</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:5</availability>
 		</model>
-		<model name='Type 2'>
-			<availability>CC:7</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Naga' unitType='Mek' omni='Clan'>
@@ -10449,6 +10449,14 @@
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
@@ -10458,24 +10466,16 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:3,MERC:3,DC:6</availability>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3A'>
 			<roles>fire_support,spotter</roles>
@@ -10508,11 +10508,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10524,29 +10524,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CJF:5</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -10571,12 +10571,12 @@
 		<model name='Mk. XXX' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
+		<model name='Mk. XXII' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
 		<model name='Mk. XXI' mechanized='true'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk. XXII' mechanized='true'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightlord Battleship' unitType='Warship'>
@@ -10588,15 +10588,15 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CHH:2,CW:2,ROS:5,NIOPS:3,CWIE:2,CGB:2</availability>
+		<model name='(LAC)'>
+			<roles>spotter</roles>
+			<availability>ROS:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<roles>spotter</roles>
-			<availability>ROS:5</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -10605,32 +10605,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,PR:5,LA:8,DoO:5,ROS:6,PG:5,DO:5,TP:5,FS:7,MERC:6,RFS:5</availability>
+		<model name='NGS-6T'>
+			<availability>PR:6,LA:6,ROS:6,PG:6,MERC:6,FS:6,RFS:6</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>PR:6,LA:6,ROS:6,PG:6,MERC:6,FS:6,RFS:6</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:7,ROS:6,MERC:3</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,LA:6,ROS:5,NIOPS:3,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -10647,11 +10647,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='NJT-4'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='NJT-3'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -10663,51 +10663,51 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:8,DC.SL:2,LA:3,CGB.FRR:4,ROS:4,MERC:3,DC:7,CGB:4</availability>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:7</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>CGB.FRR:5,ROS:6,MERC:5,DC:5,CGB:4</availability>
 		</model>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,ROS:1+,CNC:8</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -10719,12 +10719,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -10732,20 +10726,26 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support,anti_infantry</roles>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support,anti_infantry</roles>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
@@ -10761,32 +10761,32 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:2,LA:2,ROS:4,MERC:3,FS:2,DC:4,CGB:2</availability>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DTA:3,ROS:3,MERC:2,DC:3</availability>
+		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='NX-90'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
 		</model>
 		<model name='NX-100'>
 			<roles>recon</roles>
 			<availability>ROS:4,DC:2</availability>
 		</model>
-		<model name='NX-80C'>
+		<model name='NX-90'>
 			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:2,DC:3</availability>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -10798,14 +10798,14 @@
 		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:3,DC:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CNC:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -10849,42 +10849,42 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:5,HL:1,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:7,CNC:8,IS:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>fire_support</roles>
+			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:5,IS:5</availability>
+		</model>
 		<model name='HEAT'>
 			<availability>PR:2,LA:1,ROS:2,PG:2,FS:1,RFS:2</availability>
 		</model>
 		<model name='(Fusion)'>
 			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
 		</model>
-		<model name='(Sealed)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>fire_support</roles>
-			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
-		</model>
-		<model name='(MML)'>
-			<availability>MOC:5,IS:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:7,CNC:8,IS:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6,CSL:5,CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
@@ -10898,42 +10898,42 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
-		<model name='ON3-M'>
-			<roles>spotter</roles>
-			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:1-,MH:1-,CDP:1-,TC:1-</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
+		<model name='ON1-MC'>
+			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,DoO:4,DO:4,DGM:4,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
 		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,PR:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,MSC:4,RFS:4</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:1-</availability>
+		<model name='ON3-M'>
+			<roles>spotter</roles>
+			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:1-</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:8</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,PR:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,MSC:4,RFS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -10954,14 +10954,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:3,FS:6,MERC:4,CDP:3</availability>
-		<model name='OSR-5D'>
-			<availability>FS:5</availability>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
+		<model name='OSR-5D'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -10969,56 +10969,56 @@
 		<model name='OSP-26'>
 			<availability>CC:2,ROS:8</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,TC:4,Periphery:2,DC:5</availability>
+		<model name='OSR-5C'>
+			<availability>TC:4</availability>
+		</model>
+		<model name='OSR-4L'>
+			<availability>CC:7,MOC:4</availability>
+		</model>
+		<model name='OSR-2C'>
+			<roles>urban</roles>
+			<availability>Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+		</model>
+		<model name='OSR-2D'>
+			<availability>HL:2,ROS:6,IS:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-3C'>
 			<availability>FVC:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-4K'>
 			<availability>ROS:4,MERC:3,DC:4</availability>
 		</model>
-		<model name='OSR-5C'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='OSR-2C'>
-			<roles>urban</roles>
-			<availability>Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
-		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:1</availability>
 		</model>
-		<model name='OSR-2D'>
-			<availability>HL:2,ROS:6,IS:4,Periphery:4</availability>
-		</model>
 		<model name='OSR-4C'>
 			<availability>HL:2,TC:6,Periphery:3</availability>
-		</model>
-		<model name='OSR-4L'>
-			<availability>CC:7,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RA:1,CGB:3</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -11031,6 +11031,10 @@
 			<roles>recon</roles>
 			<availability>General:3-</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
 			<availability>LA:2,ROS:3,FS:1</availability>
@@ -11039,39 +11043,35 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:2,PR:2,LA:7,DoO:4,ROS:5,PG:2,DO:4,TP:4,MERC:5,FS:2,RFS:2,DC:2</availability>
 		</model>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>PR:5,DoO:5,DO:5,DGM:5,FS:5,MERC:3,Periphery:2,DTA:5,SC:5,MCM:5,ROS:4,PG:5,FWL:5,NIOPS:6,MSC:4,TP:5,RFS:5</availability>
 		<model name='OTL-7M'>
 			<availability>DTA:7,SC:8,DoO:8,MCM:8,ROS:6,FWL:6,DO:8,DGM:8,MSC:8,TP:8,MERC:4</availability>
 		</model>
-		<model name='OTL-9M'>
-			<availability>ROS:2,FWL:4</availability>
-		</model>
 		<model name='OTL-8D'>
 			<availability>FS:6</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:4,MERC:4</availability>
 		</model>
 		<model name='OTL-8M'>
 			<availability>DTA:6,SC:6,PR:6,MCM:6,PG:6,DGM:6,MSC:6,MERC:3,RFS:6</availability>
 		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,MERC:5</availability>
+		<model name='OTL-5M'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='OTL-9M'>
+			<availability>ROS:2,FWL:4</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:3,Periphery:3</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -11085,10 +11085,6 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:7,CW:4,CSL:6</availability>
-		<model name='(3070)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:5</availability>
@@ -11096,6 +11092,10 @@
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(3070)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -11107,24 +11107,32 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:7,IS:3,FS:7</availability>
-		</model>
 		<model name='A3A'>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:7,IS:3,FS:7</availability>
 		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:3,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:3,CNC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2,CLAN:6</availability>
+		</model>
+		<model name='OW-1F'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -11132,6 +11140,14 @@
 		<model name='OW-1C'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1'>
 			<roles>recon,spotter</roles>
@@ -11141,51 +11157,35 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2,CLAN:6</availability>
-		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1F'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
 		<availability>CHH:4,LA:3,ROS:3,MERC:2,CWIE:6,DC:2</availability>
-		<model name='3'>
-			<availability>CHH:4,ROS:4,CWIE:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CWIE:2</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4,ROS:4,CWIE:2</availability>
+		</model>
 		<model name='2'>
 			<availability>CWIE:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:2,CHH:2,CCC:2,CDS:4,CSR:1,CNC:2,CCO:2,CWIE:7</availability>
-		<model name='2'>
-			<availability>CDS:3,CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:3,CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -11194,21 +11194,21 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,MOC:5</availability>
 		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4,SC:3-,MCM:3-,MSC.pm:4,DGM:3-,DA:3-,RCM.pm:4</availability>
-		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4,SC:3-,MCM:3-,MSC.pm:4,DGM:3-,DA:3-,RCM.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -11220,17 +11220,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:2</availability>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pandarus' unitType='Mek'>
@@ -11242,6 +11242,9 @@
 	</chassis>
 	<chassis name='Pandion Combat WiGE' unitType='Tank'>
 		<availability>LA:1,ROS:1,FWL:1,FS:5,MERC:1</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -11250,55 +11253,52 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:2,NIOPS:2,DC:8</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:2,CGB.FRR:2,PIR:2,CNC:8,FS.DMM:2,MERC:2,DC:2,TC:2</availability>
+			<availability>IS:3-,Periphery.Deep:8,MERC:3-,Periphery:3-,DC:3-</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,CGB.FRR:2,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:3,DC:4</availability>
 		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,FVC:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:3,TC:2</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
 		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,CGB.FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
+		</model>
 		<model name='PNT-16K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
+		<model name='PNT-CA'>
 			<roles>fire_support</roles>
-			<availability>IS:3-,Periphery.Deep:8,MERC:3-,Periphery:3-,DC:3-</availability>
+			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
 		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>CGB.FRR:4,DC:4</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:3,CGB.FRR:2,FS.DMM:3,MERC:3,DC:3</availability>
+			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,CGB.FRR:2,PIR:2,CNC:8,FS.DMM:2,MERC:2,DC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -11314,13 +11314,13 @@
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:4</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<roles>recon,spotter</roles>
@@ -11329,42 +11329,42 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,HL:4,LA:7,CGB.FRR:4,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>HL:1,IS:4,Periphery:4</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='(Cell)'>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>ROS:2,FS:2</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>HL:1,IS:4,Periphery:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:4-,CC:1-,HL:3-,IS:3-,Periphery.Deep:9,FS:4-,Periphery:4-,TC:4-,RA.OA:2-,OA:2-,CDS:1,LA:3-,FWL:3-,DC:1-</availability>
-		<model name='(Standard)'>
+		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
-			<availability>General:5</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
@@ -11373,9 +11373,9 @@
 		<model name='(LRM)'>
 			<availability>IS:1-,Periphery:3-</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -11386,10 +11386,6 @@
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>PR:5,PG:5,RFS:5</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:7</availability>
@@ -11397,6 +11393,10 @@
 		<model name='PKM-2E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -11408,11 +11408,11 @@
 	</chassis>
 	<chassis name='Patron MilitiaMech' unitType='Mek'>
 		<availability>PR:4-,DoO:4-,IS.pm:2,DO:4-,DGM:4-,RCM.pm:4,SC:4-,FWL.pm:4,DA.pm:4,MCM:4-,PG:4-,MSC.pm:4,TP:4-,DTA.pm:5,RFS:4-</availability>
-		<model name='PTN-2M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PTN-2'>
 			<availability>PR:5,DoO:5,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+		</model>
+		<model name='PTN-2M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
@@ -11439,29 +11439,29 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:7</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:3-</availability>
+		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>FVC:1</availability>
-		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,ROS:6,FS:5,DC:5</availability>
 		</model>
 		<model name='X-Pulse'>
 			<roles>recon</roles>
 			<availability>DC.AL:5,General:3,DC:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MRM)'>
 			<roles>recon</roles>
-			<availability>General:3-</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,FS:8,DC:7</availability>
+		</model>
+		<model name='(Sealed)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:5,ROS:6,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -11473,20 +11473,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -11500,12 +11500,12 @@
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CGB:3</availability>
-		<model name='4'>
-			<availability>CSR:5,CBS:7,RA:8</availability>
-		</model>
 		<model name='3'>
 			<roles>anti_infantry</roles>
 			<availability>CGB:7</availability>
+		</model>
+		<model name='4'>
+			<availability>CSR:5,CBS:7,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Persepolis' unitType='Aero'>
@@ -11516,31 +11516,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:3,FWL:5,DO:6,DGM:6,MSC:4,TP:6</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1'>
 			<availability>General:8</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -11557,28 +11557,28 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:3,LA:3,FWL:4,IS:2,FS:3,MERC:3,DC:3</availability>
-		<model name='(Prototype)'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Prototype)'>
+			<availability>LA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CSR:3,CW:8,CSL:7,CCO:4,CJF:7,RA:4,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSA:7,General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>CSA:7,General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -11588,120 +11588,120 @@
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:2,CCC:5,CSR:3,CLAN:3,MERC:2,FS:2,CCO:5,RA:4,CSA:3,DTA:2,CDS:5,CBS:3,LA:2,ROS:3,MSC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<availability>CDS:3,CSR:2,CNC:3,IS:2,CCO:3,DC:3</availability>
-		</model>
 		<model name='7'>
 			<availability>CDS:5,General:4,CGB:6,DC:4</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
+		<model name='6'>
+			<availability>CDS:6,CGB:6</availability>
 		</model>
 		<model name='3'>
 			<availability>DTA:3,CDS:7,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='6'>
-			<availability>CDS:6,CGB:6</availability>
+		<model name='4'>
+			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:3,CSR:2,CNC:3,IS:2,CCO:3,DC:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CDS:2,CSR:3,CNC:2,CCO:2,RA:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='8'>
-			<availability>CDS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='PHX-HK1'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>HL:5,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,Periphery:6,CGB:2</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>DoO:4,DO:4,TP:4,DC:4</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>PR:3,LA:6,ROS:4,PG:3,MERC:5,RFS:3</availability>
-		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:4,TC:4</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:7,MOC:4,MH:4,DA:4,TC:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FVC:2-,PIR:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>SC:6,MCM:6,CLAN:5,FWL:4,DGM:6,MSC:6,BAN:1</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>CGB.FRR:8,DC:8</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:4</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-4W'>
+			<availability>MOC:4,TC:4</availability>
+		</model>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>ROS:2,CGB.FRR:4,DC:2</availability>
+		<model name='PXH-5L'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>General:2-,BAN:6,Periphery:2-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>PR:3,LA:6,ROS:4,PG:3,MERC:5,RFS:3</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:1-</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CC:3,DoO:4,CLAN:3,DO:4,DGM:5,MERC:3,SC:5,MCM:5,FWL:4,MSC:5,TP:4,DA:4,RCM:4</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>FVC:2-,PIR:2-,FS:2-,MERC:2-</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:7,MOC:4,MH:4,DA:4,TC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>ROS:2,CGB.FRR:4,DC:2</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>SC:6,MCM:6,CLAN:5,FWL:4,DGM:6,MSC:6,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>CGB.FRR:8,DC:8</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -11709,47 +11709,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:3,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:3-,OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>CC:7,MOC:6,FS:6,MERC:7,DA:8,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,IS:3,Periphery:5</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>CC:7,MOC:6,FS:6,MERC:7,DA:8,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:3,CNC:6,NIOPS:4,MERC:4</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6,MOC:2</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6,MOC:2</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:4,FS:7,MERC:4</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -11757,11 +11757,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -11772,6 +11772,9 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:5,CDS:4,CSR:2,CBS:3,RA:2,CWIE:3</availability>
+		<model name='2'>
+			<availability>CHH:3,CDS:3</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -11781,9 +11784,6 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:5,CSR:2,RA:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:3,CDS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -11798,12 +11798,12 @@
 		<model name='(Streak)'>
 			<availability>HL:2,IS:6,TC:6,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,IS:5,Periphery:5</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>HL:3,FWL:5,IS:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,IS:5,Periphery:5</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:3</availability>
@@ -11839,18 +11839,21 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:4,MOC:2,MERC:2,DA:4,CDP:4,TC:2</availability>
+		</model>
 		<model name='(HV)'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:4,MOC:2,MERC:2,DA:4,CDP:4,TC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:5,MOC:4</availability>
+		<model name='(Standard)'>
+			<availability>CC:7,MOC:7</availability>
+		</model>
 		<model name='(Gauss)'>
 			<availability>General:8</availability>
 		</model>
@@ -11858,17 +11861,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,CC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:7,MOC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:3,SC:5,MCM:5,ROS:3,FWL:3,DGM:5,MSC:4,RCM:3,MERC:2</availability>
-		<model name='PGD-L3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PGD-L3'>
+			<availability>General:4</availability>
 		</model>
 		<model name='PGD-R3'>
 			<roles>ground_support</roles>
@@ -11877,42 +11877,42 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CHH:1,CCC:2,CDS:5,CSR:3,NIOPS:1,CCO:2,RA:4,CWIE:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CCO:6,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator' unitType='Mek'>
@@ -11926,23 +11926,23 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6,CBS:4,CSL:6,CCO:6</availability>
-		<model name='(Quad)'>
-			<availability>CHH:5+</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:1,CCO:1</availability>
-		</model>
-		<model name='4'>
-			<availability>CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CHH:8,CBS:8,CSL:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:8,CBS:8,CSL:8,CCO:8</availability>
+		<model name='4'>
+			<availability>CCO:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:1,CCO:1</availability>
+		</model>
+		<model name='(Quad)'>
+			<availability>CHH:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -11960,9 +11960,9 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
+		<model name='(RAF)'>
 			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+			<availability>ROS:6</availability>
 		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
@@ -11972,47 +11972,47 @@
 			<roles>support</roles>
 			<availability>General:4,Periphery:3</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
-			<availability>IS:4,Periphery:4,CGB:4,RA:4</availability>
-		</model>
-		<model name='(RAF)'>
+		<model name='(Support)'>
 			<roles>apc</roles>
-			<availability>ROS:6</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>General:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4,CGB:4,RA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CLAN:7,MERC:2+,CCO:6,RA:5,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:8,CW:8,CBS:6,ROS:2+,CNC:8,CJF:5,CGB:6</availability>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:3,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:3,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12032,24 +12032,24 @@
 		<model name='[PPC] (RAF)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>HL:4,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>HL:4,Periphery.Deep:4,Periphery:6</availability>
@@ -12060,21 +12060,21 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
-		</model>
-		<model name='QKD-5A'>
-			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:5,FWL:7</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='QKD-5A'>
+			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
+		</model>
 		<model name='QKD-8K'>
 			<availability>CGB.FRR:5,ROS:5,MERC:4,DC:8</availability>
-		</model>
-		<model name='QKD-C'>
-			<availability>CGB.FRR:8,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:3-,OA:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
@@ -12082,72 +12082,64 @@
 		<model name='QKD-4H'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
+		<model name='QKD-C'>
+			<availability>CGB.FRR:8,MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:5,FWL:7</availability>
+		<model name='QKD-5K'>
+			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='(Standard)'>
-			<availability>CCC:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,ROS:3,MERC:3,FS:4</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
-		</model>
-		<model name='MDG-1Ar'>
-			<availability>ROS:8,FS:4,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1Ar'>
+			<availability>ROS:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:4,LA:4,ROS:5,ROS.pm:6,FWL:4,MH:5,MERC:5,FS:4,CDP:4,DC:4</availability>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:2</availability>
-		</model>
-		<model name='VV2'>
-			<roles>urban</roles>
-			<availability>LA:2,ROS:2,FWL:2,MERC:2,FS:2</availability>
 		</model>
 		<model name='VV22'>
 			<roles>urban</roles>
@@ -12157,23 +12149,31 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='VV2'>
+			<roles>urban</roles>
+			<availability>LA:2,ROS:2,FWL:2,MERC:2,FS:2</availability>
+		</model>
+		<model name='VV1 (MG)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
-		<model name='RPR-100'>
-			<availability>General:3,NIOPS:8</availability>
-		</model>
-		<model name='RPR-300S'>
-			<availability>LA:4</availability>
+		<model name='RPR-300'>
+			<availability>LA:6,ROS:3,MERC:3</availability>
 		</model>
 		<model name='RPR-200'>
 			<availability>CSR:1,CBS:1</availability>
 		</model>
+		<model name='RPR-100'>
+			<availability>General:3,NIOPS:8</availability>
+		</model>
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:6,ROS:3,MERC:3</availability>
+		<model name='RPR-300S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -12186,68 +12186,60 @@
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='RPT-3X'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>FS:4,DC:6</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='RTX1-OA'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:3,Periphery.CM:3,Periphery.ME:3,FWL:2,MH:4,MERC:2,TC:3,Periphery:2</availability>
-		<model name='(MH)' mechanized='false'>
-			<availability>MH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
+		</model>
+		<model name='(MH)' mechanized='false'>
+			<availability>MH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:7,MOC:3,FWL:3,MERC:6,DA:4,TC:3</availability>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:4,MOC:2</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
@@ -12256,21 +12248,29 @@
 			<roles>spotter</roles>
 			<availability>CC:3,MOC:2,FWL:1,MERC:2,DC:2,TC:2</availability>
 		</model>
+		<model name='RVN-4Lr'>
+			<roles>spotter</roles>
+			<availability>CC:4,MOC:2</availability>
+		</model>
 		<model name='RVN-4L'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6,DA:6,TC:6</availability>
 		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>PR:3,DoO:4,DO:4,MERC:4,FS:4,LA:6,ROS:3,CGB.FRR:5,PG:3,MH:3,TP:4,DA:3,RFS:3</availability>
-		<model name='RZK-10T'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='RZK-10S'>
 			<availability>LA:4</availability>
@@ -12285,12 +12285,12 @@
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -12301,15 +12301,23 @@
 		<model name='(Stealth)'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:1,CW:1,General:8,CNC:1</availability>
@@ -12318,27 +12326,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,MOC:2,CC:3,DGM:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:2,PR:6,DoO:6,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
+		<model name='F-100'>
+			<availability>FVC:3-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>MOC:2,CC:2,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,ROS:6,FWL:6,MSC:8,TP:8,DC:6</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>CGB.FRR:1-,DC:2-</availability>
@@ -12349,42 +12352,42 @@
 		<model name='F-700'>
 			<availability>CC:8,MOC:2,PR:8,DoO:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>MOC:2,CC:2,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,ROS:6,FWL:6,MSC:8,TP:8,DC:6</availability>
-		</model>
-		<model name='F-100'>
-			<availability>FVC:3-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:2,PR:6,DoO:6,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:3,CNC:5,IS:3,RA:4,CGB:5</availability>
-		<model name='8'>
-			<availability>CC:3,DoO:3,IS:2,DO:3,DGM:3,FS:3,MERC:3,SC:3,CDS:4,LA:3,MCM:3,MSC:3,TP:3,DC:3,CGB:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CSA:6,CDS:4,IS:4,CLAN.HW:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,CBS:2,ROS:4,MERC:4,FS:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:6,DC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CSA:6,CDS:4,IS:4,CLAN.HW:4</availability>
+		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,CBS:5,ROS:4,FS:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CC:3,DoO:3,IS:2,DO:3,DGM:3,FS:3,MERC:3,SC:3,CDS:4,LA:3,MCM:3,MSC:3,TP:3,DC:3,CGB:6</availability>
 		</model>
 		<model name='6'>
 			<availability>CSA:6,CHH:4,CDS:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,CBS:2,ROS:4,MERC:4,FS:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CNC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+		<model name='RFL-5D'>
+			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		</model>
 		<model name='RFL-7M'>
 			<availability>MOC:3,PR:7,DoO:7,IS:2,DO:7,DGM:7,CDP:3,TC:3,DTA:7,SC:7,MCM:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
 		</model>
@@ -12392,12 +12395,8 @@
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FVC:1-,FS:1-</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:2</availability>
@@ -12406,8 +12405,22 @@
 			<roles>fire_support</roles>
 			<availability>CC:2-,MOC:2-,DoO:2-,PIR:2-,MH:2-,DO:2-,TP:2-,FS:2-,DA:2-,RCM:2-</availability>
 		</model>
+		<model name='RFL-5M'>
+			<availability>CC:3,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:3,DC:3</availability>
+		</model>
 		<model name='C 2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='RFL-8X'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='RFL-7X'>
+			<roles>fire_support</roles>
+			<availability>ROS:4,MERC:4</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:4</availability>
@@ -12415,61 +12428,48 @@
 		<model name='RFL-9T'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='RFL-8X'>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-7X'>
-			<roles>fire_support</roles>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='RFL-5M'>
-			<availability>CC:3,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:3,DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,CSR:1,LA:5,CGB.FRR:5,ROS:6,CLAN:2,NIOPS:6,FS:5,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5,ROS:4,FS:3</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>CNC:3,FS:2,DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:3</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>CNC:3,FS:2,DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CSR:4,CBS:7,CNC:7,CSL:4,CCO:8,RA:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSR:5,CBS:8,CNC:6,CSL:6,CCO:8,RA:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:3,CBS:6,CNC:4,CCO:4,RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:3,CCO:4,RA:6</availability>
@@ -12477,6 +12477,9 @@
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CGB:6-</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HR' mechanized='true'>
 			<roles>recon</roles>
 			<availability>CGB:2</availability>
@@ -12485,27 +12488,21 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>PR:4,FS:4,MERC:2,CWIE:6,TC:6,RA.OA:5,FVC:4,OA:5,LA:6,CGB.FRR:4,ROS:4,PG:4,RFS:4</availability>
-		<model name='(Gauss)'>
-			<availability>OA:0,FRR:0,General:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:0,General:3,TC:0,CWIE:0</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>OA:0,FRR:0,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
 		<availability>DTA:3,ROS:2,FS:3,MERC:3</availability>
-		<model name='NH-3X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='NH-2'>
 			<availability>General:8</availability>
 		</model>
@@ -12517,6 +12514,9 @@
 		</model>
 		<model name='NH-1B'>
 			<availability>ROS:4-,MERC:5-,FS:5-</availability>
+		</model>
+		<model name='NH-3X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -12536,12 +12536,12 @@
 			<roles>recon</roles>
 			<availability>LA:5</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:7</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -12554,29 +12554,29 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.WD:6,CDS:6,CSR:4,CBS:7,CLAN:5,MERC:3+,CJF:6,RA:4,BAN:6,CWIE:6,DC:4+</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:5,CCC:5,CBS:4,CLAN:3,General:2</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:5,CCC:5,CBS:4,CLAN:3,General:2</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CSR:3,CNC:4,General:5,CCO:7,CJF:4,RA:6,CWIE:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:3,CBS:6,General:5,RA:6,CWIE:5,CGB:6</availability>
@@ -12590,20 +12590,20 @@
 		<model name='3'>
 			<availability>CHH:8,ROS:4,CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:8,IS:8,CGB:8</availability>
-		</model>
 		<model name='2'>
 			<availability>ROS:6,CGB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:8,IS:8,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
 		<availability>CNC:7,DC:5</availability>
-		<model name='SM1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Telos)'>
 			<availability>CNC:2,DC:2</availability>
+		</model>
+		<model name='SM1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1A Tank Destroyer' unitType='Tank'>
@@ -12624,13 +12624,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:7,Periphery:4</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:8,LA:8,FWL:8,IS:7,FS:8,DC:6,Periphery:6</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:7,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -12641,14 +12641,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,OA:2-,LA:4,ROS:3,FWL:2-,DC:5</availability>
-		<model name='SB-27'>
-			<availability>General:4-</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
+		<model name='SB-27'>
+			<availability>General:4-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
@@ -12660,17 +12660,8 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -12679,8 +12670,17 @@
 		<model name='D'>
 			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>CSR:2,General:1,CJF:3,RA:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -12688,21 +12688,21 @@
 		<model name='SGT-8R'>
 			<availability>FVC:8,FS:6</availability>
 		</model>
-		<model name='SGT-10X'>
-			<availability>ROS:3,FS:3,MERC:3</availability>
-		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:3,FS:3,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittarii' unitType='Aero'>
 		<availability>ROS:4</availability>
-		<model name='SGT-2R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SGT-3R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='SGT-2R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
@@ -12710,14 +12710,14 @@
 		<model name='S-4C'>
 			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
-		<model name='S-3'>
-			<availability>DC:1-</availability>
+		<model name='S-4'>
+			<availability>CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
 		</model>
 		<model name='S-8'>
 			<availability>ROS:7,DC:5</availability>
 		</model>
-		<model name='S-4'>
-			<availability>CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
+		<model name='S-3'>
+			<availability>DC:1-</availability>
 		</model>
 		<model name='S-7'>
 			<availability>ROS:6,CNC:6,DC:6</availability>
@@ -12725,29 +12725,29 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:5,DC.AL:9,IS:5,MERC:5,Periphery.OS:5,FS:4,Periphery:4,RA.OA:4,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:7,DC:8</availability>
+		</model>
 		<model name='(LB-X)'>
 			<availability>IS:6,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:5-,Periphery:5-</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:7,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CSR:3,CW:6,RA:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CSR:3,CW:6,RA:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -12756,10 +12756,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -12767,6 +12763,10 @@
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
@@ -12779,21 +12779,21 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>LA:5,CGB.FRR:4,ROS:5,DC:1</availability>
-		<model name='SL-27'>
-			<availability>IS:6,DC:3</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:3-,Periphery:4,TC:4,RA.OA:6,OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:7-</availability>
-		<model name='(MRM)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -12817,17 +12817,17 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:2,CBS:5,CNC:2,CCO:7,RA:3</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CSR:2,CNC:4,RA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CSR:2,CNC:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XP'>
 			<availability>CNC:6</availability>
@@ -12835,11 +12835,8 @@
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CHH:2,CW:5,CCO:9</availability>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
@@ -12847,8 +12844,11 @@
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -12870,10 +12870,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -12881,6 +12877,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -12900,33 +12900,33 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,DoO:4,CGB.FRR:4,ROS:4,FWL:4,DO:4,TP:4,FS:4,MERC:4,DC:4,CGB:3</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -12937,33 +12937,33 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:1,HL:3,IS:3,Periphery.Deep:5,MERC:3,FS:3,Periphery:4,TC:3,RA:3,RA.OA:4,OA:3,LA:3,CGB.FRR:2,CNC:3,FWL:2,DC:1</availability>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
+		<model name='(Armor)'>
+			<availability>CNC:7,IS:5,RA:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>CNC:7,IS:5,RA:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
-		<model name='(Missile)'>
-			<availability>IS:1</availability>
+		<model name='(Standard)'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5-</availability>
+		<model name='(Missile)'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:7,DC:8</availability>
@@ -12971,49 +12971,49 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(Minesweeper)'>
-			<roles>minesweeper</roles>
-			<availability>CC:2-,MOC:1-</availability>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
-			<availability>General:4-</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:3,DC:5,TC:4</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>General:4-</availability>
 		</model>
 		<model name='(ML)'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
+		<model name='(LAC)'>
+			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:3,DC:5,TC:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:4-</availability>
+		</model>
+		<model name='(Minesweeper)'>
+			<roles>minesweeper</roles>
+			<availability>CC:2-,MOC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2,FVC:1,HL:2,LA:4,CGB.FRR:2-,ROS:1,Periphery.Deep:4-,FWL:2,NIOPS:2-,MERC:2,Periphery:3,DC:3</availability>
-		<model name='SCP-1N'>
-			<availability>FRR:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+		<model name='SCP-12S'>
+			<availability>LA:3,ROS:2,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>FRR:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>HL:1,IS:5,Periphery:3</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:3,ROS:2,MERC:2</availability>
+		<model name='SCP-1TB'>
+			<availability>ROS:4,MERC:4</availability>
 		</model>
 		<model name='SCP-10M'>
 			<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
-		</model>
-		<model name='SCP-1TB'>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -13031,14 +13031,14 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
+		<model name='3'>
+			<availability>CJF:2</availability>
+		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='3'>
-			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero'>
@@ -13049,38 +13049,38 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:3,CW:4,CNC:5,CLAN:4,CJF:6,CCO:4,RA:4,CWIE:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(SRM6)'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:3</availability>
@@ -13094,25 +13094,25 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,HL:2,LA:6,CGB.FRR:3,IS:4,FWL:4,FS:5,Periphery:3,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:8,FWL:4,IS:5,FS:8</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CLAN:2,FS:5,MERC:4,CWIE:2,DC.GHO:3,FVC:5,CDS:2,CW:2,LA:5,CBS:2,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -13130,22 +13130,26 @@
 			<roles>interceptor</roles>
 			<availability>LA:2-,Periphery.Deep:8,Periphery:2-</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:8,CGB.FRR:6,ROS:4,FS:8,MERC:6</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>RA.OA:2-,OA:2-,HL:3-,FRR:2-,ROS:2-,FWL:2-,Periphery:5-,TC:3-,DC:2-</availability>
-		</model>
 		<model name='SYD-Z3A'>
 			<availability>LA:6,CGB.FRR:3,ROS:3,MERC:3,FS:3</availability>
 		</model>
 		<model name='SYD-45X &apos;Starling&apos;'>
 			<availability>LA:1</availability>
 		</model>
+		<model name='SYD-Z1'>
+			<roles>interceptor</roles>
+			<availability>RA.OA:2-,OA:2-,HL:3-,FRR:2-,ROS:2-,FWL:2-,Periphery:5-,TC:3-,DC:2-</availability>
+		</model>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>LA:8,CGB.FRR:6,ROS:4,FS:8,MERC:6</availability>
+		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,FVC:2,OA:5,HL:1,LA:6,CGB.FRR:2,ROS:4,MERC:5,FS:2,Periphery:2</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:1-</availability>
 		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -13154,21 +13158,17 @@
 		<model name='SYD-Z2B'>
 			<availability>RA.OA:4,OA:4,LA:4,ROS:4,PIR:3,FS:3,MERC:3,RA:4</availability>
 		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:1-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6,MOC:5</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -13190,16 +13190,12 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CDS:5,CSR:2,ROS:3+,CNC:7,CSL:4,MERC:1+,CJF:5,RA:4</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:2,General:8,RA:3</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:3,CCO:7</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSR:5,CW:3,General:6,RA:8</availability>
-		</model>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSR:2,CW:3,General:6,RA:3</availability>
 		</model>
 		<model name='J'>
 			<availability>General:5</availability>
@@ -13207,72 +13203,76 @@
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
+		<model name='A'>
 			<roles>recon</roles>
-			<availability>CSR:2,General:8,RA:3</availability>
+			<availability>CSR:2,CW:3,General:6,RA:3</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSR:5,CW:3,General:6,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,SC:3,OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:2,RFS:3,CGB:5,IS:2,DGM:3,MERC:4,RA:5,DTA:3,LA:3,MCM:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
-		<model name='8'>
-			<availability>CDS:4,LA:4,CNC:5,IS:2,CWIE:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:2,CCC:2,CGB:3</availability>
-		</model>
-		<model name='7'>
-			<availability>RA.OA:6,OA:2,CSR:2,RA:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:5,CNC:5,IS:2,RA:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:5,CNC:5,IS:2</availability>
+		<model name='6'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:7,LA:7,CGB.FRR:6,FWL:7,IS:5,FS:7,MERC:7,DC:7,CGB:4</availability>
 		</model>
-		<model name='6'>
-			<availability>CHH:6</availability>
+		<model name='2'>
+			<availability>CSA:2,CCC:2,CGB:3</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:4,LA:4,CNC:5,IS:2,CWIE:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:5,CNC:5,IS:2,RA:4</availability>
+		</model>
+		<model name='7'>
+			<availability>RA.OA:6,OA:2,CSR:2,RA:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:4,CDS:5,CNC:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,BAN:4,Periphery:6,CGB:4</availability>
-		<model name='SHD-2K'>
-			<availability>MERC:1-,DC:3-</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,DGM:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
 		</model>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,FS:5</availability>
+		<model name='SHD-3K'>
+			<availability>CGB.FRR:4,DC:5,CGB:2</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:2-,MOC:2-,FWL:2-,MH:3-,MERC:2-</availability>
 		</model>
-		<model name='SHD-2H'>
-			<availability>General:3-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,DGM:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
-		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:4,FWL:5,MERC:6,Periphery:2,DC:6</availability>
-		</model>
-		<model name='SHD-8L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,DoO:6,DO:6,DGM:6,MERC:4,CDP:3,TC:3,DTA:6,SC:6,FVC:3,MCM:6,ROS:4,MSC:6,TP:6,RCM:6</availability>
-		</model>
-		<model name='SHD-9D'>
-			<availability>FS:5</availability>
 		</model>
 		<model name='SHD-5D'>
 			<availability>LA:4,ROS:4,FS:6,MERC:5</availability>
 		</model>
-		<model name='SHD-3K'>
-			<availability>CGB.FRR:4,DC:5,CGB:2</availability>
+		<model name='SHD-2K'>
+			<availability>MERC:1-,DC:3-</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,DoO:6,DO:6,DGM:6,MERC:4,CDP:3,TC:3,DTA:6,SC:6,FVC:3,MCM:6,ROS:4,MSC:6,TP:6,RCM:6</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>General:3-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='SHD-8L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -13280,23 +13280,23 @@
 		<model name='(Flamer)'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:4,CDS:4,CSR:2,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:5,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,OA:4,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:3,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>ROS:6,MERC:3,DC:7</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RA.OA:2,OA:2,CGB.FRR:2,ROS:3,MERC:2,RA:2,DC:3</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>ROS:6,MERC:3,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Shiva' unitType='Aero'>
@@ -13310,6 +13310,9 @@
 		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SHV-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
 		</model>
@@ -13319,40 +13322,37 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:2,DoO:4,DO:4,DGM:4,FS:1,DTA:3,SC:4,MCM:4,ROS:2,FWL:3,MSC:3,TP:4,RCM:2,DC:1</availability>
-		<model name='SKW-2F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SKW-4G'>
 			<availability>General:2</availability>
+		</model>
+		<model name='SKW-2F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,ROS:2,CNC:5,CGB:3,CWIE:2,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,DC:6</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:2,CW:6,ROS:4,CNC:6,CJF:6,DC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
 		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:1,OA:3,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
-		<model name='SL-22'>
-			<availability>FVC:4,HL:2,CGB.FRR:8,ROS:8,MERC:2,DC:8,Periphery:2</availability>
-		</model>
 		<model name='SL-21L'>
 			<roles>raider,ground_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='SL-22'>
+			<availability>FVC:4,HL:2,CGB.FRR:8,ROS:8,MERC:2,DC:8,Periphery:2</availability>
 		</model>
 		<model name='SL-21'>
 			<availability>FVC:4,HL:3,Periphery.Deep:7,MERC:4,DC:4,Periphery:5</availability>
@@ -13385,23 +13385,23 @@
 	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CSA:4,CCC:4,CCO:4</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:4,CCC:4,CCO:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,SC:5,DoO:5,MCM:5,ROS:2,DO:5,DGM:5,MSC:4,TP:5,MERC:3</availability>
-		<model name='SRC-5C'>
-			<availability>DTA:5,SC:5,DoO:5,MCM:5,ROS:5,FWL:5,DO:5,DGM:5,MSC:5,TP:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>DTA:5,SC:5,DoO:5,MCM:5,ROS:5,FWL:5,DO:5,DGM:5,MSC:5,TP:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:5,DO:5,DGM:5,MSC:5,TP:5</availability>
@@ -13416,27 +13416,27 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:4-</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:4-</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
-		<model name='SL-15A'>
-			<availability>OA:1</availability>
+		<model name='SL-15'>
+			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 		</model>
 		<model name='SL-15R'>
 			<availability>RA.OA:6,OA:6,CSR:3,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4,CGB:6</availability>
@@ -13444,17 +13444,17 @@
 		<model name='SL-15K'>
 			<availability>CGB.FRR:4,ROS:4,MERC:2,DC:4,CGB:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
+		<model name='SL-15A'>
+			<availability>OA:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:3</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>LA:3</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Snake' unitType='Mek'>
@@ -13478,11 +13478,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -13494,10 +13494,6 @@
 	</chassis>
 	<chassis name='Sokuryou' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='SKU-181 SurveyMech'>
-			<roles>support,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='SKU-197 SurveyMech'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -13505,6 +13501,10 @@
 		<model name='SKU-198 SurveyMech'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKU-181 SurveyMech'>
+			<roles>support,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -13532,31 +13532,31 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+		<model name='SPR-H5K'>
+			<roles>interceptor</roles>
+			<availability>OA:1</availability>
+		</model>
+		<model name='SPR-7D'>
+			<availability>ROS:5,FS:5,MERC:5</availability>
+		</model>
+		<model name='SPR-DH'>
+			<availability>RA.OA:4-,FVC:4-,OA:4-,MERC:4-,Periphery:1-</availability>
+		</model>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:3,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:3-,Periphery.Deep:8,FS:3-,MERC:3-,CDP:3-,TC:3-</availability>
-		</model>
-		<model name='SPR-7D'>
-			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-H5K'>
-			<roles>interceptor</roles>
-			<availability>OA:1</availability>
-		</model>
-		<model name='SPR-DH'>
-			<availability>RA.OA:4-,FVC:4-,OA:4-,MERC:4-,Periphery:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -13571,12 +13571,12 @@
 		<model name='SPR-5S'>
 			<availability>CC:4,LA:4,ROS:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8</availability>
-		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -13584,27 +13584,39 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:3</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:4,CNC:2</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:4,CNC:2</availability>
 		</model>
-		<model name='2'>
-			<availability>ROS:6,CNC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:3,MERC:3,FS:3,Periphery:2,TC:2,FVC:3,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:3,CC:3,FWL:8,MH:3,MERC:2</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:3,MERC:3</availability>
+		</model>
+		<model name='SDR-8X'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>IS:1-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-7K'>
 			<availability>ROS:4,MERC:4,DC:5</availability>
@@ -13615,23 +13627,11 @@
 		<model name='SDR-7KC'>
 			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='SDR-8K'>
-			<availability>ROS:2,MERC:2,DC:3</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>ROS:3,MERC:3,DC:4</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:3,MERC:3</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:3,CC:3,FWL:8,MH:3,MERC:2</availability>
-		</model>
-		<model name='SDR-8X'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
+		<model name='SDR-8K'>
+			<availability>ROS:2,MERC:2,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -13651,13 +13651,17 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:2,FVC:2,LA:7,CGB.FRR:7,ROS:7,IS:6,MH:1,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>CGB.FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>CGB.FRR:5,IS:4,DC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -13666,10 +13670,6 @@
 		<model name='(Interdictor)'>
 			<roles>spotter</roles>
 			<availability>FVC:2,LA:4,ROS:4,FWL:4,IS:2,MERC:4,FS:4,DC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -13680,14 +13680,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
+		<model name='STK-4P'>
+			<availability>MERC:1,Periphery:1</availability>
+		</model>
 		<model name='STK-8S'>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>MERC:1,Periphery:1</availability>
+		<model name='STK-6M'>
+			<availability>CC:4,MOC:4,PR:6,DoO:6,DO:6,MERC:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
@@ -13695,20 +13698,17 @@
 		<model name='STK-7D'>
 			<availability>ROS:4,FS:4,MERC:3</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
-		</model>
-		<model name='STK-6M'>
-			<availability>CC:4,MOC:4,PR:6,DoO:6,DO:6,MERC:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
+		<model name='STK-3F'>
+			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
@@ -13716,12 +13716,12 @@
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -13741,12 +13741,12 @@
 	</chassis>
 	<chassis name='Starslayer' unitType='Mek'>
 		<availability>MOC:4,CC:4,PR:3,DoO:4,DO:4,FS:4,MERC:4,LA:6,CGB.FRR:4,ROS:3,PG:3,TP:4,DA:3,RFS:3</availability>
+		<model name='STY-3Dr'>
+			<availability>CC:3,MOC:3,PR:6,LA:5,ROS:6,PG:6,MERC:4,RFS:6</availability>
+		</model>
 		<model name='STY-3D'>
 			<roles>raider</roles>
 			<availability>MOC:5,CC:2,LA:5,DoO:3,ROS:3,DO:3,TP:3,FS:2,MERC:5</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:3,MOC:3,PR:6,LA:5,ROS:6,PG:6,MERC:4,RFS:6</availability>
 		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
@@ -13755,6 +13755,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>LA:3,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
@@ -13763,17 +13767,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>FS:6,MERC:4</availability>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
@@ -13784,11 +13784,11 @@
 		<model name='STO-4B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-6S'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -13798,47 +13798,43 @@
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
+		<availability>IS:1</availability>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>IS:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='STG-5G'>
-			<roles>recon</roles>
-			<availability>CC:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,FVC:4,HL:1,MERC:2,DA:4,TC:4,Periphery:2</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:6,ROS:5,MERC:6,FS:4</availability>
 		</model>
-		<model name='STG-3Gb'>
+		<model name='STG-6L'>
 			<roles>recon</roles>
-			<availability>CC:3,DoO:6,CLAN:8,DGM:6,DO:6,MERC:2,BAN:2,SC:6,MCM:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
+			<availability>CC:6,MOC:4,DA:4</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
-		<model name='STG-6L'>
+		<model name='STG-5G'>
 			<roles>recon</roles>
-			<availability>CC:6,MOC:4,DA:4</availability>
+			<availability>CC:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,FVC:4,HL:1,MERC:2,DA:4,TC:4,Periphery:2</availability>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>CC:3,DoO:6,CLAN:8,DGM:6,DO:6,MERC:2,BAN:2,SC:6,MCM:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>IS:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -13852,35 +13848,36 @@
 			<roles>recon</roles>
 			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:4,RFS:5,MOC:3,CC:5,IS:3,DGM:6,MERC:5,TC:2,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
-		<model name='F-95'>
-			<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
-		</model>
 		<model name='F-94'>
 			<availability>MOC:2,Periphery.MW:2,Periphery.ME:2,IS:4,MH:2</availability>
-		</model>
-		<model name='F-92'>
-			<availability>MOC:2,Periphery.MW:2,Periphery.ME:2,FWL:5,IS:4,MH:2</availability>
 		</model>
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
 		</model>
+		<model name='F-92'>
+			<availability>MOC:2,Periphery.MW:2,Periphery.ME:2,FWL:5,IS:4,MH:2</availability>
+		</model>
+		<model name='F-95'>
+			<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -13888,11 +13885,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -13904,41 +13904,47 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:3,MOC:3,LA:5,ROS:4,FWL:5,FS:5,MERC:5,DA:3,DC:7</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
 		</model>
@@ -13950,23 +13956,17 @@
 			<roles>fire_support</roles>
 			<availability>FVC:3-,IS:2-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
+		<model name='(SRM)'>
+			<availability>FVC:3-,IS:2-</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,ROS:3,FS.DMM:8,FS:3</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>FVC:3-,IS:2-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:4,LA:6,ROS:6,CNC:4,FS:7,DC:5,CWIE:4</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:4,LA:6,ROS:6,CNC:4,FS:7,DC:5,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
@@ -13986,33 +13986,33 @@
 		<model name='STU-K5'>
 			<availability>FVC:3-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>ROS:6,FS:7,MERC:2</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>ROS:6,CLAN:8,FS:4,MERC:2,BAN:2</availability>
-		</model>
 		<model name='STU-K10'>
-			<availability>OA:1</availability>
-		</model>
-		<model name='STU-K15'>
 			<availability>OA:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>ROS:6,CLAN:8,FS:4,MERC:2,BAN:2</availability>
+		</model>
+		<model name='STU-D7'>
+			<availability>ROS:6,FS:7,MERC:2</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:3,PR:4,CDS:2,HL:2,LA:5,ROS:4,PG:4,CNC:3,MERC:1,FS:3,RFS:4,CWIE:3</availability>
+		<model name='(Heavy Gauss)'>
+			<availability>PR:4,LA:6,PG:4,CNC:6,RFS:4,CWIE:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Heavy Gauss)'>
-			<availability>PR:4,LA:6,PG:4,CNC:6,RFS:4,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
@@ -14031,12 +14031,6 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
 		</model>
@@ -14046,20 +14040,30 @@
 		<model name='A'>
 			<availability>CSA:7,CSR:4,CBS:6,General:2,RA:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CDS:2,CW:5,ROS:2</availability>
-		<model name='2'>
-			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:4,CW:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:4,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OX'>
-			<availability>General:1</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OE'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
@@ -14068,36 +14072,32 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
+		<model name='SD1-OX'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CDS:4,CW:5,ROS:2,CNC:9,CWIE:5,CGB:3</availability>
-		<model name='2'>
-			<availability>ROS:6,CNC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:6,CNC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -14142,15 +14142,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -14158,19 +14158,15 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CSR:5,CLAN:8,RA:9</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CDS:2,CSR:2,RA:3</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
@@ -14179,15 +14175,19 @@
 			<roles>recon</roles>
 			<availability>CSR:1,RA:1</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>ROS:3,DC:6</availability>
+		<model name='TSH-8S'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Taihou Assault Dropship' unitType='Dropship'>
@@ -14211,65 +14211,65 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(RL)'>
-			<availability>MOC:4</availability>
 		</model>
 		<model name='2'>
 			<availability>MOC:3</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(RL)'>
+			<availability>MOC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DoO:6,DO:6,DGM:6,MERC:4,DTA:6,SC:6,MCM:6,ROS:4,FWL:6,MSC:4,TP:6,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>MOC:2,CC:5,ROS:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:7,SC:8,DoO:8,MCM:8,ROS:6,DO:8,DGM:8,MSC:8,TP:8,MERC:6,DC:7</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>DTA:7,SC:8,DoO:8,MCM:8,ROS:5,FWL:7,DGM:8,DO:8,MSC:8,TP:8,MERC:4,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>MOC:2,CC:5,ROS:5,FWL:5,MERC:5,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:2</availability>
-		<model name='TRG-2N'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='TRG-1N'>
 			<roles>recon</roles>
 			<availability>ROS:8</availability>
 		</model>
+		<model name='TRG-2N'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CGB.FRR:5,ROS:3,CNC:4,DC:6</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OE'>
+			<availability>General:5</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OE'>
-			<availability>General:5</availability>
 		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
@@ -14284,60 +14284,64 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:4,DTA:8,SC:8,MCM:8,ROS:5,Periphery.MW:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RFS:8</availability>
-		<model name='TMP-3M'>
-			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>SC:4,PR:4,MCM:4,ROS:4,PG:4,DGM:4,MSC:4,MERC:4,RFS:4</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,DO:6,DGM:6,MSC:6,TP:6,MERC:2</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>ROS:2,FWL:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,DO:6,DGM:6,MSC:6,TP:6,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:5</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OI'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OE'>
+		<model name='TLR1-OF'>
 			<roles>spotter</roles>
-			<availability>General:3</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OF'>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OE'>
 			<roles>spotter</roles>
-			<availability>General:2</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>ROS:4,DC:4</availability>
+		<model name='TSN-C3M'>
+			<roles>recon,spotter</roles>
+			<availability>ROS:4,DC:4</availability>
+		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
@@ -14346,20 +14350,16 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-C3M'>
-			<roles>recon,spotter</roles>
-			<availability>ROS:4,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1,RA:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -14367,11 +14367,11 @@
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TNS-6S'>
-			<availability>LA:5,IS:4</availability>
-		</model>
 		<model name='TNS-4T'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='TNS-6S'>
+			<availability>LA:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -14383,8 +14383,15 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:2,CLAN:3,CCO:3,RA:1,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:3,CW:3,ROS:1+,CNC:3,CJF:5,CGB:3</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
@@ -14392,77 +14399,70 @@
 		<model name='D'>
 			<availability>CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CWIE:5</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>ROS:8,NIOPS:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>ROS:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:6</availability>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:1,RA:1</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:3-,FVC:3-,HL:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:3,MERC:2</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4,FVC:1,FWL:1,FS:1,MERC:1,Periphery:1</availability>
+		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:3-,FVC:3-,HL:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -14482,13 +14482,13 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>HL:3,IS:4,Periphery.Deep:8,Periphery:4</availability>
-		<model name='Angel'>
-			<roles>artillery</roles>
-			<availability>DTA:4,LA:3,ROS:3,FWL:3,FS:3,DC:3</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:6,IS:4</availability>
+		</model>
+		<model name='Angel'>
+			<roles>artillery</roles>
+			<availability>DTA:4,LA:3,ROS:3,FWL:3,FS:3,DC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
@@ -14497,9 +14497,6 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:4,ROS:5,DC:4</availability>
-		<model name='TFT-A9'>
-			<availability>ROS:5,General:4</availability>
-		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
@@ -14507,18 +14504,21 @@
 		<model name='TFT-L8'>
 			<availability>LA:5</availability>
 		</model>
+		<model name='TFT-A9'>
+			<availability>ROS:5,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:4,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6,ROS:6,MERC:2</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:6,ROS:6,MERC:2</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6,ROS:6,MERC:2</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4,ROS:4</availability>
@@ -14526,30 +14526,30 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,PR:5,PG:5,MERC:4,DA:5,RFS:5,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-1L'>
-			<availability>General:7</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-C4'>
 			<availability>CC:3,MOC:3,CC.LCC:4</availability>
+		</model>
+		<model name='THR-1L'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
@@ -14560,13 +14560,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:2,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:2,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -14575,44 +14575,53 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:5,HL:2,IS:4,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='TDR-1C'>
-			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
-		</model>
-		<model name='TDR-60-RLA'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:1,MERC:6,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:4,LA:5,FS:3,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:1,MERC:4,FS:2</availability>
-		</model>
-		<model name='TDR-9T'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:3-,LA:1-,General:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:5,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:7,MH:2,MERC:5</availability>
+		</model>
+		<model name='TDR-17S'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='TDR-60-RLA'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:2,PIR:2,MH:2,MERC:3,FS:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:1,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9M'>
 			<availability>MOC:3,CC:3,DoO:5,DO:5,DGM:5,MERC:2,DTA:5,SC:5,MCM:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
 		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:3-,LA:1-,General:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:3-,MERC:1-</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:6,CCC:6</availability>
+		<model name='TDR-9T'>
+			<availability>TC:4</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:2,PIR:2,MH:2,MERC:3,FS:3</availability>
+		<model name='C'>
+			<availability>CSA:6,CCC:6</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:3,MERC:3</availability>
@@ -14620,30 +14629,21 @@
 		<model name='TDR-10M'>
 			<availability>CC:2,ROS:6,FWL:4,MERC:2</availability>
 		</model>
-		<model name='TDR-17S'>
-			<availability>LA:5</availability>
-		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:1,MERC:6,FS:2</availability>
-		</model>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:8,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
+		<model name='TSG-9C'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='TSG-9DDC'>
 			<availability>CC:2,CC.WHO:6</availability>
 		</model>
-		<model name='TSG-9C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
@@ -14680,15 +14680,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:4,CNC:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>CGB.FRR:4-,DC:4-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
 		</model>
@@ -14696,14 +14687,23 @@
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>CGB.FRR:4-,DC:4-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>CGB.FRR:2-,DC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CW:3,ROS:7,CLAN:2,NIOPS:9,MERC:3,DC:6</availability>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -14712,15 +14712,12 @@
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CW:2</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -14729,6 +14726,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -14740,14 +14740,10 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:2,MH:1</availability>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Small Laser]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
@@ -14758,6 +14754,10 @@
 		</model>
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -14789,17 +14789,17 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
 		<model name='TR-13'>
 			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
@@ -14807,16 +14807,16 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
-		<model name='TR-11'>
-			<roles>recon</roles>
-			<availability>General:1</availability>
+		<model name='TR-13G'>
+			<roles>ground_support,assault</roles>
+			<availability>CC:4</availability>
 		</model>
 		<model name='TR-12'>
 			<availability>CC:6,MOC:3</availability>
 		</model>
-		<model name='TR-13G'>
-			<roles>ground_support,assault</roles>
-			<availability>CC:4</availability>
+		<model name='TR-11'>
+			<roles>recon</roles>
+			<availability>General:1</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>CC:4,MOC:4,General:6,TC:4</availability>
@@ -14843,21 +14843,8 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:2,MOC:2,PR:6,IS:2,FS:1,MERC:2,Periphery:4,TC:4,RA.OA:2,OA:2,LA:2,CGB.FRR:4,ROS:4,Periphery.MW:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:1-,MOC:5-,LA:1-,FWL:1-,IS:3-,NIOPS:2-,FS:1-,MERC:3-,DC:1-,Periphery:5-</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>SC:4,PR:4,MCM:4,ROS:5,PG:4,NIOPS:5,DGM:4,MSC:4,MERC:4,RFS:4</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>SC:5,MCM:5,ROS:5,DGM:5,MSC:5,MERC:4</availability>
+		<model name='TBT-5S'>
+			<availability>Periphery.Deep:4,CDP:2-,TC:2-</availability>
 		</model>
 		<model name='TBT-9K'>
 			<roles>fire_support</roles>
@@ -14867,11 +14854,24 @@
 			<roles>fire_support</roles>
 			<availability>TC:4</availability>
 		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>SC:5,MCM:5,ROS:5,DGM:5,MSC:5,MERC:4</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>SC:4,PR:4,MCM:4,ROS:5,PG:4,NIOPS:5,DGM:4,MSC:4,MERC:4,RFS:4</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:1-</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>Periphery.Deep:4,CDP:2-,TC:2-</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:1-,MOC:5-,LA:1-,FWL:1-,IS:3-,NIOPS:2-,FS:1-,MERC:3-,DC:1-,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -14885,40 +14885,40 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7,MOC:7,MH:4,TC:7</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:4,TC:4</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:5</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:4,TC:4</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:4,TC:4</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,HL:8,CBS:5,CLAN:2,IS:9,Periphery.Deep:8,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>IS:3,DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -14962,19 +14962,19 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:5+,ROS:2,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>General:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CW:1</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -14991,52 +14991,52 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CW:2,CNC:4,CJF:7,CLAN.HW:4</availability>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -15045,13 +15045,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -15063,66 +15063,66 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,CGB.FRR:2,ROS:2,CGB:5,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CGB.FRR:8,CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CGB.FRR:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='2'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CHH:3,MERC.WD:2,CSR:3,CW:3,CBS:5,MERC:1+,CCO:1,CJF:5,RA:4,CWIE:3</availability>
-		<model name='F'>
-			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4,RA:6</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4,RA:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Umbra' unitType='Aero'>
@@ -15134,11 +15134,11 @@
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:4,CW:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -15150,13 +15150,13 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:3</availability>
-		<model name='(3071)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(3071)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -15183,6 +15183,31 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:3,Periphery:3</availability>
+		</model>
+		<model name='UM-R60L'>
+			<roles>urban</roles>
+			<availability>CC:2-,FVC:1,Periphery:2</availability>
+		</model>
+		<model name='UM-R68'>
+			<roles>urban</roles>
+			<availability>CC:6,FS:6,DC:6</availability>
+		</model>
+		<model name='UM-R70'>
+			<roles>urban</roles>
+			<availability>CC:3,MOC:3,SC:3,MCM:3,FS.CMM:6,DGM:3,MSC:3,FS:4</availability>
+		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>CC:3-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
 		<model name='UM-R80'>
 			<roles>urban,spotter</roles>
 			<availability>CC:4,MOC:4,IS:2,FWL:3,MERC:3,Periphery:2</availability>
@@ -15190,31 +15215,6 @@
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:6,Periphery:6</availability>
-		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:6,FS:6,DC:6</availability>
-		</model>
-		<model name='UM-R60L'>
-			<roles>urban</roles>
-			<availability>CC:2-,FVC:1,Periphery:2</availability>
-		</model>
-		<model name='UM-R60'>
-			<roles>urban</roles>
-			<availability>CC:3-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='UM-R70'>
-			<roles>urban</roles>
-			<availability>CC:3,MOC:3,SC:3,MCM:3,FS.CMM:6,DGM:3,MSC:3,FS:4</availability>
-		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -15230,10 +15230,6 @@
 			<deployedWith>IS</deployedWith>
 			<availability>CGB:2</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -15242,6 +15238,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -15271,41 +15271,41 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
-		<model name='VLK-QF'>
+		<model name='VLK-QD3'>
 			<roles>recon,fire_support</roles>
-			<availability>FS:1-,MERC:1-</availability>
-		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:5,ROS:4,MERC:2</availability>
-		</model>
-		<model name='VLK-QD'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:5,LA:5,ROS:6,FS:7,MERC:6</availability>
-		</model>
-		<model name='VLK-QD2'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,FS:4</availability>
+			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:3-,FS:3-,MERC:3-,CDP:3-,TC:3-</availability>
 		</model>
-		<model name='VLK-QD1'>
+		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+			<availability>LA:5,ROS:4,MERC:2</availability>
+		</model>
+		<model name='VLK-QD2'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,FS:4</availability>
+		</model>
+		<model name='VLK-QF'>
+			<roles>recon,fire_support</roles>
+			<availability>FS:1-,MERC:1-</availability>
+		</model>
+		<model name='VLK-QD'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:5,LA:5,ROS:6,FS:7,MERC:6</availability>
 		</model>
 		<model name='VLK-QT2'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
-		<model name='VLK-QD3'>
-			<roles>recon,fire_support</roles>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QD4'>
 			<roles>recon,fire_support</roles>
 			<availability>ROS:3,FS:2</availability>
+		</model>
+		<model name='VLK-QD1'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -15320,24 +15320,24 @@
 		<model name='D'>
 			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:3,General:5,RA:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:3,General:5,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -15349,52 +15349,52 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>HL:9,IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Liao)'>
-			<availability>CC:3-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,DTA:5,PR:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
+		<model name='V7'>
+			<availability>LA:3,ROS:3,FS:3,MERC:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>CC:1-,General:1-</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:3-</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,DTA:5,PR:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
 		</model>
 		<model name='V-G7X'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:3-</availability>
-		</model>
-		<model name='V7'>
-			<availability>LA:3,ROS:3,FS:3,MERC:4</availability>
-		</model>
 		<model name='(Cell)'>
 			<availability>CC:4,LA:4,FWL:4,IS:2,FS:4,MERC:5,DC:4,Periphery:2</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,IS:1,FS:4,Periphery:1,TC:1,RA.OA:1,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
-		<model name='(2682)'>
+		<model name='(3056)'>
 			<roles>asf_carrier</roles>
-			<availability>General:3</availability>
+			<availability>IS:3,FS:8</availability>
 		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:3,CC:3</availability>
 		</model>
-		<model name='(3056)'>
+		<model name='(2682)'>
 			<roles>asf_carrier</roles>
-			<availability>IS:3,FS:8</availability>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -15414,74 +15414,74 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:3</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:3,CC:6,HL:3,IS:3-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
-		<model name='VTR-9B'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,HL:2,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>CC:1,FVC:3,ROS:3,FS:3,MERC:3,DC:2,Periphery:1</availability>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:2</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
+		<model name='VTR-9Ka'>
+			<availability>CC:1,FVC:3,ROS:3,FS:3,MERC:3,DC:2,Periphery:1</availability>
 		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,HL:2,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
+		<model name='VTR-9D'>
+			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 		<model name='VTR-9A1'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:1-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-9D'>
-			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
 		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
+		<model name='VTR-9S'>
+			<availability>LA:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CGB.FRR:7,ROS:4,MERC:4,CGB:5</availability>
+		<model name='VKG-3A'>
+			<roles>missile_artillery</roles>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
 		<model name='VKG-2G'>
 			<availability>CGB.FRR:6,ROS:6,MERC:6,CGB:6</availability>
 		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-3A'>
-			<roles>missile_artillery</roles>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -15497,11 +15497,8 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:2,MERC:4,TC:6</availability>
-		<model name='VND-5L'>
-			<availability>CC:3,MOC:2,MERC:2,TC:2</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:7,MOC:6</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:3</availability>
@@ -15509,14 +15506,17 @@
 		<model name='VND-3L'>
 			<availability>CC:6,MOC:3,General:3,TC:3</availability>
 		</model>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
+		<model name='VND-4L'>
+			<availability>CC:7,MOC:6</availability>
 		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-5L'>
+			<availability>CC:3,MOC:2,MERC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -15533,49 +15533,49 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:3,General:2,CJF:6,RA:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CJF:4</availability>
+		<model name='5'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:2,CJF:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,DC:6+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:5</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CNC:8</availability>
-		</model>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -15591,32 +15591,24 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CGB.FRR:4,PIR:2,FS:2,DC:3</availability>
-		<model name='VNL-K75N'>
-			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
-		</model>
 		<model name='VNL-X71 (Yakuza)'>
 			<availability>PIR:8</availability>
+		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>HL:2,MERC:6,FS:4,CDP:3,Periphery:3,TC:1</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>General:4,FS:8,CDP:4</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:2,MOC:4,LA:5,CGB.FRR:4,FWL:5,IS:3,NIOPS:3,Periphery:4,TC:4</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>DoO:6,DO:6,TP:6,DA:6,RCM:5</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:2-,General:3-,FS:2-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:3,PIR:2,IS:2,FS:3-,Periphery:2,TC:2</availability>
@@ -15625,9 +15617,17 @@
 			<roles>anti_infantry</roles>
 			<availability>CGB.FRR:3,FWL:8,MERC:3,DC:3</availability>
 		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>FVC:2-,General:3-,FS:2-</availability>
+		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:5,LA:5,CGB.FRR:5,ROS:6,MH:4,FS:5,MERC:5</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>DoO:6,DO:6,TP:6,DA:6,RCM:5</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -15639,29 +15639,29 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,CSR:3,General:4,CCO:6,RA:5,CGB:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:5,CLAN:3,General:2,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CNC:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='War Dog' unitType='Mek'>
@@ -15675,8 +15675,21 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:1,CLAN:7,IS:3,TC:1</availability>
-		<model name='9'>
-			<availability>CDS:4</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
+		</model>
+		<model name='6'>
+			<availability>CSR:3,RA:6,CGB:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CC:3,CHH:3,CSR:1,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
+		</model>
+		<model name='7'>
+			<availability>CSR:2,RA:5</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:5,IS:4</availability>
@@ -15684,37 +15697,35 @@
 		<model name='8'>
 			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
 		</model>
-		<model name='6'>
-			<availability>CSR:3,RA:6,CGB:6</availability>
-		</model>
-		<model name='7'>
-			<availability>CSR:2,RA:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CC:3,CHH:3,CSR:1,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>IS:3</availability>
+		<model name='9'>
+			<availability>CDS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>HL:5,LA:8,IS:7,FWL:8,NIOPS:4-,Periphery.Deep:5,TC:8,Periphery:6</availability>
+		<model name='WHM-5L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:6,MERC:3</availability>
+		</model>
+		<model name='WHM-8D2'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='WHM-6L'>
 			<availability>CC:1-</availability>
 		</model>
-		<model name='WHM-9S'>
-			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
+		<model name='WHM-6K'>
+			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>PR:6,PG:6,FWL:4,RFS:6</availability>
+		<model name='WHM-8K'>
+			<availability>DC:6</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WHM-6D'>
+			<availability>FVC:2-,FS:1-</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:3,PIR:4,IS:2,MH:3,FS:3,MERC:3,CDP:3,TC:4</availability>
@@ -15722,53 +15733,42 @@
 		<model name='WHM-6R'>
 			<availability>General:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
-		<model name='WHM-6K'>
-			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-</availability>
+		<model name='WHM-10T'>
+			<availability>FS:3,TC:7</availability>
 		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6,MOC:3</availability>
+		<model name='WHM-8M'>
+			<availability>PR:6,PG:6,FWL:4,RFS:6</availability>
 		</model>
 		<model name='WHM-11T'>
 			<availability>MOC:3,TC:2</availability>
 		</model>
-		<model name='WHM-8K'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:3,LA:2,DoO:3,ROS:3,DO:3,TP:3</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FVC:2-,FS:1-</availability>
+		<model name='WHM-6Rb'>
+			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:2</availability>
 		</model>
 		<model name='WHM-7M'>
 			<availability>CC:3,FVC:3,CGB.FRR:1,ROS:4,FWL:7,MERC:3,DC:1,Periphery:3</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
+		<model name='WHM-9S'>
+			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:6,MERC:3</availability>
+		<model name='WHM-4L'>
+			<availability>CC:6,MOC:3</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:3,TC:7</availability>
+		<model name='WHD-10CT'>
+			<availability>CC:3,LA:2,DoO:3,ROS:3,DO:3,TP:3</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:2</availability>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:3,FS:5</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:5</availability>
@@ -15776,24 +15776,24 @@
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:3,RA:4,RA.OA:6,OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:3,FWL:5,MH:6,DC:4</availability>
+		<model name='H-9'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='H-7'>
 			<availability>IS:3-,Periphery:3-</availability>
+		</model>
+		<model name='H-7A'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='H-8'>
+			<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:2,Periphery.Deep:4,FWL:2,FS:6,MERC:6,Periphery:6,RA:8</availability>
 		</model>
 		<model name='H-10'>
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-8'>
-			<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:2,Periphery.Deep:4,FWL:2,FS:6,MERC:6,Periphery:6,RA:8</availability>
-		</model>
-		<model name='H-7A'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
 		<model name='H-7C'>
 			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='H-9'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -15804,101 +15804,104 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-110'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,Periphery:6,RA:4</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:2,IS:2,TC:5</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:4,LA:5,FS:4,MERC:2</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FVC:2-,FS:1-</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>CC:2-,MOC:2-,FVC:3-,FWL:2-,RCM:2-,Periphery:2-</availability>
-		</model>
-		<model name='WSP-3L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
 		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:4,OA:2,RA:8</availability>
 		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:2,IS:2,TC:5</availability>
+		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>CC:2-,MOC:2-,FVC:3-,FWL:2-,RCM:2-,Periphery:2-</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:1-</availability>
+		</model>
+		<model name='WSP-3L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
+		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FVC:2-,FS:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:6,FS:8,MERC:5,CDP:5,DC:4</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,CDP:2,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CSR:1,CJF:1,RA:1</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,Periphery.DD:1,MERC:2,Periphery.OS:1,Periphery:2,TC:1,RA.OA:1,FVC:2,OA:1,FS.CMM:2,NIOPS:1-,MH:1,DC:2</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:5</availability>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,MH:5,Periphery:3</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -15911,26 +15914,23 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:6,OA:6,MH:6,MERC:4,CDP:6,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,MH:5,Periphery:3</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:4,LA:4,CNC:2-,FWL:4,IS:3,MERC:4,DC:7</availability>
-		<model name='WGT-2LAW'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='WGT-4NC &apos;Dezgra&apos;'>
-			<availability>CNC:8</availability>
+		<model name='WGT-2LAWC3'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='WGT-2LAWC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-4NC &apos;Dezgra&apos;'>
+			<availability>CNC:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>LA:5,FWL:5,IS:4,MERC:5,DC:6</availability>
@@ -15940,6 +15940,9 @@
 		</model>
 		<model name='WGT-3SC'>
 			<availability>CC:8,LA:5,FWL:5,IS:5,MERC:5</availability>
+		</model>
+		<model name='WGT-2LAW'>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -15951,11 +15954,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:3,MERC:3,DC:5-</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>ROS:6</availability>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:4</availability>
 		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
@@ -15963,51 +15963,43 @@
 		<model name='WFT-C'>
 			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:4</availability>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,DoO:3,DO:3,DGM:3,FS:2,MERC:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:2,LA:7,MCM:3,CGB.FRR:5,ROS:5,MH:4,MSC:2,TP:3</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
-		</model>
-		<model name='WLF-1'>
-			<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-3M'>
 			<availability>DTA:8,SC:8,DoO:8,MCM:8,FWL:8,DO:8,DGM:8,MSC:8,TP:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
 		<model name='WLF-2H'>
 			<availability>LA:3,MERC:2,CWIE:3</availability>
 		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:4,CWIE:5</availability>
+		<model name='WLF-1'>
+			<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:4,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FWL:5,MH:2,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-9D'>
-			<roles>spotter</roles>
-			<availability>FS:6,MERC:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:3,CGB:5</availability>
-		</model>
 		<model name='WVR-9W2'>
 			<availability>IS:4,DC:6</availability>
 		</model>
@@ -16015,38 +16007,49 @@
 			<roles>recon</roles>
 			<availability>CGB.FRR:8,MERC:6,CGB:8,DC:6</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:2-,MH:4-</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:3,DC:6</availability>
+		<model name='WVR-9D'>
+			<roles>spotter</roles>
+			<availability>FS:6,MERC:4</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:3,CGB:5</availability>
+		</model>
 		<model name='WVR-9M'>
 			<availability>LA:2,ROS:4,FWL:5,MH:2,MERC:3</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:3</availability>
+		</model>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:3,DC:6</availability>
+		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,FWL:5,MH:2,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:6,LA:5,ROS:4,FS:5,MERC:3</availability>
 		</model>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:3</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:2-,MH:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -16060,6 +16063,9 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:2</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
@@ -16067,9 +16073,6 @@
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -16085,13 +16088,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:2,PR:2,DoO:2,IS:2,DO:2,DGM:2,FS:7,MERC:5,DC.GHO:4,SC:2,DTA:2,FVC:2,MCM:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
-		</model>
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -16107,14 +16110,14 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:3,Periphery.CM:3,MERC:4,DC:3,Periphery:1,TC:3</availability>
+		<model name='XNT-4O'>
+			<availability>CC:6,MOC:6,LA:6</availability>
+		</model>
 		<model name='XNT-2O'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:5,MOC:5,LA:5,ROS:5,MERC:5</availability>
-		</model>
-		<model name='XNT-4O'>
-			<availability>CC:6,MOC:6,LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -16126,24 +16129,18 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CSR:3,CLAN:5,RA:4</availability>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -16151,8 +16148,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:5</availability>
+		</model>
 		<model name='(PPC)'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -16180,31 +16183,31 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>DC.GHO:2,CGB.FRR:5,CLAN:3,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CGB.FRR:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
@@ -16226,35 +16229,35 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-,ROS:4</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,CGB.FRR:4,ROS:5,PIR:4,MH:4,FS:4-,MERC:5,CDP:4,TC:4</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:6,LA:8,CGB.FRR:6,PIR:6,MH:3,MERC:6,CDP:6,TC:6</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:2-</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>HL:3,General:1-,Periphery:5</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:6,LA:8,CGB.FRR:6,PIR:6,MH:3,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -16271,11 +16274,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,ROS:4,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CW:6,ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -1126,38 +1126,35 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,LA:8,CGB.FRR:8,FWL:8,IS:6,FS:8,TC:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,General:4,Periphery.Deep:6,Periphery:3</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,LA:8,CGB.FRR:8,FWL:8,IS:6,FS:8,TC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>OP:4,PR:4,DoO:4,DO:4,DTA:4,RF:4,PG:4,FWL:4,MSC:4,TP:4,RCM:4,DA:4,RFS:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='(3088)'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:3</availability>
@@ -1166,16 +1163,19 @@
 			<roles>assault</roles>
 			<availability>CC:8,OP:8,PR:8,DoO:8,IS:5,DO:8,DTA:8,RF:8,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8,DC:3</availability>
 		</model>
+		<model name='(3088)'>
+			<availability>DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:2,CCC:2,MERC.WD:1,CDS:1,ROS:1,CNC:5,CJF:5,RA:5,CWIE:2</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>ROS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>ROS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aerie PA(L)' unitType='BattleArmor'>
@@ -1214,11 +1214,11 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CSL:6,CJF:6</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
@@ -1256,6 +1256,16 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
@@ -1263,51 +1273,41 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CNC:4,DC:6</availability>
-		<model name='AKU-2XK'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='AKU-2XC'>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,DC:5</availability>
 		</model>
 		<model name='AKU-2X'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='AKU-2XC'>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='AKU-2XK'>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,CW:3,LA:6,ROS:5,CNC:4,NIOPS:7,FS:5,MERC:2,CWIE:6,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>LA:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>DTA:5,OP:5,DoO:5,ROS:4,FWL:5,DO:5,MSC:5,TP:5,MERC:2</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,MERC:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,OP:6,DoO:6,FWL:6,DO:6,MSC:6,TP:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,MERC:8</availability>
 		</model>
 		<model name='ALB-3Ur'>
 			<availability>ROS:4,FWL:4,MERC:4</availability>
@@ -1315,11 +1315,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CGB:5</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:1</availability>
@@ -1334,23 +1334,23 @@
 	</chassis>
 	<chassis name='Angerona Scout Suit' unitType='BattleArmor'>
 		<availability>ROS:4+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Recon)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CSA:6,CHH:6,CLAN:2,RA:4</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,CGB:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,CGB:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1361,20 +1361,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:3,CHH:3,MERC.WD:8,LA:4,ROS:5,MERC:3,CCO:2,CWIE:4,BAN:2,RA:3,CGB:2</availability>
-		<model name='C 2'>
-			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
-		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:3,ROS:3,MERC:3,CWIE:5</availability>
 		</model>
-		<model name='ANH-2A'>
-			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5,CHH:4,LA:5,ROS:5,MERC:5,CWIE:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,IS:3,BAN:3</availability>
 		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5,CHH:4,LA:5,ROS:5,MERC:5,CWIE:4</availability>
+		<model name='ANH-2A'>
+			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		</model>
+		<model name='C 2'>
+			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1393,11 +1393,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:5,MOC:6,DA:3,TC:3</availability>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
+		</model>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-4C'>
 			<availability>CC:4,MOC:4</availability>
@@ -1409,25 +1409,25 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,ROS:4,PG:6,FWL:5,MSC:6,TP:6,DA:6,RFS:6</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,OP:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
+		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,OP:5,PR:5,RF:5,DoO:5,PG:5,DO:5,MSC:5,TP:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='ANV-5M'>
-			<availability>DTA:5,OP:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
-		</model>
-		<model name='ANV-6M'>
-			<roles>spotter</roles>
-			<availability>ROS:2,FWL:3,MERC:2</availability>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4</availability>
 		</model>
 		<model name='ANV-5Q'>
 			<availability>DTA:4,PR:4,RF:4,PG:4,MSC:4,RFS:4</availability>
 		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
 		<model name='ANV-3M'>
 			<availability>ROS:6,FWL:4,MERC:4</availability>
+		</model>
+		<model name='ANV-6M'>
+			<roles>spotter</roles>
+			<availability>ROS:2,FWL:3,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
@@ -1439,17 +1439,13 @@
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:2,ROS:4,Periphery.ME:2,FWL:8,MH:3,MSC:8,MERC:4,DC:6</availability>
-		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,MERC:3,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>MSC:5</availability>
+		</model>
+		<model name='APL-1R'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,MERC:3,DC:3</availability>
 		</model>
 		<model name='APL-2S'>
 			<roles>fire_support</roles>
@@ -1458,6 +1454,10 @@
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -1473,14 +1473,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,CNC:5,MERC:3,FS:3,DC:3</availability>
+		<model name='2'>
+			<availability>General:4</availability>
+		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1497,11 +1497,11 @@
 	</chassis>
 	<chassis name='Arcas' unitType='Mek'>
 		<availability>CDS:3,ROS:3,CGB:6</availability>
-		<model name='2'>
-			<availability>ROS:3,CGB:3</availability>
-		</model>
 		<model name='3'>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='2'>
+			<availability>ROS:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -1509,38 +1509,6 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:1-,Periphery:4,DC:5,CGB:2</availability>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:7,MOC:3</availability>
-		</model>
-		<model name='ARC-9W'>
-			<roles>fire_support</roles>
-			<availability>ROS:5</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
-		</model>
-		<model name='ARC-9KC'>
-			<roles>fire_support</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:3,MERC:3</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:3</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:5</availability>
-		</model>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,TC:5,Periphery:4</availability>
-		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
@@ -1549,74 +1517,106 @@
 			<roles>fire_support</roles>
 			<availability>LA:5,ROS:4,FWL:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='C'>
+		<model name='ARC-6W'>
 			<roles>fire_support</roles>
-			<availability>CSA:6,CCC:6</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:8,MERC:4,CGB:5</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
-		</model>
-		<model name='ARC-4M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FVC:4,PIR:5,FWL:5,MERC:4,DC:4,Periphery:3</availability>
+			<availability>FVC:4,HL:2,TC:5,Periphery:4</availability>
 		</model>
 		<model name='ARC-2K'>
 			<roles>fire_support</roles>
 			<availability>CGB.FRR:1-,DC:2-</availability>
 		</model>
+		<model name='ARC-9W'>
+			<roles>fire_support</roles>
+			<availability>ROS:5</availability>
+		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3</availability>
+		</model>
+		<model name='ARC-4M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FVC:4,PIR:5,FWL:5,MERC:4,DC:4,Periphery:3</availability>
+		</model>
+		<model name='ARC-9KC'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>DTA:5,MOC:3,OP:5,DoO:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,DO:5,MSC:5,TP:5,MERC:4</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:8,MERC:4,CGB:5</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:7,MOC:3</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:3,MERC:3</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:3</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CCC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:4,ROS:3,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2,CWIE:3</availability>
-		<model name='A'>
-			<roles>fire_support</roles>
+		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
@@ -1628,20 +1628,20 @@
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>MERC.KH:3,CNC:4,CWIE:6,CGB:3</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:1,MERC.WD:2,ROS:0,CWIE:4</availability>
-		<model name='A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:2</availability>
 		</model>
 		<model name='J'>
 			<availability>General:8</availability>
@@ -1649,11 +1649,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Attack Craft' unitType='Small Craft'>
@@ -1665,11 +1665,11 @@
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CW:8,CLAN:6,CCO:7,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
@@ -1677,38 +1677,22 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
@@ -1716,33 +1700,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1751,13 +1751,13 @@
 			<roles>assault</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Refit)'>
 			<roles>assault</roles>
 			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Arrow IV Assault Vehicle' unitType='Tank'>
@@ -1773,22 +1773,22 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:3,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
 		<availability>ROS:5,DC:5</availability>
-		<model name='(3082)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(3062)'>
 			<roles>troop_carrier</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(3082)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1800,90 +1800,106 @@
 	</chassis>
 	<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CLAN:8</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Proto AC)'>
 			<roles>recon</roles>
 			<availability>CSL:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CDS:5,CW:5,ROS:4,CSL:8,CJF:3,RA:5,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:7,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:4,ROS:4,CLAN:1</availability>
-		<model name='AS7-D-H2'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='AS7-D-H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='AS7-D-H2'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:5,Periphery:2,TC:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>PR:4,RF:4,LA:4,PG:4,RFS:4,DC:4</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:3,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:6,Periphery:3,TC:3</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1-,MERC:0,DC:1-</availability>
 		</model>
 		<model name='AS7-K3'>
 			<availability>LA:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:4</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1-,MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:6,CNC:4,IS:4,CLAN.IS:3,Periphery:4,CWIE:4</availability>
-		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>CGB.FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:4</availability>
 		</model>
 		<model name='AS7-D'>
 			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:6,CNC:4,IS:4,CLAN.IS:3,Periphery:4,CWIE:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:2,ROS:3,MERC:3</availability>
+		</model>
+		<model name='AS7-K4'>
+			<availability>PR:4,RF:4,LA:4,PG:4,RFS:4,DC:4</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>CGB.FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:2,ROS:3,MERC:3</availability>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		<model name='AS7-C'>
+			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:3,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:6,Periphery:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -1893,25 +1909,9 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1926,62 +1926,62 @@
 		<model name='A'>
 			<availability>CSA:7,General:6,RA:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:7,CCO:8,RA:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5,CCO:6</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5,CCO:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:7,CCO:8,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>CNC:5,IS:4,DC:6,CGB:4</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OR'>
-			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
 		<model name='AV1-OE'>
 			<availability>General:6</availability>
 		</model>
+		<model name='AV1-OR'>
+			<availability>General:3+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -1997,11 +1997,8 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:1-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-10KM'>
-			<availability>DTA:4,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,DC:5</availability>
-		</model>
-		<model name='AWS-8Q'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='AWS-9Ma'>
+			<availability>DTA:3,OP:3,LA:3,ROS:3,FWL:3,MSC:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:3,PIR:4,FWL:5,IS:4,MH:3,TC:3,Periphery:3</availability>
@@ -2009,17 +2006,20 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:5,HL:2,FWL:5,IS:5,MH:5,TC:5,Periphery:4</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:3,OP:3,LA:3,ROS:3,FWL:3,MSC:3,FS:3,MERC:3</availability>
+		<model name='AWS-10KM'>
+			<availability>DTA:4,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,DC:5</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>CDS:4,ROS:4,CGB.FRR:6,FS:4,CWIE:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CGB.FRR:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -2033,86 +2033,82 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:5,CGB.FRR:2,ROS:4,FS:2,MERC:1</availability>
+		<model name='AXM-4D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:5,ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='AXM-6T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-4D'>
-			<availability>FS:5</availability>
+		<model name='AXM-1N'>
+			<availability>FVC:4,LA:4,CGB.FRR:4,MERC:4,FS:4</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>FVC:1,LA:2,FS:1</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:4,LA:4,CGB.FRR:4,MERC:4,FS:4</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:5,ROS:4,FS:6,MERC:4</availability>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CJF:5,RA:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:4,CHH:2,CW:4,LA:2,ROS:3,CSL:2</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:4</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:3,MERC:4</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2124,11 +2120,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2136,15 +2128,23 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,IS:8</availability>
+		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>General:2</availability>
@@ -2155,41 +2155,53 @@
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4+</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:4,HL:2,LA:3,ROS:4,FWL:4,MERC:8,FS:4,DA:4,Periphery:3</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:3</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1,CSL:2</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2197,33 +2209,21 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank'>
@@ -2235,14 +2235,6 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -2255,14 +2247,6 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -2271,52 +2255,65 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='I'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,FVC:3-,RF:3-,LA:4-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:2-,RFS:3-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:4-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>PR:2-,RF:2-,PG:2-,MSC:2-,RFS:2-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:4,CGB.FRR:3,MH:3,FS:6,MERC:5</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:4-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>RA.OA:1-,LA:2-,MERC:1-,CDP:1,TC:1-,Periphery:2-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:4,CGB.FRR:3,MH:3,FS:6,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,CGB.FRR:4,ROS:4,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:5</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
@@ -2325,6 +2322,9 @@
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:5</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2340,37 +2340,37 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:4,IS:2+,RA:7,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CNC:8,General:7,RA:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CNC:3,CLAN:2,RA:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CNC:8,General:7,RA:8</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>General:1,RA:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CNC:3,CLAN:2,RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2381,11 +2381,8 @@
 		<model name='H'>
 			<availability>CSA:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2393,8 +2390,11 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2417,11 +2417,11 @@
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
 		<availability>LA:2-,ROS:3,FS:6,MERC:4</availability>
-		<model name='BKX-7K'>
-			<availability>FS:2-,MERC:4-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>ROS:8,FS:8,MERC:6</availability>
+		</model>
+		<model name='BKX-7K'>
+			<availability>FS:2-,MERC:4-</availability>
 		</model>
 		<model name='BKX-1X'>
 			<availability>LA:8-,FS:2-</availability>
@@ -2429,32 +2429,24 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:2,LA:2,FWL:2,FS:2,Periphery:2,DC:2</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:3,OP:3,DoO:3,CLAN:8,DO:3,MSC:3,TP:3,FS:3,MERC:3,BAN:2,DC:3</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>MSC:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:2-</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
-		</model>
-		<model name='BLR-1S'>
-			<availability>LA:1-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='BLR-10S'>
 			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
+		<model name='BLR-4S'>
+			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
+		</model>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='BLR-1S'>
+			<availability>LA:1-</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:3,OP:3,DoO:3,CLAN:8,DO:3,MSC:3,TP:3,FS:3,MERC:3,BAN:2,DC:3</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:3</availability>
@@ -2462,35 +2454,43 @@
 		<model name='BLR-1G'>
 			<availability>IS:2-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:3-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
+		<model name='BLR-6X'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>DTA:5,OP:5,DoO:5,ROS:4,DO:5,TP:5,DA:5,MERC:4</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:2-</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CC:2,LA:2,FWL:2,FS:2,Periphery:2,DC:2</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>MSC:2</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:6,OP:6,DoO:6,DO:6,MSC:6,TP:6</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>CGB.FRR:5,ROS:4,DC:5</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
-		</model>
-		<model name='BLR-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2512,12 +2512,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>CSA:7,CCC:7,General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2532,14 +2532,14 @@
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>ROS:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
@@ -2556,18 +2556,18 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:2,HL:3,IS:2,MERC:2,FS:3,Periphery:4,RA.OA:3,CDS:5,LA:2,CGB.FRR:3,PIR:2,CNC:5,FWL:2,DC:5</availability>
-		<model name='(Kurita)'>
-			<availability>CLAN:6,IS:6,DC:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,DC:2</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,DC:2</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:6,IS:6,DC:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2598,25 +2598,25 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:4,CGB:5</availability>
-		<model name='BEO-12'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='BEO-14'>
 			<roles>recon</roles>
 			<availability>ROS:5</availability>
 		</model>
+		<model name='BEO-12'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>PR:5,RF:5,LA:7,CGB.FRR:3,ROS:4,PG:5,FS:3,MERC:3,RFS:5</availability>
-		<model name='BRZ-A3'>
-			<availability>PR:8,RF:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>PR:4,RF:4,LA:6,ROS:6,PG:4,MERC:6,RFS:4</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:2</availability>
+		<model name='BRZ-A3'>
+			<availability>PR:8,RF:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2624,12 +2624,12 @@
 		<model name='BSN-3K'>
 			<availability>General:8</availability>
 		</model>
+		<model name='BSN-5KC'>
+			<availability>ROS:5,DC:5</availability>
+		</model>
 		<model name='BSN-4K'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='BSN-5KC'>
-			<availability>ROS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishop Transport VTOL' unitType='VTOL'>
@@ -2641,53 +2641,59 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:2,CW:2,ROS:3+,IS:2+,CJF:2,RA:2,BAN:3,CWIE:2,CGB:2</availability>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,CGB.FRR:6,IS:5,FS:5,MERC:5,DC:8</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
@@ -2697,23 +2703,17 @@
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
 		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:7,CDS:5,CNC:5,IS:4,MERC:5,CWIE:5</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>General:4</availability>
@@ -2721,53 +2721,53 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:4,CGB.FRR:4,FWL:5,NIOPS:7,MSC:6,RFS:6,CGB:6,MOC:2,CC:2,OP:6,IS:4,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,RF:6,LA:5,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>OP:6,DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
-		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='BLK-NT-2Y'>
 			<availability>ROS:6,FS:6</availability>
 		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
-		</model>
 		<model name='BLK-NT-3A'>
 			<availability>FS:6</availability>
 		</model>
-		<model name='BL-12-KNT'>
-			<availability>ROS:6,FS:6</availability>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>OP:6,DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CJF:7,CCO:4</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>CJF:2</availability>
+		<model name='E'>
+			<availability>CLAN:6,CCO:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:6,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='X'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -2783,59 +2783,59 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:3-,MOC:3,RA.OA:4,FVC:5,HL:3,FS:5,MERC:3,TC:3,Periphery:4</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
+		</model>
 		<model name='BJ-1'>
 			<availability>Periphery.Deep:8,Periphery:2</availability>
-		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>FVC:4,LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:3,ROS:4,FWL:5,IS:2,FS:6,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OU'>
+		<model name='BJ2-OX'>
 			<availability>General:2</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OX'>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
+		</model>
+		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -2857,18 +2857,15 @@
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>PR:4,RF:4,LA:6,ROS:4,PG:4,MSC:4,MERC:4,RFS:4</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>PR:4,RF:4,LA:6,ROS:4,PG:4,RFS:4</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -2876,20 +2873,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CSL:5</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>CSA:7,General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -2901,26 +2901,26 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:8</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -2951,22 +2951,22 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:2</availability>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='Prime'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
+		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2981,13 +2981,13 @@
 			<roles>fire_support</roles>
 			<availability>Periphery.Deep:8</availability>
 		</model>
-		<model name='BMB-05A'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RA.OA:8</availability>
-		</model>
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='BMB-05A'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RA.OA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -2999,20 +2999,20 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4</availability>
-		<model name='3'>
-			<availability>CHH:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
@@ -3026,15 +3026,6 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-X3'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-5'>
 			<availability>PIR:5</availability>
 		</model>
@@ -3043,6 +3034,15 @@
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X3'>
+			<availability>PIR:4</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LDT-X4'>
+			<availability>PIR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -3066,17 +3066,17 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(PPC)'>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:5,MOC:5,RA.OA:4,IS:4,FS:4</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3105,28 +3105,28 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>MOC:1-,CC:2-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
+		<model name='(Standard)'>
+			<availability>LA:2-,General:8,FS:2-,MERC:2-,DC:2-</availability>
+		</model>
+		<model name='(AC2)'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>LA:6,ROS:6,FS:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>LA:2-,General:8,FS:2-,MERC:2-,DC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3137,11 +3137,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,ROS:6,CNC:4,NIOPS:7,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burrock' unitType='Mek'>
@@ -3162,17 +3162,17 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
-		<model name='BSW-S2r'>
-			<availability>General:3</availability>
-		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:1</availability>
+		</model>
+		<model name='BSW-X2'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BSW-X2'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='BSW-S2r'>
+			<availability>General:3</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>MERC:4</availability>
@@ -3196,17 +3196,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:5,LA:4,FS:5,MERC:4</availability>
-		<model name='CES-4R'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>FVC:8,FS:3,MERC:3</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3222,11 +3222,11 @@
 	</chassis>
 	<chassis name='Canis' unitType='Mek'>
 		<availability>CDS:4,CCO:6,CJF:4</availability>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carnivore Assault Tank' unitType='Tank'>
@@ -3243,13 +3243,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CDS:3,CW:1,CNC:5,CCO:1,CJF:1,RA:3,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3268,108 +3268,108 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
-		<model name='CTF-2X'>
-			<availability>CC:1-,MOC:1,FVC:1,MERC:1,TC:1</availability>
+		<model name='CTF-3LL'>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:4,MH:3,FS:4,MERC:3</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
-		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4,MERC:3</availability>
+		<model name='CTF-1X'>
+			<availability>General:2-,Periphery:3-</availability>
 		</model>
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>General:2-,Periphery:3-</availability>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='CTF-2X'>
+			<availability>CC:1-,MOC:1,FVC:1,MERC:1,TC:1</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,OP:3,DoO:3,DO:3,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:3,DA:4,RCM:3,DC:6</availability>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:6,DC:8</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:3,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C6'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FVC:2,CLAN:6,MERC:2,Periphery:2,DC:4</availability>
 		</model>
 		<model name='CPLT-C5A'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FVC:2,CLAN:6,MERC:2,Periphery:2,DC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:6,DC:8</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,OP:3,DoO:3,DO:3,TP:3,MERC:3,DA:3,RCM:3</availability>
 		</model>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:3,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CDS:5,CNC:5,RA:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
@@ -3377,59 +3377,59 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:4</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>RA:3</availability>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CNC:6,CSL:5,RA:5</availability>
-		<model name='3'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CNC:8,CSL:4</availability>
+		</model>
+		<model name='3'>
+			<availability>RA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:6</availability>
@@ -3437,30 +3437,24 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='Commando'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='Commando'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>LA:1-,Periphery.HR:2,FS:2-,MERC:1-,Periphery.OS:2,Periphery:2</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
@@ -3468,32 +3462,23 @@
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>LA:1-,Periphery.HR:2,FS:2-,MERC:1-,Periphery.OS:2,Periphery:2</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,OP:2,DoO:2,DO:2,Periphery.OS:4,FS:8,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:2,TP:2</availability>
-		<model name='CN9-AL'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:1-,FS:1-,MERC:1-</availability>
-		</model>
-		<model name='CN9-A'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:3-,Periphery.Deep:8,FS:1-,MERC:1-,Periphery:3-</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:4,HL:2,FS:2,MERC:5,Periphery:4</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:4</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CDP:3</availability>
 		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-AH'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:1-,FS:1-,MERC:1-</availability>
+		<model name='CN10-B'>
+			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-H'>
 			<availability>MH:5</availability>
@@ -3501,17 +3486,32 @@
 		<model name='CN9-D4D'>
 			<availability>DTA:3,OP:3,DoO:3,ROS:3,DO:3,MSC:3,TP:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:3</availability>
+		<model name='CN9-A'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:3-,Periphery.Deep:8,FS:1-,MERC:1-,Periphery:3-</availability>
 		</model>
 		<model name='CN9-D3'>
 			<availability>FVC:2,ROS:3,FS:3,MERC:3,CDP:3</availability>
 		</model>
-		<model name='CN10-B'>
-			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
+		<model name='CN9-D'>
+			<availability>FVC:4,HL:2,FS:2,MERC:5,Periphery:4</availability>
+		</model>
+		<model name='CN9-AL'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:1-,FS:1-,MERC:1-</availability>
 		</model>
 		<model name='CN9-Da'>
 			<availability>OP:3,FVC:3,DoO:3,ROS:2,FWL:2,DO:3,MSC:3,TP:3,FS:2,MERC:2,Periphery:3</availability>
+		</model>
+		<model name='CN9-AH'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:1-,FS:1-,MERC:1-</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -3543,11 +3543,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3565,21 +3565,21 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,ROS:4,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:4,ROS:3,FS.CMM:4,FS.DMM:4,FS:3,FS.CrMM:4</availability>
+		</model>
+		<model name='XII'>
+			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:4,ROS:3,FS.CMM:4,FS.DMM:4,FS:3,FS.CrMM:4</availability>
+		<model name='X'>
+			<availability>General:8</availability>
 		</model>
 		<model name='XIVs'>
 			<availability>LA:3,ROS:4,FS:3,DC:3</availability>
-		</model>
-		<model name='XII'>
-			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -3587,6 +3587,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>HL:2,LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -3596,118 +3600,114 @@
 			<roles>training</roles>
 			<availability>General:2-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>HL:2,LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,CGB.FRR:4,FWL:2,NIOPS:5,MSC:2,RFS:2,CGB:4,CC:3,OP:2,IS:2,MERC:1,DTA:2,FVC:2,RF:2,LA:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:2</availability>
-		<model name='CHP-3N'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
+		<model name='C'>
+			<availability>CHH:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>DC.GHO:2-,CHH:2,LA:4,NIOPS:4,MERC.SI:4,MERC:4,BAN:3,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-1N2'>
+			<availability>CC:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CGB.FRR:3+,ROS:4,IS:3,NIOPS:4,MERC:2,BAN:4,Periphery:2,CGB:2</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>missile_artillery</roles>
+			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:2-,MOC:2-,RA.OA:2-,FVC:2,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-,CGB:1-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:2,CGB.FRR:3,ROS:3,MERC:3,DC:3,CGB:1</availability>
+		</model>
+		<model name='CGR-3K'>
+			<availability>CGB.FRR:3-,MERC:2-,DC:3-</availability>
+		</model>
 		<model name='CGR-2A2'>
 			<availability>MOC:5,RA.OA:10,FVC:5,HL:2,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:2,MERC:3</availability>
+		</model>
+		<model name='CGR-1A9'>
+			<availability>RA.OA:3-,FVC:3-,Periphery:3-</availability>
 		</model>
 		<model name='CGR-SA5'>
 			<roles>urban</roles>
 			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CGR-3K'>
-			<availability>CGB.FRR:3-,MERC:2-,DC:3-</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:2,CGB.FRR:3,ROS:3,MERC:3,DC:3,CGB:1</availability>
+		<model name='CGR-1L'>
+			<availability>CC:2-,FVC:3,Periphery:3</availability>
 		</model>
 		<model name='CGR-C'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='CGR-1A9'>
-			<availability>RA.OA:3-,FVC:3-,Periphery:3-</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:2,MERC:3</availability>
-		</model>
-		<model name='CGR-1L'>
-			<availability>CC:2-,FVC:3,Periphery:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:3,RA.OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:10,RFS:8,MOC:5,CC:2,OP:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,RF:8,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
-		<model name='F-13'>
-			<availability>DTA:4,CC:3,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,FS:3,MERC:4</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,OP:2,PR:2,DoO:2,DO:2,MERC:2,Periphery:2,DTA:2,FVC:2,RF:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2-,FVC:2,FWL:2-,MERC:2-,Periphery:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:2-,OP:2-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,MERC:2-,Periphery:2-,DTA:2-,RF:2-,PG:2-,FWL:2-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>CC:3,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:6,DTA:8,RF:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:2,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 		<model name='OF-17A-R'>
 			<roles>recon</roles>
 			<availability>ROS:4,MSC:5</availability>
 		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,OP:2,PR:2,DoO:2,DO:2,MERC:2,Periphery:2,DTA:2,FVC:2,RF:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
+		</model>
+		<model name='F-12-S'>
+			<availability>FWL:1-</availability>
+		</model>
 		<model name='F-14-S'>
 			<availability>OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,PG:8,FWL:8,MH:4,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2-,FVC:2,FWL:2-,MERC:2-,Periphery:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:3,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:6,DTA:8,RF:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:2,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='F-13'>
+			<availability>DTA:4,CC:3,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,FS:3,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:2,CDS:3,LA:2,ROS:5,CNC:4,NIOPS:5,FS:2,RCM:2,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
@@ -3715,13 +3715,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:5,CDS:6,LA:5,ROS:6,FS:5,RCM:5,DC:5</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3732,63 +3732,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>OP:4,PR:4,DoO:4,DO:4,FS:1,MERC:5,DTA:4,FVC:4,RF:4,LA:6,ROS:4,PG:4,FWL:4,MH:4,TP:4,DA:4,RFS:4,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2,BAN:0</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2,BAN:0</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:3,CDP:3,TC:3</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:7</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CSA:6,CNC:5,RA:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,PR:5,RF:5,PG:5,FWL:5,MSC:5,MERC:2,CDP:3,RFS:5,Periphery:3,DC:2</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,CGB.FRR:6,FWL:5,MERC:6,DC:6</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6,Periphery:3</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:4,IS:4</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>PR:6,RF:6,PG:6,FWL:8,MSC:6,RFS:6</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,CGB.FRR:6,FWL:5,MERC:6,DC:6</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -3825,20 +3825,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -3855,23 +3855,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -3879,14 +3879,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -3903,32 +3903,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3936,11 +3936,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3949,14 +3949,14 @@
 			<roles>marine</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>CDS:6,CW:4,CNC:6,CGB:4,CWIE:6</availability>
+		<model name='(Volk)' mechanized='true'>
+			<availability>CW:5</availability>
 		</model>
 		<model name='(Rache)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Volk)' mechanized='true'>
-			<availability>CW:5</availability>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>CDS:6,CW:4,CNC:6,CGB:4,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -3964,20 +3964,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3989,10 +3989,6 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='V3'>
-			<roles>assault</roles>
-			<availability>LA:4,ROS:6,FS:4</availability>
-		</model>
 		<model name='Interceptor'>
 			<roles>assault</roles>
 			<availability>LA:1</availability>
@@ -4001,20 +3997,30 @@
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='V3'>
+			<roles>assault</roles>
+			<availability>LA:4,ROS:6,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>CW:5,CNC:5,RA:3,CGB:5</availability>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,PR:3,HL:2,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,RF:3,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
 		<model name='CLNT-2-3U'>
 			<availability>CC:4,LA:2,General:6</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
@@ -4025,12 +4031,6 @@
 		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>Periphery.Deep:8,NIOPS:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -4081,59 +4081,59 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
+		<model name='COM-3A'>
 			<roles>recon</roles>
-			<availability>MOC:5,FVC:3,LA:8,CGB.FRR:6,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:5,Periphery:3</availability>
-		</model>
-		<model name='COM-2Dr'>
-			<roles>recon</roles>
-			<availability>HL:3,LA:5,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>LA:5,ROS:8</availability>
+			<availability>LA:1-,MERC:1-,Periphery:2</availability>
 		</model>
 		<model name='COM-1A'>
 			<roles>recon</roles>
 			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
 		</model>
-		<model name='COM-3A'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:1-,MERC:1-,Periphery:2</availability>
+			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:5,Periphery:3</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,MERC:7</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>MOC:5,FVC:3,LA:8,CGB.FRR:6,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>LA:5,ROS:8</availability>
+		</model>
+		<model name='COM-2Dr'>
+			<roles>recon</roles>
+			<availability>HL:3,LA:5,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>General:2-,Periphery.Deep:8,TC:2-,Periphery:3-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:7,MERC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:3,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CC:3-,FVC:3-,General:2-,FS:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:8</availability>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CC:1,LA:1,FS:1</availability>
 		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:3-,FVC:3-,General:2-,FS:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:4-</availability>
+		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
@@ -4147,13 +4147,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>CGB.FRR:4,IS:5,Periphery.Deep:6,Periphery:6,CGB:2</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:6,IS:4,DC:7</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Condottiere Assault Craft' unitType='Small Craft'>
@@ -4172,13 +4172,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,NIOPS:6,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -4201,23 +4201,23 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:5</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>CGB:2</availability>
-		<model name='(SRM)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LMG)' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
@@ -4254,50 +4254,50 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='CRX-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-OR'>
 			<availability>RA.OA:3,CLAN:8</availability>
+		</model>
+		<model name='CRX-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:6,CCC:4,CLAN.IS:4,CSL:4,CCO:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)' mechanized='true'>
 			<availability>CSA:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,RA.OA:3,LA:3,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
+		<model name='CSR-V12'>
+			<availability>IS:2-,Periphery.Deep:8,BAN:4,Periphery:3-</availability>
 		</model>
 		<model name='CSR-12D'>
 			<availability>FS:6</availability>
 		</model>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		</model>
 		<model name='CSR-V12b'>
 			<availability>ROS:4,CLAN:6,FS:4,MERC:3,BAN:2</availability>
 		</model>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,FS.AH:1-,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>IS:2-,Periphery.Deep:8,BAN:4,Periphery:3-</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
@@ -4324,11 +4324,11 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:1</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -4336,16 +4336,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CW:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -4353,8 +4352,9 @@
 		<model name='H'>
 			<availability>CSA:6,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -4372,54 +4372,54 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
-		<model name='CRB-27b'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>CGB.FRR:6,ROS:8,CLAN:4,FWL:8,MERC:8,BAN:2,DC:6</availability>
+			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
 		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
+		<model name='CRB-27b'>
+			<roles>raider</roles>
+			<availability>CGB.FRR:6,ROS:8,CLAN:4,FWL:8,MERC:8,BAN:2,DC:6</availability>
+		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
 		<availability>CC:3,CDS:5,LA:4,ROS:4,CNC:5,MSC:3,FS:3,MERC:4,CJF:5,CWIE:5,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:8,CLAN.IS:8,MSC:8,FS:8</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:4,CJF:4</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,CLAN.IS:8,MSC:8,FS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CC:8,CDS:4,CNC:4,MERC:8,DC:8</availability>
 		</model>
+		<model name='4'>
+			<availability>CDS:4,CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CDS:4,RA:4</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4427,23 +4427,23 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>DC.GHO:1,CHH:5,CDS:3,CW:5,CGB.FRR:6,ROS:4,CLAN:4,NIOPS:9,CJF:3,RA:3,CWIE:5,CGB:5</availability>
-		<model name='CRK-5004-1'>
-			<availability>CGB.FRR:4,ROS:6</availability>
+		<model name='CRK-5003-3'>
+			<availability>CGB.FRR:4,ROS:8</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>ROS:8</availability>
+		<model name='CRK-5003-1'>
+			<availability>ROS:4,CLAN:6,NIOPS:4,BAN:8</availability>
+		</model>
+		<model name='CRK-5004-1'>
+			<availability>CGB.FRR:4,ROS:6</availability>
 		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:2-,NIOPS:0</availability>
 		</model>
-		<model name='CRK-5003-1'>
-			<availability>ROS:4,CLAN:6,NIOPS:4,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-3'>
-			<availability>CGB.FRR:4,ROS:8</availability>
+		<model name='CRK-5005-1'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -4463,33 +4463,37 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:3,CW:2,CLAN:2,CNC:3,CCO:4,CJF:2,RA:5,CWIE:3,CGB:2</availability>
-		<model name='A'>
-			<availability>General:5</availability>
+		<model name='U'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='U'>
-			<availability>CLAN:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>CC:3,MOC:3,ROS:4,CNC:3,IS:2,FWL:3,MERC:3,DC:4</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
@@ -4498,51 +4502,47 @@
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>HL:4,CLAN:5,IS:6,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-8S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:3,MOC:3,FWL:8,FS:3,MERC:4,CDP:3,DC:3,TC:3</availability>
-		</model>
 		<model name='CRD-7W'>
 			<availability>DTA:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,MSC:5,MERC:3,RCM:5</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>CGB.FRR:6,DC:5</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:5,MERC:5</availability>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:5,MERC:5</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:5,MERC:4</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:7</availability>
+		</model>
 		<model name='CRD-4L'>
 			<availability>CC:3,MOC:3</availability>
 		</model>
-		<model name='CRD-5K'>
-			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
+		<model name='CRD-8S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='CRD-3R'>
+			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:5,MERC:5</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>CGB.FRR:6,DC:5</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>FVC:3,ROS:5,CLAN:4,FWL:5,IS:3,MERC:5,BAN:2</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:5,MERC:5</availability>
+		<model name='CRD-5M'>
+			<availability>CC:3,MOC:3,FWL:8,FS:3,MERC:4,CDP:3,DC:3,TC:3</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4556,23 +4556,31 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>MOC:4,CGB.FRR:8,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>MOC:4,CC:5,LA:5,FWL:5,IS:5,MH:4,FS:6,CDP:4,DC:2,TC:4,Periphery:2</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>General:3-</availability>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:2,DC:2</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:6,MOC:5,IS:3+,MERC:6,DC:6</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>MOC:4,CGB.FRR:8,IS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -4581,31 +4589,23 @@
 		<model name='CP-11-H'>
 			<availability>FVC:6,HL:4,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
 		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:2,DC:2</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:4,MERC.WD:2,ROS:2,CWIE:3</availability>
-		<model name='4'>
-			<availability>General:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
+		<model name='4'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4618,25 +4618,25 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,HL:2,ROS:4,General:4,NIOPS:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>MOC:3,CDP:3,TC:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4658,35 +4658,35 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='DAI-01r'>
 			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -4706,14 +4706,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:5,DC:7,CGB:4</availability>
-		<model name='DMO-4K'>
-			<availability>DC:8</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:4</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>CGB.FRR:4,DC:6</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:4</availability>
+		<model name='DMO-4K'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -4722,27 +4722,26 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CCO:6</availability>
@@ -4750,8 +4749,9 @@
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4770,31 +4770,31 @@
 	</chassis>
 	<chassis name='Dark Crow' unitType='Mek'>
 		<availability>RA:4</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:3,FS:6,MERC:4</availability>
-		<model name='DRT-6T'>
-			<availability>LA:5,ROS:8,FS:5,MERC:5</availability>
-		</model>
 		<model name='DRT-3S'>
 			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='DRT-6T'>
+			<availability>LA:5,ROS:8,FS:5,MERC:5</availability>
 		</model>
 		<model name='DRT-4S'>
 			<availability>LA:3,MH:4,FS:4,MERC:4</availability>
@@ -4802,11 +4802,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:5,General:5,CDP:3</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5,CDP:3</availability>
 		</model>
@@ -4818,25 +4821,15 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2,CDP:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
+			<availability>FVC:5,General:5,CDP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:4,CCC:2,MERC.WD:3,CDS:2,CLAN:2,IS:3+,CCO:1,CJF:3,BAN:3,CGB:6</availability>
-		<model name='H'>
-			<availability>CSA:6,CDS:5,General:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
@@ -4844,27 +4837,34 @@
 		<model name='K'>
 			<availability>General:2,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CDS:5,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
 		<availability>CDS:4,LA:3,ROS:3,CNC:3,IS:2,FS:3,RA:3,CGB:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6,IS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -4884,15 +4884,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4,MOC:4,MSC:3</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4907,11 +4907,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:5,MERC:4</availability>
-		<model name='DFN-3S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -4925,18 +4925,18 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='S'>
 			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -4951,18 +4951,6 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:2,IS:2,Periphery.Deep:6,Periphery:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,MOC:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,IS:8,FS:8,DC:8,TC:8,CWIE:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,HL:2,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
@@ -4970,8 +4958,20 @@
 		<model name='(MRM)'>
 			<availability>FVC:4,HL:2,DC:8,Periphery:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,MOC:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,IS:8,FS:8,DC:8,TC:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:2,IS:2,Periphery.Deep:6,Periphery:4</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
+		</model>
+		<model name='(Defensive)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 	</chassis>
@@ -4981,11 +4981,11 @@
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>LA:4,ROS:4,CWIE:4</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:3,CWIE:3</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>LA:4,ROS:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5021,23 +5021,23 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:1,CC:1,OP:3,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
-		<model name='DV-8D'>
-			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
-		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,IS:1-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:5,FS:6,MERC:4</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='DV-6Mr'>
 			<availability>General:2</availability>
 		</model>
 		<model name='DV-1S'>
 			<availability>IS:2-</availability>
+		</model>
+		<model name='DV-8D'>
+			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>CLAN:4,IS:1-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -5051,11 +5051,11 @@
 		<model name='DVS-3'>
 			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5080,10 +5080,10 @@
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
 		<availability>PIR:1</availability>
-		<model name='(Reflective)&apos;Terrorizer&apos; (Flamer)' mechanized='true'>
+		<model name='(Reflective)&apos;Terrorizer&apos; (SL)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Reflective)&apos;Terrorizer&apos; (SL)' mechanized='true'>
+		<model name='(Reflective)&apos;Terrorizer&apos; (Flamer)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Reflective)&apos;Terrorizer&apos; (MG)' mechanized='true'>
@@ -5102,16 +5102,16 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Close Support)'>
-			<roles>spotter</roles>
-			<availability>CHH:6,CGB:4</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8,CJF:2</availability>
+		</model>
+		<model name='(Close Support)'>
+			<roles>spotter</roles>
+			<availability>CHH:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5146,14 +5146,14 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,CGB.FRR:6,MERC:3,DC:4</availability>
-		<model name='DRG-7N'>
-			<availability>MERC:6,DC:6</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:2</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>HL:2,CGB.FRR:4,MERC:4,DC:4,Periphery:4</availability>
+		</model>
+		<model name='DRG-7N'>
+			<availability>MERC:6,DC:6</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
@@ -5161,12 +5161,12 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,MERC.WD:3,CHH:4,ROS:3+,CGB:5</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
@@ -5174,26 +5174,26 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:2</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
+		<model name='A'>
+			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:7,CHH:7,CCC:7,CDS:8,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
+		</model>
 		<model name='I'>
+			<availability>General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,General:4,CCO:6,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5212,17 +5212,17 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:2-,Periphery:2-,FVC:2-,LA:6,ROS:3,FWL:2-,CC.MAC:2-,DC:2-</availability>
-		<model name='(Standard)'>
-			<availability>CC:2-,General:2-</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>LA:3,ROS:3,FS:3</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CC:2-,General:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:2-,General:2-</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:3,ROS:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5234,33 +5234,33 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:3,TC:4</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6b'>
-			<availability>OP:5,DoO:5,DO:5,MSC:5,TP:5,RCM:5</availability>
-		</model>
 		<model name='EGL-R11'>
 			<availability>PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:5,FS:6,RFS:6</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>General:4-</availability>
 		</model>
+		<model name='EGL-R6b'>
+			<availability>OP:5,DoO:5,DO:5,MSC:5,TP:5,RCM:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,PR:6,RF:6,PG:6,FWL:6,MH:4,MSC:7,MERC:4,DA:5,RFS:6</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
 		<model name='EGL-3M'>
 			<availability>DTA:4,FWL:4,MSC:4</availability>
@@ -5272,13 +5272,13 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='MEB-9'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='MEB-11'>
 			<roles>recon</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='MEB-9'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -5286,11 +5286,11 @@
 		<model name='EFT-7X'>
 			<availability>IS:8,MH:6</availability>
 		</model>
-		<model name='EFT-4J'>
-			<availability>MERC:2-,Periphery:8</availability>
-		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='EFT-4J'>
+			<availability>MERC:2-,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5301,19 +5301,19 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:5,ROS:4,MERC:3</availability>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
-		</model>
 		<model name='EST-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='EST-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='EST-OC'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
 		</model>
-		<model name='EST-OA'>
+		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -5329,41 +5329,14 @@
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,MERC.WD:5,CW:5,CLAN:5,CNC:5+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:4</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -5371,43 +5344,66 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>CW:2,CGB:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:4</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5</availability>
-		<model name='X' mechanized='true'>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X' mechanized='true'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:3,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:4</availability>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 		<model name='EMP-7L'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='EMP-6A'>
-			<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
+		<model name='EMP-6L'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='EMP-6S'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
+		<model name='EMP-6A'>
+			<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>LA:5-,ROS:3-,FS:2-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:5,MERC:5</availability>
@@ -5419,11 +5415,24 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:7,MERC:5</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6G'>
+			<availability>ROS:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-7C3BS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6T'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:1</availability>
@@ -5431,34 +5440,21 @@
 		<model name='ENF-6Ma'>
 			<availability>FVC:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='ENF-6T'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='ENF-6G'>
-			<availability>ROS:4,FS:2,MERC:4</availability>
-		</model>
-		<model name='ENF-7C3BS'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:6,FS:6,MERC:3,CDP:2,TC:2</availability>
-		<model name='ENF-5D'>
-			<availability>FVC:8,FS:8,MERC:6,CDP:5,TC:5</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>FVC:3-,General:1-,FS:2-,TC:2-</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>FVC:8,FS:8,MERC:6,CDP:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -5467,28 +5463,36 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
 		<availability>CSA:4,CHH:6,CSL:5,CJF:3,RA:4,CGB:4,CWIE:4</availability>
-		<model name='(ER Pulse)'>
-			<availability>CHH:7,CGB:4</availability>
+		<model name='(LB-X) &apos;Sholef&apos;'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LB-X) &apos;Sholef&apos;'>
-			<availability>CHH:4</availability>
+		<model name='(ER Pulse)'>
+			<availability>CHH:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGB:3+,CWIE:4+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -5498,10 +5502,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -5509,13 +5509,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CDS:2,ROS:1,CCO:1,RA:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -5524,12 +5524,12 @@
 			<roles>troop_carrier</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:4,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:3,FS:6</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5545,13 +5545,13 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>FWL:1,IS:1,NIOPS:3</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
@@ -5573,27 +5573,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MERC:3</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
-		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5614,12 +5614,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,MSC:6</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5630,11 +5630,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-9R'>
-			<availability>General:6</availability>
-		</model>
 		<model name='FLC-8R'>
 			<availability>General:5</availability>
+		</model>
+		<model name='FLC-9R'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5646,13 +5646,13 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Standard)'>
-			<roles>cruiser</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cruiser</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
@@ -5667,62 +5667,62 @@
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='&apos;Longshot&apos;' mechanized='false'>
-			<availability>General:4</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='&apos;Longshot&apos;' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,MERC.KH:3+,CHH:2,CW:5,CJF:3,CWIE:5,CGB:2</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CCO:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
@@ -5739,36 +5739,36 @@
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:3,HL:4,LA:4,ROS:3,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3,FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='&apos;Fermi&apos;'>
 			<roles>apc</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:4</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>HL:2,IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -5780,59 +5780,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5840,39 +5792,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -5887,19 +5891,15 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CSA:7,CLAN:6,IS:3</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-10D'>
-			<availability>LA:5,ROS:5,FS:5,MERC:5</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-10D'>
+			<availability>LA:5,ROS:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='ALM-8D'>
 			<roles>recon,raider</roles>
@@ -5928,11 +5928,19 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-S2'>
-			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		<model name='FS9-S1'>
+			<roles>recon</roles>
+			<availability>LA:4,General:3,FS:3</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S2'>
+			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:2,MOC:3,LA:4,CGB.FRR:3,General:3,FS:3,TC:2</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
@@ -5945,73 +5953,62 @@
 		<model name='FS9-S3'>
 			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:2,MOC:3,LA:4,CGB.FRR:3,General:3,FS:3,TC:2</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:4,General:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:4,LA:5,IS:3,FS:4,MERC:4,DC:7</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:2+,DC:2+</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:2+,DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
 		<availability>CJF:3</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:4</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -6021,44 +6018,47 @@
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:1,CLAN:1,DC.GHO:5,CDS:1,LA:4,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:5,CJF:2,CGB:1,DC:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:5,LA:8,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
-		</model>
 		<model name='FLS-9M'>
 			<availability>FWL:6,MSC:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:5,LA:8,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,CLAN.IS:5,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,CLAN.IS:5,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -6067,11 +6067,11 @@
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 		</model>
-		<model name='FLE-20'>
-			<availability>CC:4,MOC:2</availability>
-		</model>
 		<model name='FLE-17'>
 			<availability>CC:6,PR:7,RF:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:4,MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6082,8 +6082,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -6095,20 +6095,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -6137,17 +6137,17 @@
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
 		<availability>ROS:2,FS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(VSP)'>
+		<model name='(Interdictor)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Interdictor)'>
+		<model name='(VSP)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6185,10 +6185,6 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,ROS:5,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
@@ -6197,6 +6193,10 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CHH:3,CW:2,ROS:5,FS:5,MERC:3,CJF:2,CGB:3</availability>
@@ -6204,29 +6204,29 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>ROS:5,FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:8,FS:8,MERC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>ROS:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:8,OP:8,PR:8,DoO:8,DO:8,DTA:8,RF:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:2-,General:8</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:8,OP:8,PR:8,DoO:8,DO:8,DTA:8,RF:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
@@ -6246,24 +6246,24 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CW:3,ROS:2,RA:3</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,ROS:8,CCO:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6274,28 +6274,28 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:3,LA:4,ROS:4,CNC:3,IS:3,FS:4,MERC:3,CDP:3,CWIE:3,TC:3</availability>
-		<model name='GLT-7-0'>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='GLT-8-0'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
+		<model name='GLT-7-0'>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,RA.OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:1,Periphery:4</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,RA.OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:1,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -6303,35 +6303,35 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-,CWIE:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-,CWIE:8</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='GRM-01A2'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
 		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRM-01A2'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Garuda Heavy VTOL' unitType='VTOL'>
@@ -6343,66 +6343,66 @@
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CHH:3,HL:5,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,ROS:5,General:2,FS:8</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
 		<availability>CC:2,MOC:2,OP:3,DoO:3,IS:2,DO:3,MERC:2,FS:2,TC:2,DTA:3,FVC:2,LA:3,PIR:2,FWL:2,MH:2,MSC:3,TP:3,DC:2</availability>
-		<model name='GST-50'>
-			<availability>DTA:5,OP:5,DoO:5,DO:5,MSC:5,TP:5</availability>
-		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
 		</model>
 		<model name='GST-11'>
 			<availability>General:4</availability>
 		</model>
+		<model name='GST-50'>
+			<availability>DTA:5,OP:5,DoO:5,DO:5,MSC:5,TP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CDS:5,ROS:3+,CNC:5,CLAN:5,CJF:4,BAN:4,CGB:9</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		<model name='A'>
+			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='B'>
+			<availability>General:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CGB:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		</model>
 		<model name='P'>
 			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6442,14 +6442,6 @@
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(Light Gauss)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
@@ -6458,23 +6450,31 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:5</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6486,24 +6486,16 @@
 	</chassis>
 	<chassis name='Goblin Infantry Support Vehicle' unitType='Tank'>
 		<availability>FVC:5,LA:2,ROS:4,FS:3,MERC:4</availability>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Goblin Medium Tank' unitType='Tank'>
 		<availability>CC:1,FVC:2,LA:1-,FS:2-,TC:2-,DC:1</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc,urban</roles>
-			<availability>CGB.FRR:4,DC:4</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc,urban</roles>
 			<availability>CC:4,FVC:5,FS:5</availability>
@@ -6512,12 +6504,17 @@
 			<roles>apc,urban</roles>
 			<availability>CC:2,FVC:4,LA:2,CGB.FRR:2,NIOPS:2,FS:4,DC:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>apc,urban</roles>
+			<availability>CGB.FRR:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CGB:7</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>CGB:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
@@ -6528,44 +6525,47 @@
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,HL:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-4S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,MOC:4,FWL:8,MH:4,MERC:6,CDP:4,TC:4</availability>
-		</model>
-		<model name='GOL-6M'>
-			<roles>fire_support</roles>
-			<availability>ROS:4,FWL:4,MERC:3</availability>
-		</model>
-		<model name='GOL-3L'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>HL:2,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:6,Periphery:4</availability>
 		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='GOL-6M'>
+			<roles>fire_support</roles>
+			<availability>ROS:4,FWL:4,MERC:3</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
+		<model name='GOL-4S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>CC:2-,LA:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
-		<model name='GOL-2H'>
-			<roles>fire_support</roles>
-			<availability>HL:2,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:6,Periphery:4</availability>
-		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>HL:2,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon Carrier' unitType='Dropship'>
@@ -6581,24 +6581,24 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CNC:5,RA:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,RA:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CNC:5,RA:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>RA:5</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
+			<availability>RA:4</availability>
+		</model>
+		<model name='3'>
+			<roles>marine</roles>
 			<availability>RA:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -6607,32 +6607,35 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>OP:7,DoO:7,CLAN:3,DO:7,MERC:4,DTA:7,CDS:4,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:7,TP:7</availability>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,HL:3,ROS:6,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,MERC:5,BAN:2,Periphery:5</availability>
 		</model>
-		<model name='GTHA-400'>
-			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>DTA:7,OP:7,DoO:7,ROS:7,DO:7,MSC:7,TP:7</availability>
 		</model>
+		<model name='GTHA-400'>
+			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:6,MERC:3,DC:7,CGB:4</availability>
-		<model name='DRG-1G'>
-			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>CGB.FRR:6,ROS:6,CNC:8,MERC:6,DC:4,CGB:8</availability>
 		</model>
+		<model name='DRG-7K'>
+			<availability>ROS:6,MERC:4,DC:4</availability>
+		</model>
+		<model name='DRG-1G'>
+			<availability>CGB.FRR:2-,DC:2-</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:5</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='DRG-9KC'>
 			<roles>spotter</roles>
@@ -6640,9 +6643,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>ROS:6,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -6659,26 +6659,26 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:5,TC:6</availability>
+		<model name='GHR-7P'>
+			<availability>LA:8,MERC:4</availability>
+		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='GHR-5J'>
-			<availability>HL:2,IS:6,Periphery.Deep:1,Periphery:4</availability>
-		</model>
-		<model name='GHR-6K'>
-			<availability>CGB.FRR:4,ROS:4,MERC:2,FS:2,DC:4</availability>
-		</model>
 		<model name='GHR-5H'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='GHR-7P'>
-			<availability>LA:8,MERC:4</availability>
 		</model>
 		<model name='GHR-5N'>
 			<availability>General:1-</availability>
 		</model>
 		<model name='GHR-C'>
 			<availability>IS:3,DC:3</availability>
+		</model>
+		<model name='GHR-5J'>
+			<availability>HL:2,IS:6,Periphery.Deep:1,Periphery:4</availability>
+		</model>
+		<model name='GHR-6K'>
+			<availability>CGB.FRR:4,ROS:4,MERC:2,FS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Heavy Suit' unitType='BattleArmor'>
@@ -6699,14 +6699,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -6731,20 +6731,14 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:4</availability>
+		<model name='[Flamer]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[LRR]' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
@@ -6753,26 +6747,35 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[Heavy Flamer]' mechanized='false'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:6,CDS:2,CSL:6,CCO:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -6780,32 +6783,29 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,LA:3,CNC:7,IS:3,CCO:6,CJF:3,CWIE:4,DC:4</availability>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,IS:8,CCO:8</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CNC:3</availability>
 		</model>
-		<model name='6'>
-			<availability>ROS:4,CNC:6,DC:6</availability>
+		<model name='7'>
+			<availability>ROS:4,CNC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:6,CNC:4</availability>
 		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:5</availability>
+		<model name='6'>
+			<availability>ROS:4,CNC:6,DC:6</availability>
 		</model>
 		<model name='8'>
 			<availability>CW:5,LA:5,ROS:4,CJF:5,CWIE:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
@@ -6813,54 +6813,54 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-1S'>
-			<availability>LA:2-,MERC:2-</availability>
-		</model>
-		<model name='GRF-2N'>
-			<availability>CC:4,MOC:3,OP:4,DoO:4,CLAN:6,DO:4,FS:4,MERC:4,BAN:4,MH:3,MSC:4,TP:4,RCM:4,DC:4</availability>
+		<model name='GRF-1N'>
+			<availability>General:2-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:2-,MERC:2-,TC:3-</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,OP:6,DoO:6,ROS:5,DO:6,MSC:6,TP:6,MERC:5</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>MOC:3,OP:5,PR:6,DoO:5,IS:5,DO:5,FS:4,DTA:5,RF:6,LA:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CC:3,ROS:6,CGB.FRR:5,CNC:3,FWL:3,FS:3,DC:3,CGB:5</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:5,LA:3,CGB.FRR:3,ROS:4,FS:5,MERC:3,DC:4</availability>
+		<model name='GRF-6S'>
+			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CNC:6,DC:6</availability>
 		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,OP:6,DoO:6,ROS:5,DO:6,MSC:6,TP:6,MERC:5</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:5,LA:3,CGB.FRR:3,ROS:4,FS:5,MERC:3,DC:4</availability>
+		</model>
+		<model name='GRF-1S'>
+			<availability>LA:2-,MERC:2-</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>MOC:3,OP:5,PR:6,DoO:5,IS:5,DO:5,FS:4,DTA:5,RF:6,LA:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
+		</model>
 		<model name='GRF-4N'>
 			<availability>TC:4</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CC:3,ROS:6,CGB.FRR:5,CNC:3,FWL:3,FS:3,DC:3,CGB:5</availability>
 		</model>
 		<model name='GRF-5L'>
 			<availability>CC:5</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:2-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
+		<model name='GRF-2N'>
+			<availability>CC:4,MOC:3,OP:4,DoO:4,CLAN:6,DO:4,FS:4,MERC:4,BAN:4,MH:3,MSC:4,TP:4,RCM:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -6879,11 +6879,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CC:1,FWL:1,Periphery:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
@@ -6891,30 +6891,30 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>MERC.KH:3,MERC.WD:3,CHH:2-,CW:4,LA:3,ROS:3,CNC:2-,CCO:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:4,CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4,IS:8,CCO:6,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,DC.GHO:2,CHH:2,ROS:6,FWL:5,NIOPS:7,MSC:5,FS:5,MERC:3,RA:2,Periphery:2</availability>
-		<model name='GLT-6WB3'>
+		<model name='GLT-8D'>
 			<roles>raider</roles>
-			<availability>ROS:3,MSC:6,MERC:3</availability>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>FWL:2-,Periphery.Deep:8,NIOPS:0,MERC:2-,Periphery:2-</availability>
 		</model>
-		<model name='GLT-8D'>
-			<roles>raider</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='GLT-6WB3'>
+			<roles>raider</roles>
+			<availability>ROS:3,MSC:6,MERC:3</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -6927,22 +6927,22 @@
 			<roles>spotter</roles>
 			<availability>LA:6,General:3,FS:5,DC:5</availability>
 		</model>
-		<model name='GUN-1ERD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GUN-2ERDr'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
 		</model>
+		<model name='GUN-1ERD'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6+,ROS:4,FS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6954,9 +6954,9 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CNC:5,IS:4,DC:4,CWIE:4</availability>
-		<model name='HKO-1C'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>LA:6,DC:6</availability>
+			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,DC:4+</availability>
@@ -6964,20 +6964,20 @@
 		<model name='2'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='HKO-1C'>
 			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
+			<availability>LA:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,RA.OA:4,CHH:7,LA:2,ROS:3,CLAN:5,FS:2,MERC:2</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:8,CDS:4,RA:8,CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:8,CDS:4,RA:8,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -6989,79 +6989,79 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>MOC:2,CC:2,FWL:6,MH:2,MERC:5</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,MERC:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,MERC:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,MERC:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:4,MERC:3</availability>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
-		</model>
 		<model name='HMH-3D'>
 			<availability>General:2-,MERC:2-</availability>
-		</model>
-		<model name='HMH-5D'>
-			<availability>General:2,MERC:4</availability>
 		</model>
 		<model name='HMH-6E'>
 			<availability>General:5,MERC:5</availability>
 		</model>
+		<model name='HMH-5D'>
+			<availability>General:2,MERC:4</availability>
+		</model>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
-		<model name='HMR-HE'>
-			<availability>ROS:4,NIOPS:8</availability>
+		<model name='HMR-HDb'>
+			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>ROS:4,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,ROS:3+,CNC:5,CJF:4,CCO:3,CGB:3</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7080,59 +7080,59 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:2-,Periphery.MW:2-,FWL:5,MH:3,MSC:5,RFS:5,MOC:3,CC:3,OP:5,IS:2-,MERC:3,Periphery:1-,DTA:5,RF:5,LA:3,PG:5,Periphery.ME:2-,TP:5,DA:5,RCM:5,DC:2-</availability>
-		<model name='(MML)'>
-			<availability>MOC:3,CC:3,OP:4,PR:4,DoO:4,DO:4,MERC:3,DTA:4,RF:4,LA:3,PG:4,MSC:4,TP:4,RCM:4,DA:4,RFS:4</availability>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:2-</availability>
 		</model>
 		<model name='(LRM)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:2-</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>CC:2,MOC:2,OP:3,PR:3,DoO:3,DO:3,MERC:2,DTA:3,RF:3,PG:3,MH:2,MSC:3,TP:3,DA:3,RCM:3,RFS:3</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:3,CC:3,OP:4,PR:4,DoO:4,DO:4,MERC:3,DTA:4,RF:4,LA:3,PG:4,MSC:4,TP:4,RCM:4,DA:4,RFS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:3,CHH:6,CSL:6</availability>
-		<model name='(Standard)'>
-			<availability>CSA:4,CHH:4,CSL:4</availability>
+		<model name='3'>
+			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8,CSL:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CHH:6,CSL:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:4,CHH:4,CSL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:5,MERC:2,DC:6</availability>
-		<model name='HTM-28T'>
-			<availability>ROS:4,DC:3</availability>
+		<model name='HTM-27T'>
+			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:4</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
+		<model name='HTM-28T'>
+			<availability>ROS:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
 		<availability>CGB.FRR:2,DC:2</availability>
+		<model name='HTM-27U'>
+			<availability>General:2-</availability>
+		</model>
 		<model name='HTM-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='HTM-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='HTM-27U'>
-			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaeru' unitType='Mek'>
@@ -7164,40 +7164,40 @@
 		<model name='HCT-6S'>
 			<availability>LA:7,MERC:6</availability>
 		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:2,FS:1,MERC:1,CDP:2</availability>
 		</model>
-		<model name='HCT-6M'>
-			<availability>DTA:8,ROS:4,FWL:8,MSC:8,MERC:3</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:4,LA:4,CGB.FRR:4,FS:4,MERC:4,DC:2,Periphery:3</availability>
-		</model>
 		<model name='HCT-5DD'>
 			<availability>ROS:6,FS:6,MERC:6,CDP:3</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:2-,MERC:2-,Periphery:2-</availability>
 		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:4,LA:4,CGB.FRR:4,FS:4,MERC:4,DC:2,Periphery:3</availability>
+		</model>
 		<model name='HCT-6D'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-6M'>
+			<availability>DTA:8,ROS:4,FWL:8,MSC:8,MERC:3</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7209,18 +7209,14 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OD'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='HA1-OA'>
 			<availability>General:7</availability>
@@ -7228,14 +7224,18 @@
 		<model name='HA1-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HA1-OD'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,OP:5,PR:5,DoO:5,IS:3,DO:5,FS:4,DTA:5,RF:5,LA:3,CGB.FRR:3,PG:5,FWL:5,MSC:5,TP:5,RCM:4,DA:3,RFS:5,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -7263,25 +7263,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7293,11 +7293,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,RA.OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -7328,23 +7328,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>ROS:2,FS:3,MERC:2</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>ROS:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7355,6 +7355,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7363,20 +7371,20 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7386,20 +7394,15 @@
 			<roles>apc,support</roles>
 			<availability>ROS:3</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:3,LA:3+,CNC:3,CSL:4,RA:3,CWIE:5</availability>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:4</availability>
@@ -7408,22 +7411,19 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:3,MOC:3,IS:3,MERC:3</availability>
-		<model name='HEP-1H'>
-			<roles>artillery</roles>
-			<availability>CC:2-,MOC:2-,MERC:2-</availability>
-		</model>
 		<model name='HEP-4H'>
 			<roles>artillery</roles>
 			<availability>General:8,MERC:8</availability>
+		</model>
+		<model name='HEP-1H'>
+			<roles>artillery</roles>
+			<availability>CC:2-,MOC:2-,MERC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -7431,11 +7431,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7455,26 +7455,26 @@
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:3</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:3,CCC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:1,CHH:3,CDS:2,ROS:2,DC.AL:1,CNC:6,CJF:3</availability>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
@@ -7485,25 +7485,25 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CNC:5,CSL:5,CCO:5,CJF:2</availability>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:4,General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
@@ -7511,7 +7511,7 @@
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
@@ -7519,12 +7519,12 @@
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
@@ -7545,36 +7545,36 @@
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
 		<availability>CHH:3</availability>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AP)'>
 			<roles>recon,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7599,42 +7599,46 @@
 			<roles>recon</roles>
 			<availability>ROS:3-,FWL:2-,MERC:3-</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>OP:4,DoO:4,FWL:4,DO:4,MSC:4,TP:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>CC:3,MOC:3,FWL:4,MERC:3</availability>
-		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+			<availability>MOC:4,IS:4,MH:3</availability>
 		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:5,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5Sr'>
+		<model name='HER-2S'>
 			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:3</availability>
+			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>OP:4,DoO:4,FWL:4,DO:4,MSC:4,TP:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>CC:3,MOC:3,FWL:4,MERC:3</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>DC.GHO:6,OP:8,DoO:8,CGB.FRR:3,FWL:7,NIOPS:3,DO:8,MSC:8,TP:8,MERC:4,DC:6</availability>
+		<model name='HER-3S'>
+			<roles>recon</roles>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='HER-4S'>
+			<roles>recon</roles>
+			<availability>OP:4,DoO:4,CGB.FRR:3,FWL:4,DO:4,MSC:4,TP:4</availability>
+		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:2-,CLAN:6,NIOPS:4,BAN:8</availability>
-		</model>
-		<model name='HER-3S'>
+		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
@@ -7642,84 +7646,80 @@
 			<roles>recon</roles>
 			<availability>OP:6,DoO:6,DO:6,MSC:6,TP:6,MERC:4,DC:8</availability>
 		</model>
-		<model name='HER-4S'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>OP:4,DoO:4,CGB.FRR:3,FWL:4,DO:4,MSC:4,TP:4</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:4</availability>
+			<availability>DC.GHO:2-,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:6,Periphery:6,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:5-</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,PR:5,RF:5,PG:5,DA:5,CDP:5,RFS:5,TC:6</availability>
 		</model>
 		<model name='(Scout)'>
 			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,PR:5,RF:5,PG:5,DA:5,CDP:5,RFS:5,TC:6</availability>
-		</model>
-		<model name='(AC10)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CC:1,IS:1,Periphery:1</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
 		<availability>LA:1,IS:1</availability>
+		<model name='(Cunnington)'>
+			<roles>spotter</roles>
+			<availability>LA:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>LA:5,General:8</availability>
 		</model>
-		<model name='(Cunnington)'>
-			<roles>spotter</roles>
-			<availability>LA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CHH:5,CDS:4,CW:6,LA:3,ROS:4,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CW:4</availability>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:4,CLAN:2,CNC:4,IS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:6,CW:3,ROS:4,CJF:6,CGB:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:4,CLAN:2,CNC:4,IS:8</availability>
+		<model name='2'>
+			<availability>CW:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:3,CC:4,LA:6,CLAN:4,IS:3,FWL:3,NIOPS:9,MH:3,MERC:4,FS:5,CJF:5,DC:3</availability>
-		<model name='HGN-734'>
-			<availability>LA:6,ROS:6,MERC:6</availability>
-		</model>
-		<model name='HGN-732b'>
-			<availability>LA:4,CLAN:4,IS:3,FWL:3,MH:4,FS:4,BAN:2</availability>
-		</model>
 		<model name='HGN-733'>
 			<availability>CC:2-,MOC:3-,:0,LA:2-,DC:2-</availability>
-		</model>
-		<model name='HGN-732'>
-			<availability>MOC:6,CC:5,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:5,NIOPS:3,MERC.SI:8,MH:6,DC:5</availability>
 		</model>
 		<model name='HGN-738'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='HGN-732b'>
+			<availability>LA:4,CLAN:4,IS:3,FWL:3,MH:4,FS:4,BAN:2</availability>
+		</model>
+		<model name='HGN-732'>
+			<availability>MOC:6,CC:5,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:5,NIOPS:3,MERC.SI:8,MH:6,DC:5</availability>
+		</model>
+		<model name='HGN-734'>
+			<availability>LA:6,ROS:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:4</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7727,7 +7727,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7753,11 +7753,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7775,12 +7775,12 @@
 			<roles>recon,urban</roles>
 			<availability>FVC:1-,IS:1-</availability>
 		</model>
+		<model name='HNT-171'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:2-</availability>
-		</model>
-		<model name='HNT-171'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -7822,14 +7822,14 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:4,CDS:7,CW:5,CJF:5,CGB:5,CWIE:4,RA:5</availability>
-		<model name='2'>
-			<availability>CSA:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:6,RA:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,RA:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCO:8,RA:8</availability>
@@ -7837,80 +7837,61 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='HBK-6S'>
-			<availability>LA:6,ROS:5,MERC:6</availability>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-7R'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='HBK-4J'>
-			<availability>CC:1-,FWL:1-,MERC:1-,Periphery:1-</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:6,MERC:4</availability>
-		</model>
-		<model name='HBK-4H'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5H'>
-			<availability>FVC:3,HL:2,MH:6,Periphery:4</availability>
+		<model name='HBK-6S'>
+			<availability>LA:6,ROS:5,MERC:6</availability>
 		</model>
 		<model name='HBK-4SP'>
 			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
 		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
+		<model name='HBK-4J'>
+			<availability>CC:1-,FWL:1-,MERC:1-,Periphery:1-</availability>
 		</model>
-		<model name='HBK-4P'>
-			<availability>IS:1-,Periphery:2-</availability>
+		<model name='HBK-5H'>
+			<availability>FVC:3,HL:2,MH:6,Periphery:4</availability>
+		</model>
+		<model name='HBK-5SS'>
+			<availability>LA:6</availability>
 		</model>
 		<model name='HBK-5S'>
 			<availability>LA:4,CGB.FRR:3,ROS:3,MH:3,MERC:2,FS:3</availability>
 		</model>
-		<model name='HBK-4N'>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:6,MERC:4</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-4H'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-6N'>
 			<availability>ROS:3,FWL:3,MH:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,CDS:4,CLAN:3,CCO:4,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:3-</availability>
-		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>PR:6,RF:6,LA:8,ROS:6,PG:6,FS:6,RCM:6,MERC:6,DA:6,RFS:6</availability>
-		</model>
-		<model name='(LRM10)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='(Ammo)'>
 			<roles>fire_support</roles>
 			<availability>General:1-</availability>
@@ -7921,35 +7902,57 @@
 		<model name='(Amphibious)'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
+		<model name='(LRM10)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>PR:6,RF:6,LA:8,ROS:6,PG:6,FS:6,RCM:6,MERC:6,DA:6,RFS:6</availability>
+		</model>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:3-</availability>
+		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>LA:4,CGB.FRR:5,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:2+</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='HSCL-1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:2+</availability>
+		</model>
+		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OD'>
@@ -7958,18 +7961,15 @@
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:2,LA:2,CGB.FRR:1,ROS:3,CLAN:3,NIOPS:4,MERC:2,DC:1</availability>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,NIOPS:4,MERC.SI:4,BAN:8</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -7981,17 +7981,17 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CLAN:6,RA:6</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:6,CLAN:4,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:6,CLAN:4,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -8012,8 +8012,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:3,MOC:8,LA:2,ROS:4,FWL:3,IS:8,MH:8,FS:1,DC:1,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8021,20 +8021,20 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='[SRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
 		<availability>FWL.pm:3,ROS:2,FWL:3,MH:2,MERC:2</availability>
-		<model name='ICR-1S'>
-			<availability>General:4-</availability>
-		</model>
 		<model name='ICR-2S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='ICR-1S'>
+			<availability>General:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus' unitType='Mek'>
@@ -8059,11 +8059,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:6,MERC.KH:8</availability>
-		</model>
 		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-4E'>
+			<availability>MERC.WD:6,MERC.KH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8088,34 +8088,34 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CW:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
 		<availability>MERC:1,TC:1</availability>
-		<model name='&apos;Waddle&apos;' mechanized='true'>
-			<roles>recon</roles>
-			<availability>LA:6,FS:6,TC:6</availability>
-		</model>
 		<model name='(Special Ops)' mechanized='true'>
 			<roles>specops</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='&apos;Waddle&apos;' mechanized='true'>
+			<roles>recon</roles>
+			<availability>LA:6,FS:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8124,13 +8124,13 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:3,LA:3,ROS:4,FWL:3,FS:3,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>assault</roles>
-			<availability>CC:8,ROS:6,FWL:8</availability>
-		</model>
 		<model name='(SCC)'>
 			<roles>assault</roles>
 			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>assault</roles>
+			<availability>CC:8,ROS:6,FWL:8</availability>
 		</model>
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
@@ -8139,39 +8139,39 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>OP:8,PR:8,DoO:8,IS:2,DO:8,DTA:8,RF:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>OP:8,PR:8,DoO:8,IS:2,DO:8,DTA:8,RF:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,CLAN:9,IS:7,Periphery.Deep:7,FS:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,CGB.FRR:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:4</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Fire)' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -8184,17 +8184,20 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,LA:2,ROS:3,CLAN:4,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CHH:7,CW:3,ROS:3,CJF:4,CWIE:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>CCC:6,CLAN:4,RA:7,CGB:6</availability>
+		<model name='2'>
+			<availability>RA:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
@@ -8202,12 +8205,14 @@
 			<roles>recon</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,RA.OA:4,CLAN:6,IS:6,NIOPS:6,MH:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8218,11 +8223,6 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8231,20 +8231,24 @@
 	</chassis>
 	<chassis name='J-37 Ordnance Transport' unitType='Tank'>
 		<availability>General:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>support</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>MOC:2-,DC.LV:3-,DC.GR:2-,FS.AH:2-,IS:2-,Periphery.Deep:5,FS:2-,Periphery:2-,TC:3-,RA.OA:2-,LA:2-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:2-</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -8254,34 +8258,26 @@
 			<roles>recon,raider</roles>
 			<availability>DC:8,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>HL:2,IS:3,TC:3,Periphery:3</availability>
-		<model name='(3082 Upgrade)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>TC:5</availability>
+		</model>
+		<model name='(3082 Upgrade)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
 		<availability>CC:4,LA:4,ROS:4,CGB.FRR:4,IS:4,FWL:4,FS:5,MERC:4,CJF:4,CGB:5,Periphery:3,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>IS:3,CGB:8,Periphery:6</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>ROS:5,FS:5,CJF:8</availability>
@@ -8289,6 +8285,10 @@
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>IS:3,CGB:8,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='JI2A1 Attack APC' unitType='Tank'>
@@ -8331,27 +8331,17 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>MOC:5,DTA:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5,MSC:6,MERC:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>HL:6,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>DTA:5,ROS:5,MSC:5,MERC:5</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>HL:6,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,General:2,RA:4</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CW:4,CLAN:2,RA:6</availability>
@@ -8359,8 +8349,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,General:2,RA:4</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8374,21 +8374,6 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:2-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>CC:2-,CGB.FRR:1-,IS:2-,FS:2-,Periphery:5</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:4,MERC:6</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
@@ -8397,24 +8382,59 @@
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
+		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,LA:2,ROS:2,CGB.FRR:2,FS:2,MERC:2,CDP:3,DC:2</availability>
 		</model>
-		<model name='JM7-C3BS'>
+		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:6</availability>
+			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>MOC:3,RA.OA:5,FVC:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>CC:2-,CGB.FRR:1-,IS:2-,FS:2-,Periphery:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,LA:1,Periphery.HR:4,ROS:4</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:4,MERC:6,CDP:6,TC:6</availability>
@@ -8423,83 +8443,67 @@
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
+		<model name='X'>
+			<availability>General:1,CJF:2,RA:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='X'>
-			<availability>General:1,CJF:2,RA:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:6,ROS:4,CNC:8,CCO:5,DC:3</availability>
-		<model name='3'>
-			<availability>CCC:6,CNC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CNC:4,CLAN:1</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:7,CNC:8,IS:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CCC:6,CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:4,CNC:4,CLAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:1-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:4,Periphery:3,CGB.FRR:8,FS.DMM:5,FWL:1-,DC:8</availability>
-		<model name='JR7-C4'>
-			<roles>raider</roles>
-			<availability>DC:3</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:1-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>ROS:4,DC:6</availability>
+		</model>
+		<model name='JR7-C4'>
+			<roles>raider</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:1-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -8509,17 +8513,9 @@
 			<roles>raider</roles>
 			<availability>MERC:6,FS:6,DC:5</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8527,6 +8523,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -8539,11 +8539,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -8562,26 +8562,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -8599,29 +8599,45 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:3,DC:6</availability>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 		<model name='C' mechanized='true'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>ROS:2,DC:2</availability>
 		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
@@ -8631,29 +8647,13 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -8665,36 +8665,36 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.NSR:6,DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>CGB:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -8706,30 +8706,34 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>HL:2,PIR:2,IS:3,Periphery.Deep:4,Periphery:3,RA:2</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:5,MERC:5</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
-		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:3</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>FWL:5,IS:6</availability>
 		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>MH:5,MERC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,CGB.FRR:2,DC:6</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-2'>
 			<availability>CGB.FRR:8,DC:2-</availability>
 		</model>
@@ -8739,13 +8743,16 @@
 		<model name='CRK-5003-C'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:3,LA:2,CGB.FRR:2,ROS:3,CLAN:3,FS:3,DC:2</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -8753,30 +8760,29 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:3,CGB:3,DC:4</availability>
-		<model name='KGC-001'>
-			<availability>LA:4,IS:4,MH:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CGB.FRR:5,ROS:6,CLAN:4,BAN:2,DC:5</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:8,ROS:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
+		</model>
+		<model name='KGC-001'>
+			<availability>LA:4,IS:4,MH:6</availability>
+		</model>
+		<model name='KGC-005r'>
+			<availability>ROS:3,MERC:3</availability>
 		</model>
 		<model name='KGC-0000'>
 			<availability>IS:2-</availability>
@@ -8784,37 +8790,31 @@
 		<model name='KGC-008B'>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='KGC-000'>
-			<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-005r'>
-			<availability>ROS:3,MERC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,ROS:3+,CNC:3,RA:3,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
@@ -8829,44 +8829,44 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,CGB.FRR:4,ROS:6,NIOPS:7,FS:2,MERC:4,DC:4</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:6</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:3,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-18'>
-			<availability>:0,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='KTO-20'>
-			<availability>CGB.FRR:3,MERC:5,DC:4</availability>
 		</model>
 		<model name='KTO-19b'>
 			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
+		<model name='KTO-20'>
+			<availability>CGB.FRR:3,MERC:5,DC:4</availability>
+		</model>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:6</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='KTO-18'>
+			<availability>:0,FS:2-,MERC:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8878,13 +8878,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kobold Battle Armor IIC' unitType='BattleArmor'>
@@ -8899,22 +8899,29 @@
 		<model name='[GL]' mechanized='true'>
 			<availability>CGB.FRR:4</availability>
 		</model>
+		<model name='(GB) [SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CGB:1</availability>
+		</model>
 		<model name='[SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CGB.FRR:8</availability>
 		</model>
-		<model name='(GB) [GL/Flamer]' mechanized='true'>
-			<availability>CGB:1</availability>
+		<model name='[SL/Flamer]' mechanized='true'>
+			<availability>CGB.FRR:6</availability>
+		</model>
+		<model name='[GL/Flamer]' mechanized='true'>
+			<availability>CGB.FRR:6</availability>
 		</model>
 		<model name='(GB) [SL/Flamer]' mechanized='true'>
 			<availability>CGB:1</availability>
 		</model>
-		<model name='[SL/Flamer]' mechanized='true'>
-			<availability>CGB.FRR:6</availability>
-		</model>
-		<model name='(GB) [SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
+		<model name='(GB) [GL/Flamer]' mechanized='true'>
 			<availability>CGB:1</availability>
+		</model>
+		<model name='[GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CGB.FRR:6</availability>
 		</model>
 		<model name='(GB) [GL]' mechanized='true'>
 			<availability>CGB:1</availability>
@@ -8923,18 +8930,11 @@
 			<roles>spotter</roles>
 			<availability>CGB:1</availability>
 		</model>
-		<model name='[GL/Flamer]' mechanized='true'>
-			<availability>CGB.FRR:6</availability>
-		</model>
-		<model name='[GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CGB.FRR:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CCC:3,ROS:4,CCO:3,RA:6,CGB:8</availability>
-		<model name='5'>
-			<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -8943,11 +8943,11 @@
 		<model name='2'>
 			<availability>ROS:6,CGB:5</availability>
 		</model>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:4,CGB:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -8956,23 +8956,20 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:4</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>OP:5,DoO:5,ROS:5,FWL:4,DO:5,TP:5,MERC:4</availability>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>OP:4,DoO:4,DO:4,TP:4</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -8980,55 +8977,34 @@
 		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>OP:4,DoO:4,DO:4,TP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:3,ROS:3,MERC:4</availability>
+		<model name='KSC-5MC'>
+			<availability>MOC:8,CC:8,MERC:3</availability>
+		</model>
 		<model name='KSC-4I'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-4L'>
 			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-5I'>
 			<availability>DTA:8,ROS:8,MERC:8</availability>
 		</model>
-		<model name='KSC-5MC'>
-			<availability>MOC:8,CC:8,MERC:3</availability>
-		</model>
 		<model name='KSC-5X'>
 			<roles>urban</roles>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='KSC-4L'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,MERC.WD:5,CDS:5,CW:5,IS:4+,CCO:1,CJF:4,BAN:6,RA:5</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -9038,14 +9014,38 @@
 			<roles>recon</roles>
 			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
 		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:4,IS:3</availability>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9053,27 +9053,27 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='KTO-3A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>ROS:2,CJF:3,RA:3</availability>
-		<model name='4'>
-			<availability>ROS:8,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<availability>ROS:8,CJF:6</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
@@ -9110,11 +9110,11 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>CGB.FRR:3,CGB:3</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9149,44 +9149,44 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>ROS:4,CGB.FRR:3,CLAN:4,NIOPS:6,BAN:7,DC:4</availability>
-		<model name='LNC25-02'>
-			<roles>fire_support</roles>
-			<availability>:0,CGB.FRR:2-,DC:2-</availability>
-		</model>
 		<model name='LNC25-01'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,CGB.FRR:6,CLAN:8,NIOPS:4,MERC.SI:4,BAN:6,DC:5</availability>
 		</model>
+		<model name='LNC25-02'>
+			<roles>fire_support</roles>
+			<availability>:0,CGB.FRR:2-,DC:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:3,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:3,MERC:3,DTA:6,FVC:3,RF:6,LA:3,ROS:3,Periphery.MW:3,Periphery.CM:3,PG:6,Periphery.ME:3,FWL:6,MH:3,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
-		<model name='LX-2A'>
-			<availability>OP:5,PR:5,DoO:5,DO:5,MERC:5,DTA:5,RF:5,LA:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LX-2A'>
+			<availability>OP:5,PR:5,DoO:5,DO:5,MERC:5,DTA:5,RF:5,LA:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-4E'>
-			<availability>CC:4</availability>
-		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:7,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='LHU-4E'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9198,21 +9198,21 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
-		<model name='LGN-2F'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
-		</model>
 		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='LGN-2XA'>
-			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
+		<model name='LGN-2F'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='LGN-2XA'>
+			<roles>missile_artillery</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
@@ -9223,24 +9223,24 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:2-</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -9279,15 +9279,17 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:3,FWL:8,IS:3</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:2,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:3,HL:5,LA:3</availability>
@@ -9295,11 +9297,9 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:3,FWL:8,IS:3</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:2,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9310,12 +9310,12 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,NIOPS:2,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='(ERSL)'>
 			<availability>ROS:4</availability>
@@ -9323,50 +9323,50 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:4-</availability>
+		<model name='LTN-G16D'>
+			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:5,MOC:5,CLAN:3,IS:3,MERC:4</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>ROS:6,FS:6,MERC:4</availability>
+		<model name='LTN-G16O'>
+			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:4-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:6,MOC:6,PR:4,RF:4,PG:4,MSC:4,MERC:4,DA:6,RFS:4</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>RA.OA:6,FVC:4,CDP:4</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,MERC.KH:3+,CW:5,CCO:4,CJF:4,RA:5,CWIE:6</availability>
-		<model name='B'>
-			<availability>CDS:4,General:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -9386,13 +9386,13 @@
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
 		<availability>CHH:7,MERC.WD:4,CLAN:4,NIOPS:6,BAN:4</availability>
-		<model name='(2595)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3052) (WD)'>
 			<roles>mech_carrier</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='(2595)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2835)'>
 			<roles>troop_carrier</roles>
@@ -9401,10 +9401,6 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CW:6,CJF:2</availability>
-		<model name='2'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8</availability>
 		</model>
@@ -9412,26 +9408,15 @@
 			<roles>anti_infantry</roles>
 			<availability>CW:2</availability>
 		</model>
+		<model name='2'>
+			<roles>anti_infantry</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,ROS:3,CJF:6,DC:3,CGB:6</availability>
-		<model name='6'>
-			<availability>CW:5,CGB:5</availability>
-		</model>
-		<model name='9'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:3</availability>
-		</model>
-		<model name='8'>
-			<availability>ROS:5,CGB:6,DC:5</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:4,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
@@ -9439,151 +9424,166 @@
 		<model name='5'>
 			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
+		<model name='8'>
+			<availability>ROS:5,CGB:6,DC:5</availability>
+		</model>
+		<model name='6'>
+			<availability>CW:5,CGB:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
+		<model name='7'>
+			<availability>CHH:4,ROS:2</availability>
+		</model>
+		<model name='9'>
+			<availability>CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>HL:5,CLAN:2-,IS:7,NIOPS:2-,Periphery.Deep:5,Periphery:4</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
-		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:3,MSC:3</availability>
-		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:4,CC:4,FVC:4,TC:6</availability>
-		</model>
-		<model name='LCT-5M3'>
-			<availability>ROS:4,MSC:4</availability>
-		</model>
-		<model name='LCT-1Vb'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:3,CLAN:6,FWL:3,MERC:3,BAN:2</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='LCT-5M'>
+		<model name='LCT-1S'>
 			<roles>recon</roles>
-			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
+			<availability>LA:2-,MERC:2-</availability>
 		</model>
-		<model name='LCT-1V2'>
-			<roles>recon</roles>
-			<availability>PIR:4,MH:4,MERC:2</availability>
+		<model name='LCT-5M3'>
+			<availability>ROS:4,MSC:4</availability>
 		</model>
 		<model name='LCT-5W2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,CLAN:3,IS:3,FS:4,DC:4</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:2-,General:2-,FS:2-</availability>
+		<model name='LCT-5M2'>
+			<availability>ROS:3,MSC:3</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-1Vb'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
+			<availability>CC:5,MOC:3,CLAN:6,FWL:3,MERC:3,BAN:2</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
-		<model name='LCT-3S'>
+		<model name='LCT-1V2'>
 			<roles>recon</roles>
-			<availability>LA:8,CGB.FRR:6,MERC:6</availability>
+			<availability>PIR:4,MH:4,MERC:2</availability>
 		</model>
 		<model name='LCT-3M'>
 			<roles>recon</roles>
 			<availability>MOC:3,OP:5,PR:5,DoO:5,IS:3,DO:5,MERC:5,DTA:5,RF:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='LCT-1S'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>LA:2-,MERC:2-</availability>
+			<availability>LA:2-,General:2-,FS:2-</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-3S'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>LA:8,CGB.FRR:6,MERC:6</availability>
+		</model>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:4,CC:4,FVC:4,TC:6</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-6M'>
+			<roles>recon</roles>
+			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CW:4,IS:1+,CJF:1,BAN:5,CWIE:4</availability>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CSA:4,CCC:1,CHH:3,MERC.WD:2,CDS:2,CW:1,ROS:1,CNC:3,CCO:2,RA:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:3</availability>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:3</availability>
-		</model>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>LA:4,CGB.FRR:4,FWL:4,IS:3,FS:5,MERC:4,CGB:3</availability>
-		</model>
-		<model name='LGB-12R'>
-			<roles>fire_support</roles>
-			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:3</availability>
-		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:2-,General:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:3,TC:3</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:3</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:4,OP:6,DoO:6,DO:6,FS:6,MERC:6,ROS:6,MSC:6,TP:6,DA:6,RCM:6,DC:6</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGB-12R'>
+			<roles>fire_support</roles>
+			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:3</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>LA:4,CGB.FRR:4,FWL:4,IS:3,FS:5,MERC:4,CGB:3</availability>
+		</model>
 		<model name='LGB-14C2'>
 			<roles>fire_support</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -9591,17 +9591,17 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer III' unitType='Aero'>
@@ -9621,14 +9621,14 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,HL:4,LA:6,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:3,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:4-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:2-,FS:2-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:3,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -9637,13 +9637,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:2-</availability>
@@ -9662,24 +9662,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>ROS:8,MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -9687,13 +9687,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -9727,17 +9727,30 @@
 		<model name='MSK-6S'>
 			<availability>PR:8,RF:8,PG:8,FWL:8,RFS:8</availability>
 		</model>
-		<model name='MSK-9H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MSK-5S'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='MSK-9H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,MERC.KH:3+,MERC.WD:6,CDS:4,CW:6,ROS:2+,CLAN:2,MERC:1+,CCO:4,CJF:4,BAN:2,CWIE:6</availability>
 		<model name='B'>
 			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CHH:4,CW:5,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:3,General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>CHH:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
@@ -9746,32 +9759,19 @@
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CHH:4,CW:5,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:3,General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:4,LA:4,ROS:4,CNC:3,IS:3,CWIE:3,DC:4</availability>
-		<model name='4'>
+		<model name='5'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
@@ -9779,22 +9779,22 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='5'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='2'>
+			<availability>General:6</availability>
+		</model>
+		<model name='4'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:4,CNC:6,CLAN:4,IS:4,FS:4,CWIE:4,DC:4</availability>
-		<model name='Enhanced'>
-			<availability>CGB.FRR:6,CLAN:6,CNC:4,CWIE:4</availability>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -9805,8 +9805,8 @@
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
+		<model name='Enhanced'>
+			<availability>CGB.FRR:6,CLAN:6,CNC:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -9826,18 +9826,18 @@
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,OP:8,Periphery.MM:3,PR:8,DoO:8,DO:8,MERC:3,DTA:8,RF:8,LA:3,ROS:3,Periphery.CM:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Malaika' unitType='Aero'>
@@ -9862,58 +9862,61 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:6,CDS:6,CW:6,CNC:2,CJF:6,BAN:5,CWIE:6</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1</availability>
-		</model>
-		<model name='G'>
-			<availability>General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:3,CCO:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='G'>
+			<availability>General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3,CCO:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:3,PR:3,RF:3,LA:3,ROS:3,PG:3,MERC:3,RFS:3,CWIE:5</availability>
-		<model name='MNL-4S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:5,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
 		</model>
+		<model name='MNL-4S'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
 		<availability>ROS:6</availability>
-		<model name='(Support)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Support)'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:6,ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
@@ -9921,162 +9924,159 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:6,RA.OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,PR:8,RF:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='(HPPC)'>
+			<availability>CC:3,MOC:3,DTA:3,LA:3,ROS:5,FS:5,MERC:3,DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:2,LA:1-,General:2-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='(HPPC)'>
-			<availability>CC:3,MOC:3,DTA:3,LA:3,ROS:5,FS:5,MERC:3,DC:5</availability>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,PR:8,RF:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,LA:3,CGB.FRR:3,FWL:4,IS:3,FS:5,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:6,CW:5,CNC:5,CJF:6,RA:5,CWIE:5,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,CJF:4,CGB:4</availability>
+		<model name='4'>
+			<availability>CNC:6,RA:3,CGB:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:4,CWIE:6</availability>
 		</model>
-		<model name='6'>
-			<availability>CW:5,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:2,CJF:5,CGB:5</availability>
-		</model>
 		<model name='7'>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,CJF:4,CGB:4</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:6,RA:3,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:5,CJF:4</availability>
 		</model>
 		<model name='8'>
 			<availability>CJF:4,CGB:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:2,CJF:5,CGB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:3,FS:6,MERC:6,TC:4,MERC.WD:6,LA:3,CGB.FRR:5,ROS:6,PIR:4,FWL:6,MH:4,DC:6</availability>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='MAD-5A'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='MAD-6M'>
-			<availability>ROS:4,FWL:5,MERC:5</availability>
+		<model name='C'>
+			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='MAD-4L'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
-		<model name='MAD-4S'>
-			<availability>LA:8,CGB.FRR:5,ROS:6,CNC:8,FWL:2,FS:6,MERC:7,DC:2</availability>
+		<model name='MAD-4H'>
+			<availability>PIR:6,MH:6,TC:6</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:1</availability>
+		<model name='MAD-6M'>
+			<availability>ROS:4,FWL:5,MERC:5</availability>
 		</model>
 		<model name='MAD-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='MAD-4H'>
-			<availability>PIR:6,MH:6,TC:6</availability>
+		<model name='MAD-5A'>
+			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:5</availability>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:1</availability>
+		</model>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='MAD-4S'>
+			<availability>LA:8,CGB.FRR:5,ROS:6,CNC:8,FWL:2,FS:6,MERC:7,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:1-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:6,OP:6,DoO:6,DO:6,MSC:6,TP:6,MERC:3,DA:6</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:2-,MH:2-,FS:2-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:6</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>OP:5,PR:5,RF:5,DoO:5,ROS:4,PG:5,DO:5,TP:5,MERC:4,DA:5,RFS:5,DC:3</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:6</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>MOC:4,ROS:4,FWL:7,MERC:4</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:5,MOC:4</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>IS:2-,Periphery.Deep:8,Periphery:3-,TC:3-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
+		<model name='MAD-7D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='MAD-5R'>
 			<availability>FS:4,MERC:3</availability>
 		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		<model name='MAD-9W2'>
+			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
+		</model>
+		<model name='MAD-9S'>
+			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>IS:2-,Periphery.Deep:8,Periphery:3-,TC:3-</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>MOC:4,ROS:4,FWL:7,MERC:4</availability>
 		</model>
 		<model name='MAD-5L'>
 			<availability>CC:6,MOC:5</availability>
 		</model>
+		<model name='MAD-6L'>
+			<availability>CC:5,MOC:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FVC:2-,MH:2-,FS:2-</availability>
+		</model>
 		<model name='MAD-5S'>
 			<availability>FVC:3,LA:5,CGB.FRR:3,FS:3,MERC:4</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:6,OP:6,DoO:6,DO:6,MSC:6,TP:6,MERC:3,DA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -10092,26 +10092,26 @@
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:5,IS:3</availability>
-		<model name='M1'>
-			<availability>ROS:2,ROS.pm:8,General:8</availability>
-		</model>
 		<model name='M1A'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='M1'>
+			<availability>ROS:2,ROS.pm:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CSA:4,CHH:4,CCC:3,ROS:4,CSL:4,CCO:3,CGB:3</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:4,CDS:4,ROS:4,CGB:4</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CSA:4,CHH:4,CCC:3,ROS:4,CSL:4,CCO:3,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10125,11 +10125,11 @@
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MHL-6MC'>
-			<availability>MOC:4,CC:3</availability>
-		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,HL:2,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:4,CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
@@ -10144,11 +10144,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,MERC.WD:2,CDS:5,CW:3,CNC:2,MERC:2+,CJF:4,RA:3,BAN:3,CGB:4</availability>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
@@ -10156,8 +10153,14 @@
 		<model name='A'>
 			<availability>CDS:8,General:5,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:5,General:4,CCO:6,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CGB:8</availability>
@@ -10165,55 +10168,52 @@
 		<model name='B'>
 			<availability>CDS:8,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:5,General:4,CCO:6,CGB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>CGB.FRR:5,MERC:5,DC:7</availability>
-		<model name='MAL-1R'>
-			<availability>CGB.FRR:8,MERC:6,DC:1</availability>
+		<model name='MAL-3R'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='MAL-C'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='MAL-3R'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='MAL-1K'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='MAL-1R'>
+			<availability>CGB.FRR:8,MERC:6,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(Intermediate)'>
-			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:6</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
+		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
 		</model>
 		<model name='(Basic)'>
 			<roles>apc</roles>
@@ -10222,8 +10222,8 @@
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
@@ -10231,61 +10231,61 @@
 		<model name='(LB-X)'>
 			<availability>FWL:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
+			<availability>IS:1-,Periphery:2-</availability>
 		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2-</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(C3S)'>
+		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
+			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2-</availability>
+			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
@@ -10305,13 +10305,13 @@
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>CSA:1,CCC:1,RA:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -10341,39 +10341,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>HL:4,IS:5,Periphery.Deep:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -10385,33 +10382,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10446,23 +10446,19 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10470,13 +10466,17 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mengqin' unitType='Aero'>
@@ -10517,25 +10517,25 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Dropship'>
 		<availability>PR:2,RF:2,FWL:6</availability>
-		<model name='R1'>
-			<roles>assault</roles>
-			<availability>PR:8,RF:8,PG:8,RFS:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>assault</roles>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='R1'>
+			<roles>assault</roles>
+			<availability>PR:8,RF:8,PG:8,RFS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,HL:3,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:3-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10544,6 +10544,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Targeting Computer)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Gauss) &apos;Sandblaster&apos;'>
 			<roles>urban</roles>
@@ -10555,22 +10560,17 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Targeting Computer)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSL:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='XP'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8</availability>
+		</model>
+		<model name='XP'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='P2'>
 			<availability>CHH:5</availability>
@@ -10592,11 +10592,11 @@
 	</chassis>
 	<chassis name='Mithras Light Tank' unitType='Tank'>
 		<availability>CSA:6,CCC:6,CSL:4,CCO:6</availability>
-		<model name='(ERLL)'>
-			<availability>CSL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(ERLL)'>
+			<availability>CSL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mjolnir Battlecruiser' unitType='Warship'>
@@ -10608,22 +10608,18 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:5,ROS:4,FS:3,MERC:3</availability>
-		<model name='MLR-B2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MLR-BX'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='MLR-B2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -10633,11 +10629,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -10678,13 +10678,13 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>LA:4,ROS:5,MERC:4</availability>
-		<model name='MON-268'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3,ROS:3,MERC:3</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
+		<model name='MON-268'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
@@ -10700,11 +10700,11 @@
 	</chassis>
 	<chassis name='Mongrel' unitType='Mek'>
 		<availability>CHH:3,CWIE:4,CGB:4</availability>
-		<model name='MGL-T2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='MGL-T1'>
 			<availability>IS:8,CGB:4,CWIE:4</availability>
+		</model>
+		<model name='MGL-T2'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -10715,11 +10715,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:3,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -10730,20 +10730,20 @@
 	</chassis>
 	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:4,LA:5,CWIE:4</availability>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MR-1SC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MR-1SA'>
 			<roles>interceptor,ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SC'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -10775,14 +10775,14 @@
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
 		<availability>CSA:5,CLAN:4,IS:4</availability>
-		<model name='(HAG)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mortar Carrier' unitType='Tank'>
@@ -10808,7 +10808,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -10821,17 +10824,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -10857,29 +10857,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(3080 Upgrade)'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(3080 Upgrade)'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:5</availability>
 		</model>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -10902,6 +10902,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
@@ -10910,24 +10918,16 @@
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3A'>
 			<roles>fire_support,spotter</roles>
@@ -10947,11 +10947,11 @@
 	</chassis>
 	<chassis name='Narukami Heavy Tank' unitType='Tank'>
 		<availability>DC:5</availability>
-		<model name='NK-1C'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NK-BC3'>
 			<availability>General:4</availability>
+		</model>
+		<model name='NK-1C'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nekohono&apos;o' unitType='Dropship'>
@@ -10969,11 +10969,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10985,29 +10985,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CJF:5</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -11032,12 +11032,12 @@
 		<model name='Mk. XXX' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
+		<model name='Mk. XXII' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
 		<model name='Mk. XXI' mechanized='true'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='Mk. XXII' mechanized='true'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightlord Battleship' unitType='Warship'>
@@ -11049,15 +11049,15 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CHH:2,CW:2,ROS:5,NIOPS:3,CWIE:2,CGB:2</availability>
+		<model name='(LAC)'>
+			<roles>spotter</roles>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<roles>spotter</roles>
-			<availability>ROS:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -11066,32 +11066,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>OP:5,PR:5,DoO:5,DO:5,FS:7,MERC:6,Periphery.R:2,RF:5,LA:8,ROS:6,PG:5,TP:5,RFS:5</availability>
+		<model name='NGS-6T'>
+			<availability>PR:6,RF:6,LA:6,ROS:6,PG:6,MERC:6,FS:6,RFS:6</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>OP:5,PR:5,RF:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,OP:4,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,RF:4,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>PR:6,RF:6,LA:6,ROS:6,PG:6,MERC:6,FS:6,RFS:6</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>OP:5,PR:5,RF:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:7,ROS:6,MERC:3</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>CSA:6,LA:6,ROS:5,NIOPS:3,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -11108,11 +11108,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='NJT-4'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='NJT-3'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11124,51 +11124,51 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:8,DC.SL:2,LA:3,CGB.FRR:4,ROS:5,MERC:3,DC:7,CGB:4</availability>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>CGB.FRR:5,ROS:6,MERC:5,DC:5,CGB:4</availability>
 		</model>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,ROS:2+,CNC:8</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11180,12 +11180,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -11193,20 +11187,26 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support,anti_infantry</roles>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support,anti_infantry</roles>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
@@ -11222,32 +11222,32 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:3,LA:3,ROS:5,MERC:3,FS:3,DC:4,CGB:3</availability>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='NX-90'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
 		</model>
 		<model name='NX-100'>
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='NX-80C'>
+		<model name='NX-90'>
 			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -11259,14 +11259,14 @@
 		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:2,DC:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CNC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -11288,11 +11288,11 @@
 	</chassis>
 	<chassis name='Ogre Battle Armor' unitType='BattleArmor'>
 		<availability>RF:4</availability>
-		<model name='(Interdictor)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Interdictor)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Okinawa' unitType='Dropship'>
@@ -11325,42 +11325,42 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:5,HL:2,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:6,CNC:8,IS:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>fire_support</roles>
+			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,General:2,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:5,IS:5</availability>
+		</model>
 		<model name='HEAT'>
 			<availability>PR:2,RF:2,LA:2,ROS:2,PG:2,FS:2,RFS:2</availability>
 		</model>
 		<model name='(Fusion)'>
 			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
 		</model>
-		<model name='(Sealed)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>fire_support</roles>
-			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
-		</model>
-		<model name='(MML)'>
-			<availability>MOC:5,IS:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,General:2,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:6,CNC:8,IS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6,CSL:5,CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
@@ -11374,42 +11374,42 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
-		<model name='ON3-M'>
-			<roles>spotter</roles>
-			<availability>CC:4,FWL:4,MERC:4</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
 		</model>
 		<model name='ON1-V'>
 			<availability>IS:1-,MH:1-,CDP:1-,TC:1-</availability>
 		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
+		<model name='ON1-MC'>
+			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,OP:4,DoO:4,DO:4,MERC:2,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
 		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,PR:4,RF:4,ROS:4,PG:4,FWL:4,MSC:4,MERC:2,FS:2,RFS:4</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:1-</availability>
+		<model name='ON3-M'>
+			<roles>spotter</roles>
+			<availability>CC:4,FWL:4,MERC:4</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:1-</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:8</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,PR:4,RF:4,ROS:4,PG:4,FWL:4,MSC:4,MERC:2,FS:2,RFS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11430,14 +11430,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-5D'>
-			<availability>FS:5</availability>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
+		<model name='OSR-5D'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11445,56 +11445,56 @@
 		<model name='OSP-26'>
 			<availability>CC:4,ROS:8</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,TC:4,Periphery:2,DC:5</availability>
+		<model name='OSR-5C'>
+			<availability>TC:4</availability>
+		</model>
+		<model name='OSR-4L'>
+			<availability>CC:7,MOC:4</availability>
+		</model>
+		<model name='OSR-2C'>
+			<roles>urban</roles>
+			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		</model>
+		<model name='OSR-2D'>
+			<availability>HL:2,ROS:6,IS:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-3C'>
 			<availability>FVC:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-4K'>
 			<availability>ROS:4,MERC:3,DC:5</availability>
 		</model>
-		<model name='OSR-5C'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='OSR-2C'>
-			<roles>urban</roles>
-			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
-		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:2</availability>
 		</model>
-		<model name='OSR-2D'>
-			<availability>HL:2,ROS:6,IS:4,Periphery:4</availability>
-		</model>
 		<model name='OSR-4C'>
 			<availability>HL:2,TC:6,Periphery:4</availability>
-		</model>
-		<model name='OSR-4L'>
-			<availability>CC:7,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RA:2,CGB:3</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -11507,6 +11507,10 @@
 			<roles>recon</roles>
 			<availability>General:2-</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
 			<availability>LA:3,ROS:3,FS:1</availability>
@@ -11515,39 +11519,35 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:3,OP:4,PR:4,DoO:4,DO:4,MERC:5,FS:3,RF:4,LA:7,ROS:5,PG:4,TP:4,RFS:4,DC:3</availability>
 		</model>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>OP:5,PR:5,DoO:5,DO:5,FS:5,MERC:3,Periphery:1,DTA:5,RF:5,ROS:4,PG:5,FWL:5,NIOPS:6,MSC:5,TP:5,RFS:5</availability>
 		<model name='OTL-7M'>
 			<availability>DTA:8,OP:8,DoO:8,ROS:6,FWL:6,DO:8,MSC:8,TP:8,MERC:4</availability>
 		</model>
-		<model name='OTL-9M'>
-			<availability>ROS:4,FWL:4</availability>
-		</model>
 		<model name='OTL-8D'>
 			<availability>FS:6</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:4,MERC:4</availability>
 		</model>
 		<model name='OTL-8M'>
 			<availability>DTA:6,PR:6,RF:6,PG:6,MSC:6,MERC:3,RFS:6</availability>
 		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,MERC:5</availability>
+		<model name='OTL-5M'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='OTL-9M'>
+			<availability>ROS:4,FWL:4</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:3,Periphery:3</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -11561,10 +11561,6 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:8,CW:4,CSL:6</availability>
-		<model name='(3070)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:5</availability>
@@ -11572,6 +11568,10 @@
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(3070)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -11583,24 +11583,32 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:7,IS:3,FS:7</availability>
-		</model>
 		<model name='A3A'>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:7,IS:3,FS:7</availability>
 		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:3,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2,CLAN:6</availability>
+		</model>
+		<model name='OW-1F'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -11609,27 +11617,19 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1A'>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2,CLAN:6</availability>
 		</model>
 		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='OW-1F'>
+		<model name='OW-1'>
 			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
-		<model name='OW-1B'>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -11643,32 +11643,32 @@
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
 		<availability>CHH:5,LA:4,ROS:4,MERC:3,CWIE:7,DC:3</availability>
-		<model name='3'>
-			<availability>CHH:4,ROS:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4,ROS:4,CWIE:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CWIE:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:2,CHH:2,CCC:2,CDS:4,CNC:2,CCO:2,CWIE:7</availability>
-		<model name='2'>
-			<availability>CDS:5,CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:5,CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -11677,21 +11677,21 @@
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,MOC:5</availability>
 		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
-		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -11703,17 +11703,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:3</availability>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pandarus' unitType='Mek'>
@@ -11725,6 +11725,9 @@
 	</chassis>
 	<chassis name='Pandion Combat WiGE' unitType='Tank'>
 		<availability>LA:2,ROS:2,FWL:2,FS:5,MERC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -11733,55 +11736,52 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,RA:1,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:1,NIOPS:2,DC:8,CGB:1</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:2,CGB.FRR:2,PIR:2,CNC:8,FS.DMM:2,MERC:2,DC:2,TC:2</availability>
+			<availability>IS:2-,Periphery.Deep:8,MERC:2-,Periphery:3-,DC:2-</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,CGB.FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:3,DC:3</availability>
 		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4,CGB:1</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,FVC:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:3,TC:2,CGB:0</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
 		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,CGB.FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
+		</model>
 		<model name='PNT-16K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
+		<model name='PNT-CA'>
 			<roles>fire_support</roles>
-			<availability>IS:2-,Periphery.Deep:8,MERC:2-,Periphery:3-,DC:2-</availability>
+			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
 		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>CGB.FRR:4,DC:5,CGB:1</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:2,CGB.FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
+			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4,CGB:1</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,CGB.FRR:2,PIR:2,CNC:8,FS.DMM:2,MERC:2,DC:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -11797,13 +11797,13 @@
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:6</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<roles>recon,spotter</roles>
@@ -11812,42 +11812,42 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,HL:4,LA:7,CGB.FRR:4,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='(Cell)'>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>ROS:2,FS:2</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:3-,CC:1-,HL:2-,IS:2-,Periphery.Deep:9,FS:3-,Periphery:3-,TC:3-,RA.OA:2-,CDS:1,LA:2-,FWL:2-,DC:1-</availability>
-		<model name='(Standard)'>
+		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
-			<availability>General:4</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
@@ -11856,9 +11856,9 @@
 		<model name='(LRM)'>
 			<availability>IS:1-,Periphery:3-</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -11869,10 +11869,6 @@
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>PR:5,RF:5,PG:5,RFS:5</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
@@ -11880,6 +11876,10 @@
 		<model name='PKM-2E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -11891,11 +11891,11 @@
 	</chassis>
 	<chassis name='Patron MilitiaMech' unitType='Mek'>
 		<availability>PR:4-,DoO:4-,IS.pm:2,DO:4-,RCM.pm:4,FWL.pm:4,DA.pm:4,RF.pm:4,OP.pm:4,PG:4-,MSC.pm:4,TP:4-,DTA.pm:5,RFS:4-</availability>
-		<model name='PTN-2M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PTN-2'>
 			<availability>DTA:4,PR:4,DoO:4,PG:4,FWL:4,DO:4,TP:4,RCM:4,DA:4,RFS:4</availability>
+		</model>
+		<model name='PTN-2M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
@@ -11922,29 +11922,29 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:2-</availability>
+		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>FVC:1</availability>
-		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 		<model name='X-Pulse'>
 			<roles>recon</roles>
 			<availability>DC.AL:7,General:3,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MRM)'>
 			<roles>recon</roles>
-			<availability>General:2-</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,FS:8,DC:7</availability>
+		</model>
+		<model name='(Sealed)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -11956,20 +11956,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -11983,12 +11983,12 @@
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CGB:3</availability>
-		<model name='4'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='3'>
 			<roles>anti_infantry</roles>
 			<availability>CGB:8</availability>
+		</model>
+		<model name='4'>
+			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Persepolis' unitType='Aero'>
@@ -11999,31 +11999,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,OP:6,DoO:6,ROS:4,FWL:5,DO:6,MSC:6,TP:6</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1'>
 			<availability>General:8</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12040,28 +12040,28 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:3,FS:4,MERC:4,DC:4</availability>
-		<model name='(Prototype)'>
-			<availability>OP:1,LA:2</availability>
-		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Prototype)'>
+			<availability>OP:1,LA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CW:8,CSL:7,CCO:4,CJF:7,RA:6,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CSA:7,General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>CSA:7,General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -12071,120 +12071,120 @@
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,CCC:5,CLAN:3,MERC:3,FS:3,CCO:5,RA:5,CSA:3,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CDS:3,CNC:3,IS:2,CCO:2,DC:3</availability>
-		</model>
 		<model name='7'>
 			<availability>CDS:5,General:4,CGB:6,DC:4</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
+		<model name='6'>
+			<availability>CDS:6,CGB:6</availability>
 		</model>
 		<model name='3'>
 			<availability>DTA:3,CDS:7,RF:3,LA:3,ROS:3,MSC:3,FS:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='6'>
-			<availability>CDS:6,CGB:6</availability>
+		<model name='4'>
+			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:3,CNC:3,IS:2,CCO:2,DC:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CDS:2,CNC:2,CCO:2,RA:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='8'>
-			<availability>CDS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='PHX-HK1'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK1R'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='PHX-HK2'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='PHX-HK2M'>
 			<availability>IS:2,FWL:4</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>HL:5,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,Periphery:6,CGB:3</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>OP:4,DoO:4,DO:4,TP:4,DC:4</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>PR:3,RF:3,LA:6,ROS:4,PG:3,MERC:5,RFS:3</availability>
-		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:4,TC:4</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:7,MOC:4,MH:4,DA:4,TC:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FVC:2-,PIR:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:4,MSC:6,BAN:1</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>CGB.FRR:8,DC:8,CGB:1</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:4</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-4W'>
+			<availability>MOC:4,TC:4</availability>
+		</model>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>OP:8,PR:8,DoO:8,IS:4,DO:8,DTA:8,RF:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>ROS:2,CGB.FRR:4,CGB:1,DC:2</availability>
+		<model name='PXH-5L'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>General:2-,BAN:6,Periphery:2-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>PR:3,RF:3,LA:6,ROS:4,PG:3,MERC:5,RFS:3</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:1-</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>OP:8,PR:8,DoO:8,IS:4,DO:8,DTA:8,RF:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CC:3,OP:4,DoO:4,CLAN:3,FWL:4,DO:4,MSC:5,TP:4,MERC:3,DA:4,RCM:4</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>FVC:2-,PIR:2-,FS:2-,MERC:2-</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:7,MOC:4,MH:4,DA:4,TC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>ROS:2,CGB.FRR:4,CGB:1,DC:2</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:4,MSC:6,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>CGB.FRR:8,DC:8,CGB:1</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -12198,47 +12198,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:2,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:2,IS:2,Periphery:4</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,CNC:6,NIOPS:4,MERC:4</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6,MOC:4</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12246,11 +12246,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -12261,6 +12261,9 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:5,CDS:4,RA:3,CWIE:3</availability>
+		<model name='2'>
+			<availability>CHH:6,CDS:6</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -12270,9 +12273,6 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,RA:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6,CDS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -12293,12 +12293,12 @@
 		<model name='(Streak)'>
 			<availability>HL:2,IS:6,TC:6,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,IS:5,Periphery:5</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>HL:3,FWL:5,IS:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,IS:5,Periphery:5</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:3</availability>
@@ -12334,39 +12334,39 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
+		</model>
 		<model name='(HV)'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:4,DA:4</availability>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Stealth)'>
 			<availability>CC:3,MOC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:4,CC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:4,ROS:4,FWL:4,MSC:5,RCM:4,MERC:3</availability>
-		<model name='PGD-L3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PGD-L3'>
+			<availability>General:4</availability>
 		</model>
 		<model name='PGD-R3'>
 			<roles>ground_support</roles>
@@ -12375,42 +12375,42 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CHH:1,CCC:2,CDS:5,NIOPS:1,CCO:2,RA:5,CWIE:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CCO:6,CWIE:8</availability>
+		<model name='D'>
+			<availability>CSA:3,General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:3,General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:6,General:8,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:4,CDS:9,CW:6,General:7,CGB:6</availability>
+		<model name='Prime'>
+			<availability>CDS:6,General:8,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator' unitType='Mek'>
@@ -12433,23 +12433,23 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6,CSL:6,CCO:6</availability>
-		<model name='(Quad)'>
-			<availability>CHH:5+</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:1,CCO:1</availability>
-		</model>
-		<model name='4'>
-			<availability>CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CHH:8,CSL:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:8,CSL:8,CCO:8</availability>
+		<model name='4'>
+			<availability>CCO:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:1,CCO:1</availability>
+		</model>
+		<model name='(Quad)'>
+			<availability>CHH:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12467,9 +12467,9 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Support)'>
+		<model name='(RAF)'>
 			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+			<availability>ROS:6</availability>
 		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
@@ -12479,47 +12479,47 @@
 			<roles>support</roles>
 			<availability>General:4,Periphery:4</availability>
 		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
-			<availability>IS:4,Periphery:4,CGB:4,RA:4</availability>
-		</model>
-		<model name='(RAF)'>
+		<model name='(Support)'>
 			<roles>apc</roles>
-			<availability>ROS:6</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>General:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>IS:4,Periphery:4,CGB:4,RA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:7,MERC:2+,CCO:6,RA:7,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:8,CW:8,ROS:3+,CNC:8,CJF:5,CGB:6</availability>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CLAN:4,General:3,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CSA:5,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12539,15 +12539,15 @@
 		<model name='[PPC] (RAF)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Quaestor Mobile Tactical Command HQ' unitType='Tank'>
@@ -12559,11 +12559,11 @@
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>HL:4,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>HL:4,Periphery.Deep:4,Periphery:6</availability>
@@ -12574,25 +12574,25 @@
 		<model name='QKD-5K2'>
 			<availability>MERC:1,DC:1</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
-		</model>
-		<model name='QKD-5A'>
-			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:5,FWL:7</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='QKD-9M'>
-			<roles>spotter</roles>
-			<availability>CC:3,MOC:3,ROS:2,DA:3,FS:2</availability>
+		<model name='QKD-5A'>
+			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
 		</model>
 		<model name='QKD-8K'>
 			<availability>CGB.FRR:5,ROS:5,MERC:4,DC:8,CGB:1</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>CGB.FRR:8,MERC:6,DC:8</availability>
+		<model name='QKD-9M'>
+			<roles>spotter</roles>
+			<availability>CC:3,MOC:3,ROS:2,DA:3,FS:2</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
@@ -12600,20 +12600,20 @@
 		<model name='QKD-4H'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
+		<model name='QKD-C'>
+			<availability>CGB.FRR:8,MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:5,FWL:7</availability>
+		<model name='QKD-5K'>
+			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:3,ROS:4,RCM:3,DA:3,MERC:3</availability>
-		<model name='(GL)' mechanized='true'>
+		<model name='(David)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(David)' mechanized='true'>
+		<model name='(GL)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -12627,6 +12627,10 @@
 	</chassis>
 	<chassis name='R10 Mechanized ICV' unitType='Tank' omni='IS'>
 		<availability>DTA:4,OP:4,RF:4,ROS:3,CNC:3,FWL:4,MSC:5,MERC:3,DA:4,RCM:4,CWIE:3</availability>
+		<model name='(B)'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Prime)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
@@ -12635,70 +12639,58 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(B)'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='(Standard)'>
-			<availability>CCC:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CCC:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,ROS:3,MERC:3,FS:4</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
-		</model>
-		<model name='MDG-1Ar'>
-			<availability>ROS:8,FS:4,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1Ar'>
+			<availability>ROS:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:5,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:4,CDP:5,DC:4</availability>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV2'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4</availability>
 		</model>
 		<model name='VV22'>
 			<roles>urban</roles>
@@ -12708,20 +12700,28 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='VV2'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4</availability>
+		</model>
+		<model name='VV1 (MG)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
+		<model name='RPR-300'>
+			<availability>LA:6,ROS:6,MERC:3</availability>
+		</model>
 		<model name='RPR-100'>
 			<availability>General:3,NIOPS:8</availability>
-		</model>
-		<model name='RPR-300S'>
-			<availability>LA:4</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:6,ROS:6,MERC:3</availability>
+		<model name='RPR-300S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -12734,68 +12734,60 @@
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='RPT-3X'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>FS:4,DC:6</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='RTX1-OA'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:3,MH:6,MERC:3,TC:4,Periphery:3</availability>
-		<model name='(MH)' mechanized='false'>
-			<availability>MH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
+		</model>
+		<model name='(MH)' mechanized='false'>
+			<availability>MH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:7,MOC:3,FWL:3,MERC:6,DA:3,TC:3</availability>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:3</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
@@ -12804,21 +12796,29 @@
 			<roles>spotter</roles>
 			<availability>CC:3,MOC:2,FWL:1,MERC:2,DC:2,TC:2</availability>
 		</model>
+		<model name='RVN-4Lr'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:3</availability>
+		</model>
 		<model name='RVN-4L'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6,DA:6,TC:6</availability>
 		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>OP:4,PR:4,DoO:4,DO:4,MERC:4,FS:4,RF:4,LA:6,ROS:4,CGB.FRR:5,PG:4,MH:4,TP:4,DA:4,RFS:4</availability>
-		<model name='RZK-10T'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='RZK-10S'>
 			<availability>LA:4</availability>
@@ -12833,12 +12833,12 @@
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -12849,15 +12849,23 @@
 		<model name='(Stealth)'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:1,CW:1,General:8,CNC:1</availability>
@@ -12866,27 +12874,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:8,RFS:7,MOC:2,CC:2,OP:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,RF:7,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:5,MERC:7,DTA:6,RF:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
+		<model name='F-100'>
+			<availability>FVC:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>MOC:3,CC:3,DTA:8,OP:8,DoO:8,ROS:6,FWL:6,DO:8,MSC:8,TP:8,MERC:6,DC:6</availability>
 		</model>
 		<model name='F-100b'>
 			<availability>CGB.FRR:1-,DC:1-</availability>
@@ -12897,42 +12900,42 @@
 		<model name='F-700'>
 			<availability>CC:8,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:8,DTA:8,RF:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>MOC:3,CC:3,DTA:8,OP:8,DoO:8,ROS:6,FWL:6,DO:8,MSC:8,TP:8,MERC:6,DC:6</availability>
-		</model>
-		<model name='F-100'>
-			<availability>FVC:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:5,MERC:7,DTA:6,RF:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CNC:5,IS:3,RA:5,CGB:5</availability>
-		<model name='8'>
-			<availability>CC:3,OP:3,DoO:3,IS:3,DO:3,FS:3,MERC:3,CDS:4,LA:3,MSC:3,TP:3,DC:3,CGB:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CSA:6,CDS:4,IS:4,CLAN.HW:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,ROS:4,MERC:4,FS:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:6,DC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CSA:6,CDS:4,IS:4,CLAN.HW:4</availability>
+		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,ROS:4,FS:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CC:3,OP:3,DoO:3,IS:3,DO:3,FS:3,MERC:3,CDS:4,LA:3,MSC:3,TP:3,DC:3,CGB:6</availability>
 		</model>
 		<model name='6'>
 			<availability>CSA:6,CHH:4,CDS:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,ROS:4,MERC:4,FS:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CNC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+		<model name='RFL-5D'>
+			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		</model>
 		<model name='RFL-7M'>
 			<availability>MOC:3,OP:7,PR:7,DoO:7,IS:3,DO:7,CDP:3,TC:3,DTA:7,RF:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
 		</model>
@@ -12940,12 +12943,8 @@
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FVC:1-,FS:1-</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:2</availability>
@@ -12954,8 +12953,22 @@
 			<roles>fire_support</roles>
 			<availability>CC:2-,MOC:2-,OP:2-,DoO:2-,PIR:2-,MH:2-,DO:2-,TP:2-,FS:2-,DA:2-,RCM:2-</availability>
 		</model>
+		<model name='RFL-5M'>
+			<availability>CC:3,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:3,DC:3</availability>
+		</model>
 		<model name='C 2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='RFL-8X'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='RFL-7X'>
+			<roles>fire_support</roles>
+			<availability>ROS:4,MERC:4</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:4</availability>
@@ -12963,61 +12976,48 @@
 		<model name='RFL-9T'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='RFL-8X'>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-7X'>
-			<roles>fire_support</roles>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='RFL-5M'>
-			<availability>CC:3,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:3,DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,CGB.FRR:5,ROS:6,CLAN:2,NIOPS:6,FS:5,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5,ROS:4,FS:3</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>CNC:3,FS:3,DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:3</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>CNC:3,FS:3,DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CNC:7,CSL:4,CCO:8,RA:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CNC:6,CSL:6,CCO:8,RA:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:4,CCO:4,RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CCO:4,RA:6</availability>
@@ -13025,6 +13025,9 @@
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CGB:6-</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HR' mechanized='true'>
 			<roles>recon</roles>
 			<availability>CGB:1</availability>
@@ -13033,15 +13036,9 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>PR:4,FS:4,MERC:2,CWIE:6,TC:6,RA.OA:5,FVC:4,RF:4,LA:6,CGB.FRR:4,ROS:4,PG:4,RFS:4</availability>
-		<model name='(Gauss)'>
-			<availability>FRR:0,General:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
@@ -13052,6 +13049,9 @@
 			<roles>artillery,fire_support</roles>
 			<availability>LA:3,CWIE:3</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>FRR:0,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
 		<availability>FS:3</availability>
@@ -13061,9 +13061,6 @@
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
 		<availability>DTA:4,ROS:3,FS:3,MERC:3</availability>
-		<model name='NH-3X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='NH-2'>
 			<availability>General:8</availability>
 		</model>
@@ -13075,6 +13072,9 @@
 		</model>
 		<model name='NH-1B'>
 			<availability>ROS:4-,MERC:4-,FS:4-</availability>
+		</model>
+		<model name='NH-3X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -13094,12 +13094,12 @@
 			<roles>recon</roles>
 			<availability>LA:5</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:7</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13112,29 +13112,29 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.WD:6,CDS:5,CLAN:5,MERC:3+,CJF:5,RA:6,BAN:6,CWIE:6,DC:4+</availability>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:5,CCC:5,CLAN:3,General:2</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
+		<model name='B'>
+			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:5,CCC:5,CLAN:3,General:2</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CNC:4,General:5,CCO:7,CJF:4,RA:6,CWIE:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5,RA:6,CWIE:5,CGB:6</availability>
@@ -13148,20 +13148,20 @@
 		<model name='3'>
 			<availability>CHH:8,ROS:4,CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:8,IS:8,CGB:8</availability>
-		</model>
 		<model name='2'>
 			<availability>ROS:6,CGB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:8,IS:8,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
 		<availability>CNC:7,DC:5</availability>
-		<model name='SM1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Telos)'>
 			<availability>CNC:2,DC:3</availability>
+		</model>
+		<model name='SM1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1A Tank Destroyer' unitType='Tank'>
@@ -13172,13 +13172,13 @@
 	</chassis>
 	<chassis name='SM2 Heavy Artillery Vehicle' unitType='Tank'>
 		<availability>DTA:3,OP:3,ROS:3,CNC:4,MSC:3,MERC:3,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LTC)'>
 			<roles>artillery</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM3 Tank Destroyer' unitType='Tank'>
@@ -13193,13 +13193,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:8,Periphery:4</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,DC:6,Periphery:6</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13210,14 +13210,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
-		<model name='SB-27'>
-			<availability>General:4-</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
+		<model name='SB-27'>
+			<availability>General:4-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
@@ -13229,17 +13229,8 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -13248,8 +13239,17 @@
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -13257,21 +13257,21 @@
 		<model name='SGT-8R'>
 			<availability>FVC:8,FS:6</availability>
 		</model>
-		<model name='SGT-10X'>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittarii' unitType='Aero'>
 		<availability>ROS:5</availability>
-		<model name='SGT-2R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SGT-3R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='SGT-2R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
@@ -13279,14 +13279,14 @@
 		<model name='S-4C'>
 			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
-		<model name='S-3'>
-			<availability>DC:1-</availability>
+		<model name='S-4'>
+			<availability>CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
 		</model>
 		<model name='S-8'>
 			<availability>ROS:7,DC:6</availability>
 		</model>
-		<model name='S-4'>
-			<availability>CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
+		<model name='S-3'>
+			<availability>DC:1-</availability>
 		</model>
 		<model name='S-7'>
 			<availability>ROS:6,CNC:6,DC:6</availability>
@@ -13294,29 +13294,29 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:3,DC.AL:9,IS:5,MERC:5,Periphery.OS:3,FS:4,Periphery:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:8,DC:8</availability>
+		</model>
 		<model name='(LB-X)'>
 			<availability>IS:6,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:8,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CW:6,RA:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CW:6,RA:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -13325,10 +13325,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -13336,6 +13332,10 @@
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
@@ -13348,21 +13348,21 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>LA:5,CGB.FRR:4,ROS:5,DC:1</availability>
-		<model name='SL-27'>
-			<availability>IS:6,DC:4</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:2-,Periphery:4,TC:4,RA.OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:6-</availability>
-		<model name='(MRM)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -13393,17 +13393,17 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CNC:3,CCO:7,RA:4</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CNC:4,RA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CNC:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XP'>
 			<availability>CNC:8</availability>
@@ -13411,11 +13411,8 @@
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CHH:3,CW:5,CCO:10</availability>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
@@ -13423,8 +13420,11 @@
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -13446,10 +13446,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -13457,6 +13453,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -13476,53 +13476,53 @@
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:2</availability>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
+		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,OP:4,DoO:4,CGB.FRR:4,ROS:5,FWL:4,DO:4,TP:4,FS:4,MERC:4,DC:4,CGB:4</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='SCK-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCK-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SCK-OA'>
 			<roles>interceptor</roles>
@@ -13537,33 +13537,33 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:2,CC:1,HL:3,IS:2,Periphery.Deep:5,MERC:2,FS:2,Periphery:4,TC:2,RA:4,RA.OA:3,LA:2,CGB.FRR:2,CNC:4,FWL:2,DC:1</availability>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
+		<model name='(Armor)'>
+			<availability>CNC:7,IS:5,RA:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>CNC:7,IS:5,RA:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
-		<model name='(Missile)'>
-			<availability>IS:1</availability>
+		<model name='(Standard)'>
+			<availability>General:4-</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4-</availability>
+		<model name='(Missile)'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:8,DC:8</availability>
@@ -13571,49 +13571,49 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(Minesweeper)'>
-			<roles>minesweeper</roles>
-			<availability>CC:3-,MOC:2-</availability>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
-			<availability>General:4-</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:4,DC:5,TC:4</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>General:4-</availability>
 		</model>
 		<model name='(ML)'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
+		<model name='(LAC)'>
+			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:4,DC:5,TC:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:4-</availability>
+		</model>
+		<model name='(Minesweeper)'>
+			<roles>minesweeper</roles>
+			<availability>CC:3-,MOC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2,FVC:2,HL:2,LA:4,CGB.FRR:2-,ROS:2,Periphery.Deep:4-,FWL:2,NIOPS:2-,MERC:2,Periphery:3,DC:3</availability>
-		<model name='SCP-1N'>
-			<availability>FRR:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		<model name='SCP-12S'>
+			<availability>LA:3,ROS:2,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>FRR:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>HL:2,IS:4,Periphery.Deep:1,Periphery:4</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:3,ROS:2,MERC:2</availability>
+		<model name='SCP-1TB'>
+			<availability>ROS:4,MERC:4</availability>
 		</model>
 		<model name='SCP-10M'>
 			<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
-		</model>
-		<model name='SCP-1TB'>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -13631,14 +13631,14 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
+		<model name='3'>
+			<availability>CJF:4</availability>
+		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero'>
@@ -13649,38 +13649,38 @@
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CW:4,CNC:5,CLAN:4,CJF:6,CCO:4,RA:5,CWIE:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(SRM6)'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:3</availability>
@@ -13694,25 +13694,25 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,HL:2,LA:6,CGB.FRR:3,IS:4,FWL:4,FS:5,Periphery:3,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:8,FWL:4,IS:5,FS:8</availability>
 		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CLAN:1,FS:5,MERC:4,CWIE:1,DC.GHO:3,FVC:5,CDS:1,CW:1,LA:5,ROS:4,NIOPS:4,CJF:2,CGB:2,DC:3</availability>
-		<model name='STN-3L'>
-			<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -13730,22 +13730,26 @@
 			<roles>interceptor</roles>
 			<availability>LA:2-,Periphery.Deep:8,Periphery:2-</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:8,CGB.FRR:6,ROS:4,FS:8,MERC:6,CGB:1</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>RA.OA:2-,HL:3-,ROS:2-,Periphery:5-,TC:2-</availability>
-		</model>
 		<model name='SYD-Z3A'>
 			<availability>LA:6,CGB.FRR:3,ROS:3,MERC:3,FS:3,CGB:1</availability>
 		</model>
 		<model name='SYD-45X &apos;Starling&apos;'>
 			<availability>LA:1</availability>
 		</model>
+		<model name='SYD-Z1'>
+			<roles>interceptor</roles>
+			<availability>RA.OA:2-,HL:3-,ROS:2-,Periphery:5-,TC:2-</availability>
+		</model>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>LA:8,CGB.FRR:6,ROS:4,FS:8,MERC:6,CGB:1</availability>
+		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,FVC:4,HL:2,LA:6,CGB.FRR:2,ROS:4,MERC:5,FS:4,Periphery:4</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:1-</availability>
 		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -13754,21 +13758,17 @@
 		<model name='SYD-Z2B'>
 			<availability>RA.OA:4,LA:4,ROS:4,PIR:3,FS:4,MERC:4,RA:4</availability>
 		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:1-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6,MOC:5</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -13790,16 +13790,12 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CDS:5,ROS:4+,CNC:7,CSL:4,MERC:2+,CJF:5,RA:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:3,CCO:7</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CW:3,General:6,RA:8</availability>
-		</model>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CW:3,General:6,RA:3</availability>
 		</model>
 		<model name='J'>
 			<availability>General:5</availability>
@@ -13807,72 +13803,76 @@
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
+		<model name='A'>
 			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
+			<availability>CW:3,General:6,RA:3</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CW:3,General:6,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:3,RFS:3,CGB:5,OP:3,IS:2,MERC:4,RA:5,DTA:3,RF:3,LA:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
-		<model name='8'>
-			<availability>CDS:4,LA:4,CNC:5,IS:3,CWIE:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:2,CCC:2,CGB:3</availability>
-		</model>
-		<model name='7'>
-			<availability>RA.OA:6,RA:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:5,CNC:5,IS:4,RA:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:5,CNC:5,IS:4</availability>
+		<model name='6'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:8,LA:8,CGB.FRR:6,FWL:8,IS:6,FS:8,MERC:8,DC:8,CGB:4</availability>
 		</model>
-		<model name='6'>
-			<availability>CHH:6</availability>
+		<model name='2'>
+			<availability>CSA:2,CCC:2,CGB:3</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:4,LA:4,CNC:5,IS:3,CWIE:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:5,CNC:5,IS:4,RA:4</availability>
+		</model>
+		<model name='7'>
+			<availability>RA.OA:6,RA:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:4,CDS:5,CNC:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,BAN:4,Periphery:6,CGB:4</availability>
-		<model name='SHD-2K'>
-			<availability>MERC:1-,DC:2-</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
 		</model>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,FS:5</availability>
+		<model name='SHD-3K'>
+			<availability>CGB.FRR:4,DC:6,CGB:2</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:2-,MOC:2-,FWL:2-,MH:3-,MERC:2-</availability>
 		</model>
-		<model name='SHD-2H'>
-			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
-		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:4,FWL:5,MERC:6,Periphery:3,DC:6</availability>
-		</model>
-		<model name='SHD-8L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,OP:6,DoO:6,DO:6,MERC:4,CDP:3,TC:3,DTA:6,FVC:3,ROS:4,MSC:6,TP:6,RCM:6</availability>
-		</model>
-		<model name='SHD-9D'>
-			<availability>FS:5</availability>
 		</model>
 		<model name='SHD-5D'>
 			<availability>LA:4,ROS:4,FS:6,MERC:5</availability>
 		</model>
-		<model name='SHD-3K'>
-			<availability>CGB.FRR:4,DC:6,CGB:2</availability>
+		<model name='SHD-2K'>
+			<availability>MERC:1-,DC:2-</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,OP:6,DoO:6,DO:6,MERC:4,CDP:3,TC:3,DTA:6,FVC:3,ROS:4,MSC:6,TP:6,RCM:6</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='SHD-8L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -13880,40 +13880,40 @@
 		<model name='(Flamer)'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:4,CDS:4,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:6,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
 		<availability>MOC:6,FVC:2,PIR:2,IS:6,CDP:2</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MOC:8,IS:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>recon</roles>
 			<availability>FVC:8,PIR:8,IS:4,CDP:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MOC:8,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shen Long Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:4</availability>
+		<model name='[Pop-Up Mine]' mechanized='false'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[David Light Gauss]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Interdictor]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Pop-Up Mine]' mechanized='false'>
-			<availability>General:5</availability>
-		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[David Light Gauss]' mechanized='false'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='false'>
 			<availability>General:8</availability>
@@ -13921,12 +13921,12 @@
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
 		<availability>CC:4</availability>
+		<model name='SHY-3B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='SHY-5B'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='SHY-3B'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sheriff Infantry Support Tank' unitType='Tank'>
@@ -13944,14 +13944,14 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RA.OA:2,CGB.FRR:2,ROS:2,MERC:2,RA:2,DC:2</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shiva' unitType='Aero'>
@@ -13965,6 +13965,9 @@
 		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SHV-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
 		</model>
@@ -13974,40 +13977,37 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:3,DTA:4,OP:4,DoO:4,ROS:3,FWL:4,DO:4,MSC:4,TP:4,FS:2,RCM:3,DC:2</availability>
-		<model name='SKW-2F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SKW-4G'>
 			<availability>General:2</availability>
+		</model>
+		<model name='SKW-2F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,ROS:3,CNC:5,CGB:4,CWIE:3,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,DC:6</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
 		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
-		<model name='SL-22'>
-			<availability>FVC:4,HL:2,CGB.FRR:8,ROS:8,Periphery.Deep:1,MERC:4,DC:8,Periphery:4</availability>
-		</model>
 		<model name='SL-21L'>
 			<roles>raider,ground_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='SL-22'>
+			<availability>FVC:4,HL:2,CGB.FRR:8,ROS:8,Periphery.Deep:1,MERC:4,DC:8,Periphery:4</availability>
 		</model>
 		<model name='SL-21'>
 			<availability>FVC:4,HL:3,Periphery.Deep:8,MERC:3,DC:3,Periphery:5</availability>
@@ -14040,23 +14040,23 @@
 	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='(Standard)'>
+			<availability>CSA:4,CCC:4,CCO:4</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:4,CCC:4,CCO:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,OP:5,DoO:5,ROS:3,DO:5,MSC:5,TP:5,MERC:3</availability>
-		<model name='SRC-5C'>
-			<availability>DTA:5,OP:5,DoO:5,ROS:5,FWL:5,DO:5,MSC:5,TP:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>DTA:5,OP:5,DoO:5,ROS:5,FWL:5,DO:5,MSC:5,TP:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>DTA:5,OP:5,DoO:5,ROS:1,FWL:5,DO:5,MSC:5,TP:5</availability>
@@ -14083,42 +14083,42 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:4-</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:4-</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,CGB.FRR:7,ROS:4,DC:7,CGB:5</availability>
+		<model name='SL-15'>
+			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>RA.OA:6,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4,CGB:6</availability>
 		</model>
 		<model name='SL-15K'>
 			<availability>CGB.FRR:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='(Huntsman)' mechanized='false'>
 			<availability>LA:4,MERC:4,FS:4</availability>
@@ -14152,11 +14152,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -14168,10 +14168,6 @@
 	</chassis>
 	<chassis name='Sokuryou' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='SKU-181 SurveyMech'>
-			<roles>support,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='SKU-197 SurveyMech'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -14179,6 +14175,10 @@
 		<model name='SKU-198 SurveyMech'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKU-181 SurveyMech'>
+			<roles>support,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -14212,27 +14212,27 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+		<model name='SPR-7D'>
+			<availability>ROS:5,FS:5,MERC:5</availability>
+		</model>
+		<model name='SPR-DH'>
+			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:2-</availability>
+		</model>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:4,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:2-,Periphery.Deep:8,FS:2-,MERC:2-,CDP:2-,TC:2-</availability>
-		</model>
-		<model name='SPR-7D'>
-			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-DH'>
-			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -14247,21 +14247,21 @@
 		<model name='SPR-5S'>
 			<availability>CC:4,LA:4,ROS:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8</availability>
 		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:4,CDP:4,RA:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(RA)' mechanized='true'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -14269,27 +14269,39 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:4,CNC:4-</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:4,CNC:6</availability>
 		</model>
-		<model name='2'>
-			<availability>ROS:6,CNC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:3,MERC:3,FS:3,Periphery:2,TC:2,FVC:3,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:3,CC:3,FWL:8,MH:3,MERC:2</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:3,MERC:3</availability>
+		</model>
+		<model name='SDR-8X'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>IS:1-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-7K'>
 			<availability>ROS:4,MERC:4,DC:5</availability>
@@ -14300,23 +14312,11 @@
 		<model name='SDR-7KC'>
 			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='SDR-8K'>
-			<availability>ROS:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>ROS:3,MERC:3,DC:4</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:3,MERC:3</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:3,CC:3,FWL:8,MH:3,MERC:2</availability>
-		</model>
-		<model name='SDR-8X'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
+		<model name='SDR-8K'>
+			<availability>ROS:3,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -14336,13 +14336,17 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:3,FVC:3,LA:7,CGB.FRR:7,ROS:7,IS:6,MH:2,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>CGB.FRR:5,IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>CGB.FRR:5,IS:4,DC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -14351,10 +14355,6 @@
 		<model name='(Interdictor)'>
 			<roles>spotter</roles>
 			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,DC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14365,14 +14365,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
+		<model name='STK-4P'>
+			<availability>MERC:1,Periphery:1</availability>
+		</model>
 		<model name='STK-8S'>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,IS:2-,TC:2-,Periphery:2-</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>MERC:1,Periphery:1</availability>
+		<model name='STK-6M'>
+			<availability>CC:5,MOC:5,OP:6,PR:6,DoO:6,DO:6,MERC:6,RF:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
@@ -14380,20 +14383,17 @@
 		<model name='STK-7D'>
 			<availability>ROS:4,FS:4,MERC:3</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,OP:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,RF:3,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
-		</model>
-		<model name='STK-6M'>
-			<availability>CC:5,MOC:5,OP:6,PR:6,DoO:6,DO:6,MERC:6,RF:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
+		<model name='STK-3F'>
+			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
@@ -14401,12 +14401,12 @@
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -14426,12 +14426,12 @@
 	</chassis>
 	<chassis name='Starslayer' unitType='Mek'>
 		<availability>MOC:4,CC:4,OP:4,PR:4,DoO:4,DO:4,FS:4,MERC:4,RF:4,LA:6,CGB.FRR:4,ROS:4,PG:4,TP:4,DA:4,RFS:4</availability>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:6,RFS:6</availability>
+		</model>
 		<model name='STY-3D'>
 			<roles>raider</roles>
 			<availability>MOC:5,CC:3,OP:3,LA:5,DoO:3,ROS:3,DO:3,TP:3,FS:3,MERC:5</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:6,RFS:6</availability>
 		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
@@ -14440,6 +14440,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>LA:3,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
@@ -14448,28 +14452,24 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>FS:6,MERC:4</availability>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:4,LA:4</availability>
-		<model name='STM-OB'>
+		<model name='STM-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STM-OA'>
+		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14481,11 +14481,11 @@
 		<model name='STO-4B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-6S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -14503,46 +14503,42 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A5'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
+			<availability>IS:1,DC:2</availability>
+		</model>
+		<model name='STG-A5'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>IS:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='STG-5G'>
-			<roles>recon</roles>
-			<availability>CC:4,OP:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,FVC:4,HL:2,MERC:4,DA:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:6,ROS:5,MERC:6,FS:4</availability>
 		</model>
-		<model name='STG-3Gb'>
+		<model name='STG-6L'>
 			<roles>recon</roles>
-			<availability>CC:3,OP:6,DoO:6,CLAN:8,FWL:5,DO:6,MSC:6,TP:6,RCM:6,DA:6,MERC:3,BAN:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
+			<availability>CC:6,MOC:4,DA:4</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
-		<model name='STG-6L'>
+		<model name='STG-5G'>
 			<roles>recon</roles>
-			<availability>CC:6,MOC:4,DA:4</availability>
+			<availability>CC:4,OP:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,FVC:4,HL:2,MERC:4,DA:4,TC:4,Periphery:4</availability>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>CC:3,OP:6,DoO:6,CLAN:8,FWL:5,DO:6,MSC:6,TP:6,RCM:6,DA:6,MERC:3,BAN:2</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>IS:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -14556,35 +14552,36 @@
 			<roles>recon</roles>
 			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:6,RFS:5,MOC:3,CC:5,OP:6,IS:3,MERC:5,TC:3,DTA:6,RF:5,LA:5,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
-		<model name='F-95'>
-			<availability>CC:4,OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,LA:4,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
-		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
-		</model>
-		<model name='F-92'>
-			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:5,IS:4,MH:4</availability>
 		</model>
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
 		</model>
+		<model name='F-92'>
+			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:5,IS:4,MH:4</availability>
+		</model>
+		<model name='F-95'>
+			<availability>CC:4,OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,LA:4,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CGB:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -14592,11 +14589,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14608,56 +14608,62 @@
 	</chassis>
 	<chassis name='Storm Raider' unitType='Mek'>
 		<availability>RF:2,LA:3,ROS:2,MH:2,MERC:2,FS:2,Periphery:2</availability>
-		<model name='STM-R1'>
-			<availability>General:3</availability>
-		</model>
 		<model name='STM-R3'>
 			<availability>LA:8,MH:8,MERC:8</availability>
-		</model>
-		<model name='STM-R2'>
-			<availability>General:4</availability>
 		</model>
 		<model name='STM-R4'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
+		<model name='STM-R1'>
+			<availability>General:3</availability>
+		</model>
+		<model name='STM-R2'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:4,DC:7</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2,CGB:1</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
 		</model>
@@ -14669,23 +14675,17 @@
 			<roles>fire_support</roles>
 			<availability>FVC:3-,IS:2-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
+		<model name='(SRM)'>
+			<availability>FVC:2-,IS:2-</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,ROS:3,FS.DMM:8,FS:3</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>FVC:2-,IS:2-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:5,LA:6,ROS:6,CNC:5,FS:7,DC:5,CWIE:5</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:5,LA:6,ROS:6,CNC:5,FS:7,DC:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
@@ -14705,27 +14705,27 @@
 		<model name='STU-K5'>
 			<availability>FVC:3-,IS:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>ROS:6,FS:7,MERC:3</availability>
+		<model name='STU-D6'>
+			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>ROS:6,CLAN:8,FS:4,MERC:3,BAN:2</availability>
 		</model>
-		<model name='STU-D6'>
-			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
+		<model name='STU-D7'>
+			<availability>ROS:6,FS:7,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>PR:4,HL:2,MERC:1,FS:3,CWIE:3,Periphery.R:3,CDS:2,RF:4,LA:5,ROS:4,PG:4,CNC:3,RFS:4</availability>
+		<model name='(Heavy Gauss)'>
+			<availability>PR:4,RF:4,LA:6,PG:4,CNC:6,RFS:4,CWIE:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Heavy Gauss)'>
-			<availability>PR:4,RF:4,LA:6,PG:4,CNC:6,RFS:4,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
@@ -14744,12 +14744,6 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:6,General:2,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
 		</model>
@@ -14759,20 +14753,30 @@
 		<model name='A'>
 			<availability>CSA:7,General:2,RA:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CSA:6,General:2,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CDS:3,CW:5,ROS:3,FS:3,MERC:2</availability>
-		<model name='2'>
-			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:4,CW:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OX'>
-			<availability>General:1</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OE'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
@@ -14781,36 +14785,32 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
+		<model name='SD1-OX'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CDS:4,CW:5,ROS:3,CNC:9,CWIE:5,CGB:3</availability>
-		<model name='2'>
-			<availability>ROS:6,CNC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:6,CNC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -14845,11 +14845,11 @@
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:3,LA:4,ROS:3,FWL:3,FS:3,MERC:3</availability>
-		<model name='(Original)'>
-			<availability>LA:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<availability>LA:4,MERC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -14864,15 +14864,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -14880,19 +14880,15 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CCC:9,CLAN:8,RA:9</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CDS:2,RA:4</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:4</availability>
@@ -14905,15 +14901,19 @@
 			<roles>recon</roles>
 			<availability>RA:1</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>ROS:4,DC:6</availability>
+		<model name='TSH-8S'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Taihou Assault Dropship' unitType='Dropship'>
@@ -14937,65 +14937,65 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(RL)'>
-			<availability>MOC:4</availability>
 		</model>
 		<model name='2'>
 			<availability>MOC:3</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(RL)'>
+			<availability>MOC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DTA:6,OP:6,DoO:6,ROS:4,FWL:6,DO:6,MSC:6,TP:6,MERC:4,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>MOC:4,CC:5,ROS:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,DoO:8,ROS:6,DO:8,MSC:8,TP:8,MERC:6,DC:8</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,DoO:8,ROS:5,FWL:8,DO:8,MSC:8,TP:8,MERC:4,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:5,ROS:5,FWL:5,MERC:5,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:3</availability>
-		<model name='TRG-2N'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='TRG-1N'>
 			<roles>recon</roles>
 			<availability>ROS:8</availability>
 		</model>
+		<model name='TRG-2N'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:1,CGB.FRR:5,ROS:4,CNC:4,DC:6</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OE'>
+			<availability>General:5</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OE'>
-			<availability>General:5</availability>
 		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
@@ -15010,56 +15010,56 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,ROS:5,Periphery.MW:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RFS:8</availability>
-		<model name='TMP-3M'>
-			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>PR:4,RF:4,ROS:4,PG:4,MSC:4,MERC:4,RFS:4</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>DTA:6,OP:6,DoO:6,ROS:6,DO:6,MSC:6,TP:6,MERC:3</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>ROS:2,FWL:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>DTA:6,OP:6,DoO:6,ROS:6,DO:6,MSC:6,TP:6,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:5</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OI'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OE'>
+		<model name='TLR1-OF'>
 			<roles>spotter</roles>
-			<availability>General:3</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OF'>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OE'>
 			<roles>spotter</roles>
-			<availability>General:2</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -15071,6 +15071,10 @@
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>ROS:6,DC:4</availability>
+		<model name='TSN-C3M'>
+			<roles>recon,spotter</roles>
+			<availability>ROS:4,DC:4</availability>
+		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
@@ -15079,20 +15083,16 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-C3M'>
-			<roles>recon,spotter</roles>
-			<availability>ROS:4,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CW:1,CCO:1,CJF:1,RA:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -15100,11 +15100,11 @@
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TNS-6S'>
-			<availability>LA:5,IS:4</availability>
-		</model>
 		<model name='TNS-4T'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='TNS-6S'>
+			<availability>LA:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -15123,8 +15123,15 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CLAN:2,CCO:2,RA:2,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:2,CW:2,ROS:2+,CNC:3,CJF:5,CGB:2</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
@@ -15132,45 +15139,38 @@
 		<model name='D'>
 			<availability>CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CWIE:5</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,NIOPS:3,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>ROS:8,NIOPS:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>ROS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
@@ -15179,14 +15179,14 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
@@ -15194,34 +15194,34 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:6</availability>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,RA:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:2-,FVC:3-,HL:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:4-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:3</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4,FVC:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:2-,FVC:3-,HL:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -15241,13 +15241,13 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>HL:3,IS:4,Periphery.Deep:8,Periphery:4</availability>
-		<model name='Angel'>
-			<roles>artillery</roles>
-			<availability>DTA:5,LA:4,ROS:4,FWL:4,FS:4,DC:4</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:6,IS:5</availability>
+		</model>
+		<model name='Angel'>
+			<roles>artillery</roles>
+			<availability>DTA:5,LA:4,ROS:4,FWL:4,FS:4,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
@@ -15256,9 +15256,6 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:4,ROS:5,DC:4</availability>
-		<model name='TFT-A9'>
-			<availability>ROS:8,General:4</availability>
-		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
@@ -15266,18 +15263,21 @@
 		<model name='TFT-L8'>
 			<availability>LA:8</availability>
 		</model>
+		<model name='TFT-A9'>
+			<availability>ROS:8,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:5,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6,ROS:6,MERC:4</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6,ROS:6,MERC:4</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4,ROS:4</availability>
@@ -15285,51 +15285,51 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,PR:5,RF:5,PG:5,MERC:4,DA:5,RFS:5,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-1L'>
-			<availability>General:6</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-C4'>
 			<availability>CC:3,MOC:3,CC.LCC:5</availability>
+		</model>
+		<model name='THR-1L'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:6</availability>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Pulse Laser]' mechanized='true'>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
+		<model name='[Pulse Laser]' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
@@ -15340,13 +15340,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:4,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:4,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -15361,44 +15361,53 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:5,HL:2,IS:3,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,LA:6,ROS:5,NIOPS:3-,MH:4,DC:4</availability>
-		<model name='TDR-1C'>
-			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
-		</model>
-		<model name='TDR-60-RLA'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:4,LA:5,FS:3,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
-		</model>
-		<model name='TDR-9T'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:2-,LA:1-,General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:5,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:6,MH:3,MERC:5</availability>
+		</model>
+		<model name='TDR-17S'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='TDR-60-RLA'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:2,MH:2,MERC:3,FS:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9M'>
 			<availability>MOC:3,CC:3,OP:5,DoO:5,DO:5,MERC:3,DTA:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
 		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:2-,LA:1-,General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
 		<model name='TDR-5SS'>
 			<availability>LA:2-,MERC:1-</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:6,CCC:6</availability>
+		<model name='TDR-9T'>
+			<availability>TC:4</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:2,MH:2,MERC:3,FS:3</availability>
+		<model name='C'>
+			<availability>CSA:6,CCC:6</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:3,MERC:3</availability>
@@ -15409,30 +15418,21 @@
 		<model name='TDR-10S'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='TDR-17S'>
-			<availability>LA:5</availability>
-		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
-		</model>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:8,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
+		<model name='TSG-9C'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='TSG-9DDC'>
 			<availability>CC:4,CC.WHO:6</availability>
 		</model>
-		<model name='TSG-9C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
@@ -15443,11 +15443,11 @@
 	</chassis>
 	<chassis name='Tian-Zong' unitType='Mek'>
 		<availability>CC:4+</availability>
-		<model name='TNZ-N1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='TNZ-N2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='TNZ-N1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiburon' unitType='Mek'>
@@ -15473,13 +15473,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,NIOPS:3,RA:5</availability>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2953)'>
 			<roles>asf_carrier</roles>
@@ -15488,15 +15488,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CNC:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>CGB.FRR:4-,DC:4-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
 		</model>
@@ -15504,21 +15495,30 @@
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>CGB.FRR:4-,DC:4-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>CGB.FRR:2-,DC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CW:4</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>urban</roles>
@@ -15527,8 +15527,8 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CW:3,ROS:7,CLAN:2,NIOPS:9,MERC:4,DC:6</availability>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -15537,15 +15537,12 @@
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CW:2</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -15554,6 +15551,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -15565,14 +15565,10 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:2,MH:1</availability>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Small Laser]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
@@ -15583,6 +15579,10 @@
 		</model>
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -15614,17 +15614,17 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,PR:3,RF:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
 		<model name='TR-13'>
 			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='TR-16'>
 			<availability>CC:7,MOC:5,PR:8,RF:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
@@ -15632,16 +15632,16 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
-		<model name='TR-11'>
-			<roles>recon</roles>
-			<availability>General:1</availability>
+		<model name='TR-13G'>
+			<roles>ground_support,assault</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='TR-12'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='TR-13G'>
-			<roles>ground_support,assault</roles>
-			<availability>CC:5</availability>
+		<model name='TR-11'>
+			<roles>recon</roles>
+			<availability>General:1</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>CC:3,MOC:4,General:6,TC:4</availability>
@@ -15668,24 +15668,11 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:2,MOC:2,PR:6,IS:2,FS:1,MERC:2,Periphery:4,TC:4,RA.OA:2,RF:6,LA:2,CGB.FRR:4,Periphery.MW:4,ROS:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:1-,MOC:4-,LA:1-,FWL:1-,IS:2-,NIOPS:2-,FS:1-,MERC:2-,DC:1-,Periphery:4-</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>PR:4,RF:4,ROS:5,PG:4,NIOPS:5,MSC:4,MERC:4,RFS:4</availability>
+		<model name='TBT-5S'>
+			<availability>RF:4,Periphery.Deep:4,CDP:2-,TC:2-</availability>
 		</model>
 		<model name='TBT-K7R'>
 			<availability>ROS:2</availability>
-		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,MSC:5,MERC:4</availability>
 		</model>
 		<model name='TBT-9K'>
 			<roles>fire_support</roles>
@@ -15695,11 +15682,24 @@
 			<roles>fire_support</roles>
 			<availability>TC:4</availability>
 		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,MSC:5,MERC:4</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>PR:4,RF:4,ROS:5,PG:4,NIOPS:5,MSC:4,MERC:4,RFS:4</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:1-</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>RF:4,Periphery.Deep:4,CDP:2-,TC:2-</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:1-,MOC:4-,LA:1-,FWL:1-,IS:2-,NIOPS:2-,FS:1-,MERC:2-,DC:1-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -15713,28 +15713,28 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,MH:4,TC:8</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:4,TC:4</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:5</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:4,TC:4</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:4,TC:4</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:5</availability>
 		</model>
 	</chassis>
@@ -15751,13 +15751,13 @@
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,HL:8,CLAN:2,IS:9,Periphery.Deep:8,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -15801,19 +15801,19 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:5+,ROS:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>General:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CW:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -15830,52 +15830,52 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CW:3,CNC:4,CJF:7,CLAN.HW:4</availability>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -15884,13 +15884,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -15902,17 +15902,20 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,CGB.FRR:2,ROS:3,CGB:5,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CGB.FRR:8,CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CGB.FRR:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -15920,52 +15923,49 @@
 			<roles>assault</roles>
 			<availability>CHH:6,CGB:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CHH:3,MERC.WD:2,CW:3,MERC:1+,CCO:1,CJF:5,RA:5,CWIE:3</availability>
-		<model name='F'>
-			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,General:5,CCO:4,RA:6</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,General:5,CCO:4,RA:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Umbra' unitType='Aero'>
@@ -15977,11 +15977,11 @@
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:4,CW:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -15993,13 +15993,13 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:3</availability>
-		<model name='(3071)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(3071)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -16026,6 +16026,31 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:3,Periphery:3</availability>
+		</model>
+		<model name='UM-R60L'>
+			<roles>urban</roles>
+			<availability>CC:2-,FVC:1,Periphery:2</availability>
+		</model>
+		<model name='UM-R68'>
+			<roles>urban</roles>
+			<availability>CC:6,FS:6,DC:6</availability>
+		</model>
+		<model name='UM-R70'>
+			<roles>urban</roles>
+			<availability>CC:3,MOC:3,FS.CMM:6,MSC:3,FS:4</availability>
+		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>CC:2-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
 		<model name='UM-R80'>
 			<roles>urban,spotter</roles>
 			<availability>CC:4,MOC:4,IS:3,FWL:3,MERC:3,Periphery:3</availability>
@@ -16033,31 +16058,6 @@
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:6,Periphery:6</availability>
-		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:6,FS:6,DC:6</availability>
-		</model>
-		<model name='UM-R60L'>
-			<roles>urban</roles>
-			<availability>CC:2-,FVC:1,Periphery:2</availability>
-		</model>
-		<model name='UM-R60'>
-			<roles>urban</roles>
-			<availability>CC:2-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='UM-R70'>
-			<roles>urban</roles>
-			<availability>CC:3,MOC:3,FS.CMM:6,MSC:3,FS:4</availability>
-		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -16073,10 +16073,6 @@
 			<deployedWith>IS</deployedWith>
 			<availability>CGB:2</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -16085,6 +16081,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -16117,41 +16117,41 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
-		<model name='VLK-QF'>
+		<model name='VLK-QD3'>
 			<roles>recon,fire_support</roles>
-			<availability>FS:1-,MERC:1-</availability>
-		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:5,ROS:4,MERC:3</availability>
-		</model>
-		<model name='VLK-QD'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:5,LA:5,ROS:6,FS:6,MERC:6</availability>
-		</model>
-		<model name='VLK-QD2'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,FS:4</availability>
+			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:3-,FS:2-,MERC:2-,CDP:3-,TC:2-</availability>
 		</model>
-		<model name='VLK-QD1'>
+		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+			<availability>LA:5,ROS:4,MERC:3</availability>
+		</model>
+		<model name='VLK-QD2'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,FS:4</availability>
+		</model>
+		<model name='VLK-QF'>
+			<roles>recon,fire_support</roles>
+			<availability>FS:1-,MERC:1-</availability>
+		</model>
+		<model name='VLK-QD'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:5,LA:5,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='VLK-QT2'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
-		<model name='VLK-QD3'>
-			<roles>recon,fire_support</roles>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QD4'>
 			<roles>recon,fire_support</roles>
 			<availability>ROS:6,FS:4</availability>
+		</model>
+		<model name='VLK-QD1'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -16166,24 +16166,24 @@
 		<model name='D'>
 			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -16195,52 +16195,52 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CHH:1,HL:9,CW:1,IS:10,Periphery.Deep:8,CJF:1,Periphery:10</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Liao)'>
-			<availability>CC:2-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,DTA:5,PR:5,RF:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
+		<model name='V7'>
+			<availability>LA:4,ROS:4,FS:4,MERC:5</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>CC:1-,General:1-</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
+		<model name='(Standard)'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:2-</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,DTA:5,PR:5,RF:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
 		</model>
 		<model name='V-G7X'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2-</availability>
-		</model>
-		<model name='V7'>
-			<availability>LA:4,ROS:4,FS:4,MERC:5</availability>
-		</model>
 		<model name='(Cell)'>
 			<availability>CC:5,LA:4,FWL:5,IS:4,FS:4,MERC:5,DC:4,Periphery:3</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,RA.OA:1,LA:4,CGB.FRR:4,IS:1,FWL:4,NIOPS:5,FS:4,Periphery:1,TC:1,DC:4</availability>
-		<model name='(2682)'>
+		<model name='(3056)'>
 			<roles>asf_carrier</roles>
-			<availability>General:3</availability>
+			<availability>IS:3,FS:8</availability>
 		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:3,CC:3</availability>
 		</model>
-		<model name='(3056)'>
+		<model name='(2682)'>
 			<roles>asf_carrier</roles>
-			<availability>IS:3,FS:8</availability>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -16260,60 +16260,60 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:3</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:3,CC:6,HL:3,IS:2-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
-		<model name='VTR-9B'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,HL:2,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>CC:2,FVC:3,ROS:3,FS:3,MERC:3,DC:3,Periphery:2</availability>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:2</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
+		<model name='VTR-9Ka'>
+			<availability>CC:2,FVC:3,ROS:3,FS:3,MERC:3,DC:3,Periphery:2</availability>
 		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,HL:2,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
+		<model name='VTR-9D'>
+			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 		<model name='VTR-9A1'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:1-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-9D'>
-			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
 		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
+		<model name='VTR-9S'>
+			<availability>LA:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -16331,16 +16331,16 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CGB.FRR:7,ROS:6,MERC:5,CGB:5</availability>
+		<model name='VKG-3A'>
+			<roles>missile_artillery</roles>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
 		<model name='VKG-2G'>
 			<availability>CGB.FRR:6,ROS:6,MERC:6,CGB:6</availability>
 		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-3A'>
-			<roles>missile_artillery</roles>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -16356,11 +16356,8 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:3,MERC:4,TC:6</availability>
-		<model name='VND-5L'>
-			<availability>CC:3,MOC:2,MERC:2,TC:1</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:8,MOC:6</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>CGB.FRR:0,General:2</availability>
@@ -16368,14 +16365,17 @@
 		<model name='VND-3L'>
 			<availability>CC:5,MOC:3,General:3,TC:3</availability>
 		</model>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
+		<model name='VND-4L'>
+			<availability>CC:8,MOC:6</availability>
 		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-5L'>
+			<availability>CC:3,MOC:2,MERC:2,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -16401,49 +16401,49 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:6,RA:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CJF:4</availability>
+		<model name='5'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:2,CJF:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,DC:6+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:6</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CNC:8</availability>
-		</model>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -16459,32 +16459,24 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CGB.FRR:4,PIR:2,FS:2,DC:3</availability>
-		<model name='VNL-K75N'>
-			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
-		</model>
 		<model name='VNL-X71 (Yakuza)'>
 			<availability>PIR:8</availability>
+		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>HL:3,Periphery.Deep:1,MERC:6,FS:4,CDP:3,Periphery:4,TC:1</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>General:4,FS:8,CDP:4</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:2,MOC:4,LA:5,CGB.FRR:4,FWL:5,IS:3,NIOPS:3,Periphery:4,CGB:1,TC:4</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>OP:6,DoO:6,DO:6,TP:6,DA:6,RCM:6</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:2-,General:3-,FS:2-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:2,PIR:2,IS:2,FS:2-,Periphery:2,TC:2</availability>
@@ -16493,9 +16485,17 @@
 			<roles>anti_infantry</roles>
 			<availability>CGB.FRR:3,FWL:8,MERC:3,DC:3</availability>
 		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>FVC:2-,General:3-,FS:2-</availability>
+		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:5,LA:5,CGB.FRR:5,ROS:6,MH:4,FS:5,MERC:5,CGB:1</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>OP:6,DoO:6,DO:6,TP:6,DA:6,RCM:6</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -16507,29 +16507,29 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CCO:6,RA:5,CGB:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:5,CLAN:3,General:2,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='War Dog' unitType='Mek'>
@@ -16549,52 +16549,63 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:2,CLAN:7,IS:3,TC:2</availability>
-		<model name='9'>
-			<availability>CDS:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4</availability>
-		</model>
 		<model name='10'>
 			<availability>MOC:1,CLAN:1,IS:1,TC:1</availability>
 		</model>
-		<model name='8'>
-			<availability>MOC:5,CLAN:5,IS:5,TC:5</availability>
-		</model>
-		<model name='6'>
-			<availability>RA:6,CGB:6</availability>
-		</model>
-		<model name='7'>
-			<availability>RA:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CC:3,CHH:4,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
+		<model name='11'>
+			<availability>MOC:1,CLAN:1,IS:1,TC:1</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
 		</model>
-		<model name='11'>
-			<availability>MOC:1,CLAN:1,IS:1,TC:1</availability>
+		<model name='3'>
+			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
+		</model>
+		<model name='6'>
+			<availability>RA:6,CGB:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CC:3,CHH:4,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
+		</model>
+		<model name='7'>
+			<availability>RA:5</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:5,IS:4</availability>
+		</model>
+		<model name='8'>
+			<availability>MOC:5,CLAN:5,IS:5,TC:5</availability>
+		</model>
+		<model name='9'>
+			<availability>CDS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>HL:5,LA:8,IS:7,FWL:8,NIOPS:4-,Periphery.Deep:5,TC:8,Periphery:6</availability>
+		<model name='WHM-5L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:6,MERC:3</availability>
+		</model>
+		<model name='WHM-8D2'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='WHM-6L'>
 			<availability>CC:1-</availability>
 		</model>
-		<model name='WHM-9S'>
-			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
+		<model name='WHM-6K'>
+			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>PR:6,RF:6,PG:6,FWL:4,RFS:6</availability>
-		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
+		<model name='WHM-8K'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WHM-6D'>
+			<availability>FVC:2-,FS:1-</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:3,PIR:4,IS:2,MH:3,FS:3,MERC:3,CDP:3,TC:4</availability>
@@ -16602,53 +16613,42 @@
 		<model name='WHM-6R'>
 			<availability>General:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
-		<model name='WHM-6K'>
-			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-</availability>
+		<model name='WHM-10T'>
+			<availability>FS:3,TC:7</availability>
 		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6,MOC:3</availability>
+		<model name='WHM-8M'>
+			<availability>PR:6,RF:6,PG:6,FWL:4,RFS:6</availability>
 		</model>
 		<model name='WHM-11T'>
 			<availability>MOC:3,TC:4</availability>
 		</model>
-		<model name='WHM-8K'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:3,OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FVC:2-,FS:1-</availability>
+		<model name='WHM-6Rb'>
+			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:3</availability>
 		</model>
 		<model name='WHM-7M'>
 			<availability>CC:3,FVC:3,CGB.FRR:1,ROS:4,FWL:6,MERC:3,DC:1,Periphery:3</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
+		<model name='WHM-9S'>
+			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:6,MERC:3</availability>
+		<model name='WHM-4L'>
+			<availability>CC:6,MOC:3</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:3,TC:7</availability>
+		<model name='WHD-10CT'>
+			<availability>CC:3,OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:3</availability>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:5</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:5</availability>
@@ -16656,24 +16656,24 @@
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+		<model name='H-9'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='H-7'>
 			<availability>IS:3-,Periphery:3-</availability>
+		</model>
+		<model name='H-7A'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='H-8'>
+			<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:3,Periphery.Deep:4,FWL:4,FS:6,MERC:6,Periphery:6,RA:8</availability>
 		</model>
 		<model name='H-10'>
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-8'>
-			<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:3,Periphery.Deep:4,FWL:4,FS:6,MERC:6,Periphery:6,RA:8</availability>
-		</model>
-		<model name='H-7A'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
 		<model name='H-7C'>
 			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='H-9'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -16684,101 +16684,104 @@
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
-		<availability>IS:2</availability>
-		<model name='WSP-100A'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
+		<model name='WSP-100A'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
-		<availability>IS:3</availability>
-		<model name='WSP-105M'>
-			<availability>IS:2</availability>
+		<availability>IS:1</availability>
+		<model name='WSP-110'>
+			<availability>IS:1</availability>
 		</model>
 		<model name='WSP-105'>
 			<availability>IS:4</availability>
 		</model>
+		<model name='WSP-105M'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,Periphery:6,RA:4</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:2,IS:3,TC:6</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:4,LA:5,FS:4,MERC:2</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FVC:2-,FS:1-</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>CC:2-,MOC:2-,FVC:3-,FWL:2-,RCM:2-,Periphery:3-</availability>
-		</model>
-		<model name='WSP-3L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
 		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:4,RA:8</availability>
 		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:2,IS:3,TC:6</availability>
+		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>CC:2-,MOC:2-,FVC:3-,FWL:2-,RCM:2-,Periphery:3-</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:1-</availability>
+		</model>
+		<model name='WSP-3L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
+		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FVC:2-,FS:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:6,FS:8,MERC:5,CDP:5,DC:4</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,CDP:3,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CJF:1,RA:2</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>MOC:1,RA.OA:1,Periphery.DD:1,FVC:2,FS.CMM:2,NIOPS:1-,MH:1,MERC:2,Periphery.OS:1,Periphery:2,TC:1,DC:2</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:6</availability>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -16791,26 +16794,23 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:6,MH:6,MERC:4,CDP:6,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:5,LA:5,CNC:2-,FWL:5,IS:4,MERC:5,DC:8</availability>
-		<model name='WGT-2LAW'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='WGT-4NC &apos;Dezgra&apos;'>
-			<availability>CNC:8</availability>
+		<model name='WGT-2LAWC3'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='WGT-2LAWC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-4NC &apos;Dezgra&apos;'>
+			<availability>CNC:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>LA:5,FWL:5,IS:4,MERC:5,DC:6</availability>
@@ -16821,23 +16821,26 @@
 		<model name='WGT-3SC'>
 			<availability>CC:8,LA:5,FWL:5,IS:5,MERC:5</availability>
 		</model>
+		<model name='WGT-2LAW'>
+			<availability>DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
 		<availability>LA:5</availability>
-		<model name='WKT-1S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WKT-2S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='WKT-1S'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:4,ROS.pm:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LAC)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -16849,11 +16852,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:3,MERC:3,DC:5-</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>ROS:6</availability>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:5</availability>
 		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
@@ -16861,51 +16861,43 @@
 		<model name='WFT-C'>
 			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:5</availability>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,OP:3,MERC.KH:7,DoO:3,DO:3,FS:2,MERC:4,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,CGB.FRR:5,ROS:5,MH:4,MSC:3,TP:3</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
-		</model>
-		<model name='WLF-1'>
-			<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-3M'>
 			<availability>DTA:8,OP:8,DoO:8,FWL:8,DO:8,MSC:8,TP:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
 		<model name='WLF-2H'>
 			<availability>LA:4,MERC:2,CWIE:3</availability>
 		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:5,CWIE:5</availability>
+		<model name='WLF-1'>
+			<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:5,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FWL:5,MH:4,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-9D'>
-			<roles>spotter</roles>
-			<availability>FS:6,MERC:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:2,CGB:5</availability>
-		</model>
 		<model name='WVR-9W2'>
 			<availability>IS:4,DC:6</availability>
 		</model>
@@ -16913,38 +16905,49 @@
 			<roles>recon</roles>
 			<availability>CGB.FRR:8,MERC:6,CGB:8,DC:6</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:2-,MH:4-</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:3,DC:6</availability>
+		<model name='WVR-9D'>
+			<roles>spotter</roles>
+			<availability>FS:6,MERC:4</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:2,CGB:5</availability>
+		</model>
 		<model name='WVR-9M'>
 			<availability>LA:3,ROS:4,FWL:5,MH:3,MERC:3</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:3</availability>
+		</model>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:3,DC:6</availability>
+		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,FWL:5,MH:4,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:6,LA:5,ROS:4,FS:5,MERC:3</availability>
 		</model>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:3</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:2-,MH:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -16965,6 +16968,9 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:3</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
@@ -16972,9 +16978,6 @@
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -16990,13 +16993,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:2,OP:2,PR:2,DoO:2,IS:2,DO:2,FS:7,MERC:5,DC.GHO:3,DTA:2,FVC:2,RF:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
-		</model>
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -17012,6 +17015,9 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,DC:2,Periphery:2,TC:4</availability>
+		<model name='XNT-4O'>
+			<availability>CC:6,MOC:6,LA:6</availability>
+		</model>
 		<model name='XNT-6O'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
@@ -17020,9 +17026,6 @@
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:5,MOC:5,LA:5,ROS:5,MERC:5</availability>
-		</model>
-		<model name='XNT-4O'>
-			<availability>CC:6,MOC:6,LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -17034,14 +17037,14 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yao Lien' unitType='Mek'>
@@ -17052,6 +17055,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:3,CDS:3,CNC:3,IS:3,CWIE:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='&apos;Spectre&apos;'>
 			<availability>General:3</availability>
 		</model>
@@ -17059,18 +17065,9 @@
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -17078,8 +17075,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:5</availability>
+		</model>
 		<model name='(PPC)'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -17107,35 +17110,41 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>DC.GHO:2,CGB.FRR:5,CLAN:3,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CGB.FRR:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank' omni='IS'>
 		<availability>ROS:2</availability>
+		<model name='(Omnidrone) C'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) Prime'>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Omnidrone) B'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
@@ -17143,12 +17152,6 @@
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) Prime'>
-			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
@@ -17170,8 +17173,8 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-,ROS:4</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:5</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:3-</availability>
@@ -17179,29 +17182,29 @@
 		<model name='ZEU-X'>
 			<availability>LA:3</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,CGB.FRR:4,ROS:5,PIR:3,MH:3,FS:4-,MERC:5,CDP:3,TC:3</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:6,LA:8,CGB.FRR:6,PIR:6,MH:4,MERC:6,CDP:6,TC:6</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:2-</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>HL:2,General:1-,Periphery:4</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:6,LA:8,CGB.FRR:6,PIR:6,MH:4,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -17218,29 +17221,29 @@
 	</chassis>
 	<chassis name='Zibler Fast Strike Tank' unitType='Tank' omni='IS'>
 		<availability>LA:3,ROS:3,FS:4</availability>
-		<model name='(C)'>
+		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(B)'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='(C)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,ROS:6,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CW:6,ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CLAN:4,CJF:1</availability>
@@ -17248,19 +17251,19 @@
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>LA:4,IS:2,Periphery:2,CGB:2</availability>
+		<model name='F'>
+			<roles>support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='E'>
-			<roles>support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -17271,9 +17274,9 @@
 		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
+		<model name='C'>
 			<roles>support</roles>
-			<availability>General:5</availability>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -1163,38 +1163,35 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,RA.OA:4,LA:5,CGB.FRR:4,IS:4,FWL:4,FS:5,Periphery:4,TC:4,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,LA:8,FWL:8,IS:6,FS:8,TC:6,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>Periphery:2</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,LA:8,FWL:8,IS:6,FS:8,TC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:4,OP:4,RF:4,FWL:4,MSC:4,RCM:4,DA:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,RA.OA:1,LA:2,CLAN:4,IS:2,FWL:4,FS:2,BAN:5,Periphery:1,TC:1,DC:6</availability>
-		<model name='(3088)'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
@@ -1203,16 +1200,19 @@
 			<roles>assault</roles>
 			<availability>CC:8,DTA:8,OP:8,RF:8,FWL:8,IS:6,MSC:8,DA:8,RCM:8,DC:4</availability>
 		</model>
+		<model name='(3088)'>
+			<availability>DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>MERC.WD:1,CDS:1,ROS:1,CNC:5,CJF:5,RA:5,CWIE:2</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>ROS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>ROS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aegis Point Defense Suit' unitType='BattleArmor'>
@@ -1250,22 +1250,22 @@
 	</chassis>
 	<chassis name='Aesir Medium AA Vehicle' unitType='Tank'>
 		<availability>CHH:4,CW:5,ROS:4,MERC:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>CHH:4,General:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<roles>anti_aircraft</roles>
 			<availability>CHH:8,CW:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>CHH:4,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CJF:6</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
@@ -1310,6 +1310,16 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
@@ -1317,51 +1327,41 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CNC:4,DC:6</availability>
-		<model name='AKU-2XK'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='AKU-2XC'>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,DC:5</availability>
 		</model>
 		<model name='AKU-2X'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='AKU-2XC'>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='AKU-2XK'>
+			<availability>DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,CW:4,LA:6,ROS:5,CNC:4,FS:5,CWIE:6,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>LA:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>DTA:5,OP:5,ROS:4,FWL:5,MSC:5,MERC:2</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,MERC:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,OP:6,FWL:6,MSC:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,MERC:8</availability>
 		</model>
 		<model name='ALB-3Ur'>
 			<availability>ROS:4,FWL:4,MERC:4</availability>
@@ -1378,11 +1378,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CHH:5,RD:5,CDS:6,CW:5,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>RD:6,CGB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anat APC' unitType='Tank'>
@@ -1394,23 +1394,23 @@
 	</chassis>
 	<chassis name='Angerona Scout Suit' unitType='BattleArmor'>
 		<availability>ROS:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Recon)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CHH:6,CLAN:2,RA:4</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,RD:8,CGB:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,RD:8,CGB:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1421,20 +1421,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:8,CHH:3,RD:1,LA:3,ROS:4,MERC:3,CWIE:3,BAN:2,CGB:1,RA:3</availability>
-		<model name='C 2'>
-			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
-		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:4,ROS:4,MERC:4,CWIE:5</availability>
 		</model>
-		<model name='ANH-2A'>
-			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,IS:4,BAN:3</availability>
 		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
+		<model name='ANH-2A'>
+			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		</model>
+		<model name='C 2'>
+			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1460,14 +1460,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:6,MOC:7,DA:3,TC:3</availability>
-		<model name='ABS-5Y'>
-			<availability>MOC:4,CC:4</availability>
+		<model name='ABS-3T'>
+			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-3R'>
 			<availability>General:4</availability>
-		</model>
-		<model name='ABS-3T'>
-			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-4C'>
 			<availability>CC:4,MOC:4</availability>
@@ -1480,53 +1477,52 @@
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
+		<model name='ABS-5Y'>
+			<availability>MOC:4,CC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:4,MSC:6,MERC:4,DA:6</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:4,OP:4,FWL:4,DA:4</availability>
+		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,OP:5,RF:5,MSC:5,DA:5</availability>
 		</model>
-		<model name='ANV-5M'>
-			<availability>DTA:4,OP:4,FWL:4,DA:4</availability>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='ANV-5Q'>
+			<availability>DTA:4,RF:4,MSC:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:3,MERC:3</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>ROS:3,FWL:3,MERC:3</availability>
 		</model>
-		<model name='ANV-5Q'>
-			<availability>DTA:4,RF:4,MSC:4</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:3,MERC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
 		<availability>DTA:4,OP:4,MSC:6</availability>
-		<model name='ZU-J70'>
-			<availability>MSC:6</availability>
-		</model>
 		<model name='ZU-G60'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='ZU-J70'>
+			<availability>MSC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:3,ROS:4,Periphery.ME:3,FWL:8,MH:4,MSC:8,MERC:4,DC:6</availability>
-		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,MERC:3,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>MSC:6</availability>
+		</model>
+		<model name='APL-1R'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,MERC:3,DC:3</availability>
 		</model>
 		<model name='APL-2S'>
 			<roles>fire_support</roles>
@@ -1535,6 +1531,10 @@
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -1556,14 +1556,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,CNC:6,MERC:4,FS:3,DC:3</availability>
+		<model name='2'>
+			<availability>General:4</availability>
+		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1580,11 +1580,11 @@
 	</chassis>
 	<chassis name='Arcas' unitType='Mek'>
 		<availability>RD:6,CDS:3,ROS:3,CGB:6</availability>
-		<model name='2'>
-			<availability>RD:3,ROS:3,CGB:3</availability>
-		</model>
 		<model name='3'>
 			<availability>RD:5,CGB:5</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:3,ROS:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -1592,38 +1592,6 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,RD:3,LA:6,CGB.FRR:4,FWL:6,Periphery:3,DC:5,CGB:3</availability>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:8,MOC:4</availability>
-		</model>
-		<model name='ARC-9W'>
-			<roles>fire_support</roles>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:4,BAN:2</availability>
-		</model>
-		<model name='ARC-9KC'>
-			<roles>fire_support</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:2,MERC:2</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>RD:4,LA:2,ROS:4,MERC:3,CGB:4</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,TC:6,Periphery:4</availability>
-		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
@@ -1632,66 +1600,98 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,ROS:4,FWL:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,TC:6,Periphery:4</availability>
+		</model>
+		<model name='ARC-9W'>
+			<roles>fire_support</roles>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:4</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>RD:6,MERC:3,CGB:6</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:2-,BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,FVC:4,PIR:5,FWL:4,MERC:2,DC:2,Periphery:4</availability>
 		</model>
+		<model name='ARC-9KC'>
+			<roles>fire_support</roles>
+			<availability>DC:5</availability>
+		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>DTA:5,MOC:3,OP:5,ROS:4,PIR:3,MH:3,MSC:5,MERC:4</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:2-,BAN:2,Periphery:2-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:4,MERC:4,BAN:2</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>RD:6,MERC:3,CGB:6</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:8,MOC:4</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:2,MERC:2</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>RD:4,LA:2,ROS:4,MERC:3,CGB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:5,ROS:4,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:4,CWIE:5</availability>
-		<model name='A'>
-			<roles>fire_support</roles>
+		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
@@ -1703,20 +1703,20 @@
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>MERC.KH:3,RD:3,CNC:4,CWIE:6,CGB:3</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:1,MERC.WD:2,ROS:2,CWIE:3</availability>
-		<model name='A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:2</availability>
 		</model>
 		<model name='J'>
 			<availability>General:8</availability>
@@ -1724,11 +1724,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Attack Craft' unitType='Small Craft'>
@@ -1740,11 +1740,11 @@
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CW:8,CLAN:6,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
@@ -1752,38 +1752,22 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
@@ -1791,33 +1775,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1826,13 +1826,13 @@
 			<roles>assault</roles>
 			<availability>FS:2</availability>
 		</model>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Refit)'>
 			<roles>assault</roles>
 			<availability>ROS:6,FS:6</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Arrow IV Assault Vehicle' unitType='Tank'>
@@ -1848,22 +1848,22 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
 		<availability>ROS:5,DC:5</availability>
-		<model name='(3082)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(3062)'>
 			<roles>troop_carrier</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(3082)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1882,11 +1882,11 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,RD:6,CDS:5,CW:5,ROS:4,CJF:3,RA:5,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:8,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas III' unitType='Mek'>
@@ -1903,61 +1903,77 @@
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:3,MOC:3,RA.OA:3,LA:6,CLAN:4,IS:3,FWL:3,FS:5,Periphery:3,TC:3,DC:8</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>RF:4,LA:4,DC:4</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CDP:3,DC:5,Periphery:4,TC:3</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
+		<model name='AS7-D-DC'>
+			<availability>MERC:0,DC:1-</availability>
 		</model>
 		<model name='AS7-K3'>
 			<availability>LA:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:5</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:8,CNC:5,IS:5,CLAN.IS:4,Periphery:5,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>CGB.FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>Periphery:1-</availability>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:5</availability>
 		</model>
 		<model name='AS7-D'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:8,CNC:5,IS:5,CLAN.IS:4,Periphery:5,CWIE:5</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:1,ROS:3,MERC:3</availability>
+		</model>
+		<model name='AS7-K4'>
+			<availability>RF:4,LA:4,DC:4</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:1,ROS:3,MERC:3</availability>
+		<model name='AS7-RS'>
+			<availability>Periphery:1-</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		<model name='AS7-C'>
+			<availability>MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CDP:3,DC:5,Periphery:4,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -1967,25 +1983,9 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -2000,62 +2000,62 @@
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:7,RA:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5</availability>
+		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:7,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>RD:4,CNC:5,IS:4,DC:6,CGB:4</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OR'>
-			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
 		<model name='AV1-OE'>
 			<availability>General:6</availability>
 		</model>
+		<model name='AV1-OR'>
+			<availability>General:3+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -2071,11 +2071,8 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,Periphery:8,TC:5,DC:6</availability>
-		<model name='AWS-10KM'>
-			<availability>DTA:4,OP:4,ROS:4,FWL:4,MSC:4,DC:6</availability>
-		</model>
-		<model name='AWS-8Q'>
-			<availability>Periphery:2-</availability>
+		<model name='AWS-9Ma'>
+			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:2,PIR:4,FWL:4,IS:2,MH:2,TC:2,Periphery:4</availability>
@@ -2083,17 +2080,20 @@
 		<model name='AWS-9Q'>
 			<availability>MOC:6,FWL:4,IS:6,MH:6,TC:6,Periphery:4</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
+		<model name='AWS-10KM'>
+			<availability>DTA:4,OP:4,ROS:4,FWL:4,MSC:4,DC:6</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>RD:6,CDS:4,ROS:4,CGB.FRR:6,FS:4,CWIE:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>RD:4,CGB.FRR:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -2107,88 +2107,84 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:1,LA:5,ROS:4,FS:1</availability>
+		<model name='AXM-4D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='AXM-6T'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-4D'>
-			<availability>FS:6</availability>
+		<model name='AXM-1N'>
+			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CJF:5,RA:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:4,CW:5,LA:3,ROS:4</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:4</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:3,MERC:3</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2198,11 +2194,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
@@ -2210,15 +2202,23 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,IS:8</availability>
+		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>General:2</availability>
@@ -2229,41 +2229,53 @@
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:4,LA:4,ROS:4,FWL:4,MERC:8,FS:4,DA:4,Periphery:4</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:2</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2271,33 +2283,21 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank'>
@@ -2309,14 +2309,6 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -2329,14 +2321,6 @@
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -2345,48 +2329,64 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='I'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:5-,RA.OA:5-,FVC:2-,RF:2-,LA:3-,FWL:1-,MH:5-,MSC:1-,MERC:2-,Periphery:7-,TC:5-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:6,FWL:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:2-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BNC-9S2'>
-			<availability>RF:2,LA:3</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:1-,FWL:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>RF:1-,MSC:1-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>MERC:1-,Periphery:2-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:3,MH:4,MERC:5</availability>
+		</model>
+		<model name='BNC-9S2'>
+			<availability>RF:2,LA:3</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:2-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>RA.OA:1-,CDP:1-,TC:1-,Periphery:1-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:3,MH:4,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>MERC:1-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:1-,FWL:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:6,FWL:6,CDP:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bardiche Heavy Strike Tank' unitType='Tank'>
@@ -2401,9 +2401,6 @@
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,ROS:4,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:3</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:3,ROS:3,MERC:3</availability>
 		</model>
@@ -2412,6 +2409,9 @@
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:7</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:3</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2427,25 +2427,25 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:3,IS:3+,RA:6,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CNC:8,General:7,RA:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CNC:3,CLAN:2,RA:6</availability>
-		</model>
-		<model name='A'>
-			<availability>RD:8,General:7,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CNC:8,General:7,RA:8</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>General:1,RA:3</availability>
+		</model>
+		<model name='A'>
+			<availability>RD:8,General:7,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CNC:3,CLAN:2,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2456,11 +2456,8 @@
 		<model name='H'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2468,8 +2465,11 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2492,35 +2492,30 @@
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
 		<availability>ROS:4,FS:6,MERC:4</availability>
-		<model name='BKX-7K'>
-			<availability>MERC:2-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>ROS:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='BKX-7K'>
+			<availability>MERC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:5,FWL:8,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>MSC:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:2-</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:2</availability>
+		<model name='BLR-10S'>
+			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
 		<model name='BLR-4S'>
 			<availability>LA:3,ROS:4,MERC:4</availability>
 		</model>
-		<model name='BLR-10S'>
-			<availability>LA:6,ROS:4,FS:4</availability>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:2</availability>
@@ -2528,35 +2523,40 @@
 		<model name='BLR-1G'>
 			<availability>BAN:8,Periphery:2-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CC:4,FVC:4,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:3,MH:5,MERC:4,Periphery:2</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
+		<model name='BLR-6X'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>DTA:5,OP:5,ROS:4,DA:5,MERC:4</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:2-</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>MSC:2</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:8,OP:8,MSC:8</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>RD:4,ROS:4,CGB.FRR:5,DC:6</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CC:4,FVC:4,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:3,MH:5,MERC:4,Periphery:2</availability>
-		</model>
-		<model name='BLR-4L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2578,12 +2578,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2598,14 +2598,14 @@
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>RD:6,ROS:4,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
@@ -2622,28 +2622,28 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,MERC:2,FS:2,Periphery:2,RA.OA:2,CDS:3,LA:2,CGB.FRR:2,PIR:2,CNC:3,FWL:2,DC:3</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>CLAN:6,IS:6,DC:8</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth II Heavy Tank' unitType='Tank'>
 		<availability>CC:5,MOC:4,LA:3,ROS:5,FWL:4,MH:3,MERC:3,TC:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2671,28 +2671,28 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>RD:6,ROS:6,CNC:4,CGB:6</availability>
-		<model name='BEO-12'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='BEO-14'>
 			<roles>recon</roles>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='BEO-12'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>RF:5,LA:7,ROS:4,FS:3,MERC:3</availability>
-		<model name='BRZ-A3'>
-			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
-		</model>
-		<model name='BRZ-D4'>
-			<availability>LA:4</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>RF:4,LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:1</availability>
+		<model name='BRZ-D4'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='BRZ-A3'>
+			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2700,12 +2700,12 @@
 		<model name='BSN-3K'>
 			<availability>General:8</availability>
 		</model>
+		<model name='BSN-5KC'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='BSN-4K'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='BSN-5KC'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishop Transport VTOL' unitType='VTOL'>
@@ -2717,53 +2717,59 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CHH:1,RD:1,CW:1,ROS:4+,CJF:1,RA:2,BAN:2,CWIE:2,CGB:1</availability>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>RD:4,CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:7,CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>RD:2,CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:7,CW:5,General:6,CJF:8,CGB:7</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,IS:5,FS:5,MERC:5,DC:8</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
 		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
@@ -2773,23 +2779,17 @@
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
 		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:8,CDS:6,CNC:6,IS:5,MERC:6,CWIE:6</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>General:4</availability>
@@ -2797,17 +2797,14 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:3,FWL:6,MSC:6,CGB:5,MOC:3,CC:3,OP:6,IS:4,MERC:4,RA:3,Periphery:3,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,BAN:2,DC:6</availability>
-		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:5,FS:5</availability>
 		</model>
 		<model name='BLK-NT-2Y'>
 			<availability>FVC:4,ROS:6,IS:6,FS:6,CDP:4</availability>
 		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,FWL:6,MERC.SI:3,DC:6</availability>
+		<model name='BLK-NT-3B'>
+			<availability>LA:4,ROS:4,FWL:4,FS:5,MERC:4</availability>
 		</model>
 		<model name='BLK-NT-4D'>
 			<availability>CDS:2,CW:2,ROS:2,CNC:3,FS:3,MERC:2,CWIE:3</availability>
@@ -2815,41 +2812,44 @@
 		<model name='BLK-NT-3A'>
 			<availability>LA:4,ROS:4,FWL:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='BL-12-KNT'>
-			<availability>ROS:5,FS:5</availability>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
 		</model>
-		<model name='BLK-NT-3B'>
-			<availability>LA:4,ROS:4,FWL:4,FS:5,MERC:4</availability>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,BAN:2,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CJF:7</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
+		<model name='E'>
 			<availability>CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>CJF:2</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='X'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -2865,62 +2865,62 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:2,CC:2-,RA.OA:3,FVC:4,MERC:2,FS:4,TC:2,Periphery:4</availability>
-		<model name='BJ-2r'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>Periphery:2</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
 		<model name='BJ-2'>
 			<availability>FVC:3,LA:4,FS:2,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='BJ-2r'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:2,ROS:4,FWL:5,IS:1,FS:6,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OU'>
+		<model name='BJ2-OX'>
 			<availability>General:2</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OX'>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
+		</model>
+		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -2928,10 +2928,6 @@
 		<availability>DTA:2,OP:2,ROS:7,MSC:2,FS:4</availability>
 		<model name='BLD-7R'>
 			<availability>DTA:8,OP:8,MSC:8</availability>
-		</model>
-		<model name='BLD-XR'>
-			<roles>fire_support</roles>
-			<availability>ROS:4,FS:8</availability>
 		</model>
 		<model name='BLD-XX'>
 			<roles>anti_aircraft</roles>
@@ -2943,21 +2939,22 @@
 		<model name='BLD-XS'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='BLD-XR'>
+			<roles>fire_support</roles>
+			<availability>ROS:4,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>RF:4,LA:6,ROS:4,MSC:4,MERC:4</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>RF:5,LA:6,ROS:5</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -2965,20 +2962,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -2990,17 +2990,17 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:9</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -3031,22 +3031,22 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:3</availability>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='Prime'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
+		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3057,13 +3057,13 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
-		<model name='BMB-05A'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RA.OA:8</availability>
-		</model>
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='BMB-05A'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RA.OA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3075,20 +3075,20 @@
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4</availability>
-		<model name='3'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
@@ -3102,15 +3102,6 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-X3'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-5'>
 			<availability>PIR:4</availability>
 		</model>
@@ -3119,6 +3110,15 @@
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X3'>
+			<availability>PIR:4</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LDT-X4'>
+			<availability>PIR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -3142,17 +3142,17 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(PPC)'>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,RA.OA:5,RD:5,IS:5,FS:5</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3181,37 +3181,37 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>LA:3,ROS:4,FS:4,MERC:3,Periphery:2-,DC:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(AC2)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
 		<availability>RF:6,FWL:5,DA:5,MERC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Buraq Fast Battle Armor' unitType='BattleArmor'>
@@ -3229,11 +3229,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,ROS:6,CNC:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -3245,17 +3245,17 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
-		<model name='BSW-S2r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='BSW-X2'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BSW-X2'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='BSW-S2r'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>MERC:4</availability>
@@ -3279,17 +3279,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:5,LA:3,FS:4,MERC:3</availability>
-		<model name='CES-4R'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>FVC:8,FS:2,MERC:2</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Calliope' unitType='Mek'>
@@ -3340,13 +3340,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CHH:1,RD:2,CDS:3,CW:1,CNC:5,CJF:1,RA:3,CGB:2</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>RD:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>RD:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3371,105 +3371,105 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:5,MOC:4,FVC:4,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:3,MERC:4,CDP:4,TC:4</availability>
-		<model name='CTF-3D'>
-			<availability>FVC:4,MH:4,FS:2,MERC:4</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='CTF-3LL'>
 			<availability>CC:5,MOC:5,MERC:3,TC:5</availability>
 		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4,MERC:3</availability>
-		</model>
-		<model name='CTF-4L'>
-			<availability>CC:6,MOC:5</availability>
+		<model name='CTF-3D'>
+			<availability>FVC:4,MH:4,FS:2,MERC:4</availability>
 		</model>
 		<model name='CTF-1X'>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='CTF-4L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:4,OP:3,FWL:2,MH:3,MERC:1,DA:4,RCM:3,Periphery:2,TC:2,DC:6</availability>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
+		<model name='CPLT-C5A'>
 			<roles>fire_support</roles>
-			<availability>BAN:2,Periphery:2-</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
 		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FVC:3,CLAN:6,MERC:3,Periphery:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C5A'>
+		<model name='CPLT-K5'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
+			<availability>DC:8</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-H2'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,OP:4,MERC:4,DA:4,RCM:4</availability>
 		</model>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>BAN:2,Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,RA:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
@@ -3477,41 +3477,41 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:5</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cave Lion' unitType='Mek'>
@@ -3522,48 +3522,42 @@
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>RA:4</availability>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CNC:6,RA:5</availability>
-		<model name='3'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CNC:8</availability>
+		</model>
+		<model name='3'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='Commando'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='Commando'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>Periphery.HR:2,Periphery.OS:2,Periphery:2</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
@@ -3571,24 +3565,23 @@
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>Periphery.HR:2,Periphery.OS:2,Periphery:2</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,OP:2,Periphery.OS:4,FS:7,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:4,FWL:2,MH:6,MSC:2</availability>
-		<model name='CN9-A'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:4,MERC:4,Periphery:4</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:3</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CDP:3</availability>
 		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
+		<model name='CN10-B'>
+			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-H'>
 			<availability>MH:4-</availability>
@@ -3596,21 +3589,37 @@
 		<model name='CN9-D4D'>
 			<availability>DTA:3,OP:3,ROS:3,MSC:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3,Periphery:4</availability>
+		<model name='CN9-A'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CN9-D3'>
 			<availability>FVC:2,ROS:2,FS:2,MERC:2,CDP:3</availability>
 		</model>
-		<model name='CN10-B'>
-			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
+		<model name='CN9-D'>
+			<availability>FVC:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='CN9-Da'>
 			<availability>OP:4,FVC:4,ROS:2,FWL:2,MSC:4,MERC:2,FS:2,Periphery:4</availability>
 		</model>
+		<model name='CN9-D5'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek' omni='IS'>
 		<availability>LA:4,ROS:4,FS:5,MERC:4</availability>
+		<model name='CN11-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='CN11-O'>
 			<availability>General:8</availability>
 		</model>
@@ -3618,15 +3627,6 @@
 			<availability>General:7</availability>
 		</model>
 		<model name='CN11-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OD'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3659,11 +3659,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>RD:5,CW:5,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3684,21 +3684,21 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,ROS:4,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:6,ROS:4,FS.CMM:6,FS.DMM:6,FS:5,FS.CrMM:6</availability>
+		</model>
+		<model name='XII'>
+			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:6,ROS:4,FS.CMM:6,FS.DMM:6,FS:5,FS.CrMM:6</availability>
+		<model name='X'>
+			<availability>General:8</availability>
 		</model>
 		<model name='XIVs'>
 			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
-		</model>
-		<model name='XII'>
-			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -3706,6 +3706,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -3715,115 +3719,111 @@
 			<roles>training</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:2,OP:1,CHH:1,DC.GHO:2,DTA:1,FVC:1,RD:4,RF:1,LA:1,ROS:2,MSC:1,DA:1,RCM:1,CGB:4,DC:1</availability>
-		<model name='CHP-3N'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
+		<model name='C'>
+			<availability>CHH:6,RD:6,CLAN:8,CGB:6</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:1,RD:1,LA:3,MERC.SI:4,MERC:3,BAN:2,CGB:1</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,RD:6,CLAN:8,CGB:6</availability>
+		<model name='CHP-1N2'>
+			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>RD:2,ROS:4,IS:3,MERC:2,BAN:4,Periphery:2,CGB:2</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>missile_artillery</roles>
+			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>MOC:1-,RA.OA:2-,FVC:1,RD:3-,LA:1-,ROS:2-,TC:1-,Periphery:1,DC:4-,CGB:3-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:3,RD:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
+		</model>
+		<model name='CGR-3K'>
+			<availability>MERC:2-,DC:3-</availability>
+		</model>
 		<model name='CGR-2A2'>
 			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='CGR-1A9'>
+			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CGR-SA5'>
 			<roles>urban</roles>
 			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CGR-3K'>
-			<availability>MERC:2-,DC:3-</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:3,RD:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
+		<model name='CGR-1L'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CGR-C'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='CGR-1A9'>
-			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
-		<model name='CGR-1L'>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
-		<model name='F-13'>
-			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,DTA:2,OP:2,FVC:2,RF:2,FWL:2,MSC:2,MERC:2,DA:2,RCM:2,Periphery:2</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>FVC:2,Periphery:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,Periphery:1-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>CC:4,MOC:4,OP:8,MERC:6,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
 		</model>
 		<model name='OF-17A-R'>
 			<roles>recon</roles>
 			<availability>ROS:4,MSC:6</availability>
 		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,DTA:2,OP:2,FVC:2,RF:2,FWL:2,MSC:2,MERC:2,DA:2,RCM:2,Periphery:2</availability>
+		</model>
 		<model name='F-14-S'>
 			<availability>DTA:8,OP:8,RF:8,FWL:8,MH:4,MSC:8,MERC:5,RCM:8,DA:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>FVC:2,Periphery:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:4,MOC:4,OP:8,MERC:6,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
+		</model>
+		<model name='F-13'>
+			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:3,CDS:4,LA:3,ROS:5,CNC:5,FS:3,RCM:3,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
@@ -3831,13 +3831,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:6,CDS:6,LA:6,ROS:6,FS:6,RCM:6,DC:6</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3848,63 +3848,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>DTA:4,OP:4,FVC:4,RF:4,LA:6,ROS:4,FWL:4,MH:4,MERC:5,DA:4,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6,CGB:3</availability>
-		<model name='CHP-W5'>
-			<availability>:0,BAN:3,Periphery:2-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:2,CDP:2,TC:2</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2,BAN:2</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2,BAN:2</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:2,CDP:2,TC:2</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,BAN:3,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CNC:6,RA:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:2,RF:4,FWL:4,MSC:4,MERC:2,CDP:2,Periphery:2</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,CGB.FRR:6,FWL:4,MERC:6</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6,Periphery:4</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:2,MERC:4</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:2,IS:4</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>RF:8,FWL:8,MSC:8</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,CGB.FRR:6,FWL:4,MERC:6</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:2,MERC:4</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -3941,20 +3941,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -3971,23 +3971,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -3995,14 +3995,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -4019,32 +4019,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -4052,11 +4052,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4065,14 +4065,14 @@
 			<roles>marine</roles>
 			<availability>RD:8,CGB:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>RD:4,CDS:5,CW:4,CNC:5,CGB:4,CWIE:5</availability>
+		<model name='(Volk)' mechanized='true'>
+			<availability>CW:4</availability>
 		</model>
 		<model name='(Rache)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Volk)' mechanized='true'>
-			<availability>CW:4</availability>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>RD:4,CDS:5,CW:4,CNC:5,CGB:4,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -4080,20 +4080,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4105,10 +4105,6 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='V3'>
-			<roles>assault</roles>
-			<availability>LA:4,ROS:8,FS:4</availability>
-		</model>
 		<model name='Interceptor'>
 			<roles>assault</roles>
 			<availability>LA:3</availability>
@@ -4117,20 +4113,27 @@
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='V3'>
+			<roles>assault</roles>
+			<availability>LA:4,ROS:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>RD:5,CW:5,CNC:5,RA:3,CGB:5</availability>
-		<model name='2'>
-			<availability>RA:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:2,MOC:2,FS:2,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,RF:2,LA:2,ROS:2,DA:2,RCM:1</availability>
 		<model name='CLNT-2-3U'>
 			<availability>CC:2,General:6</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
@@ -4141,9 +4144,6 @@
 		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -4194,56 +4194,56 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
-			<roles>recon</roles>
-			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
-		</model>
-		<model name='COM-2Dr'>
-			<roles>recon</roles>
-			<availability>LA:5,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>LA:7,ROS:8</availability>
-		</model>
 		<model name='COM-8S'>
 			<availability>LA:4,MERC:4</availability>
+		</model>
+		<model name='COM-3A'>
+			<roles>recon</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='COM-1A'>
 			<roles>recon</roles>
 			<availability>FVC:2-,LA:1-,Periphery:2-</availability>
 		</model>
-		<model name='COM-3A'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
+			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:8</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>LA:7,ROS:8</availability>
+		</model>
+		<model name='COM-2Dr'>
+			<roles>recon</roles>
+			<availability>LA:5,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,FVC:2,LA:4,ROS:3,IS:2,FWL:2,FS:3,TC:2,DC:2,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:8</availability>
-		</model>
 		<model name='(Upgrade) (Standard)'>
 			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
@@ -4257,13 +4257,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:6,IS:6,DC:8</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condottiere Assault Craft' unitType='Small Craft'>
@@ -4282,13 +4282,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -4311,23 +4311,23 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:6</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>RD:3,CGB:3</availability>
-		<model name='(SRM)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LMG)' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
@@ -4364,20 +4364,20 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='CRX-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-OR'>
 			<availability>RA.OA:4,CLAN:8</availability>
+		</model>
+		<model name='CRX-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4388,20 +4388,20 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		<model name='CSR-V12'>
+			<availability>BAN:4,Periphery:2-</availability>
 		</model>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>BAN:4,Periphery:2-</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
@@ -4428,20 +4428,20 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='X 2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='X'>
+		<model name='X 3'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
 		</model>
-		<model name='X 3'>
+		<model name='X'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -4449,16 +4449,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CW:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -4466,8 +4465,9 @@
 		<model name='H'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
@@ -4485,6 +4485,10 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:1,CLAN:1,MERC:4,RA:1,CWIE:2,DC.GHO:5,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,CGB:1,DC:5</availability>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
+		</model>
 		<model name='CRB-27b'>
 			<roles>raider</roles>
 			<availability>ROS:8,CLAN:4,FWL:8,MERC:8,BAN:2,DC:6</availability>
@@ -4492,43 +4496,39 @@
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
 		<availability>CC:3,CDS:6,LA:4,ROS:4,CNC:5,MSC:3,FS:3,MERC:4,CJF:6,CWIE:6,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:8,CLAN.IS:8,MSC:8,FS:8</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,ROS:6,MERC:4,CJF:6</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,CLAN.IS:8,MSC:8,FS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CC:8,CDS:4,CNC:4,MERC:8,DC:8</availability>
 		</model>
+		<model name='4'>
+			<availability>CDS:6,ROS:6,MERC:4,CJF:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,RA:4</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4536,19 +4536,19 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:3,CW:5,ROS:4,CLAN:4,CJF:3,RA:3,CWIE:5,CGB:5</availability>
-		<model name='CRK-5004-1'>
-			<availability>ROS:6</availability>
+		<model name='CRK-5003-3'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,BAN:8</availability>
 		</model>
-		<model name='CRK-5003-3'>
+		<model name='CRK-5004-1'>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
@@ -4569,33 +4569,37 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CDS:2,CNC:2,RA:5,CWIE:2</availability>
-		<model name='A'>
-			<availability>General:5</availability>
+		<model name='U'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='U'>
-			<availability>CLAN:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>CC:3,MOC:3,ROS:4,CNC:3,IS:2,FWL:3,MERC:3,DC:4</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
@@ -4604,51 +4608,47 @@
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CLAN:5,IS:6,Periphery:5</availability>
-		<model name='CRD-8S'>
-			<availability>LA:8,FS:4</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>BAN:1,Periphery:2-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:2,MOC:4,FWL:8,FS:2,MERC:4,CDP:4,DC:2,TC:4</availability>
-		</model>
 		<model name='CRD-7W'>
 			<availability>DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,MH:4,MSC:5,MERC:2,RCM:5</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:4,MERC:4</availability>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='CRD-4L'>
 			<availability>CC:2,MOC:4</availability>
 		</model>
-		<model name='CRD-5K'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='CRD-8S'>
+			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:5</availability>
 		</model>
+		<model name='CRD-3R'>
+			<availability>BAN:1,Periphery:2-</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,BAN:2</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6</availability>
+		<model name='CRD-5M'>
+			<availability>CC:2,MOC:4,FWL:8,FS:2,MERC:4,CDP:4,DC:2,TC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4665,33 +4665,41 @@
 	</chassis>
 	<chassis name='Cutlass' unitType='Aero'>
 		<availability>FS:5</availability>
+		<model name='CUT-01E'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CUT-01E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:3,RA.OA:2,MOC:4,RD:4,LA:3,ROS:3,IS:3,FWL:2,FS:3,Periphery:2,TC:2,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:5,CDP:4,TC:4,Periphery:2</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>General:2-</availability>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:3,DC:3</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>RD:5,IS:4</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -4700,31 +4708,23 @@
 		<model name='CP-11-H'>
 			<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
 		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:3,DC:3</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>RD:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:5,MERC.WD:3,ROS:3,CWIE:4</availability>
-		<model name='4'>
-			<availability>General:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
+		<model name='4'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4737,25 +4737,25 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>MOC:4,CDP:4,TC:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4786,35 +4786,35 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='DAI-01r'>
 			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -4834,14 +4834,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>RD:5,ROS:5,DC:7,CGB:5</availability>
-		<model name='DMO-4K'>
-			<availability>DC:8</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:3</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:3</availability>
+		<model name='DMO-4K'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -4850,27 +4850,26 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:4+,MERC:4+,BAN:3,CWIE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:4+</availability>
-		<model name='Prime'>
-			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:4,CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4</availability>
@@ -4878,8 +4877,9 @@
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4898,31 +4898,31 @@
 	</chassis>
 	<chassis name='Dark Crow' unitType='Mek'>
 		<availability>RA:5</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:4,FS:6,MERC:4</availability>
-		<model name='DRT-6T'>
-			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
-		</model>
 		<model name='DRT-3S'>
 			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='DRT-6T'>
+			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
 		</model>
 		<model name='DRT-4S'>
 			<availability>LA:2,MH:4,FS:3,MERC:4</availability>
@@ -4930,11 +4930,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,General:5,CDP:3</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
 		</model>
@@ -4946,25 +4949,15 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2,CDP:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
+			<availability>FVC:4,General:5,CDP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,RD:5,IS:3+,CJF:2,BAN:2,CGB:5</availability>
-		<model name='H'>
-			<availability>RD:5,CDS:5,General:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:7,RD:6,General:2,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>RD:2,CDS:5,General:3,CJF:4,CGB:2</availability>
+		<model name='B'>
+			<availability>CHH:6,RD:7,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2</availability>
@@ -4972,27 +4965,34 @@
 		<model name='K'>
 			<availability>RD:4,General:2,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CHH:8,RD:4,CDS:6,CW:4,CNC:4,General:5,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CHH:8,RD:8,CDS:7,CNC:7,General:6,CWIE:7,CGB:8</availability>
+		</model>
+		<model name='H'>
+			<availability>RD:5,CDS:5,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>RD:2,CDS:5,General:3,CJF:4,CGB:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:8,RD:8,CDS:4,CW:8,CNC:8,General:6,CWIE:8,CGB:8</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CHH:8,RD:8,CDS:7,CNC:7,General:6,CWIE:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CHH:7,RD:6,General:2,CWIE:5,CGB:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:6,RD:7,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CHH:8,RD:4,CDS:6,CW:4,CNC:4,General:5,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
 		<availability>RD:4,CDS:5,LA:3,ROS:4,CNC:4,IS:3,FS:3,RA:4,CGB:4,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8,IS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -5009,15 +5009,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:5,MOC:5,MSC:4</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5032,11 +5032,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='DFN-3S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -5050,21 +5050,21 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='S'>
 			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -5075,15 +5075,6 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,ROS:8,CNC:5,FWL:8,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>IS:1,Periphery:2</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,DC:8,TC:8,CWIE:4</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,LA:4,CGB.FRR:4,ROS:4,IS:2,FWL:4,FS:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -5091,9 +5082,18 @@
 		<model name='(MRM)'>
 			<availability>FVC:4,DC:8,Periphery:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,DC:8,TC:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>IS:1,Periphery:2</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
@@ -5102,11 +5102,11 @@
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>LA:5,ROS:5,CWIE:5</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:4,CWIE:4</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>LA:5,ROS:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5122,13 +5122,13 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:6-</availability>
-		<model name='(Armor)'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Armor)'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -5146,23 +5146,23 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>OP:3,FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
-		<model name='DV-8D'>
-			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
-		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,Periphery:2-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='DV-6Mr'>
 			<availability>General:1</availability>
 		</model>
 		<model name='DV-1S'>
 			<availability>IS:1-</availability>
+		</model>
+		<model name='DV-8D'>
+			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
+		</model>
+		<model name='DV-6M'>
+			<availability>CLAN:4,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Destrier Siege Vehicle' unitType='Tank'>
@@ -5183,11 +5183,11 @@
 		<model name='DVS-3'>
 			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5228,11 +5228,14 @@
 	</chassis>
 	<chassis name='Doloire' unitType='Mek' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='DLR-OC'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='DLR-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='DLR-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='DLR-OC'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-OA'>
@@ -5241,18 +5244,15 @@
 		<model name='DLR-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-O'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,RD:4,CGB:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5280,25 +5280,25 @@
 	</chassis>
 	<chassis name='Dragon II' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='DRG-11R'>
-			<roles>missile_artillery</roles>
-			<availability>General:2+</availability>
-		</model>
 		<model name='DRG-11K'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='DRG-11R'>
+			<roles>missile_artillery</roles>
+			<availability>General:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:3,DC:2</availability>
-		<model name='DRG-7N'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:1</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>MERC:4,DC:4,Periphery:5</availability>
+		</model>
+		<model name='DRG-7N'>
+			<availability>MERC:8,DC:8</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>MERC:3,DC:3</availability>
@@ -5306,12 +5306,12 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:2,CHH:3,RD:4,ROS:4+,CGB:4</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
+		<model name='Prime'>
+			<availability>RD:6,CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:8,CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>RD:5,General:2,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:6,CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
@@ -5319,26 +5319,26 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:6,CDS:9,General:8,CJF:9,CGB:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CNC:5,CLAN:3,General:2</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,General:4,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:7,CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>RD:5,General:2,CGB:5</availability>
+		<model name='A'>
+			<availability>RD:8,CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,RD:7,CDS:8,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>RD:7,CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
+		</model>
 		<model name='I'>
+			<availability>General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,General:4,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5357,11 +5357,11 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,ROS:2,FS:4</availability>
-		<model name='(Sealed)'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5373,33 +5373,33 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:4,TC:4</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='EGL-R6b'>
-			<availability>OP:6,MSC:6,RCM:6</availability>
-		</model>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>General:3-</availability>
 		</model>
+		<model name='EGL-R6b'>
+			<availability>OP:6,MSC:6,RCM:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,RF:6,FWL:6,MH:4,MSC:7,MERC:4,DA:5</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
 		<model name='EGL-3M'>
 			<availability>DTA:5,FWL:5,MSC:5</availability>
@@ -5411,10 +5411,6 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='MEB-9'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='MEB-11'>
 			<roles>recon</roles>
 			<availability>General:2</availability>
@@ -5423,17 +5419,21 @@
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
+		<model name='MEB-9'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,Periphery:4-</availability>
 		<model name='EFT-7X'>
 			<availability>IS:8,MH:6</availability>
 		</model>
-		<model name='EFT-4J'>
-			<availability>MERC:1-,Periphery:8</availability>
-		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='EFT-4J'>
+			<availability>MERC:1-,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5444,29 +5444,29 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
-		</model>
 		<model name='EST-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='EST-OC'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CHH:4,RD:5,LA:3,ROS:3,FS:3,MERC:3,CGB:5,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>RD:8,CGB.FRR:8,CGB:8</availability>
-		</model>
 		<model name='&apos;HumHov&apos;'>
 			<availability>General:8,CGB:0</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RD:8,CGB.FRR:8,CGB:8</availability>
 		</model>
 		<model name='(Streak)'>
 			<roles>fire_support</roles>
@@ -5475,41 +5475,14 @@
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,MERC.WD:4,CW:4,CLAN:4,CNC:4+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:4</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -5517,8 +5490,35 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>RD:2,CW:2,CGB:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:4</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5529,31 +5529,27 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,MH:3,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:3</availability>
-		</model>
-		<model name='EMP-7L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='EMP-6A'>
-			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
-		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 		<model name='EMP-8L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
+		<model name='EMP-7L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='EMP-6L'>
+			<availability>CC:3</availability>
+		</model>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-6A'>
+			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>LA:5-,ROS:3-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4</availability>
@@ -5565,49 +5561,49 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:5,ROS:4,FS:7,MERC:5</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='ENF-6H'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='ENF-6Ma'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='ENF-6T'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='ENF-6G'>
 			<availability>ROS:4,FS:1,MERC:4</availability>
+		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
 		</model>
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='ENF-6NAIS'>
+		<model name='ENF-6T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='ENF-6H'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='ENF-7D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:5,FS:4,MERC:2,CDP:1,TC:1</availability>
-		<model name='ENF-5D'>
-			<availability>FVC:8,FS:8,MERC:6,CDP:6,TC:6</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>FVC:2-,FS:1-,TC:1-</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>FVC:8,FS:8,MERC:6,CDP:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -5616,28 +5612,36 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
 		<availability>CHH:7,RD:5,CJF:3,RA:4,CGB:5,CWIE:4</availability>
-		<model name='(ER Pulse)'>
-			<availability>CHH:8,RD:5,CGB:5</availability>
+		<model name='(LB-X) &apos;Sholef&apos;'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LB-X) &apos;Sholef&apos;'>
-			<availability>CHH:4</availability>
+		<model name='(ER Pulse)'>
+			<availability>CHH:8,RD:5,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,RD:3+,CDS:4+,CW:4+,CNC:3+,CGB:3+,CWIE:4+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -5647,10 +5651,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -5658,13 +5658,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CDS:2,ROS:1,RA:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -5673,12 +5673,12 @@
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:4,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:4,FS:6</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5700,13 +5700,13 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>FWL:1,IS:1</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
@@ -5728,27 +5728,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MERC:3</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
-		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5766,12 +5766,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,MSC:6</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5782,11 +5782,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-9R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='FLC-8R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='FLC-9R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5798,13 +5798,13 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Standard)'>
-			<roles>cruiser</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cruiser</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
@@ -5819,44 +5819,44 @@
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='&apos;Longshot&apos;' mechanized='false'>
-			<availability>General:4</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='&apos;Longshot&apos;' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir II Assault Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='(Med. Laser)' mechanized='false'>
+		<model name='(AI)' mechanized='false'>
+			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(AI)' mechanized='false'>
-			<roles>anti_infantry</roles>
+		<model name='(Med. Laser)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)' mechanized='false'>
@@ -5868,32 +5868,32 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:4,MERC.KH:2+,CHH:2,RD:2,CW:4,CJF:2,CWIE:4,CGB:2</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>RD:6,CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:6,CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
@@ -5910,36 +5910,36 @@
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:2,LA:3,ROS:2,Periphery.HR:2,Periphery.MW:2,Periphery.CM:2,FWL:2,FS:3</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='&apos;Fermi&apos;'>
 			<roles>apc</roles>
 			<availability>FS:5</availability>
-		</model>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:3</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -5951,59 +5951,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6011,39 +5963,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -6058,19 +6062,15 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-10D'>
-			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-10D'>
+			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='ALM-8D'>
 			<roles>recon,raider</roles>
@@ -6099,11 +6099,13 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:6,IS:5,Periphery.Deep:5,Periphery:7</availability>
-		<model name='FS9-S2'>
-			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4</availability>
+		<model name='FS9-M3'>
+			<roles>spotter</roles>
+			<availability>LA:3,IS:2,TC:2</availability>
 		</model>
-		<model name='FS9-M4'>
-			<availability>OP:4,FVC:3,RF:3,LA:4,ROS:3,MH:3,FS:3,DA:3</availability>
+		<model name='FS9-S1'>
+			<roles>recon</roles>
+			<availability>LA:2,General:1,FS:1</availability>
 		</model>
 		<model name='FS9-M2'>
 			<roles>incendiary</roles>
@@ -6111,6 +6113,16 @@
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S2'>
+			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4</availability>
+		</model>
+		<model name='FS9-M4'>
+			<availability>OP:4,FVC:3,RF:3,LA:4,ROS:3,MH:3,FS:3,DA:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
@@ -6123,77 +6135,62 @@
 		<model name='FS9-S3'>
 			<availability>LA:6,ROS:5,FWL:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:2,General:1,FS:1</availability>
-		</model>
-		<model name='FS9-M3'>
-			<roles>spotter</roles>
-			<availability>LA:3,IS:2,TC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:3,LA:5,IS:2,FS:3,MERC:4,DC:7</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:3,DC:3</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
 		<availability>CJF:4</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -6203,44 +6200,47 @@
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,ROS:3,CLAN:1,FWL:4,MSC:5,CJF:2,CGB:1,DC:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,MERC.SI:5,MSC:6,BAN:8</availability>
-		</model>
 		<model name='FLS-9M'>
 			<availability>FWL:6,MSC:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,MERC.SI:5,MSC:6,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:8,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -6249,11 +6249,11 @@
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,RCM:4-,DA:4-,Periphery:6-,TC:4-</availability>
 		</model>
-		<model name='FLE-20'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='FLE-17'>
 			<availability>CC:5,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,Periphery:6</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6264,8 +6264,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -6277,20 +6277,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -6319,17 +6319,17 @@
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
 		<availability>ROS:3,FS:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(VSP)'>
-			<availability>General:4</availability>
+		<model name='(Interdictor)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:5</availability>
+		<model name='(VSP)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6367,10 +6367,6 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,ROS:5,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
@@ -6379,6 +6375,10 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CHH:3,RD:3,CW:2,ROS:5,FS:5,MERC:4,CJF:2,CGB:3</availability>
@@ -6386,38 +6386,38 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>ROS:5,FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:8,FS:8,MERC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>ROS:5,FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:8,DTA:8,OP:8,RF:8,ROS:6,General:3,FWL:8,MSC:8,RCM:8,DA:8</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:2-,General:8</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:8,DTA:8,OP:8,RF:8,ROS:6,General:3,FWL:8,MSC:8,RCM:8,DA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fusilier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,MERC:3</availability>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
@@ -6433,10 +6433,6 @@
 	</chassis>
 	<chassis name='GD Infiltrator Suit' unitType='BattleArmor'>
 		<availability>MERC.KH:4,RF:3,LA:4,ROS:3,MERC:3</availability>
-		<model name='(Remote Sensors)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
@@ -6444,13 +6440,17 @@
 		<model name='(Firedrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Sensors)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Mines)' mechanized='true'>
 			<roles>minelayer</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sensors)' mechanized='true'>
+		<model name='(Remote Sensors)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -6459,21 +6459,21 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CW:3,ROS:2,RA:3</availability>
-		<model name='2'>
-			<availability>CW:6,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:6,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6484,28 +6484,28 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:4,LA:5,ROS:5,CNC:4,IS:4,FS:5,MERC:4,CDP:4,CWIE:4,TC:4</availability>
-		<model name='GLT-7-0'>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='GLT-8-0'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
+		<model name='GLT-7-0'>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:5,Periphery:4</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -6513,35 +6513,35 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-,CWIE:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-,CWIE:8</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:4,FS:6,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='GRM-01A2'>
-			<availability>FS:5</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
 		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRM-01A2'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Garrot Superheavy Transport' unitType='VTOL'>
@@ -6560,9 +6560,6 @@
 	</chassis>
 	<chassis name='Gauntlet' unitType='Mek' omni='IS'>
 		<availability>LA:5</availability>
-		<model name='GTL-1OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='GTL-1O'>
 			<availability>General:8</availability>
 		</model>
@@ -6572,69 +6569,72 @@
 		<model name='GTL-1OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='GTL-1OC'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CHH:3,CLAN:1,CNC:4,IS:6,Periphery.Deep:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,ROS:6,General:3,FS:8</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
 		<availability>CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
-		<model name='GST-50'>
-			<availability>DTA:6,OP:6,MSC:6</availability>
-		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
 		</model>
 		<model name='GST-11'>
 			<availability>General:4</availability>
 		</model>
+		<model name='GST-50'>
+			<availability>DTA:6,OP:6,MSC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,CDS:4,ROS:4+,CNC:5,CLAN:4,CJF:3,BAN:4,CGB:8</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
+		<model name='A'>
+			<availability>RD:7,CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='B'>
+			<availability>RD:4,General:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:7,CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>RD:5,CDS:5,CW:5,CLAN:4,General:3,CGB:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='D'>
 			<availability>RD:4,CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
+		</model>
 		<model name='P'>
 			<availability>CHH:6,RD:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:4,General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6674,14 +6674,6 @@
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
 		<availability>ROS:5,FS:7</availability>
-		<model name='(Light Gauss)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>FS:5</availability>
@@ -6690,23 +6682,31 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6718,19 +6718,16 @@
 	</chassis>
 	<chassis name='Goblin Infantry Support Vehicle' unitType='Tank'>
 		<availability>FVC:5,LA:2,ROS:4,FS:2,MERC:4</availability>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,RD:7,CGB:7</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>RD:8,CGB:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
@@ -6741,44 +6738,47 @@
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>RD:8,CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-4S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,FWL:6,MH:5,MERC:6,CDP:5,TC:5</availability>
-		</model>
-		<model name='GOL-6M'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,FWL:6,MERC:4</availability>
-		</model>
-		<model name='GOL-3L'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:6,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,MH:8,Periphery:4</availability>
 		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='GOL-6M'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,FWL:6,MERC:4</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
+		<model name='GOL-4S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>MERC:1-</availability>
 		</model>
-		<model name='GOL-2H'>
-			<roles>fire_support</roles>
-			<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
-		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon Carrier' unitType='Dropship'>
@@ -6790,21 +6790,21 @@
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CNC:4,RA:6</availability>
-		<model name='3'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:5,RA:5</availability>
+		</model>
+		<model name='3'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>RA:6</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
+			<availability>RA:4</availability>
+		</model>
+		<model name='3'>
+			<roles>marine</roles>
 			<availability>RA:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -6813,38 +6813,41 @@
 	</chassis>
 	<chassis name='Gossamer VTOL' unitType='VTOL'>
 		<availability>CDS:4,LA:5,ROS:5,CNC:2,FWL:5,FS:5,RA:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,Periphery.MW:5,PIR:5,Periphery.ME:5,CLAN:3,CNC:4,FWL:7,MSC:7,MERC:4</availability>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,CNC:4,FWL:4,MERC:4,BAN:2,Periphery:4</availability>
 		</model>
-		<model name='GTHA-400'>
-			<availability>PIR:2-,FWL:2-,MH:2-,MERC:2-</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>DTA:8,OP:8,ROS:8,MSC:8</availability>
 		</model>
+		<model name='GTHA-400'>
+			<availability>PIR:2-,FWL:2-,MH:2-,MERC:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>RD:5,ROS:5,CNC:5,MERC:4,DC:6,CGB:5</availability>
-		<model name='DRG-7KC'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>RD:8,ROS:6,CNC:8,MERC:6,DC:2,CGB:8</availability>
 		</model>
+		<model name='DRG-7K'>
+			<availability>ROS:6,MERC:4,DC:3</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:4</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='DRG-9KC'>
 			<roles>spotter</roles>
@@ -6852,9 +6855,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>ROS:6,MERC:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -6871,23 +6871,23 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,IS:3,Periphery.Deep:4,MERC:7,Periphery:6,DC:4,TC:6</availability>
+		<model name='GHR-7P'>
+			<availability>LA:8,MERC:4</availability>
+		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
+		</model>
+		<model name='GHR-5H'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 		<model name='GHR-5J'>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>ROS:4,MERC:2,FS:2,DC:4</availability>
-		</model>
-		<model name='GHR-5H'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='GHR-7P'>
-			<availability>LA:8,MERC:4</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gravedigger' unitType='Mek'>
@@ -6917,14 +6917,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -6954,20 +6954,14 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:5</availability>
+		<model name='[Flamer]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[LRR]' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
@@ -6976,26 +6970,35 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[Heavy Flamer]' mechanized='false'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CHH:8,CLAN:5,IS:3</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:8,CLAN:5,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -7003,32 +7006,29 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>MERC.WD:5,CDS:6,CW:2,LA:3,CNC:7,IS:3,CJF:2,CWIE:4,DC:4</availability>
-		<model name='4'>
-			<availability>CDS:6,CNC:8,IS:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,IS:8</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CNC:2</availability>
 		</model>
-		<model name='6'>
-			<availability>ROS:4,CNC:6,DC:6</availability>
+		<model name='7'>
+			<availability>ROS:4,CNC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:6,CNC:4</availability>
 		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:6</availability>
+		<model name='6'>
+			<availability>ROS:4,CNC:6,DC:6</availability>
 		</model>
 		<model name='8'>
 			<availability>CW:6,LA:6,ROS:4,CJF:6,CWIE:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:6,CNC:8,IS:6</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
@@ -7036,54 +7036,54 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:1,RD:4,LA:7,ROS:5,CNC:2,IS:6,MERC:7,TC:5,Periphery:4,DC:7</availability>
-		<model name='GRF-2N'>
-			<availability>CC:4,MOC:4,OP:4,CLAN:6,MH:4,MSC:4,FS:4,MERC:4,RCM:4,BAN:4,DC:4</availability>
+		<model name='GRF-1N'>
+			<availability>BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:1-,MERC:1-,TC:2-</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,OP:6,ROS:5,MSC:6,MERC:5</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>DTA:5,MOC:4,OP:5,RF:6,LA:4,FWL:4,IS:4,MH:4,MSC:5,RCM:6,DA:6,DC:1</availability>
-		</model>
 		<model name='GRF-6S2'>
 			<availability>LA:3,FS:3,DC:3</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CC:4,RD:5,ROS:6,CNC:4,FWL:4,FS:4,DC:4,CGB:5</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:5,LA:2,CGB.FRR:2,ROS:3,MERC:2,DC:2</availability>
-		</model>
-		<model name='GRF-5K'>
-			<availability>CNC:8,DC:8</availability>
-		</model>
-		<model name='GRF-4N'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='GRF-5L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='GRF-6S'>
 			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='GRF-5K'>
+			<availability>CNC:8,DC:8</availability>
+		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,OP:6,ROS:5,MSC:6,MERC:5</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:5,LA:2,CGB.FRR:2,ROS:3,MERC:2,DC:2</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>DTA:5,MOC:4,OP:5,RF:6,LA:4,FWL:4,IS:4,MH:4,MSC:5,RCM:6,DA:6,DC:1</availability>
+		</model>
+		<model name='GRF-4N'>
+			<availability>TC:5</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CC:4,RD:5,ROS:6,CNC:4,FWL:4,FS:4,DC:4,CGB:5</availability>
+		</model>
+		<model name='GRF-5L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>CC:4,MOC:4,OP:4,CLAN:6,MH:4,MSC:4,FS:4,MERC:4,RCM:4,BAN:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -7102,11 +7102,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
-		</model>
 		<model name='B'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
@@ -7114,30 +7114,30 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:4,CHH:2-,CW:4,LA:4,ROS:4,CNC:2-,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:4,CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4,IS:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:4,CHH:1,ROS:5,FWL:4,MSC:5,FS:4,MERC:2,RA:1,Periphery:1</availability>
-		<model name='GLT-6WB3'>
+		<model name='GLT-8D'>
 			<roles>raider</roles>
-			<availability>ROS:3,MSC:6,MERC:3</availability>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>NIOPS:0,Periphery:1-</availability>
 		</model>
-		<model name='GLT-8D'>
-			<roles>raider</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:3,MERC:4</availability>
+		</model>
+		<model name='GLT-6WB3'>
+			<roles>raider</roles>
+			<availability>ROS:3,MSC:6,MERC:3</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -7146,11 +7146,11 @@
 	</chassis>
 	<chassis name='Gulltoppr OmniMonitor' unitType='Tank' omni='IS'>
 		<availability>MERC.KH:3,LA:3,CWIE:4</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(A)'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(B)'>
 			<roles>artillery,spotter</roles>
@@ -7163,22 +7163,22 @@
 			<roles>spotter</roles>
 			<availability>LA:6,General:4,FS:6,DC:6</availability>
 		</model>
-		<model name='GUN-1ERD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GUN-2ERDr'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
 		</model>
+		<model name='GUN-1ERD'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6,ROS:4,FS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurzil Support Tank' unitType='Tank'>
@@ -7211,9 +7211,9 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CNC:5,IS:4,DC:4,CWIE:4</availability>
-		<model name='HKO-1C'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>LA:5,DC:5</availability>
+			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,DC:4+</availability>
@@ -7221,20 +7221,20 @@
 		<model name='2'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='HKO-1C'>
 			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
+			<availability>LA:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>RA.OA:5,CHH:7,LA:3,ROS:4,CLAN:5,FS:3,MERC:3</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:8,RD:4,CDS:4,RA:8,CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:8,RD:4,CDS:4,RA:8,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hadur Fast Support Vehicle' unitType='Tank'>
@@ -7253,76 +7253,76 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>FWL:6,MERC:5</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,MERC:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,MERC:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,MERC:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:5,MERC:3</availability>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:6,MERC:6</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6E'>
-			<availability>General:6,MERC:6</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:6,CLAN:2,CNC:3</availability>
-		<model name='HMR-HE'>
-			<availability>ROS:4</availability>
+		<model name='HMR-HDb'>
+			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,RD:3,CDS:4,ROS:3+,CNC:5,CJF:4,CGB:3</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7347,9 +7347,6 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,OP:6,MERC:4,DTA:6,FWL.pm:6,RF:6,LA:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
-		<model name='(MML)'>
-			<availability>MOC:4,DTA:6,CC:4,OP:6,RF:6,LA:4,MSC:6,RCM:6,DA:6,MERC:4</availability>
-		</model>
 		<model name='(LRM)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:1</availability>
@@ -7357,17 +7354,20 @@
 		<model name='(Thunderbolt)'>
 			<availability>DTA:5,CC:4,MOC:4,OP:5,RF:5,MH:4,MSC:5,DA:5,RCM:5,MERC:4</availability>
 		</model>
+		<model name='(MML)'>
+			<availability>MOC:4,DTA:6,CC:4,OP:6,RF:6,LA:4,MSC:6,RCM:6,DA:6,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Standard)'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hasek Mechanized Combat Vehicle' unitType='Tank'>
@@ -7379,14 +7379,14 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>ROS:4,MERC:2,DC:5</availability>
-		<model name='HTM-28T'>
-			<availability>ROS:4,DC:2</availability>
+		<model name='HTM-27T'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:6</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>MERC:4,DC:4</availability>
+		<model name='HTM-28T'>
+			<availability>ROS:4,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaeru' unitType='Mek'>
@@ -7409,43 +7409,43 @@
 		<model name='HCT-6S'>
 			<availability>LA:8,MERC:6</availability>
 		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:1,FS:1,MERC:1,CDP:2</availability>
 		</model>
-		<model name='HCT-6M'>
-			<availability>DTA:8,ROS:4,FWL:8,MSC:8,MERC:4</availability>
-		</model>
-		<model name='HCT-7R'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:4,LA:3,CGB.FRR:4,FS:3,MERC:4,DC:2,Periphery:4</availability>
-		</model>
 		<model name='HCT-5DD'>
 			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:8,ROS:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:1-,TC.PL:2-,MERC:1-,Periphery:2-</availability>
 		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:4,LA:3,CGB.FRR:4,FS:3,MERC:4,DC:2,Periphery:4</availability>
+		</model>
 		<model name='HCT-6D'>
 			<availability>ROS:4,FS:2,MERC:6</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-6M'>
+			<availability>DTA:8,ROS:4,FWL:8,MSC:8,MERC:4</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:8,ROS:5,FS:5,MERC:5</availability>
+		</model>
+		<model name='HCT-7R'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7457,24 +7457,24 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OD'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='HA1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HA1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OD'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Havoc' unitType='Mek'>
@@ -7485,11 +7485,11 @@
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,DTA:5,OP:5,RF:5,LA:3,FWL:5,IS:3,MSC:5,FS:4,RCM:4,DA:3,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -7501,12 +7501,12 @@
 			<roles>artillery</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MML)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HawkWolf' unitType='Mek'>
@@ -7535,25 +7535,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7565,11 +7565,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,RA.OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -7600,23 +7600,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>ROS:2,FS:3,MERC:2</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>ROS:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7627,6 +7627,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:4,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -7635,20 +7643,20 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:4,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7658,20 +7666,15 @@
 			<roles>apc,support</roles>
 			<availability>ROS:2</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:4,LA:4+,CNC:4,RA:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:4</availability>
@@ -7680,22 +7683,19 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:4,MERC:4</availability>
-		<model name='HEP-1H'>
-			<roles>artillery</roles>
-			<availability>CC:1-,MOC:1-,MERC:1-</availability>
-		</model>
 		<model name='HEP-4H'>
 			<roles>artillery</roles>
 			<availability>General:8,MERC:8</availability>
+		</model>
+		<model name='HEP-1H'>
+			<roles>artillery</roles>
+			<availability>CC:1-,MOC:1-,MERC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -7703,11 +7703,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7733,14 +7733,14 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>CHH:3,CDS:2,ROS:2,CNC:6,CJF:3</availability>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:6,CNC:8,CWIE:8,DC:6</availability>
@@ -7751,25 +7751,25 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,CJF:2</availability>
+		<model name='C'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:7,CJF:3</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:6,CJF:3</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
@@ -7777,7 +7777,7 @@
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
@@ -7785,12 +7785,12 @@
 			<roles>spotter</roles>
 			<availability>FS:5</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
@@ -7811,36 +7811,36 @@
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
 		<availability>CHH:4</availability>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AP)'>
 			<roles>recon,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7865,42 +7865,46 @@
 			<roles>recon</roles>
 			<availability>ROS:3-,FWL:2-,MERC:3-</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>OP:4,FWL:4,MSC:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:4,MERC:4</availability>
-		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>FWL:1-,MERC:1-,Periphery:2-</availability>
+			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:6,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5Sr'>
+		<model name='HER-2S'>
 			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:4</availability>
+			<availability>FWL:1-,MERC:1-,Periphery:2-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>OP:4,FWL:4,MSC:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:4,MERC:4</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>DC.GHO:6,OP:8,FWL:7,MSC:8,MERC:5,DC:6</availability>
+		<model name='HER-3S'>
+			<roles>recon</roles>
+			<availability>FWL:2</availability>
+		</model>
+		<model name='HER-4S'>
+			<roles>recon</roles>
+			<availability>OP:4,FWL:3,MSC:4</availability>
+		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:8</availability>
-		</model>
-		<model name='HER-3S'>
+		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:2</availability>
 		</model>
@@ -7908,31 +7912,27 @@
 			<roles>recon</roles>
 			<availability>OP:6,MSC:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='HER-4S'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>OP:4,FWL:3,MSC:4</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:2</availability>
+			<availability>CLAN:6,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,CGB.FRR:1,CNC:2,IS:2-,Periphery.Deep:4,MERC:5,Periphery:6,CWIE:2</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,RF:6,DA:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CC:1,IS:1,Periphery:1</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:4-</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,RF:6,DA:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CC:1,IS:1,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hexareme HQ Hovercraft' unitType='Tank'>
@@ -7944,32 +7944,32 @@
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
 		<availability>LA:1,IS:1</availability>
+		<model name='(Cunnington)'>
+			<roles>spotter</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>LA:4,General:8</availability>
 		</model>
-		<model name='(Cunnington)'>
-			<roles>spotter</roles>
-			<availability>LA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CHH:6,RD:6,CDS:4,CW:6,LA:3,ROS:4,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CW:4</availability>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:4,CNC:4,IS:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8,RD:8,CW:4,ROS:4,CJF:8,CGB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:4,CNC:4,IS:8</availability>
+		<model name='2'>
+			<availability>CW:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:4,MH:4,MERC:4,FS:4,CJF:5,DC:4</availability>
-		<model name='HGN-734'>
-			<availability>LA:6,ROS:6,MERC:6</availability>
+		<model name='HGN-738'>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -7977,8 +7977,8 @@
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:8,ROS:8</availability>
+		<model name='HGN-734'>
+			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hippogriff' unitType='ProtoMek'>
@@ -7989,7 +7989,7 @@
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:5</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7997,7 +7997,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8023,23 +8023,23 @@
 	</chassis>
 	<chassis name='Hollander III' unitType='Mek'>
 		<availability>LA:3,FS.CMM:5,FS:4,MERC:4</availability>
-		<model name='BZK-D2'>
-			<availability>LA:8,General:4</availability>
-		</model>
 		<model name='BZK-D3'>
 			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BZK-D1'>
 			<availability>General:4,FS:8</availability>
 		</model>
+		<model name='BZK-D2'>
+			<availability>LA:8,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8056,12 +8056,12 @@
 		<model name='HNT-182'>
 			<availability>FVC:3,FS.PMM:3,FS.CMM:3,FS.DMM:3,FS.CrMM:3</availability>
 		</model>
+		<model name='HNT-171'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:1-</availability>
-		</model>
-		<model name='HNT-171'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -8115,49 +8115,59 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:1,CC:1,RA.OA:1,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,FS:2,Periphery:3,TC:1,DC:1</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='HBK-6S'>
-			<availability>LA:8,ROS:6,MERC:6</availability>
-		</model>
 		<model name='HBK-7R'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:8,MERC:4</availability>
+		<model name='HBK-6S'>
+			<availability>LA:8,ROS:6,MERC:6</availability>
 		</model>
 		<model name='HBK-5H'>
 			<availability>FVC:3,MH:6,Periphery:4</availability>
 		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3,CC:3,FWL:4,MERC:3,CDP:3,TC:3</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>Periphery:2-</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='HBK-5S'>
 			<availability>LA:3,ROS:3,MH:3,MERC:1,FS:3</availability>
 		</model>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:8,MERC:4</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='HBK-6N'>
 			<availability>ROS:3,FWL:2,MH:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3,CC:3,FWL:4,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,RD:5,CDS:4,CLAN:3,BAN:4,CGB:5</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:3,CC:5,RA.OA:4,LA:6,ROS:2,IS:4,FWL:3,MERC:4,FS:4,Periphery:4,TC:4,DC:2</availability>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='(Amphibious)'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>RF:6,LA:8,ROS:6,FS:6,RCM:6,MERC:6,DA:6</availability>
+		</model>
 		<model name='(ERLL)'>
 			<availability>LA:4,FS:4</availability>
 		</model>
@@ -8165,45 +8175,38 @@
 			<roles>fire_support</roles>
 			<availability>General:2-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>RF:6,LA:8,ROS:6,FS:6,RCM:6,MERC:6,DA:6</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Amphibious)'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:3+</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='HSCL-1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:3+</availability>
+		</model>
+		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OD'>
@@ -8212,18 +8215,15 @@
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>LA:1,ROS:2,CLAN:3,MERC:1</availability>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,MERC.SI:4,BAN:8</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8235,17 +8235,17 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CLAN:6,RA:6</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:8,CLAN:5,CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:8,CLAN:5,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -8266,8 +8266,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:2,MOC:8,LA:1,ROS:4,IS:8,FWL:3,MH:8,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8275,20 +8275,20 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='[SRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
 		<availability>FWL.pm:3,ROS:2,FWL:3,MH:2,MERC:2</availability>
-		<model name='ICR-1S'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='ICR-2S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='ICR-1S'>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Icestorm' unitType='Mek'>
@@ -8307,11 +8307,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:6,MERC.KH:8</availability>
-		</model>
 		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-4E'>
+			<availability>MERC.WD:6,MERC.KH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8336,23 +8336,23 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CW:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8361,17 +8361,17 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:4,LA:4,ROS:5,FWL:4,FS:4,DC:4</availability>
-		<model name='(3115)'>
+		<model name='(SCC)'>
 			<roles>assault</roles>
-			<availability>ROS:4</availability>
+			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>CC:8,ROS:5,FWL:8</availability>
 		</model>
-		<model name='(SCC)'>
+		<model name='(3115)'>
 			<roles>assault</roles>
-			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
@@ -8380,40 +8380,40 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,BAN:4,Periphery:3,TC:3,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>DTA:8,OP:8,RF:8,ROS:5,FWL:8,IS:3,MSC:8,DA:8,RCM:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>DTA:8,OP:8,RF:8,ROS:5,FWL:8,IS:3,MSC:8,DA:8,RCM:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,CLAN:9,IS:7,Periphery.Deep:6,FS:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,PIR:5,FWL:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:5</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -8425,17 +8425,20 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CHH:6,LA:2,ROS:3,CLAN:4,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CHH:8,CW:4,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>RD:6,CLAN:4,RA:7,CGB:6</availability>
+		<model name='2'>
+			<availability>RA:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
@@ -8443,12 +8446,14 @@
 			<roles>recon</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,RA.OA:4,CLAN:6,IS:6,MH:4,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8458,11 +8463,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8479,9 +8479,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>DC.LV:1-,DC.GR:1-,TC:1-</availability>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon,raider</roles>
-			<availability>General:7,Periphery:4</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon,raider</roles>
+			<availability>General:4,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
@@ -8491,34 +8495,26 @@
 			<roles>recon,raider</roles>
 			<availability>DC:8,TC:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(ICE)'>
-			<roles>recon,raider</roles>
-			<availability>General:4,Periphery:5</availability>
-		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>General:7,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>RD:3,IS:4,TC:4,Periphery:4</availability>
-		<model name='(3082 Upgrade)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>TC:4</availability>
+		</model>
+		<model name='(3082 Upgrade)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
 		<availability>CC:4,IS:4,FS:6,MERC:4,Periphery:4,RD:6,LA:4,ROS:5,CGB.FRR:5,FWL:4,CJF:4,CGB:6,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>RD:8,IS:3,CGB:8,Periphery:6</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>ROS:6,FS:6,CJF:8</availability>
@@ -8526,6 +8522,10 @@
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>RD:4,IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>RD:8,IS:3,CGB:8,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='JI2A1 Attack APC' unitType='Tank'>
@@ -8568,27 +8568,17 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>MOC:5,DTA:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5,MSC:6,MERC:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>FWL:3,Periphery.Deep:6,MERC:3,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>DTA:5,ROS:5,MSC:5,MERC:5</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>FWL:3,Periphery.Deep:6,MERC:3,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,General:2,RA:4</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CW:4,CLAN:2,RA:6</availability>
@@ -8596,8 +8586,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,General:2,RA:4</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8611,21 +8611,6 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>Periphery:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:3,MERC:6</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
@@ -8634,35 +8619,69 @@
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
+		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:3,DC:2</availability>
 		</model>
-		<model name='JM7-C3BS'>
+		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:8</availability>
+			<availability>ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>MOC:4,RA.OA:4,FVC:4,LA:4,MERC:4,FS:4,CDP:4,DC:4,TC:4</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jaguar' unitType='Mek'>
 		<availability>LA:3,ROS:3,CWIE:3</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,CWIE:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,FVC:7,Periphery.HR:4,ROS:4,FS:7,MERC:4,Periphery.OS:6,Periphery:3,TC:3</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
+		<model name='JVN-11P'>
+			<availability>FVC:4</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:1,LA:1,ROS:1,FS:1,MERC:1,CDP:1</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
@@ -8671,82 +8690,67 @@
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
-		</model>
-		<model name='JVN-11P'>
-			<availability>FVC:4</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:1,LA:1,ROS:1,FS:1,MERC:1,CDP:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>RD:9,CW:8,CLAN:6,CWIE:7,CGB:9</availability>
+		<model name='X'>
+			<availability>General:1,CJF:2,RA:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='X'>
-			<availability>General:1,CJF:2,RA:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CDS:6,CW:6,ROS:4,CNC:8,DC:3</availability>
-		<model name='3'>
-			<availability>CNC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CW:3,CNC:3</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:8,CNC:8,IS:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CNC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:3,CNC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:5,FS.DMM:5,MERC:4,Periphery.OS:5,FS:4,RA:4,DC:8,Periphery:3</availability>
-		<model name='JR7-C4'>
-			<roles>raider</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>ROS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>ROS:4,DC:8</availability>
+		</model>
+		<model name='JR7-C4'>
+			<roles>raider</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -8756,17 +8760,9 @@
 			<roles>raider</roles>
 			<availability>MERC:4,FS:4,DC:4</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8774,6 +8770,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -8786,11 +8786,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -8815,26 +8815,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:5,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -8852,29 +8852,45 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CJF:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:4,DC:6</availability>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 		<model name='C' mechanized='true'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>ROS:2,DC:2</availability>
 		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
@@ -8884,29 +8900,13 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -8927,36 +8927,36 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.NSR:4,DC.SL:4,General:5</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>RD:7,CGB:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -8968,39 +8968,39 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>PIR:2,IS:2,Periphery:2,RA:2</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:4,MERC:4</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
-		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:4</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>FWL:5,IS:6</availability>
 		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>MH:4,MERC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,DC:6</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:8,DC:8</availability>
 		</model>
 		<model name='CRK-5003-C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kelswa Assault Tank' unitType='Tank'>
@@ -9011,6 +9011,13 @@
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:2,LA:2,ROS:3,CLAN:2,FS:3,DC:2</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -9018,39 +9025,32 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,RD:2,LA:6,ROS:6,FWL:4,MH:4,DC:4,CGB:2</availability>
-		<model name='KGC-001'>
-			<availability>LA:3,IS:4,MH:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:6,ROS:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='KGC-008B'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 		</model>
+		<model name='KGC-001'>
+			<availability>LA:3,IS:4,MH:6</availability>
+		</model>
 		<model name='KGC-005r'>
 			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='KGC-008B'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='KGC-009'>
 			<availability>LA:6</availability>
@@ -9058,23 +9058,20 @@
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>RD:6,CDS:3,ROS:3+,CNC:3,RA:3,CGB:6</availability>
-		<model name='C'>
-			<availability>RD:3,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>RD:5,General:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:3,General:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -9082,13 +9079,16 @@
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
 		<availability>CC:3,MOC:3,RD:4,ROS:8,IS:5,MERC:6,TC:3,CGB:4</availability>
-		<model name='(PPC)'>
+		<model name='(RAC)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(RAC)'>
+		<model name='(PPC)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -9097,41 +9097,41 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,ROS:6,MERC:3,FS:1,DC:3</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:5</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:2,DC.SL:4,ROS:3,CLAN:6,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='KTO-20'>
-			<availability>MERC:4,DC:2</availability>
 		</model>
 		<model name='KTO-19b'>
 			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
+		<model name='KTO-20'>
+			<availability>MERC:4,DC:2</availability>
+		</model>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:5</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:5,CGB:6</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9149,13 +9149,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kite Reconnaissance Vehicle' unitType='Tank'>
@@ -9174,15 +9174,15 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>RD:3-,CGB:3-</availability>
-		<model name='(GB) [GL/Flamer]' mechanized='true'>
-			<availability>RD:6,CGB:6</availability>
+		<model name='(GB) [SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>RD:8,CGB:8</availability>
 		</model>
 		<model name='(GB) [SL/Flamer]' mechanized='true'>
 			<availability>RD:6,CGB:6</availability>
 		</model>
-		<model name='(GB) [SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>RD:8,CGB:8</availability>
+		<model name='(GB) [GL/Flamer]' mechanized='true'>
+			<availability>RD:6,CGB:6</availability>
 		</model>
 		<model name='(GB) [GL]' mechanized='true'>
 			<availability>RD:4,CGB:4</availability>
@@ -9194,19 +9194,19 @@
 	</chassis>
 	<chassis name='Kodiak II' unitType='Mek'>
 		<availability>RD:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>RD:7,ROS:4,RA:6,CGB:7</availability>
-		<model name='5'>
-			<availability>RD:4,CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -9215,11 +9215,11 @@
 		<model name='2'>
 			<availability>RD:5,ROS:6,CGB:5</availability>
 		</model>
+		<model name='5'>
+			<availability>RD:4,CGB:4</availability>
+		</model>
 		<model name='4'>
 			<availability>RD:4,ROS:4,CGB:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -9228,35 +9228,35 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:3</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:1</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>OP:6,ROS:5,FWL:4,MERC:4</availability>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>OP:5,MERC:4</availability>
-		</model>
-		<model name='(Mortar)' mechanized='false'>
+		<model name='(AI Mk IIr)' mechanized='false'>
 			<availability>OP:4,MERC:3</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk IIr)' mechanized='false'>
-			<availability>OP:4,MERC:3</availability>
-		</model>
 		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>OP:5,MERC:4</availability>
+		</model>
+		<model name='(Mortar)' mechanized='false'>
+			<availability>OP:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koroshiya' unitType='Aero'>
@@ -9267,56 +9267,32 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:3,ROS:3,MERC:4</availability>
-		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-5I'>
-			<availability>DTA:8,ROS:8,MERC:8</availability>
-		</model>
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8,MERC:4</availability>
-		</model>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:5</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-6L'>
 			<roles>artillery</roles>
 			<availability>CC:4,MOC:4</availability>
 		</model>
+		<model name='KSC-4I'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-5I'>
+			<availability>DTA:8,ROS:8,MERC:8</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,IS:4+,CJF:3,BAN:5,RA:4</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CNC:3,General:2</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>RD:8,CDS:3,CW:7,General:4,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>RD:6,CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>RD:4,CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -9326,14 +9302,38 @@
 			<roles>recon</roles>
 			<availability>RD:2,CDS:5,CW:7,CNC:2,General:3,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>RD:8,CDS:3,CW:7,General:4,CGB:8</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CNC:3,General:2</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>RD:4,CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:5,IS:4</availability>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9341,27 +9341,27 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='KTO-3A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>ROS:2,CJF:3,RA:3</availability>
-		<model name='4'>
-			<availability>ROS:8,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<availability>ROS:8,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -9394,11 +9394,11 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>RD:4,CGB:4</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9453,33 +9453,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
-		<model name='LX-2A'>
-			<availability>DTA:5,OP:5,RF:5,LA:5,ROS:5,FWL:5,MSC:5,RCM:5,MERC:5,DA:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LX-2A'>
+			<availability>DTA:5,OP:5,RF:5,LA:5,ROS:5,FWL:5,MSC:5,RCM:5,MERC:5,DA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-4E'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:8,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='LHU-4E'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9491,6 +9491,15 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
 		<model name='LGN-2K'>
 			<roles>raider</roles>
 			<availability>ROS:4</availability>
@@ -9498,60 +9507,51 @@
 		<model name='LGN-2F'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
-		</model>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
 		<availability>CC:3,MOC:3,OP:5,MERC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<roles>recon</roles>
+		<model name='(David)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(David)' mechanized='true'>
+		<model name='(MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(FireDrake)' mechanized='true'>
+		<model name='(Sensor)' mechanized='true'>
+			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(MG)' mechanized='true'>
+		<model name='(FireDrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,IS:7,Periphery.Deep:5,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,DTA:8,OP:8,RF:8,LA:8,ROS:8,General:3,FWL:8,MSC:8,FS:8,RCM:8,DA:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,RA.OA:8,LA:7,IS:8,Periphery.Deep:6,FWL:7,FS:7,BAN:2,Periphery:8,TC:8,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>DTA:8,OP:8,RF:8,LA:8,ROS:8,General:3,FWL:8,MSC:8,FS:8,DA:8,RCM:8</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:2-</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>DTA:8,OP:8,RF:8,LA:8,ROS:8,General:3,FWL:8,MSC:8,FS:8,DA:8,RCM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -9590,15 +9590,17 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:4,FWL:8,IS:4</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:2,LA:2</availability>
@@ -9606,11 +9608,9 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:4,FWL:8,IS:4</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9621,12 +9621,12 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(ERSL)'>
 			<availability>ROS:4</availability>
@@ -9634,50 +9634,50 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,Periphery:4,TC:4,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:3-</availability>
+		<model name='LTN-G16D'>
+			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>ROS:6,FS:6,MERC:4</availability>
+		<model name='LTN-G16O'>
+			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:3-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:6,MOC:6,RF:4,MSC:4,MERC:4,DA:6</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>RA.OA:6,FVC:4,CDP:4</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:4+,CW:5,CJF:4,RA:5,CWIE:6</availability>
-		<model name='B'>
-			<availability>RD:6,CDS:4,General:5,CGB:6</availability>
-		</model>
-		<model name='A'>
-			<availability>RD:6,CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='Prime'>
+			<availability>RD:9,CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,RD:5,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<availability>RD:6,CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:9,CDS:7,General:8,CWIE:9,CGB:9</availability>
+		<model name='B'>
+			<availability>RD:6,CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
+		<model name='C'>
+			<availability>CHH:4,RD:5,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:7,CW:6,General:5,CWIE:6,CGB:7</availability>
@@ -9708,10 +9708,6 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CW:6,CJF:3</availability>
-		<model name='2'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:8</availability>
 		</model>
@@ -9719,26 +9715,15 @@
 			<roles>anti_infantry</roles>
 			<availability>CW:2</availability>
 		</model>
+		<model name='2'>
+			<roles>anti_infantry</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,RD:6,CW:7,ROS:3,CJF:6,DC:3,CGB:6</availability>
-		<model name='6'>
-			<availability>RD:6,CW:6,CGB:6</availability>
-		</model>
-		<model name='9'>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CW:2</availability>
-		</model>
-		<model name='8'>
-			<availability>RD:6,ROS:5,CGB:6,DC:5</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:5,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:5,CW:5,LA:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CJF:2</availability>
@@ -9746,148 +9731,163 @@
 		<model name='5'>
 			<availability>CHH:4,RD:4,CW:4,ROS:4,CGB:4</availability>
 		</model>
+		<model name='8'>
+			<availability>RD:6,ROS:5,CGB:6,DC:5</availability>
+		</model>
+		<model name='6'>
+			<availability>RD:6,CW:6,CGB:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
+		<model name='7'>
+			<availability>CHH:5,ROS:2</availability>
+		</model>
+		<model name='9'>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CLAN:2-,IS:6,Periphery:4</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
-		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:4,MSC:4</availability>
-		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
-		</model>
-		<model name='LCT-5M3'>
-			<availability>ROS:5,MSC:5</availability>
-		</model>
-		<model name='LCT-1Vb'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,BAN:2</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:3,ROS:4,PIR:4,FWL:3,FS:2,MERC:2</availability>
-		</model>
-		<model name='LCT-1V2'>
-			<roles>recon</roles>
-			<availability>PIR:4,MH:4,MERC:3</availability>
-		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,ROS:6,CLAN:4,IS:4,FS:5,DC:5</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:1-,General:1-,FS:1-</availability>
-		</model>
-		<model name='LCT-5V'>
-			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='LCT-3S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:6</availability>
-		</model>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:2,DTA:6,OP:6,RF:5,FWL:4,IS:2,MSC:5,MERC:5,RCM:5,DA:5</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:2-,MERC:2-</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-5M3'>
+			<availability>ROS:5,MSC:5</availability>
+		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:5,ROS:6,CLAN:4,IS:4,FS:5,DC:5</availability>
+		</model>
+		<model name='LCT-5M2'>
+			<availability>ROS:4,MSC:4</availability>
+		</model>
+		<model name='LCT-1Vb'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,BAN:2</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4,MERC:3</availability>
+		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:2,DTA:6,OP:6,RF:5,FWL:4,IS:2,MSC:5,MERC:5,RCM:5,DA:5</availability>
+		</model>
+		<model name='LCT-1V'>
+			<roles>recon</roles>
+			<availability>LA:1-,General:1-,FS:1-</availability>
+		</model>
+		<model name='LCT-3S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:6</availability>
+		</model>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:3,ROS:4,PIR:4,FWL:3,FS:2,MERC:2</availability>
+		</model>
+		<model name='LCT-6M'>
+			<roles>recon</roles>
+			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:3,BAN:4,CWIE:3</availability>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:5,CDS:5,General:4,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,RD:3,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>RD:8,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:5,CDS:5,General:4,CWIE:5,CGB:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,RD:5,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:5,General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>RD:8,General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki Mk II (Hel)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,RD:4,CDS:4,CW:4,CJF:5,RA:4</availability>
-		<model name='B'>
-			<roles>artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<roles>artillery</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CHH:3,MERC.WD:2,CDS:2,CW:1,ROS:1,CNC:3,RA:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,IS:6,FS:5,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6,CGB:4</availability>
-		<model name='LGB-7V'>
+		<model name='LGB-14C'>
 			<roles>fire_support</roles>
-			<availability>MOC:2,FVC:4,FWL:2,IS:2,Periphery:4</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CGB:4</availability>
-		</model>
-		<model name='LGB-12R'>
-			<roles>fire_support</roles>
-			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:4</availability>
+			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:2,FVC:4,FWL:2,IS:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,OP:6,ROS:6,MSC:6,FS:6,MERC:6,DA:6,RCM:6,DC:6</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGB-12R'>
+			<roles>fire_support</roles>
+			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:4</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CGB:4</availability>
+		</model>
 		<model name='LGB-14C2'>
 			<roles>fire_support</roles>
 			<availability>IS:5</availability>
-		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -9895,17 +9895,17 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer III' unitType='Aero'>
@@ -9925,11 +9925,11 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>Periphery.R:4,FVC:2,LA:5,Periphery.MW:3,Periphery:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:4,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:1-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:4,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
@@ -9938,13 +9938,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:1-</availability>
@@ -9963,24 +9963,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>ROS:8,MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -9988,13 +9988,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -10042,19 +10042,12 @@
 		<model name='B'>
 			<availability>CHH:7,RD:4,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CHH:4,CW:5,CNC:4,CLAN:5,General:5,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CNC:5,CLAN:4,General:3</availability>
+		<model name='Prime'>
+			<availability>RD:7,CDS:8,CNC:7,General:8,CJF:8,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:5,CNC:3,General:4</availability>
@@ -10062,19 +10055,26 @@
 		<model name='A'>
 			<availability>RD:8,CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
+		<model name='F'>
+			<availability>CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:7,CDS:8,CNC:7,General:8,CJF:8,CGB:7</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:2,CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CNC:5,CLAN:4,General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:5,LA:5,ROS:5,CNC:4,IS:4,CWIE:4,DC:5</availability>
-		<model name='4'>
+		<model name='5'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -10082,25 +10082,28 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='5'>
+		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='2'>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:4,CNC:6,CLAN:4,IS:4,FS:4,CWIE:4,DC:4</availability>
-		<model name='Enhanced'>
-			<availability>CGB.FRR:6,CLAN:6,CNC:4,CWIE:4</availability>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='5'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4</availability>
@@ -10108,11 +10111,8 @@
 		<model name='4'>
 			<availability>General:5</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
-		</model>
-		<model name='5'>
-			<availability>General:4</availability>
+		<model name='Enhanced'>
+			<availability>CGB.FRR:6,CLAN:6,CNC:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -10132,18 +10132,18 @@
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:4,MOC:4,OP:8,Periphery.MM:4,MERC:4,DTA:8,RF:8,LA:4,ROS:4,Periphery.CM:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,RCM:8,DA:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -10162,58 +10162,61 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:5,CDS:5,CW:5,CJF:5,BAN:4,CWIE:5</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1</availability>
-		</model>
-		<model name='G'>
-			<availability>General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:9,CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:7,CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='G'>
+			<availability>General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
 		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:7,CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:4,RF:4,LA:4,ROS:4,MERC:4,CWIE:6</availability>
-		<model name='MNL-4S'>
-			<availability>General:5</availability>
-		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:4,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
 		</model>
+		<model name='MNL-4S'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
 		<availability>ROS:6</availability>
-		<model name='(Support)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Support)'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:6,ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
@@ -10221,43 +10224,40 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:4,CC:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,CWIE:5,RA.OA:5,LA:5,ROS:5,FWL:4,DC:6</availability>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
+		<model name='(HPPC)'>
+			<availability>CC:5,MOC:5,DTA:5,LA:5,ROS:6,FS:6,MERC:5,DC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-,Periphery:2</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='(HPPC)'>
-			<availability>CC:5,MOC:5,DTA:5,LA:5,ROS:6,FS:6,MERC:5,DC:6</availability>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore II Heavy Tank' unitType='Tank'>
@@ -10268,11 +10268,11 @@
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,LA:3,FWL:4,IS:3,FS:5,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder Battle Armor' unitType='BattleArmor'>
@@ -10288,63 +10288,99 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>MERC.WD:6,RD:6,CW:5,CNC:5,CJF:6,RA:5,CWIE:5,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,RD:3,CJF:3,CGB:3</availability>
+		<model name='4'>
+			<availability>RD:4,CNC:6,RA:4,CGB:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:3,CWIE:6</availability>
 		</model>
-		<model name='6'>
-			<availability>CW:6,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>RD:5,CJF:5,CGB:5</availability>
-		</model>
 		<model name='7'>
 			<availability>RD:5,CGB:5</availability>
 		</model>
-		<model name='2'>
-			<availability>RD:3,CJF:3,CGB:3</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,RD:3,CJF:3,CGB:3</availability>
 		</model>
-		<model name='4'>
-			<availability>RD:4,CNC:6,RA:4,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:6,CJF:4</availability>
 		</model>
 		<model name='8'>
 			<availability>RD:3,CJF:3,CGB:3</availability>
 		</model>
+		<model name='2'>
+			<availability>RD:3,CJF:3,CGB:3</availability>
+		</model>
+		<model name='3'>
+			<availability>RD:5,CJF:5,CGB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:4,MERC.WD:6,LA:3,ROS:6,PIR:4,FWL:6,MH:4,FS:6,MERC:6,TC:4,DC:6</availability>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:6</availability>
-		</model>
-		<model name='MAD-5A'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='MAD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6</availability>
+		<model name='C'>
+			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='MAD-4L'>
 			<availability>CC:8,MOC:8</availability>
 		</model>
-		<model name='MAD-4S'>
-			<availability>LA:8,ROS:6,CNC:8,FS:5,MERC:8</availability>
+		<model name='MAD-4H'>
+			<availability>PIR:5,MH:5,TC:5</availability>
+		</model>
+		<model name='MAD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6</availability>
 		</model>
 		<model name='MAD-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='MAD-4H'>
-			<availability>PIR:5,MH:5,TC:5</availability>
+		<model name='MAD-5A'>
+			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:6</availability>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:6</availability>
+		</model>
+		<model name='MAD-4S'>
+			<availability>LA:8,ROS:6,CNC:8,FS:5,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,TC:3,Periphery:2,DC:2,CGB:3</availability>
-		<model name='MAD-9M'>
+		<model name='MAD-5D'>
+			<availability>FVC:4,FS:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='MAD-9M2'>
 			<roles>spotter</roles>
-			<availability>DTA:8,OP:8,MSC:8,MERC:3,DA:8</availability>
+			<availability>OP:6,RF:6,ROS:4,MERC:4,DA:6,DC:4</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
+		</model>
+		<model name='MAD-9S'>
+			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4,CGB:4</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>Periphery:2-,TC:2-</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>MOC:4,ROS:4,FWL:6,MERC:4</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-6L'>
+			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:1-,Periphery.MW:1-,PIR:1-,Periphery.ME:1-,MH:1-</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
 		</model>
 		<model name='MAD-3D'>
 			<availability>FVC:1-,MH:2-</availability>
@@ -10352,48 +10388,12 @@
 		<model name='MAD-9D'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='MAD-9M2'>
-			<roles>spotter</roles>
-			<availability>OP:6,RF:6,ROS:4,MERC:4,DA:6,DC:4</availability>
-		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:4,FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>MOC:4,ROS:4,FWL:6,MERC:4</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>Periphery:2-,TC:2-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4,CGB:4</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
-		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:1-,Periphery.MW:1-,PIR:1-,Periphery.ME:1-,MH:1-</availability>
-		</model>
-		<model name='MAD-5L'>
-			<availability>CC:6,MOC:5</availability>
-		</model>
 		<model name='MAD-5S'>
 			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:8,OP:8,MSC:8,MERC:3,DA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -10409,11 +10409,11 @@
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:7,IS:5</availability>
-		<model name='M1'>
-			<availability>ROS:2,ROS.pm:8,General:8</availability>
-		</model>
 		<model name='M1A'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='M1'>
+			<availability>ROS:2,ROS.pm:8,General:8</availability>
 		</model>
 		<model name='M1J'>
 			<availability>General:4</availability>
@@ -10421,17 +10421,17 @@
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CHH:4,RD:3,ROS:4,CGB:3</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CJF:2</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:5,RD:4,CDS:4,ROS:4,CGB:4</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CHH:4,RD:3,ROS:4,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10445,11 +10445,11 @@
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MHL-6MC'>
-			<availability>MOC:5,CC:4</availability>
-		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:5,CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
@@ -10464,11 +10464,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:1,RD:4,CDS:4,CW:2,CNC:2,MERC:3+,CJF:3,RA:2,BAN:3,CGB:4</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
+		<model name='C'>
+			<availability>RD:6,CDS:5,CW:6,General:4,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
@@ -10476,8 +10473,14 @@
 		<model name='A'>
 			<availability>RD:5,CDS:8,General:5,CGB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>RD:6,CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='D'>
+			<availability>RD:5,CDS:5,General:4,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CDS:9,General:8,CGB:8</availability>
@@ -10485,57 +10488,54 @@
 		<model name='B'>
 			<availability>CDS:8,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:5,CDS:5,General:4,CGB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>MERC:5,DC:7</availability>
-		<model name='MAL-1R'>
-			<availability>CGB.FRR:8,MERC:6</availability>
+		<model name='MAL-3R'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='MAL-C'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='MAL-3R'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='MAL-1K'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='MAL-1R'>
+			<availability>CGB.FRR:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:6</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
@@ -10543,19 +10543,19 @@
 		<model name='(LB-X)'>
 			<availability>FWL:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
@@ -10575,13 +10575,13 @@
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>RA:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -10611,39 +10611,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -10655,33 +10652,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10716,23 +10716,19 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10740,13 +10736,17 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mengqin' unitType='Aero'>
@@ -10787,25 +10787,25 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Dropship'>
 		<availability>RF:3,FWL:6</availability>
-		<model name='R1'>
-			<roles>assault</roles>
-			<availability>RF:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>assault</roles>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='R1'>
+			<roles>assault</roles>
+			<availability>RF:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10814,6 +10814,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Targeting Computer)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Gauss) &apos;Sandblaster&apos;'>
 			<roles>urban</roles>
@@ -10825,22 +10830,17 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Targeting Computer)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CHH:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='XP'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='XP'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='P2'>
 			<availability>CHH:6</availability>
@@ -10869,22 +10869,18 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		<model name='MLR-B2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MLR-BX'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='MLR-B2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -10894,11 +10890,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -10939,13 +10939,13 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>LA:5,ROS:5,MERC:4</availability>
-		<model name='MON-268'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3,ROS:3,MERC:3</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
+		<model name='MON-268'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
@@ -10961,11 +10961,11 @@
 	</chassis>
 	<chassis name='Mongrel' unitType='Mek'>
 		<availability>RD:5,CHH:4,LA:3,MERC:4,CWIE:5</availability>
-		<model name='MGL-T2'>
-			<availability>CLAN:8,IS:4</availability>
-		</model>
 		<model name='MGL-T1'>
 			<availability>RD:4,IS:8,CWIE:4</availability>
+		</model>
+		<model name='MGL-T2'>
+			<availability>CLAN:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -10976,11 +10976,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:3,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -10991,20 +10991,20 @@
 	</chassis>
 	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:5,LA:7,CWIE:5</availability>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MR-1SC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MR-1SA'>
 			<roles>interceptor,ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SC'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -11033,25 +11033,25 @@
 			<roles>recon</roles>
 			<availability>CNC:4,DC:4</availability>
 		</model>
-		<model name='4'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
 		<availability>CLAN:5,IS:4</availability>
-		<model name='(HAG)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mortar Carrier' unitType='Tank'>
@@ -11087,7 +11087,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -11100,17 +11103,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -11136,29 +11136,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -11181,6 +11181,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,RD:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
@@ -11188,14 +11196,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nagasawa' unitType='Dropship'>
@@ -11207,13 +11207,13 @@
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3A'>
 			<roles>fire_support,spotter</roles>
@@ -11233,11 +11233,11 @@
 	</chassis>
 	<chassis name='Narukami Heavy Tank' unitType='Tank'>
 		<availability>DC:7</availability>
-		<model name='NK-1C'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NK-BC3'>
 			<availability>General:4</availability>
+		</model>
+		<model name='NK-1C'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Neanderthal' unitType='Mek'>
@@ -11264,11 +11264,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11280,29 +11280,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -11331,15 +11331,15 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CHH:2,RD:2,CW:2,ROS:5,CWIE:2,CGB:2</availability>
+		<model name='(LAC)'>
+			<roles>spotter</roles>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<roles>spotter</roles>
-			<availability>ROS:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -11348,32 +11348,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>OP:5,Periphery.R:2,RF:5,LA:8,ROS:6,FS:7,MERC:6</availability>
+		<model name='NGS-6T'>
+			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>OP:5,RF:5,LA:4,ROS:5,FS:4,MERC:4</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,OP:4,RF:4,LA:4,ROS:4,General:8,Periphery.Deep:6,FS:4,MERC:4,Periphery:8</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>OP:5,RF:5,LA:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:8,ROS:6,MERC:4</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>LA:6,ROS:5,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -11390,11 +11390,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='NJT-4'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='NJT-3'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11406,62 +11406,62 @@
 	</chassis>
 	<chassis name='Nisos Attack WIGE' unitType='Tank'>
 		<availability>CC:4,MOC:3,LA:3,DA:3,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>RD:4,DC.LV:8,DC.SL:2,LA:3,ROS:5,MERC:3,DC:8,CGB:4</availability>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>RD:4,CGB.FRR:4,ROS:6,MERC:4,DC:4,CGB:4</availability>
 		</model>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>ROS:3+,CNC:8</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11473,12 +11473,6 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -11486,20 +11480,26 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support,anti_infantry</roles>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support,anti_infantry</roles>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
@@ -11515,32 +11515,32 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:4,RD:4,LA:4,ROS:6,MERC:4,FS:4,DC:5,CGB:4</availability>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='NX-90'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
 		</model>
 		<model name='NX-100'>
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='NX-80C'>
+		<model name='NX-90'>
 			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -11552,14 +11552,14 @@
 		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:3,DC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CNC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -11581,11 +11581,11 @@
 	</chassis>
 	<chassis name='Ogre Battle Armor' unitType='BattleArmor'>
 		<availability>RF:5,LA:4,DA:4</availability>
-		<model name='(Interdictor)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Interdictor)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Okinawa' unitType='Dropship'>
@@ -11618,30 +11618,30 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,Periphery:3,TC:3,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:5,Periphery.ME:6,FWL:6,MH:3,DC:2</availability>
-		<model name='HEAT'>
-			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:5,CNC:8,IS:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:6,IS:6</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:2-,Periphery:4</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:5,CNC:8,IS:5</availability>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:6,IS:6</availability>
+		</model>
+		<model name='HEAT'>
+			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Oo-Suzumebachi' unitType='Small Craft'>
@@ -11653,14 +11653,14 @@
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4</availability>
@@ -11674,12 +11674,8 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:1,CC:2,CW:2,Periphery.MW:3,CLAN:1,Periphery.ME:3,FWL:5,FS:2,Periphery:3,TC:1,DC:3,CWIE:2</availability>
-		<model name='ON3-M'>
-			<roles>spotter</roles>
-			<availability>CC:5,FWL:6,MERC:5</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
 		</model>
 		<model name='ON1-MC'>
 			<availability>FS:2,MERC:2,DC:4</availability>
@@ -11687,20 +11683,24 @@
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,OP:4,ROS:4,FWL:4,MSC:4,DA:4,MERC:2,RCM:4,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>CLAN:2-,Periphery:2-</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2</availability>
+		<model name='ON3-M'>
+			<roles>spotter</roles>
+			<availability>CC:5,FWL:6,MERC:5</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>CLAN:2-,Periphery:2-</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:8</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11721,14 +11721,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-5D'>
-			<availability>FS:6</availability>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
+		<model name='OSR-5D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11742,49 +11742,49 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,ROS:4,IS:4,TC:4,DC:5,Periphery:2</availability>
+		<model name='OSR-5C'>
+			<availability>TC:6</availability>
+		</model>
+		<model name='OSR-4L'>
+			<availability>CC:8,MOC:4</availability>
+		</model>
+		<model name='OSR-2C'>
+			<roles>urban</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='OSR-2D'>
+			<availability>ROS:6,IS:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-3C'>
 			<availability>FVC:1-,Periphery:1-</availability>
 		</model>
 		<model name='OSR-4K'>
 			<availability>ROS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='OSR-5C'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='OSR-2C'>
-			<roles>urban</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:3</availability>
 		</model>
-		<model name='OSR-2D'>
-			<availability>ROS:6,IS:4,Periphery:4</availability>
-		</model>
 		<model name='OSR-4C'>
 			<availability>TC:6,Periphery:5</availability>
-		</model>
-		<model name='OSR-4L'>
-			<availability>CC:8,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RD:3,RA:2,CGB:3</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -11792,6 +11792,10 @@
 		<model name='OTT-7K'>
 			<roles>recon,spotter</roles>
 			<availability>FVC:8,IS:8,DC:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
@@ -11801,39 +11805,35 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:4,OP:5,RF:5,LA:8,ROS:5,MERC:5,FS:4,DC:4</availability>
 		</model>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>DTA:5,OP:5,RF:5,ROS:4,FWL:5,MSC:5,FS:5,MERC:3,Periphery:1</availability>
 		<model name='OTL-7M'>
 			<availability>DTA:8,OP:8,ROS:6,FWL:6,MSC:8,MERC:4</availability>
 		</model>
-		<model name='OTL-9M'>
-			<availability>ROS:4,FWL:5</availability>
-		</model>
 		<model name='OTL-8D'>
 			<availability>FS:8</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>Periphery:1-</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:3,MERC:4</availability>
 		</model>
 		<model name='OTL-8M'>
 			<availability>DTA:8,RF:8,MSC:6,MERC:3</availability>
 		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,MERC:5</availability>
+		<model name='OTL-5M'>
+			<availability>FWL:3,MERC:4</availability>
+		</model>
+		<model name='OTL-9M'>
+			<availability>ROS:4,FWL:5</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>Periphery:1-</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:2,Periphery:4</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -11847,10 +11847,6 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:8,CW:4</availability>
-		<model name='(3070)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:4</availability>
@@ -11858,6 +11854,10 @@
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(3070)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -11869,24 +11869,32 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:8,IS:4,FS:8</availability>
-		</model>
 		<model name='A3A'>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:8,IS:4,FS:8</availability>
 		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:2,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2,CLAN:6</availability>
+		</model>
+		<model name='OW-1F'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -11895,27 +11903,19 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1A'>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2,CLAN:6</availability>
 		</model>
 		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='OW-1F'>
+		<model name='OW-1'>
 			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
-		<model name='OW-1B'>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -11929,32 +11929,32 @@
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
 		<availability>CHH:5,LA:5,ROS:5,MERC:3,CWIE:8,DC:3</availability>
-		<model name='3'>
-			<availability>CHH:4,ROS:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4,ROS:4,CWIE:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CWIE:1</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CDS:4,CWIE:7</availability>
-		<model name='2'>
-			<availability>CDS:5,CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:5,CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -11963,21 +11963,21 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:1,CGB.FRR:2,PIR:2,General:1,FWL:1,MERC:1,FS:2,Periphery:3,DC:1</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,MOC:5</availability>
 		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
-		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:1,CGB.FRR:2,PIR:2,General:1,FWL:1,MERC:1,FS:2,Periphery:3,DC:1</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -11989,17 +11989,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Paladin Defense System' unitType='Tank'>
@@ -12018,6 +12018,9 @@
 	</chassis>
 	<chassis name='Pandion Combat WiGE' unitType='Tank'>
 		<availability>LA:3,ROS:3,FWL:3,FS:6,MERC:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -12026,35 +12029,28 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:7,CGB:5</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3,CGB:3</availability>
-		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:2,TC:2,CGB:2</availability>
 		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
-		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
 		</model>
 		<model name='PNT-12KC'>
 			<roles>raider</roles>
@@ -12064,13 +12060,17 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>RD:4,DC:6,CGB:4</availability>
+		</model>
+		<model name='PNT-12K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3,CGB:3</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -12086,13 +12086,13 @@
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:8</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<roles>recon,spotter</roles>
@@ -12108,42 +12108,42 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:5,Periphery:5</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='(Cell)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>ROS:2,FS:2</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>IS:5,Periphery:5</availability>
+		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
-		<model name='(Standard)'>
+		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
-			<availability>General:2-</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
@@ -12152,9 +12152,9 @@
 		<model name='(LRM)'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12165,10 +12165,6 @@
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>RF:6</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
@@ -12176,6 +12172,10 @@
 		<model name='PKM-2E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -12187,11 +12187,11 @@
 	</chassis>
 	<chassis name='Patron MilitiaMech' unitType='Mek'>
 		<availability>FWL.pm:4,DA.pm:4,RF.pm:4,OP.pm:4,IS.pm:2,MSC.pm:4,DTA.pm:5,RCM.pm:4</availability>
-		<model name='PTN-2M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PTN-2'>
 			<availability>DTA:3,FWL:3,RCM:3,DA:3</availability>
+		</model>
+		<model name='PTN-2M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
@@ -12221,21 +12221,21 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:8</availability>
 		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
-		</model>
 		<model name='X-Pulse'>
 			<roles>recon</roles>
 			<availability>DC.AL:8,General:4,DC:5</availability>
 		</model>
+		<model name='(MRM)'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,FS:8,DC:7</availability>
+		</model>
+		<model name='(Sealed)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -12247,20 +12247,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -12268,11 +12268,11 @@
 		<model name='PEN-2MAF'>
 			<availability>General:4</availability>
 		</model>
-		<model name='PEN-2H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PEN-3H'>
 			<availability>MOC:4</availability>
+		</model>
+		<model name='PEN-2H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -12284,40 +12284,40 @@
 	</chassis>
 	<chassis name='Persepolis' unitType='Aero'>
 		<availability>CJF:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,OP:6,ROS:4,FWL:4,MSC:6</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1'>
 			<availability>General:8</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12331,28 +12331,28 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:4,FS:4,MERC:4,DC:4</availability>
-		<model name='(Prototype)'>
-			<availability>OP:1,LA:2</availability>
-		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Prototype)'>
+			<availability>OP:1,LA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CW:8,CJF:7,RA:6,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
-		</model>
 		<model name='D'>
 			<availability>RD:4,General:5,CGB:4</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -12362,39 +12362,39 @@
 			<roles>recon</roles>
 			<availability>RD:7,General:6,CGB:7</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
 		<model name='C'>
 			<availability>RD:6,CDS:4,CNC:6,General:5,CGB:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,DTA:3,CDS:5,RF:3,LA:3,ROS:4,CLAN:3,MSC:3,MERC:3,FS:3,RA:5,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CDS:2,CNC:2,IS:3,DC:3</availability>
-		</model>
 		<model name='7'>
 			<availability>RD:8,CDS:6,General:5,CGB:8,DC:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='3'>
-			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='6'>
 			<availability>RD:6,CDS:8,CGB:6</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CDS:1,CNC:1,RA:4</availability>
+		<model name='3'>
+			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:6</availability>
 		</model>
 		<model name='5'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:6</availability>
+		<model name='(Standard)'>
+			<availability>CDS:2,CNC:2,IS:3,DC:3</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CDS:1,CNC:1,RA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk L' unitType='Mek'>
@@ -12408,61 +12408,61 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>RD:4,IS:7,FWL:8,Periphery:6,CGB:4</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>OP:4,DC:4</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
-		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:5,TC:5</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FVC:1-,PIR:2-,MERC:1-</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:5,MOC:4</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:4,MSC:6,BAN:1</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>RD:6,DC:8,CGB:6</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-4W'>
+			<availability>MOC:5,TC:5</availability>
+		</model>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>RD:4,ROS:2,CGB:4,DC:2</availability>
+		<model name='PXH-5L'>
+			<availability>CC:5,MOC:4</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>BAN:6,Periphery:1-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CC:4,OP:4,CLAN:3,FWL:4,MSC:5,MERC:4,DA:4,RCM:4</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>FVC:1-,PIR:2-,MERC:1-</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>RD:4,ROS:2,CGB:4,DC:2</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:4,MSC:6,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>RD:6,DC:8,CGB:6</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -12476,47 +12476,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,CNC:3,MH:2-,CWIE:4,Periphery:2-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>Periphery:2</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,CNC:6,MERC:4</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6,MOC:5</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12524,11 +12524,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -12539,6 +12539,9 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:6,CDS:5,RA:3,CWIE:3</availability>
+		<model name='2'>
+			<availability>CHH:8,CDS:8</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -12548,9 +12551,6 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,RA:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:8,CDS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -12571,12 +12571,12 @@
 		<model name='(Streak)'>
 			<availability>IS:6,TC:6,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>IS:4,Periphery:4</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>FWL:5,IS:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
@@ -12612,39 +12612,39 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
+		</model>
 		<model name='(HV)'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:5,DA:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Stealth)'>
 			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:5,MOC:5</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:6,CC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4</availability>
-		<model name='PGD-L3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PGD-L3'>
+			<availability>General:4</availability>
 		</model>
 		<model name='PGD-R3'>
 			<roles>ground_support</roles>
@@ -12653,42 +12653,42 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CDS:5,RA:5,CWIE:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:8,CNC:4,CWIE:8</availability>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>RD:3,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>RD:6,CDS:9,CW:6,General:7,CGB:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:8,CDS:6,General:8,CJF:7,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:3</availability>
+		<model name='H'>
+			<availability>RD:3,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>RD:6,CDS:9,CW:6,General:7,CGB:6</availability>
+		<model name='Prime'>
+			<availability>RD:8,CDS:6,General:8,CJF:7,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -12708,23 +12708,23 @@
 	</chassis>
 	<chassis name='Prefect' unitType='Mek'>
 		<availability>ROS:3</availability>
-		<model name='PRF-3R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='PRF-2R'>
 			<availability>General:4</availability>
 		</model>
 		<model name='PRF-1R'>
 			<availability>General:8</availability>
 		</model>
+		<model name='PRF-3R'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Quad)'>
-			<availability>CHH:6+</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='(Quad)'>
+			<availability>CHH:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12742,59 +12742,59 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
+		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>Periphery:4</availability>
-		</model>
-		<model name='(ECM)'>
-			<roles>support</roles>
-			<availability>General:4,Periphery:4</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
-			<availability>RD:4,IS:4,Periphery:4,CGB:4,RA:4</availability>
 		</model>
 		<model name='(Security)'>
 			<roles>apc</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
+		<model name='(ECM)'>
+			<roles>support</roles>
+			<availability>General:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>General:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>RD:4,IS:4,Periphery:4,CGB:4,RA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:6,MERC:3+,RA:6,BAN:5,CWIE:7,MERC.WD:5,RD:5,CDS:7,CW:7,ROS:4+,CNC:7,CJF:4,CGB:5</availability>
-		<model name='H'>
-			<availability>CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>RD:3,CDS:5,CW:5,General:4,CGB:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CHH:6,RD:3,CDS:7,CW:6,CNC:4,General:5,CJF:6,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:4,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>RD:5,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,RD:8,CDS:6,CW:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:3,CDS:5,CW:5,General:4,CGB:3</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CHH:6,RD:3,CDS:7,CW:6,CNC:4,General:5,CJF:6,CGB:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>RD:5,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12814,15 +12814,15 @@
 		<model name='[PPC] (RAF)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Quaestor Mobile Tactical Command HQ' unitType='Tank'>
@@ -12834,11 +12834,11 @@
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>Periphery.Deep:4,Periphery:6</availability>
@@ -12846,40 +12846,40 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:4,CC:5,OP:6,IS:3,FS:5,CDP:3,Periphery:3,TC:2,DTA:6,RA.OA:3,FVC:3,RD:5,RF:6,LA:3,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4,CGB:5</availability>
-		<model name='QKD-5K'>
-			<availability>MERC:5,DC:4</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:6,FWL:8</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:5</availability>
 		</model>
-		<model name='QKD-9M'>
-			<roles>spotter</roles>
-			<availability>CC:4,MOC:4,ROS:2,DA:4,FS:2</availability>
+		<model name='QKD-5M'>
+			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:8,IS:8,MH:8,TC:8,Periphery:4</availability>
 		</model>
 		<model name='QKD-8K'>
 			<availability>RD:5,ROS:5,MERC:4,DC:8,CGB:5</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='QKD-9M'>
+			<roles>spotter</roles>
+			<availability>CC:4,MOC:4,ROS:2,DA:4,FS:2</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:8,IS:8,MH:8,TC:8,Periphery:4</availability>
+		<model name='QKD-C'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:6,FWL:8</availability>
+		<model name='QKD-5K'>
+			<availability>MERC:5,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:4,ROS:5,RCM:4,DA:4,MERC:4</availability>
-		<model name='(GL)' mechanized='true'>
+		<model name='(David)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(David)' mechanized='true'>
+		<model name='(GL)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -12893,15 +12893,15 @@
 	</chassis>
 	<chassis name='R10 Mechanized ICV' unitType='Tank' omni='IS'>
 		<availability>CC:4,OP:5,CLAN.IS:4,MERC:4,CWIE:4,DTA:5,RF:5,CW:4,ROS:4,CNC:4,FWL:5,MSC:6,DA:5,RCM:5</availability>
+		<model name='(B)'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Prime)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='(A)'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(B)'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -12914,24 +12914,24 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:6</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden II Battle Armor' unitType='BattleArmor'>
@@ -12945,32 +12945,24 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,ROS:3,FS:4,MERC:3</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
-		</model>
-		<model name='MDG-1Ar'>
-			<availability>ROS:8,FS:4,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1Ar'>
+			<availability>ROS:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:6,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:5,CDP:6,DC:4</availability>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV2'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4</availability>
 		</model>
 		<model name='VV22'>
 			<roles>urban</roles>
@@ -12980,20 +12972,28 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='VV2'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4</availability>
+		</model>
+		<model name='VV1 (MG)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,ROS:4,CLAN:2</availability>
+		<model name='RPR-300'>
+			<availability>LA:6,ROS:6,MERC:4</availability>
+		</model>
 		<model name='RPR-100'>
 			<availability>General:2</availability>
-		</model>
-		<model name='RPR-300S'>
-			<availability>LA:6</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:6,ROS:6,MERC:4</availability>
+		<model name='RPR-300S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -13002,15 +13002,11 @@
 			<roles>specops</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='RPT-5X'>
+		<model name='RPT-2X2'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='RPT-2X2'>
+		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
@@ -13018,51 +13014,55 @@
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>FS:4,DC:6</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='RTX1-OA'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,TC:6,Periphery:4</availability>
-		<model name='(MH)' mechanized='false'>
-			<availability>MH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
 		</model>
 		<model name='(LRM)' mechanized='false'>
 			<availability>General:4,MH:0</availability>
+		</model>
+		<model name='(MH)' mechanized='false'>
+			<availability>MH:8</availability>
 		</model>
 		<model name='(LRM) [MH]' mechanized='false'>
 			<availability>General:4</availability>
@@ -13077,14 +13077,6 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:6,MOC:2,FWL:2,MERC:5,DA:3,TC:2</availability>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:4</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
@@ -13093,21 +13085,29 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,MERC:2,DC:2,TC:2</availability>
 		</model>
+		<model name='RVN-4Lr'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:4</availability>
+		</model>
 		<model name='RVN-4L'>
 			<roles>spotter</roles>
 			<availability>CC:5,MOC:5,DA:6,TC:5</availability>
 		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>OP:4,RF:4,LA:6,ROS:4,MH:4,MERC:4,FS:4,DA:4</availability>
-		<model name='RZK-10T'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='RZK-10S'>
 			<availability>LA:5</availability>
@@ -13128,12 +13128,12 @@
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -13144,15 +13144,23 @@
 		<model name='(Stealth)'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,RA.OA:7,LA:7,ROS:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,Periphery:10,TC:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:1,CW:1,General:8,CNC:1</availability>
@@ -13161,27 +13169,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:1,OP:8,FS:2,MERC:1,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8,DC:2</availability>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:5,DTA:6,OP:6,RF:6,ROS:8,FWL:7,MSC:6,FS:5,MERC:7,DA:6,RCM:6</availability>
+		<model name='F-100'>
+			<availability>FVC:2-,Periphery:2-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>MOC:5,CC:5,DTA:8,OP:8,ROS:6,FWL:8,MSC:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>FVC:3-,Periphery:3-</availability>
@@ -13189,51 +13192,47 @@
 		<model name='F-700'>
 			<availability>CC:8,MOC:5,DTA:8,OP:8,RF:8,ROS:8,FWL:8,MSC:8,MERC:8,RCM:8,DA:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>MOC:5,CC:5,DTA:8,OP:8,ROS:6,FWL:8,MSC:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='F-100'>
-			<availability>FVC:2-,Periphery:2-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:5,DTA:6,OP:6,RF:6,ROS:8,FWL:7,MSC:6,FS:5,MERC:7,DA:6,RCM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:5,CNC:5,IS:3,RA:5,CGB:5</availability>
-		<model name='8'>
-			<availability>CC:4,OP:4,RD:6,CDS:4,LA:4,IS:4,MSC:4,FS:4,MERC:4,DC:4,CGB:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:4,IS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:2,CNC:2,RA:2</availability>
+		<model name='3'>
+			<availability>CDS:4,ROS:4,MERC:4,FS:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:8,DC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:2,CNC:2,RA:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:4,IS:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='8'>
+			<availability>CC:4,OP:4,RD:6,CDS:4,LA:4,IS:4,MSC:4,FS:4,MERC:4,DC:4,CGB:6</availability>
 		</model>
 		<model name='6'>
 			<availability>CHH:4,CDS:5</availability>
 		</model>
-		<model name='3'>
-			<availability>CDS:4,ROS:4,MERC:4,FS:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CNC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:4,ROS:6,IS:4,FWL:7,FS:8,CJF:6,Periphery:3</availability>
+		<model name='RFL-5D'>
+			<availability>FVC:4,LA:2,FS:3,MERC:3</availability>
+		</model>
 		<model name='RFL-7M'>
 			<availability>DTA:8,MOC:4,OP:8,RF:8,FWL:8,IS:4,MSC:8,DA:8,RCM:8,CDP:4,DC:5,TC:4</availability>
 		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:4,LA:2,FS:3,MERC:3</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:1,FS:1,MERC:1</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:2</availability>
@@ -13242,8 +13241,22 @@
 			<roles>fire_support</roles>
 			<availability>CC:1-,MOC:2-,OP:1-,PIR:2-,MH:2-,FS:1-,DA:1-,RCM:1-</availability>
 		</model>
+		<model name='RFL-5M'>
+			<availability>CC:2,MOC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:2,DC:2</availability>
+		</model>
 		<model name='C 2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='RFL-8X'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='RFL-7X'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,MERC:5</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:3</availability>
@@ -13251,49 +13264,36 @@
 		<model name='RFL-9T'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='RFL-8X'>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:1,FS:1,MERC:1</availability>
-		</model>
-		<model name='RFL-7X'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,MERC:5</availability>
-		</model>
-		<model name='RFL-5M'>
-			<availability>CC:2,MOC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:2,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,ROS:6,CLAN:2,FS:5,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5,ROS:4,FS:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>CNC:4,FS:4,DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:4</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
+		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>CNC:4,FS:4,DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Roadrunner (Emerald Harrier)' unitType='Mek'>
@@ -13305,14 +13305,14 @@
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CHH:4,CNC:7,RA:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>RA:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:4,RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>RA:6</availability>
@@ -13320,22 +13320,19 @@
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>RD:6-,CGB:6-</availability>
-		<model name='(Hybrid)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Hybrid)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>RA.OA:5,FVC:4,RF:4,LA:5,ROS:4,FS:3,MERC:2,CWIE:6,TC:6</availability>
-		<model name='(Gauss)'>
-			<availability>FRR:0,General:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
@@ -13346,6 +13343,9 @@
 			<roles>artillery,fire_support</roles>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>FRR:0,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
 		<availability>FS:4,MERC:2</availability>
@@ -13355,14 +13355,14 @@
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
 		<availability>DTA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='NH-3X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='NH-2'>
 			<availability>General:8</availability>
 		</model>
 		<model name='NH-1B'>
 			<availability>ROS:2-,MERC:2-,FS:2-</availability>
+		</model>
+		<model name='NH-3X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -13382,12 +13382,12 @@
 			<roles>recon</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13400,29 +13400,29 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,CDS:4,CLAN:4,MERC:3+,CJF:4,RA:5,BAN:5,CWIE:5,DC:4+</availability>
-		<model name='D'>
-			<availability>RD:3,CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:3,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='A'>
 			<availability>RD:3,CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:3,General:2</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
+		<model name='B'>
+			<availability>RD:3,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CNC:4,General:5,CJF:4,RA:6,CWIE:6</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:3,CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:6,General:5,RA:6,CWIE:5,CGB:6</availability>
@@ -13436,20 +13436,20 @@
 		<model name='3'>
 			<availability>CHH:8,RD:4,ROS:4,CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>RD:8,CDS:8,IS:8,CGB:8</availability>
-		</model>
 		<model name='2'>
 			<availability>RD:6,ROS:6,CGB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RD:8,CDS:8,IS:8,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
 		<availability>CNC:7,DC:5</availability>
-		<model name='SM1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Telos)'>
 			<availability>CNC:2,DC:3</availability>
+		</model>
+		<model name='SM1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1A Tank Destroyer' unitType='Tank'>
@@ -13460,13 +13460,13 @@
 	</chassis>
 	<chassis name='SM2 Heavy Artillery Vehicle' unitType='Tank'>
 		<availability>DTA:4,OP:4,CDS:4,ROS:4,CNC:5,FWL:4,MSC:4,MERC:4,CJF:4,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LTC)'>
 			<roles>artillery</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM3 Tank Destroyer' unitType='Tank'>
@@ -13481,13 +13481,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:8,Periphery:4</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,DC:6,Periphery:6</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13498,14 +13498,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4,MOC:4,RA.OA:2-,LA:4,ROS:4,CLAN:2,IS:3-,FWL:2-,FS:3,MERC:4,Periphery:3-,DC:5</availability>
-		<model name='SB-27'>
-			<availability>General:2-</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='SB-27'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
@@ -13517,17 +13517,8 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -13536,8 +13527,17 @@
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -13545,21 +13545,21 @@
 		<model name='SGT-8R'>
 			<availability>FVC:8,FS:5</availability>
 		</model>
-		<model name='SGT-10X'>
-			<availability>ROS:6,FS:6,MERC:6</availability>
-		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:6,FS:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittarii' unitType='Aero'>
 		<availability>ROS:7</availability>
-		<model name='SGT-2R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SGT-3R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='SGT-2R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
@@ -13567,11 +13567,11 @@
 		<model name='S-4C'>
 			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
-		<model name='S-8'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
+		</model>
+		<model name='S-8'>
+			<availability>ROS:8,DC:8</availability>
 		</model>
 		<model name='S-7'>
 			<availability>ROS:6,CNC:6,DC:6</availability>
@@ -13579,26 +13579,26 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:2,LA:4,DC.AL:8,IS:4,FWL:4,MERC:4,Periphery.OS:2,FS:3,CJF:4,DC:7</availability>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>IS:8,DC:8</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CW:6,RA:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CW:6,RA:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -13607,14 +13607,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-7T'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -13623,9 +13615,17 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
 		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='PPR-7T'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
@@ -13634,33 +13634,33 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>LA:5,ROS:5</availability>
-		<model name='SL-27'>
-			<availability>IS:6,DC:6</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:3,CC:2-,Periphery.DD:5,IS:2-,Periphery.OS:5,Periphery:3,TC:3,RA.OA:5,CDS:2,LA:2-,ROS:2-,FWL:3-,DC:4-</availability>
-		<model name='(MRM)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:3-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarath' unitType='Mek' omni='IS'>
 		<availability>RF:4</availability>
+		<model name='SRTH-1O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='SRTH-1OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SRTH-1OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='SRTH-1O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -13685,17 +13685,17 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CNC:3,RA:4</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CNC:4,RA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CNC:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XP'>
 			<availability>CNC:8</availability>
@@ -13703,11 +13703,8 @@
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:5</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
@@ -13715,8 +13712,11 @@
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -13738,10 +13738,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -13749,6 +13745,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -13760,34 +13760,34 @@
 		<model name='(Primary)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(H)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(G)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(B)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(I)'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(C)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(J)'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(E)'>
 			<roles>artillery</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(I)'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(H)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(J)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(F)'>
 			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(B)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(G)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(A)'>
@@ -13807,62 +13807,62 @@
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:3</availability>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
+		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Schildkrote Line Tank' unitType='Tank'>
 		<availability>LA:3-,LA.pm:4,MERC:3-</availability>
-		<model name='(HPPC)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(HPPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,OP:4,RD:4,ROS:5,FWL:4,FS:4,MERC:4,DC:4,CGB:4</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='SCK-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCK-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SCK-OA'>
 			<roles>interceptor</roles>
@@ -13871,30 +13871,30 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>RA.OA:1,RD:3,CNC:3,Periphery:2,RA:3</availability>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:5</availability>
+		<model name='(Armor)'>
+			<availability>RD:8,CNC:8,IS:6,RA:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:5</availability>
+		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>RD:8,CNC:8,IS:6,RA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:2-,CC:2-,RA.OA:4-,Periphery.DD:3-,LA:1-,IS:1-,MERC:1-,Periphery.OS:3-,Periphery:2-,TC:2-,DC:4-</availability>
+		<model name='(Standard)'>
+			<availability>General:2-</availability>
+		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2-</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:8,DC:8</availability>
@@ -13908,58 +13908,58 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:5,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(LRM)'>
-			<availability>General:1-</availability>
-		</model>
-		<model name='(Minesweeper)'>
-			<roles>minesweeper</roles>
-			<availability>CC:4-,MOC:2-</availability>
+		<model name='(MRM)'>
+			<availability>IS:5,DC:5,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:6,MOC:5,LA:6,ROS:6,FWL:6,IS:5,MH:5,FS:6,MERC:6,CDP:5,DC:6,TC:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='(ML)'>
 			<availability>General:1-</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>IS:5,DC:5,Periphery:4</availability>
+		<model name='(LAC)'>
+			<availability>CC:6,MOC:5,LA:6,ROS:6,FWL:6,IS:5,MH:5,FS:6,MERC:6,CDP:5,DC:6,TC:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:1-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(Minesweeper)'>
+			<roles>minesweeper</roles>
+			<availability>CC:4-,MOC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2,FVC:2,LA:4,ROS:2,FWL:2,MERC:2,DC:4,Periphery:3</availability>
-		<model name='SCP-1N'>
-			<availability>Periphery:2-</availability>
+		<model name='SCP-12S'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>IS:2,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='SCP-10M'>
-			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,DC:6</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
+		<model name='SCP-10M'>
+			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Scourge' unitType='Mek'>
 		<availability>OP:4,LA:4,FWL:4,IS:3,Periphery:2</availability>
-		<model name='SCG-WF1'>
-			<availability>OP:8,LA:8,FWL:8</availability>
-		</model>
 		<model name='SCG-WD1'>
 			<availability>OP:6,LA:6,General:8,FWL:6</availability>
+		</model>
+		<model name='SCG-WF1'>
+			<availability>OP:8,LA:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -13977,38 +13977,38 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
+		<model name='3'>
+			<availability>CJF:5</availability>
+		</model>
 		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CHH:2,CW:4,CNC:5,CLAN:4,CJF:6,RA:5,CWIE:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='X'>
 			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Fox Amphibious Armor' unitType='BattleArmor'>
@@ -14019,14 +14019,14 @@
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(SRM6)'>
 			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:2</availability>
@@ -14040,13 +14040,13 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,LA:6,IS:4,FWL:4,FS:5,Periphery:3,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:8,FWL:4,IS:6,FS:8</availability>
+		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sekhmet Assault Vehicle' unitType='Tank'>
@@ -14064,14 +14064,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CLAN:1,FS:4,MERC:4,CWIE:1,DC.GHO:3,FVC:4,RD:2,CDS:1,CW:1,LA:4,ROS:3,CJF:2,CGB:2,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -14089,16 +14089,16 @@
 			<roles>interceptor</roles>
 			<availability>Periphery:1-</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6,CGB:6</availability>
+		<model name='SYD-Z3A'>
+			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3,CGB:3</availability>
 		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>Periphery:3-</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3,CGB:3</availability>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6,CGB:6</availability>
 		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
@@ -14113,14 +14113,14 @@
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6,MOC:5</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -14142,16 +14142,12 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CDS:5,ROS:4+,CNC:7,MERC:2+,CJF:5,RA:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CW:3,General:6,RA:8</availability>
-		</model>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>CW:3,General:6,RA:3</availability>
 		</model>
 		<model name='J'>
 			<availability>General:5</availability>
@@ -14159,69 +14155,73 @@
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
+		<model name='A'>
 			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
+			<availability>CW:3,General:6,RA:3</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CW:3,General:6,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>OP:3,CHH:4,IS:3,FS:3,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3,CGB:4</availability>
-		<model name='8'>
-			<availability>CDS:4,LA:6,CNC:6,IS:4,CWIE:6</availability>
-		</model>
-		<model name='2'>
-			<availability>RD:2,CGB:2</availability>
-		</model>
-		<model name='7'>
-			<availability>RA.OA:8,RA:8</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:5,CNC:5,IS:6,RA:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:5,CNC:5,IS:6</availability>
+		<model name='6'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='5'>
 			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,DC:8,CGB:4</availability>
 		</model>
-		<model name='6'>
-			<availability>CHH:8</availability>
+		<model name='2'>
+			<availability>RD:2,CGB:2</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:4,LA:6,CNC:6,IS:4,CWIE:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:5,CNC:5,IS:6,RA:6</availability>
+		</model>
+		<model name='7'>
+			<availability>RA.OA:8,RA:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:5,CNC:5,IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>RD:4,IS:4,Periphery.Deep:4,BAN:4,Periphery:6,CGB:4</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:5,FS:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>RD:4,DC:8,CGB:4</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:1-,MOC:2-,FWL:1-,MH:2-,MERC:1-</availability>
 		</model>
-		<model name='SHD-2H'>
-			<availability>General:1-,Periphery:2-</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>RD:8,ROS:5,CGB:8,DC:4</availability>
-		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,Periphery:4,DC:6</availability>
-		</model>
-		<model name='SHD-8L'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,DTA:8,OP:8,FVC:3,ROS:4,MSC:8,MERC:4,RCM:8,CDP:3,TC:3</availability>
-		</model>
-		<model name='SHD-9D'>
-			<availability>FS:6</availability>
 		</model>
 		<model name='SHD-5D'>
 			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SHD-3K'>
-			<availability>RD:4,DC:8,CGB:4</availability>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,DTA:8,OP:8,FVC:3,ROS:4,MSC:8,MERC:4,RCM:8,CDP:3,TC:3</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>General:1-,Periphery:2-</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>RD:8,ROS:5,CGB:8,DC:4</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='SHD-8L'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>FVC:5,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -14229,40 +14229,40 @@
 		<model name='(Flamer)'>
 			<availability>CDS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:4,RD:6,CDS:4,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:6,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
 		<availability>MOC:7,FVC:3,PIR:3,IS:7,CDP:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MOC:8,IS:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>recon</roles>
 			<availability>FVC:8,PIR:8,IS:3,CDP:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MOC:8,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shen Long Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MOC:5</availability>
+		<model name='[Pop-Up Mine]' mechanized='false'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[David Light Gauss]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Interdictor]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Pop-Up Mine]' mechanized='false'>
-			<availability>General:5</availability>
-		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[David Light Gauss]' mechanized='false'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='false'>
 			<availability>General:8</availability>
@@ -14270,12 +14270,12 @@
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
 		<availability>CC:5</availability>
+		<model name='SHY-3B'>
+			<availability>General:5</availability>
+		</model>
 		<model name='SHY-5B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='SHY-3B'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sheriff Infantry Support Tank' unitType='Tank'>
@@ -14299,14 +14299,14 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,CGB.FRR:7,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RD:2,CGB.FRR:2,RA:2</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shiva' unitType='Aero'>
@@ -14320,6 +14320,9 @@
 		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SHV-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
 		</model>
@@ -14329,43 +14332,40 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:4,DTA:5,OP:5,ROS:4,FWL:4,MSC:5,FS:3,RCM:4,DC:3</availability>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
+		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
 		</model>
 		<model name='SKW-6H'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,RD:4,CDS:4,CW:3,ROS:3,CNC:5,CGB:4,CWIE:3,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,DC:6</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
 		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:3,ROS:3,CGB.FRR:4,MERC:3,Periphery.OS:3,FS:1-,DC:6,Periphery:2</availability>
-		<model name='SL-22'>
-			<availability>FVC:6,RD:8,ROS:8,CGB.FRR:8,Periphery.Deep:4,MERC:6,DC:8,Periphery:6</availability>
-		</model>
 		<model name='SL-21L'>
 			<roles>raider,ground_support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='SL-22'>
+			<availability>FVC:6,RD:8,ROS:8,CGB.FRR:8,Periphery.Deep:4,MERC:6,DC:8,Periphery:6</availability>
 		</model>
 		<model name='SL-21'>
 			<availability>FVC:4,MERC:1,Periphery:4</availability>
@@ -14382,10 +14382,10 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='2'>
+		<model name='3'>
 			<availability>General:4</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -14417,10 +14417,6 @@
 	</chassis>
 	<chassis name='Simurgh' unitType='Aero' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='SMG-OA'>
-			<roles>assault</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='SMG-O'>
 			<roles>assault</roles>
 			<availability>General:8</availability>
@@ -14429,14 +14425,18 @@
 			<roles>assault</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SMG-OA'>
+			<roles>assault</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,OP:5,ROS:3,MSC:5,MERC:3</availability>
-		<model name='SRC-5C'>
-			<availability>DTA:5,OP:5,ROS:5,MSC:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>DTA:5,OP:5,ROS:5,MSC:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>DTA:6,OP:6,ROS:6,MSC:6</availability>
@@ -14463,42 +14463,42 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:2,Periphery.DD:3,IS:1,MERC:1,Periphery.OS:3,FS:1,RA.OA:1,FVC:1,LA:1,CGB.FRR:3-,ROS:2-,FWL:2,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:3-</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FVC:3,IS.pm:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:3-</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7,CGB:6</availability>
+		<model name='SL-15'>
+			<availability>ROS:0,FS:0,Periphery:2-</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>RA.OA:6,RD:6,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4,CGB:6</availability>
 		</model>
 		<model name='SL-15K'>
 			<availability>RD:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,FS:0,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>LA:1</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='(Huntsman)' mechanized='false'>
 			<availability>LA:4,MERC:4,FS:4</availability>
@@ -14532,11 +14532,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -14548,10 +14548,6 @@
 	</chassis>
 	<chassis name='Sokuryou' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='SKU-181 SurveyMech'>
-			<roles>support,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='SKU-197 SurveyMech'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -14559,6 +14555,10 @@
 		<model name='SKU-198 SurveyMech'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKU-181 SurveyMech'>
+			<roles>support,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -14596,27 +14596,27 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+		<model name='SPR-7D'>
+			<availability>ROS:5,FS:5,MERC:5</availability>
+		</model>
+		<model name='SPR-DH'>
+			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
+		</model>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:1-,FS:1-,MERC:1-,CDP:1-,TC:1-</availability>
-		</model>
-		<model name='SPR-7D'>
-			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-DH'>
-			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -14631,21 +14631,21 @@
 		<model name='SPR-5S'>
 			<availability>CC:4,LA:4,ROS:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8</availability>
 		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:6,MERC:4,CDP:6,RA:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(RA)' mechanized='true'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -14653,29 +14653,44 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:4,CNC:4-</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:4,CNC:7</availability>
 		</model>
-		<model name='2'>
-			<availability>ROS:6,CNC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:1,CC:2,FVC:2,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MERC:2,FS:2,Periphery:2,TC:1,DC:6</availability>
+		<model name='SDR-10K'>
+			<availability>ROS:3</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:5,MERC:4</availability>
+		</model>
+		<model name='SDR-8X'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>Periphery:2-</availability>
 		</model>
 		<model name='SDR-7Kr'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='SDR-10K'>
-			<availability>ROS:3</availability>
-		</model>
 		<model name='SDR-7K'>
 			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
+		<model name='SDR-8Xr'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
@@ -14683,26 +14698,11 @@
 		<model name='SDR-7KC'>
 			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='SDR-8K'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='SDR-8Xr'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>ROS:3,MERC:3,DC:4</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:5,MERC:4</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2</availability>
-		</model>
-		<model name='SDR-8X'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
+		<model name='SDR-8K'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -14722,13 +14722,17 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:5,FVC:5,LA:7,ROS:7,IS:6,MH:3,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>IS:4,DC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -14737,10 +14741,6 @@
 		<model name='(Interdictor)'>
 			<roles>spotter</roles>
 			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,DC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14751,14 +14751,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:4,CC:2,CLAN:2,IS:5,Periphery.Deep:8,FS:4,Periphery:10,TC:6,RA.OA:6,LA:5,ROS:3,FWL:6,DC:2</availability>
+		<model name='STK-4P'>
+			<availability>MERC:1,Periphery:1</availability>
+		</model>
 		<model name='STK-8S'>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:3,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>MERC:1,Periphery:1</availability>
+		<model name='STK-6M'>
+			<availability>CC:5,MOC:5,OP:6,RF:6,ROS:6,FWL:6,MERC:6,DA:5,RCM:6</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
@@ -14766,20 +14769,17 @@
 		<model name='STK-7D'>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>Periphery:2-</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,OP:3,RF:3,CLAN:8,FWL:3,MERC:3,DA:3,RCM:3,BAN:2</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:3,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
-		</model>
-		<model name='STK-6M'>
-			<availability>CC:5,MOC:5,OP:6,RF:6,ROS:6,FWL:6,MERC:6,DA:5,RCM:6</availability>
+		<model name='STK-3F'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
@@ -14805,12 +14805,12 @@
 	</chassis>
 	<chassis name='Starslayer' unitType='Mek'>
 		<availability>MOC:4,CC:4,OP:4,RF:4,LA:6,ROS:4,FS:4,DA:4</availability>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='STY-3D'>
 			<roles>raider</roles>
 			<availability>MOC:4,CC:3,OP:3,LA:4,ROS:3,FS:3,MERC:4</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
@@ -14819,6 +14819,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>LA:2,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
@@ -14827,28 +14831,24 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>FS:6,MERC:4</availability>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:5,LA:6,MERC:2</availability>
-		<model name='STM-OB'>
+		<model name='STM-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STM-OA'>
+		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14860,11 +14860,11 @@
 		<model name='STO-4B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-6S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -14879,33 +14879,29 @@
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,RD:1-,IS:7,MERC:7,Periphery:6,DC:4,CGB:1-</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>BAN:8,Periphery:2-</availability>
-		</model>
-		<model name='STG-5G'>
-			<roles>recon</roles>
-			<availability>CC:5,OP:4,FVC:4,ROS:4,MH:4,RCM:4,DA:4,FS:4,CDP:5,TC:5</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
 		</model>
-		<model name='STG-3Gb'>
-			<roles>recon</roles>
-			<availability>CC:4,OP:6,CLAN:8,FWL:5,MSC:6,RCM:6,DA:6,MERC:4,BAN:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,DC:6</availability>
-		</model>
 		<model name='STG-6L'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:4,DA:4</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
+		<model name='STG-5G'>
+			<roles>recon</roles>
+			<availability>CC:5,OP:4,FVC:4,ROS:4,MH:4,RCM:4,DA:4,FS:4,CDP:5,TC:5</availability>
+		</model>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>CC:4,OP:6,CLAN:8,FWL:5,MSC:6,RCM:6,DA:6,MERC:4,BAN:2</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>BAN:8,Periphery:2-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -14919,35 +14915,36 @@
 			<roles>recon</roles>
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
-		<model name='F-95'>
-			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:8,MSC:6,MERC:5,RCM:6,DA:6</availability>
-		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
-		</model>
-		<model name='F-92'>
-			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,IS:4,MH:4</availability>
 		</model>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
 		</model>
+		<model name='F-92'>
+			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,IS:4,MH:4</availability>
+		</model>
+		<model name='F-95'>
+			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:8,MSC:6,MERC:5,RCM:6,DA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CGB:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -14955,11 +14952,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14971,56 +14971,62 @@
 	</chassis>
 	<chassis name='Storm Raider' unitType='Mek'>
 		<availability>RF:3,LA:4,ROS:3,MH:3,MERC:3,FS:3,Periphery:3</availability>
-		<model name='STM-R1'>
-			<availability>General:3</availability>
-		</model>
 		<model name='STM-R3'>
 			<availability>LA:8,MH:8,MERC:8</availability>
-		</model>
-		<model name='STM-R2'>
-			<availability>General:4</availability>
 		</model>
 		<model name='STM-R4'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
+		<model name='STM-R1'>
+			<availability>General:3</availability>
+		</model>
+		<model name='STM-R2'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:5,MOC:5,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:5,DC:7</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,FS:5,MERC:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,FWL:1,DC:1,CGB:4</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
 		</model>
@@ -15032,23 +15038,17 @@
 			<roles>fire_support</roles>
 			<availability>FVC:2-,IS:1-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
+		<model name='(SRM)'>
+			<availability>FVC:2-,IS:1-</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,ROS:3,FS.DMM:8,FS:3</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>FVC:2-,IS:1-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
@@ -15075,27 +15075,27 @@
 		<model name='STU-K5'>
 			<availability>FVC:2-,BAN:8,Periphery:2-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>ROS:6,FS:8,MERC:4</availability>
+		<model name='STU-D6'>
+			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>ROS:6,CLAN:8,FS:4,MERC:4,BAN:2</availability>
 		</model>
-		<model name='STU-D6'>
-			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
+		<model name='STU-D7'>
+			<availability>ROS:6,FS:8,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:2,CDS:2,RF:3,LA:3,ROS:3,CNC:2,FS:2,CWIE:2</availability>
+		<model name='(Heavy Gauss)'>
+			<availability>RF:5,LA:6,CNC:6,CWIE:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='(Heavy Gauss)'>
-			<availability>RF:5,LA:6,CNC:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
@@ -15114,12 +15114,6 @@
 		<model name='E'>
 			<availability>RD:5,CW:5,CLAN:2,CGB:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:6,General:2,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>RD:6,CW:6,General:2,CGB:6</availability>
 		</model>
@@ -15129,18 +15123,31 @@
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7,CGB:7</availability>
 		</model>
+		<model name='C'>
+			<availability>RD:6,General:2,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CDS:3,CW:5,ROS:3,FS:4,MERC:2</availability>
-		<model name='2'>
-			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:4,CW:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OE'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
 		</model>
@@ -15148,36 +15155,29 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>RD:3,CDS:4,CW:5,ROS:3,CNC:9,CWIE:5,CGB:3</availability>
-		<model name='2'>
-			<availability>ROS:6,CNC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:6,CNC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -15212,11 +15212,11 @@
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:4,LA:5,ROS:4,FWL:4,FS:4,MERC:4</availability>
-		<model name='(Original)'>
-			<availability>LA:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<availability>LA:4,MERC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -15231,15 +15231,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -15247,19 +15247,15 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:2,RA:4</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:6</availability>
@@ -15268,15 +15264,19 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>ROS:4,DC:6</availability>
+		<model name='TSH-8S'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Taihou Assault Dropship' unitType='Dropship'>
@@ -15300,17 +15300,17 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(RL)'>
-			<availability>MOC:4</availability>
-		</model>
 		<model name='2'>
 			<availability>MOC:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(RL)'>
+			<availability>MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Taranis Battle Armor' unitType='BattleArmor'>
@@ -15321,10 +15321,6 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DTA:6,OP:6,ROS:4,FWL:6,MSC:6,MERC:4,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>MOC:5,CC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,ROS:6,MSC:8,MERC:6,DC:8</availability>
@@ -15333,21 +15329,21 @@
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,ROS:5,FWL:8,MSC:8,MERC:4,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>MOC:5,CC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:4,MERC:2</availability>
-		<model name='TRG-2N'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='TRG-1N'>
 			<roles>recon</roles>
 			<availability>ROS:8</availability>
@@ -15356,29 +15352,33 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TRG-2N'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,DC:6</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='MIK-OE'>
+			<availability>General:5</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OE'>
-			<availability>General:5</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-OF'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -15390,74 +15390,74 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>DTA:8,OP:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,MERC:4</availability>
-		<model name='TMP-3M'>
-			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>RF:4,ROS:4,MSC:4,MERC:4</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>DTA:6,OP:6,ROS:6,MSC:6,MERC:4</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>ROS:2,FWL:2,MERC:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>DTA:6,OP:6,ROS:6,MSC:6,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar III' unitType='Mek' omni='IS'>
 		<availability>FS:4</availability>
-		<model name='TLR2-OC'>
+		<model name='TLR2-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='TLR2-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-OB'>
+		<model name='TLR2-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-O'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:5</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OI'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OE'>
+		<model name='TLR1-OF'>
 			<roles>spotter</roles>
-			<availability>General:3</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OF'>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OE'>
 			<roles>spotter</roles>
-			<availability>General:2</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tenshi' unitType='Mek' omni='IS'>
@@ -15468,11 +15468,11 @@
 		<model name='TN-10-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TN-10-OR'>
-			<availability>General:6</availability>
-		</model>
 		<model name='TN-10-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TN-10-OR'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -15484,6 +15484,10 @@
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>ROS:6,DC:4</availability>
+		<model name='TSN-C3M'>
+			<roles>recon,spotter</roles>
+			<availability>ROS:4,DC:4</availability>
+		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
@@ -15492,20 +15496,16 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-C3M'>
-			<roles>recon,spotter</roles>
-			<availability>ROS:4,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CW:1,CJF:1,RA:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -15513,11 +15513,11 @@
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TNS-6S'>
-			<availability>LA:6,IS:4</availability>
-		</model>
 		<model name='TNS-4T'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='TNS-6S'>
+			<availability>LA:6,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -15536,8 +15536,15 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:1,CLAN:1,RA:1,BAN:3,CWIE:2,MERC.WD:2,RD:1,CDS:1,CW:1,ROS:3+,CNC:2,CJF:4,CGB:1</availability>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>RD:3,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,RD:4,CDS:4,CW:6,CNC:4,General:2,CJF:5,CWIE:5,CGB:4</availability>
@@ -15545,45 +15552,38 @@
 		<model name='D'>
 			<availability>RD:8,CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>RD:3,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>RD:6,CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:2,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>RD:6,CW:6,General:5,CJF:6,CGB:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3,CWIE:5</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:2,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
@@ -15592,14 +15592,14 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
@@ -15607,34 +15607,34 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:5</availability>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,RA:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3,FS:4,MERC:3,Periphery:3,TC:5</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:3,FVC:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -15654,13 +15654,13 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>IS:4,Periphery:4</availability>
-		<model name='Angel'>
-			<roles>artillery</roles>
-			<availability>DTA:6,LA:4,ROS:4,FWL:5,FS:4,DC:4</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:6,IS:6</availability>
+		</model>
+		<model name='Angel'>
+			<roles>artillery</roles>
+			<availability>DTA:6,LA:4,ROS:4,FWL:5,FS:4,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
@@ -15669,12 +15669,6 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:5,ROS:6,DC:4</availability>
-		<model name='TFT-A9'>
-			<availability>ROS:8,General:4</availability>
-		</model>
-		<model name='TFT-F11'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
@@ -15682,18 +15676,24 @@
 		<model name='TFT-L8'>
 			<availability>LA:8</availability>
 		</model>
+		<model name='TFT-F11'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='TFT-A9'>
+			<availability>ROS:8,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:6,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6,ROS:6,MERC:4</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:8,ROS:6,MERC:5</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6,ROS:6,MERC:4</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4,ROS:4</availability>
@@ -15701,50 +15701,50 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,RF:5,MERC:4,DA:5,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-1L'>
-			<availability>General:5</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-C4'>
 			<availability>CC:4,MOC:4,CC.LCC:6</availability>
+		</model>
+		<model name='THR-1L'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:8</availability>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Pulse Laser]' mechanized='true'>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
+		<model name='[Pulse Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -15762,13 +15762,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:7</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:5,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:5,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -15783,38 +15783,47 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:5,LA:6,ROS:5,MH:4,FS:5,MERC:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TDR-1C'>
-			<availability>CC:1-,MOC:2-,LA:1-,MERC:1-,TC:2-</availability>
-		</model>
-		<model name='TDR-60-RLA'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:4,LA:4,FS:2,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
-		</model>
-		<model name='TDR-9T'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:4,MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
+		</model>
+		<model name='TDR-17S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='TDR-60-RLA'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9M'>
 			<availability>MOC:3,DTA:5,CC:3,OP:5,PIR:3,FWL:2,MH:3,MSC:5,DA:5,MERC:4</availability>
 		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='TDR-9T'>
+			<availability>TC:5</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>CC:1-,MOC:2-,LA:1-,MERC:1-,TC:2-</availability>
+		</model>
 		<model name='TDR-5Sb'>
 			<availability>TC:6</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:4,MERC:4</availability>
@@ -15825,30 +15834,21 @@
 		<model name='TDR-10S'>
 			<availability>LA:5,MERC:5</availability>
 		</model>
-		<model name='TDR-17S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
-		</model>
-		<model name='TDR-9NAIS'>
-			<availability>FS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:8,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
+		<model name='TSG-9C'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='TSG-9DDC'>
 			<availability>CC:6,CC.WHO:8</availability>
 		</model>
-		<model name='TSG-9C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat II' unitType='Dropship'>
@@ -15865,11 +15865,11 @@
 	</chassis>
 	<chassis name='Tian-Zong' unitType='Mek'>
 		<availability>CC:5+,MOC:3+</availability>
-		<model name='TNZ-N1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='TNZ-N2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='TNZ-N1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiburon' unitType='Mek'>
@@ -15895,13 +15895,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,RA:5</availability>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:8</availability>
+		</model>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2953)'>
 			<roles>asf_carrier</roles>
@@ -15919,15 +15919,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CNC:6,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>DC:3-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
 		</model>
@@ -15935,21 +15926,30 @@
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>DC:3-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>DC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:5</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>urban</roles>
@@ -15958,8 +15958,8 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CW:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -15968,15 +15968,12 @@
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CW:1</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -15985,6 +15982,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -15996,14 +15996,10 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:1,MH:1</availability>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Small Laser]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
@@ -16015,6 +16011,10 @@
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
 		<availability>PIR:2-,MH:2-,TC:2-,Periphery:1-</availability>
@@ -16025,16 +16025,16 @@
 	</chassis>
 	<chassis name='Tortoise II' unitType='BattleArmor'>
 		<availability>ROS:2</availability>
-		<model name='(C3)' mechanized='false'>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)' mechanized='false'>
+		<model name='(SRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(aSRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRM)' mechanized='false'>
+		<model name='(C3)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -16060,11 +16060,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
+		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
 		</model>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -16075,12 +16075,12 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
-		<model name='TR-12'>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='TR-12'>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -16110,16 +16110,16 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>RF:6,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>MOC:4-,Periphery:4-</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>RF:4,ROS:5,MSC:4,MERC:4</availability>
-		</model>
 		<model name='TBT-K7R'>
 			<availability>ROS:3</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TBT-XK7'>
+			<roles>fire_support</roles>
+			<availability>TC:6</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
@@ -16129,16 +16129,16 @@
 			<roles>fire_support</roles>
 			<availability>ROS:6,MSC:6,MERC:5</availability>
 		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>RF:4,ROS:5,MSC:4,MERC:4</availability>
+		</model>
 		<model name='TBT-9R'>
 			<availability>RF:5</availability>
 		</model>
-		<model name='TBT-9K'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='TBT-XK7'>
-			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>MOC:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -16152,28 +16152,28 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,MH:4,TC:8</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:6</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:3,TC:3</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
@@ -16190,13 +16190,13 @@
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,CLAN:2,IS:9,Periphery.Deep:7,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>IS:6,DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -16247,19 +16247,19 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:6+,ROS:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>General:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CW:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -16272,52 +16272,52 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>RD:4,CLAN:2,CGB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:6,General:2,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:6,General:2,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:4,CNC:4,CJF:7</availability>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:9,CW:9,General:7,CGB:9</availability>
+		</model>
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CJF:8</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:9,CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -16326,13 +16326,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -16344,17 +16344,20 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,CGB:5,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -16362,52 +16365,49 @@
 			<roles>assault</roles>
 			<availability>RD:4,CHH:8,CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,MERC.WD:1,CW:2,MERC:2+,CJF:4,RA:4,CWIE:2</availability>
-		<model name='F'>
-			<availability>CHH:6,RD:5,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,RD:2,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>RD:2,CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,RD:4,CDS:6,CW:6,General:5,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
 		<model name='B'>
 			<availability>RD:5,CDS:8,CW:6,General:7,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>RD:8,CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>RD:1,CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,IS:2</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,RD:2,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>RD:2,CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:6,RD:5,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,IS:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,RD:4,CDS:6,CW:6,General:5,CJF:6,CWIE:6,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Umbra' unitType='Aero'>
@@ -16419,11 +16419,11 @@
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:4,CW:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -16435,13 +16435,13 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:4</availability>
-		<model name='(3071)'>
-			<roles>troop_carrier</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='(3071)'>
+			<roles>troop_carrier</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -16468,17 +16468,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,Periphery:4-,TC:3-,DC:5-</availability>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:6,MOC:6,IS:5,FWL:5,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='UM-R69'>
-			<roles>urban</roles>
-			<availability>FWL:6,IS:6,Periphery:6</availability>
-		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:6,FS:6,DC:6</availability>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:4,Periphery:4</availability>
 		</model>
 		<model name='UM-R60L'>
 			<roles>urban</roles>
@@ -16488,31 +16481,38 @@
 			<roles>urban</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R68'>
 			<roles>urban</roles>
-			<availability>Periphery:2-</availability>
+			<availability>CC:6,FS:6,DC:6</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:4,MOC:4,FS.CMM:6,MSC:4,FS:4</availability>
 		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='UM-R63'>
 			<roles>urban</roles>
 			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:4,Periphery:4</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:6,MOC:6,IS:5,FWL:5,MERC:5,Periphery:5</availability>
+		</model>
+		<model name='UM-R69'>
+			<roles>urban</roles>
+			<availability>FWL:6,IS:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursa' unitType='Mek'>
 		<availability>LA:4,ROS:3,MERC:3,CJF:3,CWIE:4</availability>
-		<model name='URA-2A'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='URA-2C'>
 			<availability>LA:4,ROS:4,CLAN:8</availability>
+		</model>
+		<model name='URA-2A'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -16528,10 +16528,6 @@
 			<deployedWith>IS</deployedWith>
 			<availability>RD:1,CGB:2</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>RD:1,CGB:1</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -16540,6 +16536,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>RD:1,CGB:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -16572,13 +16572,17 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:2,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
+		<model name='VLK-QD3'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:2-,CDP:2-</availability>
+		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:6,ROS:4,MERC:4</availability>
-		</model>
-		<model name='VLK-QD'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,LA:4,ROS:5,FS:4,MERC:6</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
@@ -16588,25 +16592,21 @@
 			<roles>recon,fire_support</roles>
 			<availability>FS:4,MERC:3</availability>
 		</model>
-		<model name='VLK-QA'>
+		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:2-,CDP:2-</availability>
-		</model>
-		<model name='VLK-QD1'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+			<availability>FVC:4,LA:4,ROS:5,FS:4,MERC:6</availability>
 		</model>
 		<model name='VLK-QT2'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
-		<model name='VLK-QD3'>
-			<roles>recon,fire_support</roles>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QD4'>
 			<roles>recon,fire_support</roles>
 			<availability>ROS:6,FS:6</availability>
+		</model>
+		<model name='VLK-QD1'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -16621,24 +16621,24 @@
 		<model name='D'>
 			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -16650,46 +16650,46 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CHH:4,CW:3,IS:10,CJF:3,Periphery:10</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
 		<model name='V9'>
 			<availability>LA:4,CLAN:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,DTA:5,RF:5,DA:5,RCM:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='V7'>
 			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,DTA:5,RF:5,DA:5,RCM:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='(Cell)'>
 			<availability>CC:6,LA:4,FWL:6,IS:4,FS:4,MERC:5,DC:4,Periphery:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,Periphery:1,TC:1,DC:4</availability>
-		<model name='(2682)'>
+		<model name='(3056)'>
 			<roles>asf_carrier</roles>
-			<availability>General:2</availability>
+			<availability>IS:4,FS:8</availability>
 		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:4,CC:4</availability>
 		</model>
-		<model name='(3056)'>
+		<model name='(2682)'>
 			<roles>asf_carrier</roles>
-			<availability>IS:4,FS:8</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -16709,57 +16709,57 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:4</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,FS:7,Periphery.OS:2,Periphery:3,TC:2,DC:4</availability>
-		<model name='VTR-9B'>
-			<availability>Periphery:2-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,DC:8,TC:4,Periphery:4</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>CC:3,FVC:3,ROS:3,FS:4,MERC:4,DC:3,Periphery:3</availability>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:2</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
+		<model name='VTR-9Ka'>
+			<availability>CC:3,FVC:3,ROS:3,FS:4,MERC:4,DC:3,Periphery:3</availability>
 		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,DC:8,TC:4,Periphery:4</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
+		<model name='VTR-9D'>
+			<availability>FVC:1,CDP:1</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='VTR-9A1'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-9D'>
-			<availability>FVC:1,CDP:1</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -16777,16 +16777,16 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>RD:7,ROS:6,MERC:5,CGB:7</availability>
+		<model name='VKG-3A'>
+			<roles>missile_artillery</roles>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
 		<model name='VKG-2G'>
 			<availability>RD:6,ROS:6,MERC:6,CGB:6</availability>
 		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-3A'>
-			<roles>missile_artillery</roles>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -16802,20 +16802,20 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:4,MERC:4,TC:6</availability>
-		<model name='VND-5L'>
-			<availability>CC:2,MOC:1,MERC:1</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:8,MOC:6</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:6,MOC:6,PIR:3,MERC:6,TC:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:3,MOC:2,General:2,TC:2</availability>
 		</model>
+		<model name='VND-4L'>
+			<availability>CC:8,MOC:6</availability>
+		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:6,MOC:6,PIR:3,MERC:6,TC:6</availability>
+		<model name='VND-5L'>
+			<availability>CC:2,MOC:1,MERC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -16841,49 +16841,49 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:6,RA:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CHH:5,CJF:3</availability>
+		<model name='5'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,DC:6+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:6</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CNC:8</availability>
-		</model>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -16899,32 +16899,24 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PIR:2,FS:1,DC:2</availability>
-		<model name='VNL-K75N'>
-			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
-		</model>
 		<model name='VNL-X71 (Yakuza)'>
 			<availability>PIR:8</availability>
+		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>General:4,FS:8,CDP:4</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>MOC:4,RD:4,LA:4,FWL:4,IS:2,Periphery:4,CGB:4,TC:4</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>OP:6,DA:6,RCM:6</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:2-,General:2-,FS:1-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:2,PIR:2,IS:2,FS:1-,Periphery:2,TC:2</availability>
@@ -16933,9 +16925,17 @@
 			<roles>anti_infantry</roles>
 			<availability>FWL:8,MERC:3,DC:3</availability>
 		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>FVC:2-,General:2-,FS:1-</availability>
+		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:6,RD:6,LA:6,ROS:6,MH:4,FS:6,MERC:6,CGB:6</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>OP:6,DA:6,RCM:6</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -16947,49 +16947,49 @@
 		<model name='B'>
 			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:4,CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>RD:8,CNC:7,General:8,CJF:7,CGB:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
-		</model>
-		<model name='D'>
-			<availability>RD:5,CDS:5,General:4,RA:5,CGB:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:3,General:2,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CDS:5,CNC:5,CLAN:4,General:3</availability>
 		</model>
+		<model name='D'>
+			<availability>RD:5,CDS:5,General:4,RA:5,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:3,General:2,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>RD:4,CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Vulture Mk III (Mad Dog Mk III)' unitType='Mek' omni='Clan'>
 		<availability>RD:5,ROS:4,RA:5</availability>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='War Dog' unitType='Mek'>
@@ -17003,58 +17003,66 @@
 	</chassis>
 	<chassis name='Warg Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CW:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Reactive)' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:3,CLAN:7,IS:3,TC:3</availability>
-		<model name='9'>
-			<availability>CDS:5</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4</availability>
-		</model>
 		<model name='10'>
 			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
 		</model>
-		<model name='8'>
-			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
-		</model>
-		<model name='6'>
-			<availability>RD:6,RA:6,CGB:6</availability>
-		</model>
-		<model name='7'>
-			<availability>RA:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,CNC:5,FS:4,RA:5,CWIE:5,CGB:5,DC:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,DC:4</availability>
+		<model name='11'>
+			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
 		</model>
-		<model name='11'>
-			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
+		<model name='3'>
+			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,DC:4</availability>
+		</model>
+		<model name='6'>
+			<availability>RD:6,RA:6,CGB:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,CNC:5,FS:4,RA:5,CWIE:5,CGB:5,DC:4</availability>
+		</model>
+		<model name='7'>
+			<availability>RA:6</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:5,IS:4</availability>
+		</model>
+		<model name='8'>
+			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
+		</model>
+		<model name='9'>
+			<availability>CDS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>LA:7,IS:7,FWL:7,TC:8,Periphery:5</availability>
-		<model name='WHM-9S'>
-			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
+		<model name='WHM-5L'>
+			<availability>CC:6</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>RF:6,FWL:4</availability>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:8,MERC:4</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:5</availability>
+		<model name='WHM-8D2'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:4,LA:4,FS:3,MERC:4</availability>
+		</model>
+		<model name='WHM-6D'>
+			<availability>FVC:1-</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:2,PIR:4,IS:2,MH:4,FS:2,MERC:3,CDP:4,TC:4</availability>
@@ -17062,50 +17070,42 @@
 		<model name='WHM-6R'>
 			<availability>BAN:8,Periphery:2-</availability>
 		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6,MOC:4</availability>
+		<model name='WHM-10T'>
+			<availability>FS:4,TC:8</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>RF:6,FWL:4</availability>
 		</model>
 		<model name='WHM-11T'>
 			<availability>MOC:4,TC:5</availability>
 		</model>
-		<model name='WHM-8K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='WHM-6D'>
-			<availability>FVC:1-</availability>
+		<model name='WHM-6Rb'>
+			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
 		</model>
 		<model name='WHM-7M'>
 			<availability>CC:3,FVC:3,ROS:4,FWL:5,MERC:2,Periphery:3</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:4,LA:4,FS:3,MERC:4</availability>
+		<model name='WHM-9S'>
+			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:8,MERC:4</availability>
+		<model name='WHM-4L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:4,TC:8</availability>
+		<model name='WHD-10CT'>
+			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:6</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:6</availability>
@@ -17113,21 +17113,21 @@
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,FS.CH:8,IS:6,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+		<model name='H-9'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='H-7'>
 			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='H-10'>
-			<roles>apc</roles>
-			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
-		</model>
-		<model name='H-8'>
-			<availability>RD:8,LA:4,FS.CH:8,ROS:6,IS:4,FWL:4,FS:6,RA:8</availability>
 		</model>
 		<model name='H-7A'>
 			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:6</availability>
+		<model name='H-8'>
+			<availability>RD:8,LA:4,FS.CH:8,ROS:6,IS:4,FWL:4,FS:6,RA:8</availability>
+		</model>
+		<model name='H-10'>
+			<roles>apc</roles>
+			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -17139,77 +17139,77 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>IS:8,Periphery:6,RA:4</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:3,LA:4,FS:2,MERC:2</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FVC:1-</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>CC:1-,MOC:2-,FVC:2-,FWL:1-,RCM:1-,Periphery:2-</availability>
-		</model>
-		<model name='WSP-3L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
-		</model>
-		<model name='WSP-3P'>
-			<availability>FVC:5,Periphery:5</availability>
 		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:6,RA:8</availability>
 		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
+		</model>
+		<model name='WSP-3P'>
+			<availability>FVC:5,Periphery:5</availability>
+		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='WSP-3K'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>CC:1-,MOC:2-,FVC:2-,FWL:1-,RCM:1-,Periphery:2-</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-3L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
+		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FVC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:6,FS:8,MERC:5,CDP:5,DC:4</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,CDP:4,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CJF:1,RA:2</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>FVC:2,FS.CMM:2,MERC:1,DC:2,Periphery:2</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:7</availability>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -17222,26 +17222,23 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:6,MH:6,MERC:6,CDP:6,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:6,LA:5,CNC:2-,FWL:5,IS:4,MERC:5,DC:8</availability>
-		<model name='WGT-2LAW'>
+		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
-		</model>
-		<model name='WGT-4NC &apos;Dezgra&apos;'>
-			<availability>CNC:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='WGT-2LAWC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-4NC &apos;Dezgra&apos;'>
+			<availability>CNC:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>LA:4,FWL:4,IS:4,MERC:4,DC:5</availability>
@@ -17252,21 +17249,21 @@
 		<model name='WGT-3SC'>
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6</availability>
 		</model>
+		<model name='WGT-2LAW'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
 		<availability>LA:7</availability>
-		<model name='WKT-1S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WKT-2S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='WKT-1S'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:5,ROS.pm:8</availability>
-		<model name='(Standard)'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(TSEMP)'>
 			<availability>General:4</availability>
 		</model>
@@ -17276,6 +17273,9 @@
 		</model>
 		<model name='(LAC)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -17287,11 +17287,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:2,MERC:2,DC:5-</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>ROS:6</availability>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:6</availability>
 		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
@@ -17299,51 +17296,43 @@
 		<model name='WFT-C'>
 			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:6</availability>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,OP:3,MERC.KH:7,MERC:4,FS:2,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,ROS:5,MH:4,MSC:3</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
-		</model>
-		<model name='WLF-1'>
-			<availability>LA:1,ROS:1,Periphery.Deep:6,MERC:1,Periphery:8</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-3M'>
 			<availability>DTA:8,OP:8,FWL:8,MSC:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
 		<model name='WLF-2H'>
 			<availability>LA:6,MERC:3,CWIE:4</availability>
 		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		<model name='WLF-1'>
+			<availability>LA:1,ROS:1,Periphery.Deep:6,MERC:1,Periphery:8</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,RD:2,LA:5,CNC:2,IS:5,FWL:8,MH:4,FS:6,DC:5,Periphery:4,CGB:2,TC:4</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:5,FWL:4,MH:5,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-9D'>
-			<roles>spotter</roles>
-			<availability>FS:6,MERC:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>RD:5,ROS:4,CNC:4,MERC:3,CGB:5</availability>
-		</model>
 		<model name='WVR-9W2'>
 			<availability>IS:4,DC:8</availability>
 		</model>
@@ -17351,48 +17340,59 @@
 			<roles>recon</roles>
 			<availability>RD:8,MERC:6,CGB:8,DC:6</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:3-,PIR:3-,Periphery.ME:3-,MH:3-</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:4,DC:7</availability>
+		<model name='WVR-9D'>
+			<roles>spotter</roles>
+			<availability>FS:6,MERC:4</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>RD:5,ROS:4,CNC:4,MERC:3,CGB:5</availability>
+		</model>
 		<model name='WVR-9M'>
 			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:4</availability>
+		</model>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:4,DC:7</availability>
+		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:5,FWL:4,MH:5,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:5,LA:4,ROS:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:4</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:3-,PIR:3-,Periphery.ME:3-,MH:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith Battle Armor' unitType='BattleArmor'>
 		<availability>RD:4,CW:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -17413,20 +17413,20 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:4</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -17441,13 +17441,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,CGB.FRR:5,ROS:5,MSC:1,RCM:1,DA:2,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
-		</model>
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -17463,6 +17463,9 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,Periphery:2,TC:4</availability>
+		<model name='XNT-4O'>
+			<availability>CC:6,MOC:6,LA:6</availability>
+		</model>
 		<model name='XNT-6O'>
 			<availability>CC:5,MOC:5</availability>
 		</model>
@@ -17471,9 +17474,6 @@
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:6,MOC:6,LA:6,ROS:6,MERC:6</availability>
-		</model>
-		<model name='XNT-4O'>
-			<availability>CC:6,MOC:6,LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -17485,14 +17485,14 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
+		<model name='2'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Xiphos Assault Battle Armor' unitType='BattleArmor'>
@@ -17500,10 +17500,10 @@
 		<model name='(C)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(A)' mechanized='false'>
+		<model name='(B)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(B)' mechanized='false'>
+		<model name='(A)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -17515,6 +17515,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:4,CDS:4,CNC:4,IS:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='&apos;Spectre&apos;'>
 			<availability>General:3</availability>
 		</model>
@@ -17522,18 +17525,9 @@
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -17541,8 +17535,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:5</availability>
+		</model>
 		<model name='(PPC)'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -17570,18 +17570,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yun' unitType='Aero'>
@@ -17600,19 +17600,25 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>DC.GHO:2,CGB.FRR:5,CLAN:3,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CGB.FRR:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank' omni='IS'>
 		<availability>ROS:3</availability>
+		<model name='(Omnidrone) C'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) Prime'>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Omnidrone) B'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
@@ -17620,12 +17626,6 @@
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) Prime'>
-			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
@@ -17647,38 +17647,38 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3,ROS:4</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:5-</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:2-</availability>
 		</model>
+		<model name='ZEU-X4'>
+			<availability>LA:8</availability>
+		</model>
 		<model name='ZEU-X'>
 			<availability>LA:3-</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
-		</model>
-		<model name='ZEU-X4'>
-			<availability>LA:8</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,ROS:5,PIR:3,MH:3,FS:2-,MERC:5,CDP:3,TC:3</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:7,MERC:4</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -17702,29 +17702,29 @@
 	</chassis>
 	<chassis name='Zibler Fast Strike Tank' unitType='Tank' omni='IS'>
 		<availability>LA:4,ROS:5,IS:4,FS:6</availability>
-		<model name='(C)'>
+		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(B)'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='(C)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CW:10,ROS:6,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CW:6,ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CLAN:4,CJF:1</availability>
@@ -17741,19 +17741,19 @@
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>RD:2,LA:4,IS:2,Periphery:2,CGB:2</availability>
+		<model name='F'>
+			<roles>support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='Prime'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='E'>
-			<roles>support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -17764,7 +17764,7 @@
 		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
+		<model name='C'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>

--- a/megamek/data/forcegenerator/3135.xml
+++ b/megamek/data/forcegenerator/3135.xml
@@ -1332,38 +1332,35 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,RA.OA:4,LA:5,IS:4,FWL:4,FS:5,CP:4,Periphery:4,TC:4,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,LA:8,FWL:8,IS:6,FS:8,CP:8,TC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>Periphery:2</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,LA:8,FWL:8,IS:6,FS:8,CP:8,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:4,OP:4,RF:4,FWL:4,MSC:4,RCM:4,DA:4,CP:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
-		<model name='(3088)'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
@@ -1372,16 +1369,19 @@
 			<roles>assault</roles>
 			<availability>CC:8,DTA:8,OP:8,RF:8,FWL:8,IS:6,MSC:8,DA:8,RCM:8,CP:8,DC:4</availability>
 		</model>
+		<model name='(3088)'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>MERC.WD:1,CDS:1,ROS:1,CNC:5,CP:3,CJF:5,RA:5,CWIE:2</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>ROS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>ROS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aegis Point Defense Suit' unitType='BattleArmor'>
@@ -1419,22 +1419,22 @@
 	</chassis>
 	<chassis name='Aesir Medium AA Vehicle' unitType='Tank'>
 		<availability>CWE:6,CHH:4,CW:6,ROS:4,MERC:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>CHH:4,General:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<roles>anti_aircraft</roles>
 			<availability>CWE:4,CHH:8,CW:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>CHH:4,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CJF:6</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
@@ -1479,6 +1479,16 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
@@ -1486,51 +1496,41 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CNC:4,CP:4,DC:6</availability>
-		<model name='AKU-2XK'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='AKU-2XC'>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,CP:5,DC:5</availability>
 		</model>
 		<model name='AKU-2X'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,CP:5,DC:5</availability>
+		</model>
+		<model name='AKU-2XC'>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='AKU-2XK'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CWE:4,CDS:4,CW:4,LA:6,ROS:5,CNC:4,FS:5,CP:4,CWIE:6,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>LA:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>DTA:5,OP:5,ROS:4,FWL:5,MSC:5,MERC:2,CP:5</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,MERC:8,CP:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,OP:6,FWL:6,MSC:6,CP:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,MERC:8,CP:8</availability>
 		</model>
 		<model name='ALB-3Ur'>
 			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
@@ -1547,11 +1547,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CW:5,CNC:5,CP:5</availability>
-		<model name='2'>
-			<availability>RD:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anat APC' unitType='Tank'>
@@ -1563,23 +1563,23 @@
 	</chassis>
 	<chassis name='Angerona Scout Suit' unitType='BattleArmor'>
 		<availability>ROS:5</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Recon)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CHH:6,CLAN:2,RA:4</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,RD:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,RD:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1590,20 +1590,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:8,CHH:3,LA:2,ROS:3,MERC:3,CWIE:2,BAN:2,RA:3</availability>
-		<model name='C 2'>
-			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
-		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:5,ROS:5,MERC:5,CWIE:5</availability>
 		</model>
-		<model name='ANH-2A'>
-			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,IS:4,BAN:3</availability>
 		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
+		<model name='ANH-2A'>
+			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		</model>
+		<model name='C 2'>
+			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1629,14 +1629,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:6,MOC:7,FVC:3,DA:3,TC:3</availability>
-		<model name='ABS-5Y'>
-			<availability>MOC:5,CC:5</availability>
+		<model name='ABS-3T'>
+			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-3R'>
 			<availability>General:4</availability>
-		</model>
-		<model name='ABS-3T'>
-			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-4C'>
 			<availability>CC:4,MOC:4</availability>
@@ -1649,53 +1646,52 @@
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
+		<model name='ABS-5Y'>
+			<availability>MOC:5,CC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:5,MSC:6,MERC:4,DA:6,CP:5</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:4,OP:4,FWL:4,DA:4,CP:4</availability>
+		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,OP:5,RF:5,FWL:3,MSC:5,DA:5,CP:3</availability>
 		</model>
-		<model name='ANV-5M'>
-			<availability>DTA:4,OP:4,FWL:4,DA:4,CP:4</availability>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4,CP:4</availability>
+		</model>
+		<model name='ANV-5Q'>
+			<availability>DTA:4,RF:4,FWL:2,MSC:4,CP:2</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:3,MERC:3,CP:3</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>ROS:3,FWL:3,MERC:3,CP:3</availability>
 		</model>
-		<model name='ANV-5Q'>
-			<availability>DTA:4,RF:4,FWL:2,MSC:4,CP:2</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4,CP:4</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:3,MERC:3,CP:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
 		<availability>DTA:6,OP:6,FWL:6:3139,MSC:7,CP:6</availability>
-		<model name='ZU-J70'>
-			<availability>FWL:4,MSC:6,CP:4</availability>
-		</model>
 		<model name='ZU-G60'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='ZU-J70'>
+			<availability>FWL:4,MSC:6,CP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:3,ROS:4,Periphery.ME:3,FWL:8,MH:4,MSC:8,MERC:4,CP:8,DC:6</availability>
-		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,MERC:3,CP:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,CP:4,DC:3</availability>
-		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>FWL:2:3139,MSC:6,CP:2</availability>
+		</model>
+		<model name='APL-1R'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,MERC:3,CP:4,DC:3</availability>
 		</model>
 		<model name='APL-2S'>
 			<roles>fire_support</roles>
@@ -1704,6 +1700,10 @@
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,CP:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -1725,14 +1725,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,CNC:6,MERC:4,FS:3,CP:4,DC:3</availability>
+		<model name='2'>
+			<availability>General:4</availability>
+		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1749,11 +1749,11 @@
 	</chassis>
 	<chassis name='Arcas' unitType='Mek'>
 		<availability>RD:6,CDS:3,ROS:3,CP:3</availability>
-		<model name='2'>
-			<availability>RD:3,ROS:3</availability>
-		</model>
 		<model name='3'>
 			<availability>RD:6</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:3,ROS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -1761,38 +1761,6 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,RD:4,LA:6,FWL:6,CP:6,Periphery:3,DC:5</availability>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:8,MOC:4</availability>
-		</model>
-		<model name='ARC-9W'>
-			<roles>fire_support</roles>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
-		</model>
-		<model name='ARC-9KC'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:1,MERC:1</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,TC:6,Periphery:4</availability>
-		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
@@ -1801,66 +1769,98 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,ROS:4,FWL:4,MERC:4,CP:4,DC:4</availability>
 		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,TC:6,Periphery:4</availability>
+		</model>
+		<model name='ARC-9W'>
+			<roles>fire_support</roles>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:4</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>RD:6,MERC:3</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>FVC:4,PIR:5,FWL:3,CP:3,Periphery:4</availability>
 		</model>
+		<model name='ARC-9KC'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>DTA:5,MOC:3,OP:5,ROS:4,PIR:3,FWL:3,MH:3,MSC:5,MERC:4,CP:3</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>BAN:2,Periphery:2-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>RD:6,MERC:3</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:8,MOC:4</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,LA:1,MERC:1</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:5,ROS:4,CNC:2-,MERC:2,CP:2-,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:6,CWIE:7</availability>
-		<model name='A'>
-			<roles>fire_support</roles>
+		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
@@ -1872,20 +1872,20 @@
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>MERC.KH:3,RD:3,CNC:4,CP:4,CWIE:6</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:1,ROS:2,CWIE:2</availability>
-		<model name='A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:2</availability>
 		</model>
 		<model name='J'>
 			<availability>General:8</availability>
@@ -1893,11 +1893,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Attack Craft' unitType='Small Craft'>
@@ -1909,11 +1909,11 @@
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CWE:8,CW:8,CLAN:6,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CWE:6,CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CWE:6,CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares' unitType='Mek' omni='IS'>
@@ -1921,15 +1921,15 @@
 		<model name='ARS-V1A Hera'>
 			<availability>General:7</availability>
 		</model>
-		<model name='ARS-V1 Zeus'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ARS-V1B Hades'>
 			<availability>General:7</availability>
 		</model>
 		<model name='ARS-V1C Aphrodite'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='ARS-V1 Zeus'>
+			<availability>General:8</availability>
 		</model>
 		<model name='ARS-V1D Hephaestus'>
 			<availability>General:7</availability>
@@ -1940,17 +1940,17 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arion' unitType='Mek'>
@@ -1961,23 +1961,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
@@ -1985,33 +1969,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -2020,13 +2020,13 @@
 			<roles>assault</roles>
 			<availability>FS:2</availability>
 		</model>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Refit)'>
 			<roles>assault</roles>
 			<availability>ROS:8,FS:8</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arrow IV Assault Vehicle' unitType='Tank'>
@@ -2042,22 +2042,22 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
 		<availability>ROS:5,DC:5</availability>
-		<model name='(3082)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(3062)'>
 			<roles>troop_carrier</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(3082)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -2076,11 +2076,11 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CWE:5,CHH:8,RD:6,CDS:5,CW:5,ROS:4,CP:5,CJF:3,RA:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:8,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas III' unitType='Mek'>
@@ -2100,55 +2100,71 @@
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:3,CC:3,RA.OA:3,LA:6,CLAN:4,IS:3,FWL:3,FS:5,CP:3,Periphery:3,TC:3,DC:8</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>RF:4,LA:4,DC:4</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
-		</model>
 		<model name='AS7-K3'>
 			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:6</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:8,CNC:6,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>IS:4,DC:4</availability>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:6</availability>
 		</model>
 		<model name='AS7-D'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:8,CNC:6,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:1,ROS:3,MERC:3</availability>
+		</model>
+		<model name='AS7-K4'>
+			<availability>RF:4,LA:4,DC:4</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:1,ROS:3,MERC:3</availability>
+		<model name='AS7-C'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -2158,31 +2174,15 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avalanche' unitType='Mek' omni='IS'>
 		<availability>CC:3:3143,CNC:4-,FWL:3:3143,CP:3,DC:4</availability>
-		<model name='AVL-1OC'>
-			<availability>General:7</availability>
+		<model name='AVL-1OR'>
+			<availability>General:6,CLAN:8</availability>
 		</model>
 		<model name='AVL-1OA'>
 			<availability>General:7</availability>
@@ -2193,8 +2193,8 @@
 		<model name='AVL-1ON'>
 			<availability>General:6</availability>
 		</model>
-		<model name='AVL-1OR'>
-			<availability>General:6,CLAN:8</availability>
+		<model name='AVL-1OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AVL-1O'>
 			<availability>General:8</availability>
@@ -2212,65 +2212,65 @@
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:7,CP:9,RA:8</availability>
-		</model>
-		<model name='B'>
-			<availability>CNC:7,General:6,CP:7</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CWE:4,CW:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5</availability>
+		</model>
 		<model name='D'>
 			<availability>CWE:6,CW:6,CLAN:4,CNC:6,CP:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6,CP:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:7,CP:9,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>RD:4,CNC:5,IS:4,CP:5,DC:6</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
+		</model>
 		<model name='AV1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AV1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AV1-OJ'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='AV1-OB'>
-			<availability>General:7</availability>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -2286,8 +2286,17 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
+		<model name='AWS-9Ma'>
+			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='AWS-9M'>
+			<availability>MOC:2,PIR:4,FWL:4,IS:2,MH:2,CP:4,TC:2,Periphery:4</availability>
+		</model>
 		<model name='AWS-11R'>
 			<availability>RF:4,MSC:4</availability>
+		</model>
+		<model name='AWS-9Q'>
+			<availability>MOC:6,FWL:4,IS:6,MH:6,CP:4,TC:6,Periphery:4</availability>
 		</model>
 		<model name='AWS-10KM'>
 			<availability>DTA:4,OP:4,ROS:4,FWL:4,MSC:4,CP:4,DC:6</availability>
@@ -2295,23 +2304,14 @@
 		<model name='AWS-8Q'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='AWS-9M'>
-			<availability>MOC:2,PIR:4,FWL:4,IS:2,MH:2,CP:4,TC:2,Periphery:4</availability>
-		</model>
-		<model name='AWS-9Q'>
-			<availability>MOC:6,FWL:4,IS:6,MH:6,CP:4,TC:6,Periphery:4</availability>
-		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>RD:6,CDS:4,ROS:4,FS:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>RD:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -2322,88 +2322,84 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:1,LA:5,ROS:4,FS:1</availability>
+		<model name='AXM-4D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='AXM-6T'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-4D'>
-			<availability>FS:6</availability>
+		<model name='AXM-1N'>
+			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CJF:5,RA:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CWE:6,MERC.WD:5,CW:6,LA:4,ROS:5</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:4</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:2,MERC:3</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2413,11 +2409,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
@@ -2425,15 +2417,23 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,IS:8</availability>
+		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>General:2</availability>
@@ -2444,44 +2444,56 @@
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:4,LA:4,ROS:4,FWL:4,MERC:8,FS:4,DA:4,CP:4,Periphery:4</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:2</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2489,33 +2501,21 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank'>
@@ -2527,14 +2527,6 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:1</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
@@ -2547,14 +2539,6 @@
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
@@ -2563,48 +2547,64 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:1</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='I'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:4-,RA.OA:4-,FVC:2-,RF:2-,LA:2-,FWL:1-,MH:4-,MSC:1-,MERC:1-,CP:1-,Periphery:7-,TC:4-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:6,FWL:6,CP:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:1-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BNC-9S2'>
-			<availability>RF:3,LA:4</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>RF:1-,MSC:1-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>Periphery:2-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:2,MH:4,MERC:5</availability>
+		</model>
+		<model name='BNC-9S2'>
+			<availability>RF:3,LA:4</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:1-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>Periphery:1-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:2,MH:4,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:6,FWL:6,CP:6,CDP:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bardiche Heavy Strike Tank' unitType='Tank'>
@@ -2619,9 +2619,6 @@
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,ROS:4,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:2</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:3,ROS:3,MERC:3</availability>
 		</model>
@@ -2630,6 +2627,9 @@
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:2</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2645,25 +2645,25 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CNC:4,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>CNC:8,General:7,CP:8,RA:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CNC:3,CLAN:2,CP:3,RA:6</availability>
-		</model>
-		<model name='A'>
-			<availability>RD:8,General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>CNC:8,General:7,CP:8,RA:8</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>General:1,RA:3</availability>
+		</model>
+		<model name='A'>
+			<availability>RD:8,General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CNC:3,CLAN:2,CP:3,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2674,11 +2674,8 @@
 		<model name='H'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2686,8 +2683,11 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2716,23 +2716,21 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>MSC:2</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:2</availability>
+		<model name='BLR-10S'>
+			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
 		<model name='BLR-4S'>
 			<availability>LA:3,ROS:4,MERC:4</availability>
 		</model>
-		<model name='BLR-10S'>
-			<availability>LA:6,ROS:4,FS:4</availability>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:2</availability>
@@ -2740,35 +2738,37 @@
 		<model name='BLR-1G'>
 			<availability>BAN:8,Periphery:1-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CC:3,MERC:3,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
+		<model name='BLR-6X'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>DTA:5,OP:5,ROS:4,FWL:4:3139,DA:5,MERC:4,CP:4</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
+		</model>
+		<model name='BLR-1Gbc'>
+			<availability>MSC:2</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:8,OP:8,FWL:6,MSC:8,CP:6</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>RD:4,ROS:4,DC:6</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CC:3,MERC:3,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
-		</model>
-		<model name='BLR-4L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2790,12 +2790,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:5,CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,CW:5,CLAN:2,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2810,14 +2810,14 @@
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>RD:6,ROS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
@@ -2834,28 +2834,28 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:1,IS:1,MERC:2,FS:2,CP:2,Periphery:2,RA.OA:2,CDS:2,LA:1,PIR:1,CNC:2,FWL:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>CLAN:6,IS:6,DC:8</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth II Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:5,LA:4,ROS:6,FWL:5,MH:4,MERC:4,CP:5,TC:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2883,28 +2883,28 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>RD:6,ROS:6,CNC:4,CP:4</availability>
-		<model name='BEO-12'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='BEO-14'>
 			<roles>recon</roles>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='BEO-12'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>RF:5,LA:7,ROS:4,FS:3,MERC:3</availability>
-		<model name='BRZ-A3'>
-			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
-		</model>
-		<model name='BRZ-D4'>
-			<availability>LA:5</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>RF:4,LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:1</availability>
+		<model name='BRZ-D4'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='BRZ-A3'>
+			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2912,12 +2912,12 @@
 		<model name='BSN-3K'>
 			<availability>General:8</availability>
 		</model>
+		<model name='BSN-5KC'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='BSN-4K'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='BSN-5KC'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishop Transport VTOL' unitType='VTOL'>
@@ -2929,63 +2929,69 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CWE:1,CHH:1,RD:1,CW:1,ROS:4+,CJF:1,RA:1,BAN:2,CWIE:1</availability>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CWE:6,RD:4,CW:6,CNC:7,General:6,CP:7,CJF:8</availability>
 		</model>
+		<model name='I'>
+			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:3,CHH:6,CW:3,CNC:5,General:4,CP:5,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CDS:5,CW:5,CLAN:4,General:2,CP:5</availability>
+		</model>
 		<model name='C'>
 			<availability>CWE:3,CHH:6,CW:3,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CWE:5,RD:7,CW:5,General:6,CJF:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CWE:2,RD:2,CDS:2,CW:2,CNC:2,CLAN:1,General:2,CP:2,CJF:2,CWIE:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:3,CHH:6,CW:3,CNC:5,General:4,CP:5,CJF:6,CWIE:5</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='T'>
 			<availability>General:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CWE:5,RD:7,CW:5,General:6,CJF:8</availability>
-		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,CNC:8,General:7,CP:8,CJF:9</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CDS:5,CW:5,CLAN:4,General:2,CP:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='I'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,IS:5,FS:5,MERC:5,DC:8</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
 		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BHKU-OG'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
@@ -2995,23 +3001,17 @@
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
 		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:8,CDS:6,CNC:6,IS:5,MERC:6,CP:5,CWIE:6</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>General:4</availability>
@@ -3019,26 +3019,11 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MSC:6,MOC:4,CC:4,OP:6,IS:4,MERC:4,CP:5,RA:3,Periphery:4,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
-		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 		<model name='BLK-NT-2Y'>
 			<availability>FVC:4,ROS:6,IS:6,FS:6,CDP:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
-		</model>
-		<model name='BLK-NT-4D'>
-			<availability>CWE:4,CDS:4,CW:4,ROS:4,CNC:5,FS:4,MERC:3,CP:4,CWIE:5</availability>
-		</model>
-		<model name='BLK-NT-3A'>
-			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
-		</model>
-		<model name='BL-12-KNT'>
-			<availability>ROS:4,FS:4</availability>
 		</model>
 		<model name='BLK-NT-3B'>
 			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:5,MERC:5</availability>
@@ -3046,35 +3031,50 @@
 		<model name='BLK-NT-5H'>
 			<availability>FWL:3,FS:4,MERC:3,CP:3,DC:3</availability>
 		</model>
+		<model name='BLK-NT-4D'>
+			<availability>CWE:4,CDS:4,CW:4,ROS:4,CNC:5,FS:4,MERC:3,CP:4,CWIE:5</availability>
+		</model>
+		<model name='BLK-NT-3A'>
+			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
+		</model>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CJF:7</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
+		<model name='E'>
 			<availability>CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>CJF:2</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='X'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -3090,80 +3090,80 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Wolf Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CW:4,CWIE:5</availability>
-		<model name='[LBX]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[ERSPL]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Mortar]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='[Heavy Mortar]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[LBX]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Heavy Flamer]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:2,RA.OA:3,FVC:4,FS:4,MERC:2,TC:2,Periphery:4</availability>
-		<model name='BJ-2r'>
-			<availability>FVC:5,FS:5,MERC:5</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>Periphery:1</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
 		<model name='BJ-2'>
 			<availability>FVC:3,LA:4,FS:2,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='BJ-2r'>
+			<availability>FVC:5,FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:2,ROS:4,FWL:5,IS:1,FS:6,MERC:3,DA:4,CP:5,DC:6</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8,CP:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7,CP:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OU'>
+		<model name='BJ2-OX'>
 			<availability>General:2</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7,CP:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OX'>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8,CP:8</availability>
+		</model>
+		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -3171,10 +3171,6 @@
 		<availability>DTA:2,OP:2,ROS:8,FWL:2:3139,MSC:2,FS:4,CP:2</availability>
 		<model name='BLD-7R'>
 			<availability>DTA:8,OP:8,FWL:8,MSC:8,CP:8</availability>
-		</model>
-		<model name='BLD-XR'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,FS:8</availability>
 		</model>
 		<model name='BLD-XX'>
 			<roles>anti_aircraft</roles>
@@ -3186,21 +3182,22 @@
 		<model name='BLD-XS'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='BLD-XR'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>RF:4,LA:6,ROS:4,MSC:4,MERC:4</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>RF:6,LA:6,ROS:6</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3208,20 +3205,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -3233,17 +3233,17 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CWE:9,CW:9</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -3274,22 +3274,22 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:4</availability>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='A'>
+		<model name='Prime'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3300,13 +3300,13 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
-		<model name='BMB-05A'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RA.OA:8</availability>
-		</model>
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='BMB-05A'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RA.OA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3318,13 +3318,6 @@
 	</chassis>
 	<chassis name='Boreas' unitType='Mek' omni='Clan'>
 		<availability>CHH:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -3332,26 +3325,33 @@
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4</availability>
-		<model name='3'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:2</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
@@ -3365,15 +3365,6 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-X3'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-5'>
 			<availability>PIR:4</availability>
 		</model>
@@ -3382,6 +3373,15 @@
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X3'>
+			<availability>PIR:4</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LDT-X4'>
+			<availability>PIR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -3405,17 +3405,17 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(PPC)'>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,RA.OA:6,RD:6,IS:6,FS:6</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3444,37 +3444,37 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>LA:3,ROS:4,FS:4,MERC:3,Periphery:1-,DC:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(AC2)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
 		<availability>RF:7,FWL:6,DA:6,MERC:5,CP:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Buraq Fast Battle Armor' unitType='BattleArmor'>
@@ -3492,11 +3492,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,ROS:6,CNC:4,CP:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -3508,17 +3508,17 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
-		<model name='BSW-S2r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='BSW-X2'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BSW-X2'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='BSW-S2r'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>MERC:4</availability>
@@ -3542,17 +3542,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:4,LA:2,FS:3,MERC:2</availability>
-		<model name='CES-4R'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>FVC:8,FS:1,MERC:1</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Calliope' unitType='Mek'>
@@ -3603,13 +3603,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CWE:1,CHH:1,RD:2,CDS:3,CW:1,CNC:5,CP:4,CJF:1,RA:3</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>RD:4,CDS:8,CNC:8,CP:8,CJF:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>RD:4,CDS:8,CNC:8,CP:8,CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3634,26 +3634,26 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:3,MERC:3,CDP:3,TC:3</availability>
-		<model name='CTF-3D'>
-			<availability>FVC:3,MH:4,FS:2,MERC:4</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='CTF-3LL'>
 			<availability>CC:6,MOC:6,MERC:3,TC:6</availability>
 		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4,MERC:3</availability>
+		<model name='CTF-3D'>
+			<availability>FVC:3,MH:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='CTF-1X'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>Periphery:2-</availability>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult II' unitType='Mek'>
@@ -3669,81 +3669,81 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:4,OP:3,FWL:3,MH:3,MERC:1,CP:2,DA:4,RCM:3,Periphery:2,TC:2,DC:6</availability>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>BAN:2</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,CDP:3,TC:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C6'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FVC:3,CLAN:6,MERC:3,Periphery:3,DC:4</availability>
 		</model>
 		<model name='CPLT-C5A'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FVC:3,CLAN:6,MERC:3,Periphery:3,DC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,OP:4,FWL:2:3139,MERC:4,DA:4,RCM:4,CP:2</availability>
 		</model>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,CP:5,RA:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
@@ -3751,41 +3751,41 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:6</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cave Lion' unitType='Mek'>
@@ -3796,16 +3796,20 @@
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>RA:4</availability>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek' omni='IS'>
 		<availability>ROS:3</availability>
-		<model name='CLR-03-OC'>
+		<model name='CLR-03-OD'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='CLR-03-OE'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3813,19 +3817,15 @@
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='CLR-03-O'>
-			<roles>spotter,specops</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='CLR-03-OD'>
-			<roles>specops</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='CLR-03-OA'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='CLR-03-OE'>
+		<model name='CLR-03-O'>
+			<roles>spotter,specops</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='CLR-03-OC'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3839,39 +3839,33 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CNC:6,CP:6,RA:5</availability>
-		<model name='3'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CNC:8,CP:8</availability>
+		</model>
+		<model name='3'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='Commando'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='Commando'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>Periphery.HR:2,Periphery.OS:2,Periphery:2</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
@@ -3879,24 +3873,23 @@
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>Periphery.HR:2,Periphery.OS:2,Periphery:2</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:4,OP:2,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,DTA:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6,MSC:2</availability>
-		<model name='CN9-A'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:3,MERC:2,Periphery:4</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:3</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CP:3,CDP:3</availability>
 		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
+		<model name='CN10-B'>
+			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-H'>
 			<availability>MH:2-</availability>
@@ -3904,21 +3897,37 @@
 		<model name='CN9-D4D'>
 			<availability>DTA:3,OP:3,ROS:3,FWL:1,MSC:3,FS:3,MERC:3,CP:1</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3,Periphery:4</availability>
+		<model name='CN9-A'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CN9-D3'>
 			<availability>FVC:2,ROS:2,FS:2,MERC:2,CDP:3</availability>
 		</model>
-		<model name='CN10-B'>
-			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
+		<model name='CN9-D'>
+			<availability>FVC:3,MERC:2,Periphery:4</availability>
 		</model>
 		<model name='CN9-Da'>
 			<availability>OP:4,FVC:4,ROS:2,FWL:2,MSC:4,MERC:2,FS:2,CP:1,Periphery:4</availability>
 		</model>
+		<model name='CN9-D5'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek' omni='IS'>
 		<availability>LA:6,ROS:6,FS:7,MERC:5</availability>
+		<model name='CN11-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='CN11-O'>
 			<availability>General:8</availability>
 		</model>
@@ -3926,15 +3935,6 @@
 			<availability>General:7</availability>
 		</model>
 		<model name='CN11-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OD'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3967,11 +3967,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CWE:5,RD:5,CW:5,CLAN:6,CJF:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3992,21 +3992,21 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,ROS:4,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
+		</model>
+		<model name='XII'>
+			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
+		<model name='X'>
+			<availability>General:8</availability>
 		</model>
 		<model name='XIVs'>
 			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
-		</model>
-		<model name='XII'>
-			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -4014,6 +4014,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -4023,115 +4027,111 @@
 			<roles>training</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:2,DC.GHO:2,RD:4,LA:1,ROS:2,DC:1</availability>
-		<model name='CHP-3N'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
+		<model name='C'>
+			<availability>CHH:6,RD:6,CLAN:8</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:1,RD:1,LA:2,MERC.SI:4,MERC:2,BAN:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,RD:6,CLAN:8</availability>
+		<model name='CHP-1N2'>
+			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>RD:2,ROS:4,IS:3,MERC:2,BAN:4,Periphery:2</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>missile_artillery</roles>
+			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>MOC:1-,RA.OA:2-,FVC:1,RD:3-,LA:1-,ROS:2-,TC:1-,Periphery:1,DC:4-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='CGR-3K'>
+			<availability>MERC:1-,DC:2-</availability>
+		</model>
 		<model name='CGR-2A2'>
 			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='CGR-1A9'>
+			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CGR-SA5'>
 			<roles>urban</roles>
 			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CGR-3K'>
-			<availability>MERC:1-,DC:2-</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CGR-C'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='CGR-1A9'>
-			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
-		<model name='CGR-1L'>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,CP:10,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
-		<model name='F-13'>
-			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,CP:4,MERC:4</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,DTA:2,OP:2,FVC:2,RF:2,FWL:2,MSC:2,MERC:2,DA:2,RCM:2,CP:2,Periphery:2</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>FVC:2,Periphery:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,CP:1-,Periphery:1-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>CC:4,MOC:4,OP:8,MERC:6,CP:8,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
 		</model>
 		<model name='OF-17A-R'>
 			<roles>recon</roles>
 			<availability>ROS:4,FWL:3:3139,MSC:6,CP:3</availability>
 		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,DTA:2,OP:2,FVC:2,RF:2,FWL:2,MSC:2,MERC:2,DA:2,RCM:2,CP:2,Periphery:2</availability>
+		</model>
 		<model name='F-14-S'>
 			<availability>DTA:8,OP:8,RF:8,FWL:8,MH:4,MSC:8,MERC:5,RCM:8,DA:8,CP:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>FVC:2,Periphery:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:4,MOC:4,OP:8,MERC:6,CP:8,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
+		</model>
+		<model name='F-13'>
+			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,CP:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:3,CDS:4,LA:3,ROS:5,CNC:5,FWL:3:3139,FS:3,CP:4,RCM:3,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
@@ -4139,13 +4139,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:6,CDS:6,LA:6,ROS:6,FWL:4:3139,FS:6,RCM:6,CP:5,DC:6</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -4156,63 +4156,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>DTA:4,OP:4,FVC:4,RF:4,LA:6,ROS:4,FWL:4,MH:4,MERC:5,DA:4,CP:4,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
-		<model name='CHP-W5'>
-			<availability>:0,BAN:3,Periphery:2-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:2,CDP:2,TC:2</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2,BAN:2</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2,BAN:2</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:2,CDP:2,TC:2</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,BAN:3,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CNC:6,CP:6,RA:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:1,RF:3,FWL:3,MSC:3,MERC:1,CP:3,CDP:2,Periphery:2</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,FWL:4,MERC:6,CP:4</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6,CP:8,Periphery:4</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:2,IS:4,CP:2</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>RF:8,FWL:8,MSC:8,CP:8</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,FWL:4,MERC:6,CP:4</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6,CP:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -4249,20 +4249,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -4279,23 +4279,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -4303,14 +4303,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -4327,32 +4327,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -4360,11 +4360,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4373,14 +4373,14 @@
 			<roles>marine</roles>
 			<availability>RD:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>CWE:4,RD:4,CDS:4,CW:4,CNC:4,CP:4,CWIE:4</availability>
+		<model name='(Volk)' mechanized='true'>
+			<availability>CWE:4,CW:4</availability>
 		</model>
 		<model name='(Rache)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Volk)' mechanized='true'>
-			<availability>CWE:4,CW:4</availability>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>CWE:4,RD:4,CDS:4,CW:4,CNC:4,CP:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -4388,20 +4388,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4413,10 +4413,6 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='V3'>
-			<roles>assault</roles>
-			<availability>LA:4,ROS:8,FS:4</availability>
-		</model>
 		<model name='Interceptor'>
 			<roles>assault</roles>
 			<availability>LA:3</availability>
@@ -4425,20 +4421,27 @@
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='V3'>
+			<roles>assault</roles>
+			<availability>LA:4,ROS:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>CWE:5,RD:5,CW:5,CNC:5,CP:5,RA:3</availability>
-		<model name='2'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:2,MOC:2,FS:2,MERC:1,CDP:2,TC:2,Periphery:3,FVC:2,RF:2,LA:2,ROS:2,DA:2,RCM:1</availability>
 		<model name='CLNT-2-3U'>
 			<availability>CC:2,General:6</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
@@ -4449,9 +4452,6 @@
 		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -4502,51 +4502,45 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
-			<roles>recon</roles>
-			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
-		</model>
-		<model name='COM-2Dr'>
-			<roles>recon</roles>
-			<availability>LA:5,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>LA:8,ROS:8</availability>
-		</model>
 		<model name='COM-8S'>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='COM-3A'>
+			<roles>recon</roles>
+			<availability>Periphery:1-</availability>
 		</model>
 		<model name='COM-1A'>
 			<roles>recon</roles>
 			<availability>FVC:1-,Periphery:1-</availability>
 		</model>
-		<model name='COM-3A'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>Periphery:1-</availability>
+			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:8</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>LA:8,ROS:8</availability>
+		</model>
+		<model name='COM-2Dr'>
+			<roles>recon</roles>
+			<availability>LA:5,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,FVC:2,LA:3,ROS:3,IS:2,FWL:2,FS:3,CP:2,TC:2,DC:2,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:8</availability>
-		</model>
 		<model name='(Upgrade) (Standard)'>
 			<availability>LA:8,FWL:6,MERC:6,CP:6</availability>
 		</model>
@@ -4555,6 +4549,12 @@
 		</model>
 		<model name='(Laser Upgrade)'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
@@ -4568,13 +4568,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:6,IS:6,DC:8</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condottiere Assault Craft' unitType='Small Craft'>
@@ -4593,13 +4593,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -4622,23 +4622,23 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:6</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>RD:3</availability>
-		<model name='(SRM)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LMG)' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
@@ -4675,20 +4675,20 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='CRX-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-OR'>
 			<availability>RA.OA:4,CLAN:8</availability>
+		</model>
+		<model name='CRX-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4699,20 +4699,20 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		<model name='CSR-V12'>
+			<availability>BAN:4,Periphery:2-</availability>
 		</model>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>BAN:4,Periphery:2-</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
@@ -4739,20 +4739,20 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='X 2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='X'>
+		<model name='X 3'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
 		</model>
-		<model name='X 3'>
+		<model name='X'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -4760,19 +4760,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='I'>
+		<model name='D'>
 			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CWE:3,CW:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -4780,12 +4776,16 @@
 		<model name='H'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='I'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
@@ -4799,16 +4799,16 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
+		</model>
 		<model name='CRB-27b'>
 			<roles>raider</roles>
 			<availability>ROS:8,CLAN:4,FWL:8,MERC:8,CP:8,BAN:2,DC:6</availability>
 		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crane Heavy Transport' unitType='VTOL'>
@@ -4820,36 +4820,36 @@
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
 		<availability>CC:3,FS:3,MERC:4,CP:5,CWIE:6,CDS:6,LA:4,ROS:4,CNC:5,FWL:4:3139,MSC:3,CJF:6,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:8,FWL:8,CLAN.IS:8,MSC:8,FS:8,CP:8</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,FWL:8,CLAN.IS:8,MSC:8,FS:8,CP:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CC:8,CDS:4,CNC:4,MERC:8,CP:4,DC:8</availability>
 		</model>
+		<model name='4'>
+			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CP:4,RA:4</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4857,19 +4857,19 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:3,CW:5,ROS:3,CLAN:4,CP:3,CJF:3,RA:3,CWIE:5</availability>
-		<model name='CRK-5004-1'>
-			<availability>ROS:6</availability>
+		<model name='CRK-5003-3'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,BAN:8</availability>
 		</model>
-		<model name='CRK-5003-3'>
+		<model name='CRK-5004-1'>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
@@ -4890,33 +4890,37 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CDS:2,CNC:2,CP:2,RA:5,CWIE:2</availability>
-		<model name='A'>
-			<availability>General:5</availability>
+		<model name='U'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='U'>
-			<availability>CLAN:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>CC:3,MOC:3,ROS:4,CNC:3,IS:2,FWL:3,MERC:3,CP:2,DC:4</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8,CP:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
@@ -4925,51 +4929,47 @@
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8,CP:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CLAN:5,IS:6,Periphery:5</availability>
-		<model name='CRD-8S'>
-			<availability>LA:8,FS:4</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>BAN:1,Periphery:2-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:1,MOC:4,FWL:8,FS:1,MERC:4,CP:8,CDP:4,DC:1,TC:4</availability>
-		</model>
 		<model name='CRD-7W'>
 			<availability>DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5:3139,MH:4,MSC:5,MERC:2,RCM:5,CP:5</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:4,MERC:4</availability>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='CRD-4L'>
 			<availability>CC:2,MOC:4</availability>
 		</model>
-		<model name='CRD-5K'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='CRD-8S'>
+			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='CRD-3R'>
+			<availability>BAN:1,Periphery:2-</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,CP:5,BAN:2</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		<model name='CRD-5M'>
+			<availability>CC:1,MOC:4,FWL:8,FS:1,MERC:4,CP:8,CDP:4,DC:1,TC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4977,11 +4977,11 @@
 	</chassis>
 	<chassis name='Cuchulainn Support Armor' unitType='BattleArmor'>
 		<availability>CWE:3:3140,MERC.KH:5,MERC.WD:4,CW:3:3140,LA:3,MERC:4,CWIE:5</availability>
-		<model name='(Clan Model)' mechanized='true'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(IS Model)' mechanized='true'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(Clan Model)' mechanized='true'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cuirass' unitType='Mek'>
@@ -4989,42 +4989,50 @@
 		<model name='CDR-1X'>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDR-2BC'>
-			<availability>General:6</availability>
-		</model>
 		<model name='CDR-2X'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CDR-2BC'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cutlass' unitType='Aero'>
 		<availability>FS:7</availability>
+		<model name='CUT-01E'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CUT-01E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,Periphery:2,TC:2,RA.OA:2,RD:4,LA:3,ROS:3,FWL:2,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>General:2-</availability>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:4,DC:4</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>RD:5,IS:5</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -5033,31 +5041,23 @@
 		<model name='CP-11-H'>
 			<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
 		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:4,DC:4</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>RD:5,IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:5,MERC.WD:3,ROS:3,CWIE:4</availability>
-		<model name='4'>
-			<availability>General:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
+		<model name='4'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyllaros' unitType='Mek'>
@@ -5076,25 +5076,25 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>MOC:4,CDP:4,TC:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -5119,35 +5119,35 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='DAI-01r'>
 			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -5167,14 +5167,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>RD:5,ROS:5,DC:7</availability>
-		<model name='DMO-4K'>
-			<availability>DC:8</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:2</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:2</availability>
+		<model name='DMO-4K'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -5183,39 +5183,39 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,DC:4+</availability>
-		<model name='Prime'>
-			<availability>CWE:5,CDS:7,CW:5,General:8,CP:7,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:2,CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CP:2,CJF:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CWE:5,CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		<model name='E'>
+			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:8,RD:4,CW:8,CNC:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		<model name='Prime'>
+			<availability>CWE:5,CDS:7,CW:5,General:8,CP:7,CJF:9</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:8,RD:4,CW:8,CNC:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		</model>
 		<model name='C'>
 			<availability>CWE:5,CDS:5,CW:5,General:4,CP:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:5,CW:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:2,CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CP:2,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -5234,31 +5234,31 @@
 	</chassis>
 	<chassis name='Dark Crow' unitType='Mek'>
 		<availability>RA:6</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:4,FS:6,MERC:4</availability>
-		<model name='DRT-6T'>
-			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
-		</model>
 		<model name='DRT-3S'>
 			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='DRT-6T'>
+			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
 		</model>
 		<model name='DRT-4S'>
 			<availability>LA:1,MH:4,MERC:4,FS:2</availability>
@@ -5266,11 +5266,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,General:5,CDP:3</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
 		</model>
@@ -5282,62 +5285,59 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2,CDP:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
+			<availability>FVC:4,General:5,CDP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,RD:4,IS:3+,CJF:2,BAN:2</availability>
+		<model name='B'>
+			<availability>CWE:7,CHH:6,RD:7,CDS:6,CW:7,General:5,CP:6,CWIE:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CDS:3,CW:4,General:2,CP:3</availability>
+		</model>
+		<model name='K'>
+			<availability>RD:4,General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CHH:8,RD:8,CDS:7,CNC:7,General:6,CP:7,CWIE:7</availability>
+		</model>
 		<model name='H'>
 			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>RD:2,CDS:5,General:3,CP:5,CJF:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CDS:3,CW:4,General:2,CP:3</availability>
+		<model name='D'>
+			<availability>CWE:8,CHH:8,RD:8,CDS:4,CW:8,CNC:8,General:6,CP:6,CWIE:8</availability>
 		</model>
 		<model name='G'>
 			<availability>General:4</availability>
 		</model>
-		<model name='K'>
-			<availability>RD:4,General:2</availability>
+		<model name='F'>
+			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CWE:4,CHH:8,RD:4,CDS:6,CW:4,CNC:4,General:5,CP:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:8,CHH:8,RD:8,CDS:4,CW:8,CNC:8,General:6,CP:6,CWIE:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,RD:8,CDS:7,CNC:7,General:6,CP:7,CWIE:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:7,CHH:6,RD:7,CDS:6,CW:7,General:5,CP:6,CWIE:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
 		<availability>RD:4,CDS:5,LA:3,ROS:4,CNC:4,IS:3,FS:3,CP:4,RA:4,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:3</availability>
+		<model name='2'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='3'>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='4'>
 			<availability>MERC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -5354,15 +5354,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2:3139,MSC:4,CP:2</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5377,11 +5377,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='DFN-3S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -5395,11 +5395,15 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='S'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -5407,25 +5411,12 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='S'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CNC:5,FWL:8,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>Periphery:2</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,CWIE:4</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -5433,9 +5424,18 @@
 		<model name='(MRM)'>
 			<availability>FVC:4,DC:8,Periphery:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>Periphery:2</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
@@ -5444,11 +5444,11 @@
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>LA:5,ROS:5,CWIE:5</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:4,CWIE:4</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>LA:5,ROS:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5464,13 +5464,13 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:6-</availability>
-		<model name='(Armor)'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Armor)'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -5488,20 +5488,20 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>OP:3,FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
+		<model name='DV-7D'>
+			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='DV-9D'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:1</availability>
+		</model>
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
 		</model>
 		<model name='DV-6M'>
 			<availability>CLAN:4,Periphery:2-</availability>
-		</model>
-		<model name='DV-9D'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='DV-6Mr'>
-			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Destrier Siege Vehicle' unitType='Tank'>
@@ -5522,11 +5522,11 @@
 		<model name='DVS-3'>
 			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5567,11 +5567,14 @@
 	</chassis>
 	<chassis name='Doloire' unitType='Mek' omni='IS'>
 		<availability>ROS:7,MERC:2</availability>
-		<model name='DLR-OC'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='DLR-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='DLR-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='DLR-OC'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-OA'>
@@ -5580,18 +5583,15 @@
 		<model name='DLR-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-O'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,RD:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5619,25 +5619,25 @@
 	</chassis>
 	<chassis name='Dragon II' unitType='Mek'>
 		<availability>DC:7</availability>
-		<model name='DRG-11R'>
-			<roles>missile_artillery</roles>
-			<availability>General:2+</availability>
-		</model>
 		<model name='DRG-11K'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='DRG-11R'>
+			<roles>missile_artillery</roles>
+			<availability>General:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:3,DC:2</availability>
-		<model name='DRG-7N'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:1</availability>
 		</model>
 		<model name='DRG-5N'>
 			<availability>Periphery.Deep:4,MERC:4,DC:4,Periphery:6</availability>
+		</model>
+		<model name='DRG-7N'>
+			<availability>MERC:8,DC:8</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>MERC:4,DC:4</availability>
@@ -5645,12 +5645,12 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:2,CHH:3,RD:4,ROS:4+</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
+		<model name='Prime'>
+			<availability>RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:8,CDS:8,General:6,CP:8,CJF:8,CWIE:6</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>RD:5,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:6,RD:6,CDS:6,CW:6,CNC:5,General:4,CP:5,CJF:6,CWIE:6</availability>
@@ -5658,26 +5658,26 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
-		</model>
 		<model name='H'>
 			<availability>CNC:5,CLAN:3,General:2,CP:5</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CW:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:7,CDS:6,CW:7,General:5,CP:6,CJF:6</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>RD:5,General:2</availability>
+		<model name='A'>
+			<availability>RD:8,CDS:8,General:6,CP:8,CJF:8,CWIE:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,RD:7,CDS:8,General:6,CP:8,CJF:8,RA:7,CWIE:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CWE:7,RD:7,CDS:6,CW:7,General:5,CP:6,CJF:6</availability>
+		</model>
 		<model name='I'>
+			<availability>General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CW:5,General:4,CP:5,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5696,11 +5696,11 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,ROS:2,FS:4</availability>
-		<model name='(Sealed)'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5712,11 +5712,11 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:4,TC:4</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Duat Military Transport' unitType='Dropship'>
@@ -5728,24 +5728,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='EGL-R6b'>
-			<availability>OP:6,FWL:5:3139,MSC:6,RCM:6,CP:5</availability>
-		</model>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>General:2-</availability>
 		</model>
+		<model name='EGL-R6b'>
+			<availability>OP:6,FWL:5:3139,MSC:6,RCM:6,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,FWL.MM:7,RF:6,FWL:6,MH:4,FWL.FO:7,MSC:7,MERC:4,DA:5,CP:6</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
 		</model>
 		<model name='EGL-3M'>
 			<availability>DTA:5,FWL:5,MSC:5,CP:5</availability>
@@ -5756,10 +5756,6 @@
 		<model name='MEB-10'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='MEB-9'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='MEB-13'>
 			<roles>recon</roles>
@@ -5773,17 +5769,21 @@
 			<roles>recon</roles>
 			<availability>CC:5</availability>
 		</model>
+		<model name='MEB-9'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,Periphery:4-</availability>
 		<model name='EFT-7X'>
 			<availability>IS:8,MH:6</availability>
 		</model>
-		<model name='EFT-4J'>
-			<availability>MERC:1-,Periphery:8</availability>
-		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='EFT-4J'>
+			<availability>MERC:1-,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5794,29 +5794,29 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
-		</model>
 		<model name='EST-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='EST-OC'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CHH:4,RD:5,LA:3,ROS:3,FS:3,MERC:3,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>RD:8</availability>
-		</model>
 		<model name='&apos;HumHov&apos;'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RD:8</availability>
 		</model>
 		<model name='(Streak)'>
 			<roles>fire_support</roles>
@@ -5825,41 +5825,14 @@
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CHH:4,MERC.WD:4,CW:4,CLAN:4,CNC:4+,CP:4+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:4</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -5867,8 +5840,35 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>CWE:2,RD:2,CW:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:4</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5879,31 +5879,27 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,MH:3,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:3</availability>
-		</model>
-		<model name='EMP-7L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='EMP-6A'>
-			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
-		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 		<model name='EMP-8L'>
 			<availability>CC:5</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
+		<model name='EMP-7L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='EMP-6L'>
+			<availability>CC:3</availability>
+		</model>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-6A'>
+			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>LA:5-,ROS:3-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4</availability>
@@ -5915,49 +5911,49 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:5,ROS:4,MERC:5,FS:7</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='ENF-6H'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='ENF-6Ma'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='ENF-6T'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='ENF-6G'>
 			<availability>ROS:4,FS:1,MERC:4</availability>
+		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
 		</model>
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='ENF-6NAIS'>
+		<model name='ENF-6T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='ENF-6H'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='ENF-7D'>
 			<availability>FS:5</availability>
 		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:5,FS:4,MERC:2,CDP:1,TC:1</availability>
-		<model name='ENF-5D'>
-			<availability>FVC:8,FS:8,MERC:6,CDP:6,TC:6</availability>
-		</model>
 		<model name='ENF-4R'>
 			<availability>FVC:1-</availability>
+		</model>
+		<model name='ENF-5D'>
+			<availability>FVC:8,FS:8,MERC:6,CDP:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -5966,28 +5962,36 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
 		<availability>CHH:7,RD:5,CJF:3,RA:4,CWIE:4</availability>
-		<model name='(ER Pulse)'>
-			<availability>CHH:8,RD:5</availability>
+		<model name='(LB-X) &apos;Sholef&apos;'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LB-X) &apos;Sholef&apos;'>
-			<availability>CHH:4</availability>
+		<model name='(ER Pulse)'>
+			<availability>CHH:8,RD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CWE:4+,CHH:6+,RD:3+,CDS:4+,CW:4+,CNC:3+,CP:3+,CWIE:4+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -5997,10 +6001,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -6008,13 +6008,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CDS:2,ROS:1,CP:2,RA:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -6023,12 +6023,12 @@
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:4,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:4,FS:6</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -6053,13 +6053,13 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>FWL:1,IS:1,CP:1</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1,CP:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
@@ -6081,27 +6081,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MERC:4</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
-		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -6116,12 +6116,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,CP:8</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,FWL:4:3139,MSC:6,CP:4</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -6132,11 +6132,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-9R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='FLC-8R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='FLC-9R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -6148,13 +6148,13 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Standard)'>
-			<roles>cruiser</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cruiser</roles>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
@@ -6163,54 +6163,54 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='FEC-5CM'>
-			<roles>spotter</roles>
+		<model name='FEC-3C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='FEC-3C'>
+		<model name='FEC-5CM'>
+			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='&apos;Longshot&apos;' mechanized='false'>
-			<availability>General:4</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='&apos;Longshot&apos;' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir II Assault Battle Armor' unitType='BattleArmor'>
 		<availability>LA:5</availability>
-		<model name='(Med. Laser)' mechanized='false'>
+		<model name='(AI)' mechanized='false'>
+			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(AI)' mechanized='false'>
-			<roles>anti_infantry</roles>
+		<model name='(Med. Laser)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)' mechanized='false'>
@@ -6222,32 +6222,32 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,MERC.WD:4,MERC.KH:2+,CHH:1,RD:1,CW:4,CJF:2,CWIE:4</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,RD:6,CDS:7,CW:6,CNC:6,General:4,CP:6,CJF:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,CNC:4,General:6,CP:5,CJF:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:6,CDS:7,CW:6,CNC:4,General:5,CP:5,CJF:7,CWIE:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:2,CP:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CWE:3,CDS:6,CW:3,CNC:5,General:4,CP:5,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,RD:6,CDS:7,CW:6,CNC:6,General:4,CP:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:6,CDS:7,CW:6,CNC:4,General:5,CP:5,CJF:7,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
@@ -6264,36 +6264,36 @@
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:1,LA:2,ROS:1,Periphery.HR:1,Periphery.MW:1,Periphery.CM:1,FWL:1,FS:2,CP:1</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='&apos;Fermi&apos;'>
 			<roles>apc</roles>
 			<availability>FS:5</availability>
-		</model>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5,CP:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:2</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5,CP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -6305,59 +6305,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6365,39 +6317,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CP:3,CJF:7</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -6412,19 +6416,15 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-10D'>
-			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-10D'>
+			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='ALM-8D'>
 			<roles>recon,raider</roles>
@@ -6450,11 +6450,13 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:6,IS:5,Periphery.Deep:5,Periphery:7</availability>
-		<model name='FS9-S2'>
-			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
+		<model name='FS9-M3'>
+			<roles>spotter</roles>
+			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
 		</model>
-		<model name='FS9-M4'>
-			<availability>OP:4,FVC:3,RF:4,LA:4,ROS:4,IS:4,MH:3,FS:4,DA:4,TC:3</availability>
+		<model name='FS9-S1'>
+			<roles>recon</roles>
+			<availability>LA:2,General:1,FS:1</availability>
 		</model>
 		<model name='FS9-M2'>
 			<roles>incendiary</roles>
@@ -6462,6 +6464,16 @@
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S2'>
+			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
+		</model>
+		<model name='FS9-M4'>
+			<availability>OP:4,FVC:3,RF:4,LA:4,ROS:4,IS:4,MH:3,FS:4,DA:4,TC:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
@@ -6474,77 +6486,62 @@
 		<model name='FS9-S3'>
 			<availability>LA:6,ROS:5,FWL:3,FS:3,MERC:3,CP:3</availability>
 		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:2,General:1,FS:1</availability>
-		</model>
-		<model name='FS9-M3'>
-			<roles>spotter</roles>
-			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:2,LA:5,IS:2,FS:3,MERC:4,DC:7</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:3,DC:3</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
 		<availability>CJF:4</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -6554,44 +6551,47 @@
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,ROS:2,CLAN:1,FWL:4,MSC:5,CP:2,CJF:2,DC:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,FWL:4:3139,MERC.SI:5,MSC:6,CP:4,BAN:8</availability>
-		</model>
 		<model name='FLS-9M'>
 			<availability>FWL:6,MSC:8,CP:6</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,FWL:4:3139,MERC.SI:5,MSC:6,CP:4,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:8,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -6600,11 +6600,11 @@
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,MERC:5-,CP:2-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,RCM:4-,DA:4-</availability>
 		</model>
-		<model name='FLE-20'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='FLE-17'>
 			<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,CP:8,Periphery:6</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6615,8 +6615,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -6628,20 +6628,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -6670,17 +6670,17 @@
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
 		<availability>ROS:3,FS:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(VSP)'>
-			<availability>General:4</availability>
+		<model name='(Interdictor)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:5</availability>
+		<model name='(VSP)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6718,10 +6718,6 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,ROS:5,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
@@ -6730,52 +6726,56 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CWE:1,CHH:3,RD:3,CW:1,ROS:5,FS:5,MERC:4,CJF:1</availability>
-		<model name='(Fury III)'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='(Fury IIIm)'>
-			<roles>spotter</roles>
-			<availability>FS:3</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>ROS:5,FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
+		<model name='(Fury III)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:8,FS:8,MERC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='(Fury IIIm)'>
+			<roles>spotter</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:5,DTA:6,OP:6,RF:6,ROS:6,General:4,FWL:6,MSC:6,RCM:6,DA:6,CP:6</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:2-,General:8</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:5,DTA:6,OP:6,RF:6,ROS:6,General:4,FWL:6,MSC:6,RCM:6,DA:6,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Fusilier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,MERC:3</availability>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
@@ -6791,10 +6791,6 @@
 	</chassis>
 	<chassis name='GD Infiltrator Suit' unitType='BattleArmor'>
 		<availability>MERC.KH:5,RF:4,LA:5,ROS:4,MERC:4</availability>
-		<model name='(Remote Sensors)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
@@ -6802,13 +6798,17 @@
 		<model name='(Firedrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Sensors)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Mines)' mechanized='true'>
 			<roles>minelayer</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sensors)' mechanized='true'>
+		<model name='(Remote Sensors)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -6817,21 +6817,21 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CWE:2,CW:2,ROS:2,RA:2</availability>
-		<model name='2'>
-			<availability>CWE:6,CW:6,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CWE:6,CW:6,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6845,28 +6845,28 @@
 		<model name='GLT-10-0'>
 			<availability>LA:3,ROS:3,FS:5,MERC:3</availability>
 		</model>
-		<model name='GLT-7-0'>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='GLT-8-0'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
+		<model name='GLT-7-0'>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3,CP:3</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,CP:7,TC:5,DC:4,Periphery:4</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,CP:7,TC:5,DC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -6874,45 +6874,45 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-,CWIE:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-,CWIE:8</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Gambit' unitType='Mek'>
 		<availability>IS:4</availability>
+		<model name='GBT-1G'>
+			<availability>General:8</availability>
+		</model>
 		<model name='GBT-1L'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='GBT-1G'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:4,FS:6,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='GRM-01A2'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
 		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRM-01A2'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Garrot Superheavy Transport' unitType='VTOL'>
@@ -6931,9 +6931,6 @@
 	</chassis>
 	<chassis name='Gauntlet' unitType='Mek' omni='IS'>
 		<availability>LA:7</availability>
-		<model name='GTL-1OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='GTL-1O'>
 			<availability>General:8</availability>
 		</model>
@@ -6943,23 +6940,23 @@
 		<model name='GTL-1OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='GTL-1OC'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CHH:3,CLAN:1,CNC:4,IS:6,Periphery.Deep:4,CP:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,ROS:6,General:4,FS:8</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
 		<availability>CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,CP:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
-		<model name='GST-50'>
-			<availability>DTA:6,OP:6,FWL:6:3139,MSC:6,CP:6</availability>
-		</model>
 		<model name='GST-90'>
 			<availability>PIR:6,MERC:6</availability>
 		</model>
@@ -6969,55 +6966,58 @@
 		<model name='GST-11'>
 			<availability>General:4</availability>
 		</model>
+		<model name='GST-50'>
+			<availability>DTA:6,OP:6,FWL:6:3139,MSC:6,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:7</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,CDS:4,ROS:4+,CNC:5,CLAN:4,CP:4,CJF:3,BAN:4</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CP:7,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CWE:5,CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CWE:7,RD:8,CW:7,General:8,CJF:9,CWIE:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
+		<model name='A'>
+			<availability>CWE:8,RD:7,CDS:5,CW:8,CNC:5,General:6,CP:5,CJF:5,CWIE:8</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:8,RD:7,CDS:5,CW:8,CNC:5,General:6,CP:5,CJF:5,CWIE:8</availability>
+		<model name='B'>
+			<availability>RD:4,General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CWE:7,RD:8,CW:7,General:8,CJF:9,CWIE:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CNC:7,General:5,CP:7,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,RD:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CWE:5,CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='D'>
 			<availability>CWE:3,RD:4,CDS:2,CW:3,CNC:3,General:2,CP:2,CJF:2,CWIE:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='P'>
 			<availability>CWE:5,CHH:6,RD:6,CDS:5,CW:5,CLAN:4,General:3,CP:5,CJF:5,CWIE:5</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,General:7</availability>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -7054,14 +7054,6 @@
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
 		<availability>ROS:5,FS:7</availability>
-		<model name='(Light Gauss)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>FS:6</availability>
@@ -7070,23 +7062,31 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:1</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -7098,19 +7098,16 @@
 	</chassis>
 	<chassis name='Goblin Infantry Support Vehicle' unitType='Tank'>
 		<availability>FVC:5,LA:2,ROS:4,FS:2,MERC:4</availability>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,RD:7</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>RD:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
@@ -7121,44 +7118,47 @@
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>RD:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-4S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:6,FWL:5,MH:6,MERC:6,CP:5,CDP:6,TC:6</availability>
-		</model>
-		<model name='GOL-6M'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
-		</model>
-		<model name='GOL-3L'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:6,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,MH:8,Periphery:4</availability>
 		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='GOL-6M'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
+		<model name='GOL-4S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>MERC:1-</availability>
 		</model>
-		<model name='GOL-2H'>
-			<roles>fire_support</roles>
-			<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
-		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon Carrier' unitType='Dropship'>
@@ -7170,19 +7170,15 @@
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CNC:4,CP:4,RA:6</availability>
-		<model name='3'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:5,CP:5,RA:5</availability>
+		</model>
+		<model name='3'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>ROS:2,RA:7</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>RA:4</availability>
@@ -7190,26 +7186,30 @@
 		<model name='RISC'>
 			<availability>ROS:8</availability>
 		</model>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>RA:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gossamer VTOL' unitType='VTOL'>
 		<availability>CDS:5,LA:6,ROS:6,CNC:3,FWL:6,FS:6,CP:4,RA:7-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,CLAN:3,CNC:4,FWL:7,MSC:7,CP:5,MERC:4</availability>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,CNC:4,FWL:4,CP:4,MERC:4,BAN:2,Periphery:4</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>DTA:8,OP:8,ROS:8,FWL:6:3139,MSC:8,CP:6</availability>
@@ -7223,17 +7223,20 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>RD:4,ROS:5,CNC:5,MERC:4,CP:5,DC:5</availability>
+		<model name='DRG-5K'>
+			<availability>RD:8,ROS:6,CNC:8,MERC:6,CP:8,DC:2</availability>
+		</model>
+		<model name='DRG-7K'>
+			<availability>ROS:6,MERC:4,DC:2</availability>
+		</model>
+		<model name='DRG-C'>
+			<availability>ROS:4,DC:3</availability>
+		</model>
 		<model name='DRG-10K'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='DRG-7KC'>
 			<availability>DC:7</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>RD:8,ROS:6,CNC:8,MERC:6,CP:8,DC:2</availability>
-		</model>
-		<model name='DRG-C'>
-			<availability>ROS:4,DC:3</availability>
 		</model>
 		<model name='DRG-9KC'>
 			<roles>spotter</roles>
@@ -7241,9 +7244,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>ROS:6,MERC:4,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -7260,23 +7260,23 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,IS:3,Periphery.Deep:4,MERC:7,Periphery:6,DC:4,TC:6</availability>
+		<model name='GHR-7P'>
+			<availability>LA:8,MERC:4</availability>
+		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
+		</model>
+		<model name='GHR-5H'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 		<model name='GHR-5J'>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>ROS:4,MERC:2,FS:2,DC:4</availability>
-		</model>
-		<model name='GHR-5H'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='GHR-7P'>
-			<availability>LA:8,MERC:4</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gravedigger' unitType='Mek'>
@@ -7306,14 +7306,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -7343,25 +7343,16 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer)[C3/HRR]' mechanized='false'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:6</availability>
+		<model name='[Flamer]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[LRR]' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='[Flamer]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+		<model name='(Hunter-Killer)[C3/HRR]' mechanized='false'>
 			<availability>FS:4</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
@@ -7371,16 +7362,25 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[Heavy Flamer]' mechanized='false'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4</availability>
-		<model name='B' mechanized='false'>
+		<model name='A' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A' mechanized='true'>
+		<model name='B' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D' mechanized='true'>
@@ -7393,20 +7393,23 @@
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CHH:8,CLAN:5,IS:3</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:8,CLAN:5,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -7414,32 +7417,29 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CWE:2,MERC.WD:5,CDS:6,CW:2,LA:3,CNC:7,IS:3,CP:6,CJF:2,CWIE:4,DC:4</availability>
-		<model name='4'>
-			<availability>CDS:6,CNC:8,IS:6,CP:7</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,IS:8,CP:6</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CNC:2</availability>
 		</model>
-		<model name='6'>
-			<availability>ROS:4,CNC:6,CP:6,DC:6</availability>
+		<model name='7'>
+			<availability>ROS:4,CNC:6,CP:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:6,CNC:4,CP:4</availability>
 		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:6,CP:6</availability>
+		<model name='6'>
+			<availability>ROS:4,CNC:6,CP:6,DC:6</availability>
 		</model>
 		<model name='8'>
 			<availability>CWE:6,CW:6,LA:6,ROS:4,CJF:6,CWIE:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:6,CNC:8,IS:6,CP:7</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CNC:4,CP:4</availability>
@@ -7447,54 +7447,54 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,IS:6,MERC:7,CP:2,TC:5,Periphery:4,RA.OA:1,RD:4,LA:7,ROS:5,CNC:2,DC:7</availability>
-		<model name='GRF-2N'>
-			<availability>CC:4,MOC:4,OP:4,CLAN:6,FS:4,MERC:4,CP:4,BAN:4,FWL:4:3139,MH:4,MSC:4,RCM:4,DC:4</availability>
+		<model name='GRF-1N'>
+			<availability>BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>TC:1-</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,OP:6,ROS:5,FWL:5:3139,MSC:6,MERC:5,CP:5</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>MOC:4,OP:5,IS:4,CP:4,DTA:5,RF:6,LA:3,FWL:4,MH:4,MSC:5,RCM:6,DA:6,DC:1</availability>
-		</model>
 		<model name='GRF-6S2'>
 			<availability>LA:4,FS:3,DC:3</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CC:4,RD:5,ROS:6,CNC:4,FWL:4,FS:4,CP:4,DC:4</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:4,ROS:3,DC:1</availability>
-		</model>
-		<model name='GRF-5K'>
-			<availability>CNC:8,CP:8,DC:8</availability>
-		</model>
-		<model name='GRF-4N'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='GRF-5L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='GRF-6S'>
 			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='GRF-5K'>
+			<availability>CNC:8,CP:8,DC:8</availability>
+		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,OP:6,ROS:5,FWL:5:3139,MSC:6,MERC:5,CP:5</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:4,ROS:3,DC:1</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>MOC:4,OP:5,IS:4,CP:4,DTA:5,RF:6,LA:3,FWL:4,MH:4,MSC:5,RCM:6,DA:6,DC:1</availability>
+		</model>
+		<model name='GRF-4N'>
+			<availability>TC:6</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CC:4,RD:5,ROS:6,CNC:4,FWL:4,FS:4,CP:4,DC:4</availability>
+		</model>
+		<model name='GRF-5L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='GRF-2N'>
+			<availability>CC:4,MOC:4,OP:4,CLAN:6,FS:4,MERC:4,CP:4,BAN:4,FWL:4:3139,MH:4,MSC:4,RCM:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -7513,11 +7513,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
-		</model>
 		<model name='B'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
@@ -7525,30 +7525,30 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.KH:4,MERC.WD:4,CHH:2-,CW:4,LA:4,ROS:4,CNC:2-,CP:2-,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:4,CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CWE:4,CW:4,IS:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:4,CHH:1,ROS:5,FWL:4,MSC:5,FS:4,CP:4,MERC:2,RA:1,Periphery:1</availability>
-		<model name='GLT-6WB3'>
+		<model name='GLT-8D'>
 			<roles>raider</roles>
-			<availability>ROS:3,FWL:4:3139,MSC:6,MERC:3,CP:4</availability>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>NIOPS:0,Periphery:1-</availability>
 		</model>
-		<model name='GLT-8D'>
-			<roles>raider</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:2,MERC:4,CP:8</availability>
+		</model>
+		<model name='GLT-6WB3'>
+			<roles>raider</roles>
+			<availability>ROS:3,FWL:4:3139,MSC:6,MERC:3,CP:4</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -7557,11 +7557,11 @@
 	</chassis>
 	<chassis name='Gulltoppr OmniMonitor' unitType='Tank' omni='IS'>
 		<availability>MERC.KH:4,LA:4,CWIE:5</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(A)'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(B)'>
 			<roles>artillery,spotter</roles>
@@ -7570,15 +7570,15 @@
 	</chassis>
 	<chassis name='Gun' unitType='Mek' omni='IS'>
 		<availability>CC:4-,MOC:3,DA:2</availability>
-		<model name='GN-2O'>
-			<availability>General:8</availability>
+		<model name='GN-2OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='GN-2OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='GN-2OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='GN-2O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -7587,12 +7587,12 @@
 			<roles>spotter</roles>
 			<availability>LA:6,General:4,FS:6,DC:6</availability>
 		</model>
-		<model name='GUN-1ERD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GUN-2ERDr'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
+		</model>
+		<model name='GUN-1ERD'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunsmith' unitType='Mek'>
@@ -7603,12 +7603,12 @@
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6,ROS:4,FS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurzil Support Tank' unitType='Tank'>
@@ -7641,9 +7641,9 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CNC:5,IS:4,CP:5,DC:4,CWIE:4</availability>
-		<model name='HKO-1C'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>LA:4,DC:4</availability>
+			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,CP:5,DC:4+</availability>
@@ -7651,20 +7651,20 @@
 		<model name='2'>
 			<availability>CDS:4,CP:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='HKO-1C'>
 			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
+			<availability>LA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>RA.OA:5,CHH:7,LA:3,ROS:4,CLAN:5,FS:3,MERC:3</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:8,RD:4,CDS:4,CP:4,RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:8,RD:4,CDS:4,CP:4,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hadur Fast Support Vehicle' unitType='Tank'>
@@ -7683,60 +7683,55 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>FWL:6,MERC:5,CP:6</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,MERC:4,CP:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,MERC:5,CP:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,MERC:6,CP:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,MERC:4,CP:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:5,MERC:3</availability>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:6,MERC:6</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6E'>
-			<availability>General:6,MERC:6</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:5,CLAN:2,CNC:3,CP:3</availability>
-		<model name='HMR-HE'>
-			<availability>ROS:4</availability>
+		<model name='HMR-HDb'>
+			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4,CP:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,RD:3,CDS:4,ROS:3+,CNC:5,CP:4,CJF:4</availability>
-		<model name='B'>
-			<availability>CNC:7,General:6,CP:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
@@ -7746,17 +7741,22 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8,CP:9</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CNC:7,General:6,CP:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8,CP:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7774,11 +7774,11 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,OP:7,MERC:5,CP:7,DTA:7,FWL.pm:7,RF:7,LA:5,FWL:7,MH:5,MSC:7,DA:7,RCM:7</availability>
-		<model name='(MML)'>
-			<availability>MOC:6,DTA:8,CC:6,OP:8,RF:8,LA:6,FWL:8:3139,MSC:8,RCM:8,DA:8,MERC:6,CP:8</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>DTA:6,CC:6,MOC:6,OP:6,RF:6,FWL:6:3139,MH:6,MSC:6,DA:6,RCM:6,CP:6,MERC:5</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:6,DTA:8,CC:6,OP:8,RF:8,LA:6,FWL:8:3139,MSC:8,RCM:8,DA:8,MERC:6,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harpagos' unitType='Mek'>
@@ -7789,14 +7789,14 @@
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Standard)'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hasek Mechanized Combat Vehicle' unitType='Tank'>
@@ -7808,14 +7808,14 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>ROS:4,MERC:2,DC:5</availability>
-		<model name='HTM-28T'>
-			<availability>ROS:4,DC:2</availability>
+		<model name='HTM-27T'>
+			<availability>MERC:3,DC:3</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:8</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>MERC:3,DC:3</availability>
+		<model name='HTM-28T'>
+			<availability>ROS:4,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Godai' unitType='Mek'>
@@ -7851,43 +7851,43 @@
 		<model name='HCT-6S'>
 			<availability>LA:8,MERC:6</availability>
 		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='HCT-5D'>
 			<availability>CDP:1</availability>
 		</model>
-		<model name='HCT-6M'>
-			<availability>DTA:8,ROS:5,FWL:8,MSC:8,MERC:6,CP:8</availability>
-		</model>
-		<model name='HCT-7R'>
-			<availability>ROS:8</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:3,LA:2,FS:2,MERC:4,DC:2,Periphery:4</availability>
-		</model>
 		<model name='HCT-5DD'>
 			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
 		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:3,LA:2,FS:2,MERC:4,DC:2,Periphery:4</availability>
+		</model>
 		<model name='HCT-6D'>
 			<availability>ROS:4,FS:2,MERC:6</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-6M'>
+			<availability>DTA:8,ROS:5,FWL:8,MSC:8,MERC:6,CP:8</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		</model>
+		<model name='HCT-7R'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7899,34 +7899,34 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HA1-OE'>
-			<availability>General:5</availability>
+		<model name='HA1-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='HA1-OM'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='HA1-OE'>
+			<availability>General:5</availability>
+		</model>
+		<model name='HA1-OT'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OT'>
-			<availability>General:4</availability>
-		</model>
-		<model name='HA1-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='HA1-OC'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Havoc' unitType='Mek'>
@@ -7937,11 +7937,11 @@
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,OP:5,IS:3,FS:4,CP:5,DTA:5,RF:5,LA:3,FWL:5,MSC:5,RCM:4,DA:3,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -7953,12 +7953,12 @@
 			<roles>artillery</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MML)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HawkWolf' unitType='Mek'>
@@ -7987,25 +7987,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -8017,11 +8017,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,RA.OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -8052,23 +8052,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>ROS:2,FS:3,MERC:2</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4,CP:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CP:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>ROS:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4,CP:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -8079,6 +8079,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:4,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -8086,33 +8094,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:4,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
@@ -8121,15 +8121,15 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
@@ -8147,11 +8147,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -8171,14 +8171,14 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>CHH:3,CDS:2,ROS:2,CNC:6,CP:4,CJF:3</availability>
-		<model name='5'>
-			<availability>ROS:5,CNC:5,CP:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:6,CP:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CNC:5,CP:5</availability>
+		</model>
+		<model name='5'>
+			<availability>ROS:5,CNC:5,CP:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:6,CNC:8,CP:7,CWIE:8,DC:6</availability>
@@ -8189,14 +8189,22 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,CP:5,CJF:2</availability>
+		<model name='C'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:7,CJF:3</availability>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='G'>
 			<availability>General:5</availability>
@@ -8204,21 +8212,13 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:6,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
@@ -8226,12 +8226,12 @@
 			<roles>spotter</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
@@ -8252,36 +8252,36 @@
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
 		<availability>CHH:4</availability>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AP)'>
 			<roles>recon,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -8306,42 +8306,46 @@
 			<roles>recon</roles>
 			<availability>ROS:2-,MERC:2-</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>OP:4,FWL:4,MSC:4,CP:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:4,MERC:4,CP:4</availability>
-		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
+			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:6,FS:6,CP:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5Sr'>
+		<model name='HER-2S'>
 			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:4</availability>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>OP:4,FWL:4,MSC:4,CP:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:4,MERC:4,CP:4</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>DC.GHO:6,OP:8,FWL:7,MSC:8,CP:7,MERC:5,DC:6</availability>
+		<model name='HER-3S'>
+			<roles>recon</roles>
+			<availability>FWL:1,CP:1</availability>
+		</model>
+		<model name='HER-4S'>
+			<roles>recon</roles>
+			<availability>OP:4,FWL:3,MSC:4,CP:3</availability>
+		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:8</availability>
-		</model>
-		<model name='HER-3S'>
+		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
@@ -8349,31 +8353,27 @@
 			<roles>recon</roles>
 			<availability>OP:6,FWL:4:3139,MSC:6,MERC:6,CP:4,DC:8</availability>
 		</model>
-		<model name='HER-4S'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>OP:4,FWL:3,MSC:4,CP:3</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:1,CP:1</availability>
+			<availability>CLAN:6,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,CNC:2,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,RF:6,DA:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CC:1,IS:1,Periphery:1</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:3-</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,RF:6,DA:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CC:1,IS:1,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hexareme HQ Hovercraft' unitType='Tank'>
@@ -8385,32 +8385,32 @@
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
 		<availability>LA:1,IS:1</availability>
+		<model name='(Cunnington)'>
+			<roles>spotter</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>LA:2,General:8</availability>
 		</model>
-		<model name='(Cunnington)'>
-			<roles>spotter</roles>
-			<availability>LA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CWE:6,CHH:6,RD:6,CDS:4,CW:6,LA:3,ROS:4,CNC:6,CP:5,CJF:6</availability>
-		<model name='2'>
-			<availability>CWE:4,CW:4</availability>
+		<model name='(Standard)'>
+			<availability>CWE:4,CDS:4,CW:4,CNC:4,IS:8,CP:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CWE:4,CHH:8,RD:8,CW:4,ROS:4,CJF:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CWE:4,CDS:4,CW:4,CNC:4,IS:8,CP:4</availability>
+		<model name='2'>
+			<availability>CWE:4,CW:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
-		<model name='HGN-734'>
-			<availability>LA:6,ROS:6,MERC:6</availability>
+		<model name='HGN-738'>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -8418,8 +8418,8 @@
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:8,ROS:8</availability>
+		<model name='HGN-734'>
+			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hippogriff' unitType='ProtoMek'>
@@ -8430,7 +8430,7 @@
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:5</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8438,7 +8438,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8464,32 +8464,32 @@
 	</chassis>
 	<chassis name='Hitotsume Kozo' unitType='Mek'>
 		<availability>DC.GHO:6,DC:4</availability>
-		<model name='HKZ-1F'>
-			<availability>DC.GHO:6,General:4</availability>
-		</model>
 		<model name='HKZ-1P'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HKZ-1F'>
+			<availability>DC.GHO:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander III' unitType='Mek'>
 		<availability>LA:5,FS.CMM:7,FS:6,MERC:5</availability>
-		<model name='BZK-D2'>
-			<availability>LA:8,General:4</availability>
-		</model>
 		<model name='BZK-D3'>
 			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BZK-D1'>
 			<availability>General:4,FS:8</availability>
 		</model>
+		<model name='BZK-D2'>
+			<availability>LA:8,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8506,15 +8506,15 @@
 		<model name='HNT-182'>
 			<availability>FVC:4,FS.PMM:4,FS.CMM:4,FS.DMM:4,FS.CrMM:4</availability>
 		</model>
-		<model name='HNT-181'>
-			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
+		<model name='HNT-171'>
+			<availability>FVC:8,FS:6,MERC:8</availability>
 		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='HNT-171'>
-			<availability>FVC:8,FS:6,MERC:8</availability>
+		<model name='HNT-181'>
+			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -8568,53 +8568,63 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='HBK-6S'>
-			<availability>LA:8,ROS:6,MERC:6</availability>
-		</model>
 		<model name='HBK-7R'>
 			<roles>spotter</roles>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
+		<model name='HBK-6S'>
+			<availability>LA:8,ROS:6,MERC:6</availability>
 		</model>
 		<model name='HBK-5H'>
 			<availability>FVC:3,MH:6,Periphery:4</availability>
 		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>Periphery:2-</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='HBK-5S'>
 			<availability>LA:3,ROS:3,MH:3,MERC:1,FS:3</availability>
 		</model>
-		<model name='HBK-6N'>
-			<availability>ROS:3,FWL:2,MH:4,MERC:3,CP:2,DC:3</availability>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='HBK-7S'>
 			<roles>spotter</roles>
 			<availability>LA:2</availability>
 		</model>
+		<model name='HBK-6N'>
+			<availability>ROS:3,FWL:2,MH:4,MERC:3,CP:2,DC:3</availability>
+		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,RD:5,CDS:4,CLAN:3,CP:4,BAN:4</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,IS:3,MERC:3,FS:3,CP:2,Periphery:3,TC:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='(Amphibious)'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>RF:6,LA:8,ROS:6,FWL:4:3139,FS:6,RCM:6,MERC:6,DA:6,CP:4</availability>
+		</model>
 		<model name='(ERLL)'>
 			<availability>LA:4,FS:4</availability>
 		</model>
@@ -8622,45 +8632,38 @@
 			<roles>fire_support</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>RF:6,LA:8,ROS:6,FWL:4:3139,FS:6,RCM:6,MERC:6,DA:6,CP:4</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Amphibious)'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 		<model name='&apos;Assault Hunter&apos;'>
 			<availability>LA:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,CP:5,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5,CP:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5,CP:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CP:4,DC:4</availability>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:3+</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='HSCL-1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:3+</availability>
+		</model>
+		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OD'>
@@ -8669,18 +8672,15 @@
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>ROS:2,CLAN:3</availability>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,MERC.SI:4,BAN:8</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8692,17 +8692,17 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CLAN:6,RA:6</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:8,CLAN:6,CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:8,CLAN:6,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -8723,8 +8723,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:2,MOC:8,LA:1,ROS:4,IS:8,FWL:3,MH:8,CP:3,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8732,10 +8732,10 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='[SRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -8761,11 +8761,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:6,MERC.KH:8</availability>
-		</model>
 		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-4E'>
+			<availability>MERC.WD:6,MERC.KH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8790,23 +8790,23 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CWE:6,CW:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8815,17 +8815,17 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:4,LA:4,ROS:5,FWL:4,FS:4,CP:4,DC:4</availability>
-		<model name='(3115)'>
+		<model name='(SCC)'>
 			<roles>assault</roles>
-			<availability>ROS:5</availability>
+			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>CC:8,ROS:4,FWL:8,CP:8</availability>
 		</model>
-		<model name='(SCC)'>
+		<model name='(3115)'>
 			<roles>assault</roles>
-			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+			<availability>ROS:5</availability>
 		</model>
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
@@ -8834,40 +8834,40 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,TC:3,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>DTA:8,OP:8,RF:8,ROS:5,FWL:8,IS:4,MSC:8,DA:8,RCM:8,CP:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>DTA:8,OP:8,RF:8,ROS:5,FWL:8,IS:4,MSC:8,DA:8,RCM:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,CLAN:9,IS:7,Periphery.Deep:6,FS:9,CP:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,PIR:5,FWL:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:5</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -8879,17 +8879,20 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CHH:6,LA:2,ROS:3,CLAN:4,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CWE:4,CHH:8,CW:4,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
+		<model name='2'>
+			<availability>RA:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
@@ -8897,12 +8900,14 @@
 			<roles>recon</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,RA.OA:4,CLAN:6,IS:6,MH:4,CP:6,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8912,11 +8917,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8933,19 +8933,15 @@
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>RD:3,IS:4,TC:4,Periphery:4</availability>
-		<model name='(3082 Upgrade)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>TC:3</availability>
+		</model>
+		<model name='(3082 Upgrade)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
 		<availability>CC:4,RD:6,LA:4,ROS:5,IS:4,FWL:4,FS:6,MERC:4,CJF:4,Periphery:4,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>RD:8,IS:3,Periphery:6</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>ROS:6,FS:6,CJF:8</availability>
@@ -8954,13 +8950,13 @@
 			<roles>fire_support</roles>
 			<availability>RD:4,IS:8,Periphery:8</availability>
 		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>RD:8,IS:3,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='JES III Missile Carrier' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(Thunderbolt)'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -8969,11 +8965,15 @@
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Speed)'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(Thunderbolt)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9018,19 +9018,15 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>MOC:5,DTA:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5,MSC:6,MERC:6,CP:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>FWL:2,Periphery.Deep:6,MERC:2,CP:2,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>DTA:5,ROS:5,FWL:3:3139,MSC:5,MERC:5,CP:3</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>FWL:2,Periphery.Deep:6,MERC:2,CP:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackalope' unitType='Mek'>
 		<availability>DTA:4,ROS:5,MERC:3,RCM:4</availability>
-		<model name='JLP-BD'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='JLP-KW &apos;Wolpertinger&apos;'>
 			<roles>recon</roles>
 			<availability>General:3</availability>
@@ -9039,6 +9035,10 @@
 			<roles>recon</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='JLP-BD'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='JLP-KA'>
 			<roles>recon</roles>
 			<availability>General:3</availability>
@@ -9046,36 +9046,26 @@
 	</chassis>
 	<chassis name='Jade Hawk' unitType='Mek'>
 		<availability>MERC:4,CJF:4</availability>
+		<model name='(Standard)'>
+			<availability>CJF:8</availability>
+		</model>
+		<model name='JHK-03'>
+			<availability>MERC:8</availability>
+		</model>
 		<model name='2'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='JHK-04'>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='JHK-03'>
-			<availability>MERC:8</availability>
-		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CJF:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,CW:8,CLAN:6</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CWE:2,CW:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:5,CW:5,General:2,RA:4</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:4,CW:4,CLAN:2,RA:6</availability>
@@ -9083,8 +9073,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:5,CW:5,General:2,RA:4</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CWE:2,CW:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -9098,21 +9098,6 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>Periphery:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:3,MERC:6</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
@@ -9121,35 +9106,69 @@
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
+		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,LA:2,ROS:2,FS:1,MERC:2,CDP:3,DC:2</availability>
 		</model>
-		<model name='JM7-C3BS'>
+		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:8</availability>
+			<availability>ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>MOC:6,RA.OA:4,FVC:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jaguar' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:4,CJF:4,CWIE:4</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,CWIE:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='JVN-11P'>
+			<availability>FVC:6</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:1,LA:1,ROS:1,FS:1,MERC:1,CDP:1</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
@@ -9158,85 +9177,70 @@
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
-		</model>
-		<model name='JVN-11P'>
-			<availability>FVC:6</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:1,LA:1,ROS:1,FS:1,MERC:1,CDP:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,RD:9,CW:8,CLAN:6,CWIE:7</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='X'>
 			<availability>General:1,CJF:2,RA:2</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CWE:6,CDS:6,CW:6,ROS:4,CNC:8,CP:7,DC:3</availability>
-		<model name='3'>
-			<availability>CNC:6,CP:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CWE:3,CW:3,CNC:3,CP:3</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:6,CP:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:8,CNC:8,IS:8,CP:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CNC:6,CP:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CWE:3,CW:3,CNC:3,CP:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:5,FS.DMM:5,MERC:4,Periphery.OS:5,FS:4,RA:4,DC:8,Periphery:3</availability>
-		<model name='JR7-C4'>
-			<roles>raider</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>ROS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>ROS:4,DC:8</availability>
+		</model>
+		<model name='JR7-C4'>
+			<roles>raider</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -9246,17 +9250,9 @@
 			<roles>raider</roles>
 			<availability>MERC:4,FS:4,DC:2</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -9264,6 +9260,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -9276,11 +9276,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -9305,26 +9305,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:5,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -9342,29 +9342,45 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CJF:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:4,DC:5</availability>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 		<model name='C' mechanized='true'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>ROS:2,DC:2</availability>
 		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
@@ -9374,29 +9390,13 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -9417,40 +9417,40 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.NSR:2,DC.SL:2,General:4</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>RD:8</availability>
-		<model name='G'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='G'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -9462,39 +9462,39 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>PIR:2,IS:2,Periphery:2,RA:2</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:2,MERC:2</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
-		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:4</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>FWL:5,IS:6,CP:5</availability>
 		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>MH:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,DC:6</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:8,DC:8</availability>
 		</model>
 		<model name='CRK-5003-C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kelswa Assault Tank' unitType='Tank'>
@@ -9505,6 +9505,13 @@
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:2,LA:2,ROS:2,CLAN:2,FS:2,DC:1</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -9512,18 +9519,11 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
-		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kheper' unitType='Mek'>
@@ -9534,23 +9534,23 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,FWL:4,MH:4,DC:4</availability>
-		<model name='KGC-001'>
-			<availability>LA:2,IS:3,MH:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:4,ROS:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='KGC-008B'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 		</model>
+		<model name='KGC-001'>
+			<availability>LA:2,IS:3,MH:6</availability>
+		</model>
 		<model name='KGC-005r'>
 			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='KGC-008B'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='KGC-009'>
 			<availability>LA:8</availability>
@@ -9558,23 +9558,20 @@
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>RD:6,CDS:3,ROS:3+,CNC:3,CP:2,RA:3</availability>
-		<model name='C'>
-			<availability>RD:3,General:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>RD:5,General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:3,General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -9582,13 +9579,16 @@
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
 		<availability>CC:4,MOC:4,RD:4,ROS:8,IS:5,MERC:6,TC:4</availability>
-		<model name='(PPC)'>
+		<model name='(RAC)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(RAC)'>
+		<model name='(PPC)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -9597,41 +9597,41 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,ROS:6,MERC:2,DC:2</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:5</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:2,DC.SL:4,ROS:3,CLAN:6,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='KTO-20'>
-			<availability>MERC:3,DC:2</availability>
 		</model>
 		<model name='KTO-19b'>
 			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
+		<model name='KTO-20'>
+			<availability>MERC:3,DC:2</availability>
+		</model>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:5</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9649,13 +9649,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kite Reconnaissance Vehicle' unitType='Tank'>
@@ -9674,15 +9674,15 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>RD:2-</availability>
-		<model name='(GB) [GL/Flamer]' mechanized='true'>
-			<availability>RD:6</availability>
+		<model name='(GB) [SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>RD:8</availability>
 		</model>
 		<model name='(GB) [SL/Flamer]' mechanized='true'>
 			<availability>RD:6</availability>
 		</model>
-		<model name='(GB) [SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>RD:8</availability>
+		<model name='(GB) [GL/Flamer]' mechanized='true'>
+			<availability>RD:6</availability>
 		</model>
 		<model name='(GB) [GL]' mechanized='true'>
 			<availability>RD:4</availability>
@@ -9694,19 +9694,19 @@
 	</chassis>
 	<chassis name='Kodiak II' unitType='Mek'>
 		<availability>RD:6</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>RD:6,ROS:4,RA:5</availability>
-		<model name='5'>
-			<availability>RD:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -9715,11 +9715,11 @@
 		<model name='2'>
 			<availability>RD:5,ROS:6</availability>
 		</model>
+		<model name='5'>
+			<availability>RD:4</availability>
+		</model>
 		<model name='4'>
 			<availability>RD:4,ROS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -9728,35 +9728,35 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:2</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:1</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>OP:6,ROS:5,FWL:5,MERC:4,CP:5</availability>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>OP:6,MERC:4</availability>
-		</model>
-		<model name='(Mortar)' mechanized='false'>
+		<model name='(AI Mk IIr)' mechanized='false'>
 			<availability>OP:4,MERC:3</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk IIr)' mechanized='false'>
-			<availability>OP:4,MERC:3</availability>
-		</model>
 		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>OP:6,MERC:4</availability>
+		</model>
+		<model name='(Mortar)' mechanized='false'>
+			<availability>OP:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koroshiya' unitType='Aero'>
@@ -9767,56 +9767,32 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:3,ROS:3,MERC:4,CC.TG:6</availability>
-		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-5I'>
-			<availability>DTA:8,ROS:8,MERC:8</availability>
-		</model>
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8,MERC:4</availability>
-		</model>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:5</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-6L'>
 			<roles>artillery</roles>
 			<availability>CC:5,MOC:5</availability>
 		</model>
+		<model name='KSC-4I'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-5I'>
+			<availability>DTA:8,ROS:8,MERC:8</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:3,MERC.WD:3,CDS:3,CW:4,IS:4+,CP:3,CJF:2,BAN:4,RA:3</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CNC:3,General:2,CP:3</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CWE:7,RD:8,CDS:3,CW:7,General:4,CP:3</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>RD:6,CDS:9,CNC:6,General:8,CP:7</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CWE:4,RD:4,CDS:7,CW:4,General:5,CP:7,CWIE:4</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -9826,14 +9802,38 @@
 			<roles>recon</roles>
 			<availability>CWE:7,RD:2,CDS:5,CW:7,CNC:2,General:3,CP:3,CJF:2,CWIE:7</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CWE:7,RD:8,CDS:3,CW:7,General:4,CP:3</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CNC:3,General:2,CP:3</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CWE:4,RD:4,CDS:7,CW:4,General:5,CP:7,CWIE:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:6,IS:5</availability>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9841,27 +9841,27 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='KTO-3A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>ROS:2,CJF:2,RA:2</availability>
-		<model name='4'>
-			<availability>ROS:8,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='4'>
+			<availability>ROS:8,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -9894,14 +9894,14 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>RD:4</availability>
-		<model name='4'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='4'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9936,17 +9936,17 @@
 	</chassis>
 	<chassis name='Lament' unitType='Mek'>
 		<availability>ROS:5</availability>
-		<model name='LMT-4RC'>
-			<availability>General:3</availability>
-		</model>
-		<model name='LMT-3C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='LMT-2R'>
 			<availability>General:8</availability>
 		</model>
 		<model name='LMT-3R'>
 			<availability>General:5</availability>
+		</model>
+		<model name='LMT-3C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='LMT-4RC'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lamprey Transport Helicopter' unitType='VTOL'>
@@ -9965,33 +9965,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,CP:6,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
-		<model name='LX-2A'>
-			<availability>DTA:5,OP:5,RF:5,LA:5,ROS:5,FWL:5,MSC:5,RCM:5,MERC:5,DA:5,CP:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LX-2A'>
+			<availability>DTA:5,OP:5,RF:5,LA:5,ROS:5,FWL:5,MSC:5,RCM:5,MERC:5,DA:5,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-4E'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:8,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='LHU-4E'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -10003,6 +10003,15 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
 		<model name='LGN-2K'>
 			<roles>raider</roles>
 			<availability>ROS:5</availability>
@@ -10010,60 +10019,51 @@
 		<model name='LGN-2F'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
-		</model>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:4,OP:6,FWL:5:3139,MH:3,MERC:4,CP:5</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<roles>recon</roles>
+		<model name='(David)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(David)' mechanized='true'>
+		<model name='(MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(FireDrake)' mechanized='true'>
+		<model name='(Sensor)' mechanized='true'>
+			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(MG)' mechanized='true'>
+		<model name='(FireDrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,IS:7,Periphery.Deep:5,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,OP:8,FS:8,CP:8,DTA:8,RF:8,LA:8,ROS:8,General:4,FWL:8,MSC:8,RCM:8,DA:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>DTA:8,OP:8,RF:8,LA:8,ROS:8,General:4,FWL:8,MSC:8,FS:8,DA:8,RCM:8,CP:8</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>DTA:8,OP:8,RF:8,LA:8,ROS:8,General:4,FWL:8,MSC:8,FS:8,DA:8,RCM:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -10109,15 +10109,17 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:2,LA:2</availability>
@@ -10125,11 +10127,9 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -10140,12 +10140,12 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(ERSL)'>
 			<availability>ROS:4</availability>
@@ -10153,53 +10153,53 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:2-</availability>
+		<model name='LTN-G16D'>
+			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>ROS:6,FS:6,MERC:4</availability>
+		<model name='LTN-G16O'>
+			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:6,MOC:6,RF:4,FWL:2:3139,MSC:4,MERC:4,DA:6,CP:2</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>RA.OA:6,FVC:4,CDP:4</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,MERC.KH:4+,CW:5,CJF:4,RA:5,CWIE:6</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:6,CDS:4,General:5,CP:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,RD:6,CW:6,General:7,CWIE:6</availability>
+		<model name='Prime'>
+			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CWE:4,CHH:4,RD:5,CW:4,CNC:3,General:3,CP:3,CJF:2,CWIE:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:6,RD:6,CW:6,General:7,CWIE:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
+		<model name='B'>
+			<availability>RD:6,CDS:4,General:5,CP:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='C'>
+			<availability>CWE:4,CHH:4,RD:5,CW:4,CNC:3,General:3,CP:3,CJF:2,CWIE:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:7,CW:6,General:5,CWIE:6</availability>
@@ -10230,10 +10230,6 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CWE:6,CW:6,CJF:3</availability>
-		<model name='2'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CWE:8,CW:8</availability>
 		</model>
@@ -10241,167 +10237,171 @@
 			<roles>anti_infantry</roles>
 			<availability>CWE:2,CW:2</availability>
 		</model>
+		<model name='2'>
+			<roles>anti_infantry</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CWE:7,CHH:6,RD:6,CW:7,ROS:3,CJF:6,DC:3</availability>
-		<model name='6'>
-			<availability>CWE:6,RD:6,CW:6</availability>
-		</model>
-		<model name='9'>
-			<availability>CJF:6</availability>
-		</model>
-		<model name='8'>
-			<availability>RD:6,ROS:5,DC:5</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:6,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CWE:5,CHH:5,CW:5,LA:6,CJF:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CWE:4,CHH:4,RD:4,CW:4,ROS:4</availability>
 		</model>
+		<model name='8'>
+			<availability>RD:6,ROS:5,DC:5</availability>
+		</model>
+		<model name='6'>
+			<availability>CWE:6,RD:6,CW:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CWE:5,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
+		<model name='7'>
+			<availability>CHH:6,ROS:2</availability>
+		</model>
+		<model name='9'>
+			<availability>CJF:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CLAN:2-,IS:6,Periphery:3</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MSC:5,MERC:3,CP:4</availability>
-		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:4,FWL:4:3139,MSC:6,CP:4</availability>
-		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='LCT-5M3'>
 			<availability>ROS:5,FWL:3:3139,MSC:5,CP:3</availability>
-		</model>
-		<model name='LCT-1Vb'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,CP:4,BAN:2</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
-		</model>
-		<model name='LCT-1V2'>
-			<roles>recon</roles>
-			<availability>PIR:4,MH:4,MERC:3</availability>
 		</model>
 		<model name='LCT-5W2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,ROS:6,CLAN:4,IS:4,FS:6,DC:6</availability>
 		</model>
-		<model name='LCT-5V'>
-			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		<model name='LCT-5M2'>
+			<availability>ROS:4,FWL:4:3139,MSC:6,CP:4</availability>
 		</model>
-		<model name='LCT-3S'>
+		<model name='LCT-1Vb'>
 			<roles>recon</roles>
-			<availability>LA:8,MERC:6</availability>
+			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,CP:4,BAN:2</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4,MERC:3</availability>
 		</model>
 		<model name='LCT-3M'>
 			<roles>recon</roles>
 			<availability>MOC:2,DTA:6,OP:6,RF:5,FWL:4,IS:2,MSC:5,MERC:4,RCM:5,DA:5,CP:4</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-3S'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>LA:8,MERC:6</availability>
+		</model>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
+		</model>
+		<model name='LCT-6M'>
+			<roles>recon</roles>
+			<availability>ROS:2,FWL:4,MSC:5,MERC:3,CP:4</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CWE:3,CHH:4,CW:3,BAN:4,CWIE:3</availability>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:4,CP:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:4,CHH:6,RD:3,CDS:6,CW:4,General:5,CP:6,CJF:7,CWIE:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>RD:8,General:8,CJF:9</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CWE:5,CHH:6,RD:5,CW:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:5,General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:8,General:8,CJF:9</availability>
+		<model name='G'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki Mk II (Hel)' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:6,RD:5,MERC.WD:3,MERC.KH:3,CDS:5,CW:5,CP:5,CJF:6,RA:5</availability>
-		<model name='B'>
-			<roles>artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<roles>artillery</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CWE:1,CHH:3,MERC.WD:2,CDS:2,CW:1,ROS:1,CNC:3,CP:2,RA:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6</availability>
-		<model name='LGB-7V'>
+		<model name='LGB-14C'>
 			<roles>fire_support</roles>
-			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CP:4</availability>
-		</model>
-		<model name='LGB-12R'>
-			<roles>fire_support</roles>
-			<availability>DTA:4,LA:4,ROS:8,FWL:2:3139,FS:4,CP:2,DC:4</availability>
+			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CP:4,CDP:4,TC:4</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,OP:6,ROS:6,FWL:6:3139,MSC:6,FS:6,MERC:6,DA:6,RCM:6,CP:6,DC:6</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGB-12R'>
+			<roles>fire_support</roles>
+			<availability>DTA:4,LA:4,ROS:8,FWL:2:3139,FS:4,CP:2,DC:4</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CP:4</availability>
+		</model>
 		<model name='LGB-14C2'>
 			<roles>fire_support</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -10409,17 +10409,17 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lu Wei Bing' unitType='Mek'>
@@ -10445,11 +10445,11 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>Periphery.R:4,FVC:2,LA:4,Periphery.MW:3,Periphery:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:4,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:4,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Luduan Scout Vehicle' unitType='Tank'>
@@ -10465,13 +10465,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:1-</availability>
@@ -10490,24 +10490,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>ROS:8,MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -10515,13 +10515,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,CP:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -10569,19 +10569,12 @@
 		<model name='B'>
 			<availability>CWE:5,CHH:7,RD:4,CDS:7,CW:5,General:6,CP:7,CJF:7,CWIE:5</availability>
 		</model>
-		<model name='F'>
-			<availability>CWE:5,CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:2,CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CP:2,CJF:3,CWIE:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CWE:5,CHH:4,CW:5,CNC:4,CLAN:5,General:5,CP:4,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CNC:5,CLAN:4,General:3,CP:5</availability>
+		<model name='Prime'>
+			<availability>RD:7,CDS:8,CNC:7,General:8,CP:7,CJF:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,CW:5,CNC:3,General:4,CP:3</availability>
@@ -10589,19 +10582,26 @@
 		<model name='A'>
 			<availability>CWE:7,RD:8,CDS:8,CW:7,General:7,CP:8,CJF:8</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
+		<model name='F'>
+			<availability>CWE:5,CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:7,CDS:8,CNC:7,General:8,CP:7,CJF:8</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:2,CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CP:2,CJF:3,CWIE:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:7,RD:2,CW:7,General:5,CJF:6,CWIE:7</availability>
 		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CNC:5,CLAN:4,General:3,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:6,LA:5,ROS:5,CNC:4,IS:4,CP:5,CWIE:4,DC:5</availability>
-		<model name='4'>
+		<model name='5'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -10609,25 +10609,31 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='5'>
+		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='2'>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:4,CNC:6,CLAN:4,IS:4,FS:4,CP:5,CWIE:4,DC:4</availability>
-		<model name='Enhanced'>
-			<availability>CLAN:6,CNC:4,CP:4,CWIE:4</availability>
+		<model name='2'>
+			<availability>CWE:4,CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,CP:4,DC:4,CWIE:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CDS:4,CP:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='5'>
+			<availability>General:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CP:4</availability>
@@ -10635,14 +10641,8 @@
 		<model name='4'>
 			<availability>General:6</availability>
 		</model>
-		<model name='6'>
-			<availability>CDS:4,CP:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CWE:4,CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,CP:4,DC:4,CWIE:4</availability>
-		</model>
-		<model name='5'>
-			<availability>General:5</availability>
+		<model name='Enhanced'>
+			<availability>CLAN:6,CNC:4,CP:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk IV (Savage Wolf)' unitType='Mek'>
@@ -10653,17 +10653,17 @@
 	</chassis>
 	<chassis name='Mad Cat Mk IV (Savage Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CDS:5,IS:3+,CLAN.IS:4,CP:5</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -10672,12 +10672,12 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MTR-7K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='MTR-7K'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='MTR-6E'>
 			<roles>recon,spotter</roles>
@@ -10686,18 +10686,18 @@
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:6,MOC:6,OP:6,Periphery.MM:6,MERC:6,CP:8,DTA:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,MSC:8,RCM:8,DA:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Malice' unitType='Mek'>
@@ -10732,61 +10732,64 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:2,MERC.WD:4,CDS:4,CW:4,CP:4,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1</availability>
-		</model>
-		<model name='G'>
-			<availability>General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:7,General:8,CP:7,CJF:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CWE:8,RD:9,CDS:4,CW:8,CNC:8,General:7,CP:6,CJF:9</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,CDS:4,CNC:6,General:5,CP:5,CJF:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:7,CDS:7,CW:7,CNC:7,General:6,CP:7,CJF:5,CWIE:7</availability>
+		<model name='G'>
+			<availability>General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,RD:5,CDS:3,CW:5,CNC:5,General:4,CP:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
 		<model name='T'>
 			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:7,RD:7,CDS:7,CW:7,CNC:7,General:6,CP:7,CJF:5,CWIE:7</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,CDS:4,CNC:6,General:5,CP:5,CJF:2</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:4,RF:4,LA:4,ROS:4,MERC:4,CWIE:6</availability>
-		<model name='MNL-4S'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:4,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
 		</model>
+		<model name='MNL-4S'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
 		<availability>ROS:6</availability>
-		<model name='(Support)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Support)'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:6,ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
@@ -10794,43 +10797,40 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,CWIE:4,RA.OA:4,LA:4,ROS:4,FWL:3,DC:5</availability>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
+		<model name='(HPPC)'>
+			<availability>CC:6,MOC:6,DTA:6,LA:6,ROS:6,FWL:4:3139,FS:6,MERC:6,CP:4,DC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-,Periphery:2</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='(HPPC)'>
-			<availability>CC:6,MOC:6,DTA:6,LA:6,ROS:6,FWL:4:3139,FS:6,MERC:6,CP:4,DC:6</availability>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore II Heavy Tank' unitType='Tank'>
@@ -10841,11 +10841,11 @@
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,LA:3,FWL:4,IS:3,FS:5,CP:4,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder Battle Armor' unitType='BattleArmor'>
@@ -10861,66 +10861,99 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:6,RD:5,CW:4,CNC:4,CP:4,CJF:5,RA:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,RD:2,CJF:2</availability>
+		<model name='4'>
+			<availability>RD:4,CNC:6,CP:6,RA:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:2,CWIE:6</availability>
 		</model>
-		<model name='6'>
-			<availability>CWE:6,CW:6,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>RD:5,CJF:5</availability>
-		</model>
 		<model name='7'>
 			<availability>RD:6</availability>
 		</model>
-		<model name='2'>
-			<availability>RD:3,CJF:3</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,RD:2,CJF:2</availability>
 		</model>
-		<model name='4'>
-			<availability>RD:4,CNC:6,CP:6,RA:4</availability>
+		<model name='6'>
+			<availability>CWE:6,CW:6,CJF:4</availability>
 		</model>
 		<model name='8'>
 			<availability>RD:2,CJF:2</availability>
 		</model>
+		<model name='2'>
+			<availability>RD:3,CJF:3</availability>
+		</model>
+		<model name='3'>
+			<availability>RD:5,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:6,MERC:5,CP:6,TC:4,MERC.WD:6,LA:2,ROS:6,PIR:4,FWL:6,MH:4,DC:6</availability>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:6</availability>
-		</model>
-		<model name='MAD-5A'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='MAD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		<model name='C'>
+			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='MAD-4L'>
 			<availability>CC:8,MOC:8</availability>
 		</model>
-		<model name='MAD-4S'>
-			<availability>LA:6,ROS:6,CNC:8,FS:4,MERC:8,CP:8</availability>
-		</model>
 		<model name='MAD-6S'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='MAD-4K'>
-			<availability>DC:8</availability>
 		</model>
 		<model name='MAD-4H'>
 			<availability>PIR:4,MH:4,TC:4</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:6</availability>
+		<model name='MAD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='MAD-5A'>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:6</availability>
+		</model>
+		<model name='MAD-4S'>
+			<availability>LA:6,ROS:6,CNC:8,FS:4,MERC:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
-		<model name='MAD-9M'>
+		<model name='MAD-5D'>
+			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='MAD-9M2'>
 			<roles>spotter</roles>
-			<availability>DTA:8,OP:8,FWL:8:3139,MSC:8,MERC:3,DA:8,CP:8</availability>
+			<availability>OP:6,RF:6,ROS:4,FWL:4:3139,MERC:4,DA:6,CP:4,DC:4</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
+		</model>
+		<model name='MAD-9S'>
+			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>Periphery:2-,TC:2-</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>MOC:4,ROS:4,FWL:6,MERC:4,CP:6</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-6L'>
+			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
 		</model>
 		<model name='MAD-3D'>
 			<availability>MH:1-</availability>
@@ -10928,45 +10961,12 @@
 		<model name='MAD-9D'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='MAD-9M2'>
-			<roles>spotter</roles>
-			<availability>OP:6,RF:6,ROS:4,FWL:4:3139,MERC:4,DA:6,CP:4,DC:4</availability>
-		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>MOC:4,ROS:4,FWL:6,MERC:4,CP:6</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>Periphery:2-,TC:2-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
-		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
-		</model>
-		<model name='MAD-5L'>
-			<availability>CC:6,MOC:5</availability>
-		</model>
 		<model name='MAD-5S'>
 			<availability>FVC:2,LA:3,MERC:3</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:8,OP:8,FWL:8:3139,MSC:8,MERC:3,DA:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -10982,11 +10982,11 @@
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:8,IS:5</availability>
-		<model name='M1'>
-			<availability>ROS:1,ROS.pm:8,General:8</availability>
-		</model>
 		<model name='M1A'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='M1'>
+			<availability>ROS:1,ROS.pm:8,General:8</availability>
 		</model>
 		<model name='M1J'>
 			<availability>General:5</availability>
@@ -10994,17 +10994,17 @@
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CHH:4,RD:3,ROS:4</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CJF:2</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:6,RD:4,CDS:4,ROS:4,CP:4</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CHH:4,RD:3,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -11018,14 +11018,14 @@
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
+		<model name='MHL-2L'>
+			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		</model>
 		<model name='MHL-3MC'>
 			<availability>MOC:4</availability>
 		</model>
 		<model name='MHL-6MC'>
 			<availability>MOC:6,CC:4</availability>
-		</model>
-		<model name='MHL-2L'>
-			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
@@ -11040,11 +11040,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,RD:3,CDS:4,CW:2,CNC:2,MERC:3+,CP:3,CJF:3,RA:2,BAN:3</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
+		<model name='C'>
+			<availability>CWE:6,RD:6,CDS:5,CW:6,General:4,CP:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
@@ -11052,8 +11049,14 @@
 		<model name='A'>
 			<availability>RD:5,CDS:8,General:5,CP:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CWE:6,RD:6,CDS:5,CW:6,General:4,CP:5</availability>
+		<model name='D'>
+			<availability>RD:5,CDS:5,General:4,CP:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CDS:9,General:8,CP:9</availability>
@@ -11061,57 +11064,54 @@
 		<model name='B'>
 			<availability>CDS:8,General:5,CP:8</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:5,CDS:5,General:4,CP:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>MERC:5,DC:7</availability>
-		<model name='MAL-1R'>
-			<availability>MERC:6</availability>
+		<model name='MAL-3R'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='MAL-C'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='MAL-3R'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='MAL-1K'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='MAL-1R'>
+			<availability>MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:6</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
@@ -11119,19 +11119,19 @@
 		<model name='(LB-X)'>
 			<availability>FWL:6,CP:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
@@ -11151,13 +11151,13 @@
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>RA:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -11187,39 +11187,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -11231,33 +11228,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -11292,26 +11292,22 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='MS1-OG'>
 			<availability>General:4</availability>
+		</model>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -11319,13 +11315,17 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mengqin' unitType='Aero'>
@@ -11366,25 +11366,25 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Dropship'>
 		<availability>RF:4,FWL:6,CP:6</availability>
-		<model name='R1'>
-			<roles>assault</roles>
-			<availability>RF:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>assault</roles>
 			<availability>FWL:8,CP:8</availability>
 		</model>
+		<model name='R1'>
+			<roles>assault</roles>
+			<availability>RF:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -11393,6 +11393,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Targeting Computer)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Gauss) &apos;Sandblaster&apos;'>
 			<roles>urban</roles>
@@ -11404,22 +11409,17 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Targeting Computer)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CHH:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='XP'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='XP'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='P2'>
 			<availability>CHH:6</availability>
@@ -11448,22 +11448,18 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		<model name='MLR-B2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MLR-BX'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='MLR-B2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,CP:5+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -11473,11 +11469,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -11518,13 +11518,13 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>LA:5,ROS:5,MERC:4</availability>
-		<model name='MON-268'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3,ROS:3,MERC:3</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
+		<model name='MON-268'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
@@ -11540,11 +11540,11 @@
 	</chassis>
 	<chassis name='Mongrel' unitType='Mek'>
 		<availability>CWE:3,RD:6,CHH:5,CW:3,LA:4,MERC:5,CWIE:6</availability>
-		<model name='MGL-T2'>
-			<availability>CLAN:8,IS:4</availability>
-		</model>
 		<model name='MGL-T1'>
 			<availability>CWE:4,RD:4,CW:4,IS:8,CWIE:4</availability>
+		</model>
+		<model name='MGL-T2'>
+			<availability>CLAN:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -11555,11 +11555,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:3,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -11570,23 +11570,23 @@
 	</chassis>
 	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
-		<model name='MR-1SE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MR-1SC'>
-			<availability>General:7</availability>
+		<model name='MR-1SE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='MR-1SA'>
 			<roles>interceptor,ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SC'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -11615,25 +11615,25 @@
 			<roles>recon</roles>
 			<availability>CNC:4,CP:4,DC:4</availability>
 		</model>
-		<model name='4'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
 		<availability>CLAN:5,IS:4</availability>
-		<model name='(HAG)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mortar Carrier' unitType='Tank'>
@@ -11669,7 +11669,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -11682,17 +11685,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -11718,29 +11718,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:8</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -11763,6 +11763,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:4,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CP:4</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CWE:6,CHH:6,CDS:6,CW:6,General:5,CP:6,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CWE:4,CHH:3,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:3,RD:3,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
@@ -11770,14 +11778,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8,CP:9</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CWE:4,CHH:3,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CWE:6,CHH:6,CDS:6,CW:6,General:5,CP:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nagasawa' unitType='Dropship'>
@@ -11789,13 +11789,13 @@
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3A'>
 			<roles>fire_support,spotter</roles>
@@ -11815,11 +11815,11 @@
 	</chassis>
 	<chassis name='Narukami Heavy Tank' unitType='Tank'>
 		<availability>DC:8</availability>
-		<model name='NK-1C'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NK-BC3'>
 			<availability>General:4</availability>
+		</model>
+		<model name='NK-1C'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Neanderthal' unitType='Mek'>
@@ -11846,11 +11846,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11862,29 +11862,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -11904,6 +11904,9 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='NSR-K7'>
+			<availability>General:2</availability>
+		</model>
 		<model name='NSR-K1'>
 			<availability>General:6</availability>
 		</model>
@@ -11912,9 +11915,6 @@
 		</model>
 		<model name='NSR-KC'>
 			<availability>General:4</availability>
-		</model>
-		<model name='NSR-K7'>
-			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Wolf' unitType='Mek'>
@@ -11932,15 +11932,15 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CWE:2,CHH:2,RD:2,CW:2,ROS:5,CWIE:2</availability>
+		<model name='(LAC)'>
+			<roles>spotter</roles>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<roles>spotter</roles>
-			<availability>ROS:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -11949,32 +11949,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>OP:5,Periphery.R:2,RF:5,LA:8,ROS:6,FWL:3:3139,FS:7,MERC:6,CP:3</availability>
+		<model name='NGS-6T'>
+			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>OP:5,RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,OP:4,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>OP:5,RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:8,ROS:6,MERC:4</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>LA:6,ROS:5,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -11991,11 +11991,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='NJT-4'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='NJT-3'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -12007,65 +12007,65 @@
 	</chassis>
 	<chassis name='Nisos Attack WIGE' unitType='Tank'>
 		<availability>CC:6,MOC:5,LA:4,DA:5,MERC:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>RD:4,DC.LV:8,DC.SL:2,LA:3,ROS:5,MERC:3,DC:8</availability>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>RD:4,ROS:6,MERC:4,DC:4</availability>
 		</model>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>ROS:3+,CNC:8,CP:8</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
-		</model>
-		<model name='F'>
-			<availability>ROS:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='F'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -12077,38 +12077,38 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:6,ROS:4+,CNC:9,CP:7,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='H'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='E'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='I'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='E'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
@@ -12125,36 +12125,36 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:4,RD:4,LA:4,ROS:6,MERC:4,FS:4,DC:5</availability>
-		<model name='NX-110'>
+		<model name='NX-80C'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='NX-90'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NX-100'>
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='NX-80C'>
+		<model name='NX-90'>
 			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+			<availability>DC:4</availability>
+		</model>
+		<model name='NX-110'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -12166,14 +12166,14 @@
 		<model name='2'>
 			<availability>CNC:6,CP:6</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:3,CP:3,DC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4,CP:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CNC:3,CP:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -12195,11 +12195,11 @@
 	</chassis>
 	<chassis name='Ogre Battle Armor' unitType='BattleArmor'>
 		<availability>RF:6,LA:4,DA:4</availability>
-		<model name='(Interdictor)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Interdictor)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Okinawa' unitType='Dropship'>
@@ -12220,10 +12220,10 @@
 	</chassis>
 	<chassis name='Onager' unitType='Mek'>
 		<availability>CJF:5</availability>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -12253,30 +12253,30 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:4,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
-		<model name='HEAT'>
-			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:4,CNC:8,IS:4,CP:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:6,IS:6</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-,Periphery:4</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:4,CNC:8,IS:4,CP:8</availability>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:6,IS:6</availability>
+		</model>
+		<model name='HEAT'>
+			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Oo-Suzumebachi' unitType='Small Craft'>
@@ -12288,14 +12288,14 @@
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4</availability>
@@ -12309,12 +12309,8 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,Periphery:3,TC:1,CWIE:2,CWE:2,CW:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
-		<model name='ON3-M'>
-			<roles>spotter</roles>
-			<availability>CC:6,FWL:6,MERC:5,CP:6</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
 		</model>
 		<model name='ON1-MC'>
 			<availability>FS:2,MERC:2,DC:4</availability>
@@ -12322,20 +12318,24 @@
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,OP:4,ROS:4,FWL:4,MSC:4,DA:4,MERC:2,RCM:4,CP:4,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>CLAN:2-,Periphery:2-</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2,CP:4</availability>
+		<model name='ON3-M'>
+			<roles>spotter</roles>
+			<availability>CC:6,FWL:6,MERC:5,CP:6</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3,CP:4</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>CLAN:2-,Periphery:2-</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:8</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -12356,14 +12356,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-5D'>
-			<availability>FS:6</availability>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
+		<model name='OSR-5D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -12371,55 +12371,55 @@
 		<model name='OSP-26'>
 			<availability>CC:4,ROS:8</availability>
 		</model>
-		<model name='OSP-36'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='OSP-25'>
 			<availability>General:6</availability>
+		</model>
+		<model name='OSP-36'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,ROS:4,IS:4,TC:4,DC:5,Periphery:2</availability>
-		<model name='OSR-4K'>
-			<availability>ROS:4,MERC:4,DC:6</availability>
-		</model>
 		<model name='OSR-5C'>
 			<availability>TC:6</availability>
+		</model>
+		<model name='OSR-4L'>
+			<availability>CC:8,MOC:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='OSR-2D'>
+			<availability>ROS:6,IS:4,Periphery:4</availability>
+		</model>
+		<model name='OSR-4K'>
+			<availability>ROS:4,MERC:4,DC:6</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:3</availability>
 		</model>
-		<model name='OSR-2D'>
-			<availability>ROS:6,IS:4,Periphery:4</availability>
-		</model>
 		<model name='OSR-4C'>
 			<availability>TC:6,Periphery:5</availability>
-		</model>
-		<model name='OSR-4L'>
-			<availability>CC:8,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -12427,6 +12427,10 @@
 		<model name='OTT-7K'>
 			<roles>recon,spotter</roles>
 			<availability>FVC:8,IS:8,DC:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
@@ -12436,36 +12440,32 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:4,OP:5,RF:5,LA:8,ROS:5,FWL:5,MERC:5,FS:4,CP:5,DC:4</availability>
 		</model>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>DTA:5,OP:5,RF:5,ROS:4,FWL:5,MSC:5,FS:5,MERC:3,CP:5</availability>
 		<model name='OTL-7M'>
 			<availability>DTA:8,OP:8,ROS:6,FWL:6,MSC:8,MERC:4,CP:6</availability>
 		</model>
-		<model name='OTL-9M'>
-			<availability>ROS:4,FWL:6,CP:6</availability>
-		</model>
 		<model name='OTL-8D'>
 			<availability>FS:8</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:2,MERC:4,CP:2</availability>
 		</model>
 		<model name='OTL-8M'>
 			<availability>DTA:8,RF:8,FWL:5:3139,MSC:6,MERC:3,CP:5</availability>
 		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,FWL:4:3139,MERC:5,CP:4</availability>
+		<model name='OTL-5M'>
+			<availability>FWL:2,MERC:4,CP:2</availability>
+		</model>
+		<model name='OTL-9M'>
+			<availability>ROS:4,FWL:6,CP:6</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:3,Periphery.HR:4,PIR:3,FS:2,Periphery:4</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,FWL:4:3139,MERC:5,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -12476,10 +12476,6 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CWE:4,CHH:8,CW:4</availability>
-		<model name='(3070)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:4</availability>
@@ -12487,6 +12483,10 @@
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(3070)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -12498,24 +12498,32 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:8,IS:6,FS:8</availability>
-		</model>
 		<model name='A3A'>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:8,IS:6,FS:8</availability>
 		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:2,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,FWL:4,FS:2,MERC:2,CP:4,DC:6</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2,CLAN:6</availability>
+		</model>
+		<model name='OW-1F'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -12523,6 +12531,14 @@
 		<model name='OW-1C'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1G'>
 			<roles>recon,spotter</roles>
@@ -12536,22 +12552,6 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2,CLAN:6</availability>
-		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1F'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='PAB-28 Sniper Suit' unitType='BattleArmor'>
 		<availability>FS:6,MERC:4</availability>
@@ -12562,29 +12562,29 @@
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
 		<availability>CHH:5,LA:5,ROS:5,MERC:3,CWIE:8,DC:3</availability>
-		<model name='3'>
-			<availability>CHH:4,ROS:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='3'>
+			<availability>CHH:4,ROS:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CDS:4,CP:4,CWIE:7</availability>
-		<model name='2'>
-			<availability>CDS:5,CP:5,CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:5,CP:5,CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -12593,21 +12593,21 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:1,PIR:2,General:1,FWL:1,MERC:1,FS:2,CP:1,Periphery:3,DC:1</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,MOC:5</availability>
 		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
-		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:1,PIR:2,General:1,FWL:1,MERC:1,FS:2,CP:1,Periphery:3,DC:1</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Anti-Missile Tank' unitType='Tank'>
@@ -12626,17 +12626,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Paladin Defense System' unitType='Tank'>
@@ -12655,6 +12655,9 @@
 	</chassis>
 	<chassis name='Pandion Combat WiGE' unitType='Tank'>
 		<availability>LA:3,ROS:3,FWL:3,FS:6,MERC:3,CP:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -12663,35 +12666,28 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,TC:2,DC:2</availability>
 		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
-		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
 		</model>
 		<model name='PNT-12KC'>
 			<roles>raider</roles>
@@ -12701,13 +12697,17 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>RD:4,DC:8</availability>
+		</model>
+		<model name='PNT-12K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -12723,13 +12723,13 @@
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:8</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<roles>recon,spotter</roles>
@@ -12738,60 +12738,60 @@
 	</chassis>
 	<chassis name='Partisan AA Vehicle' unitType='Tank'>
 		<availability>MOC:6,FWL:5,IS:4,DA:5,CP:5</availability>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(3134 Upgrade)'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:4,CP:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,CNC:5,IS:5,FS:8,CP:5,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:5,Periphery:5</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='(Cell)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>ROS:2,FS:2</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>IS:5,Periphery:5</availability>
+		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>Periphery:2-</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>Periphery:2-</availability>
-		</model>
-		<model name='(C3)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12802,10 +12802,6 @@
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>RF:6</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
@@ -12813,6 +12809,10 @@
 		<model name='PKM-2E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -12824,11 +12824,11 @@
 	</chassis>
 	<chassis name='Patron MilitiaMech' unitType='Mek'>
 		<availability>FWL.pm:4,DA.pm:4,RF.pm:4,OP.pm:4,IS.pm:2,MSC.pm:4,DTA.pm:5,RCM.pm:4</availability>
-		<model name='PTN-2M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PTN-2'>
 			<availability>DTA:2,FWL:2,RCM:2,DA:2</availability>
+		</model>
+		<model name='PTN-2M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
@@ -12858,21 +12858,21 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:8</availability>
 		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
-		</model>
 		<model name='X-Pulse'>
 			<roles>recon</roles>
 			<availability>DC.AL:8,General:4,DC:5</availability>
 		</model>
+		<model name='(MRM)'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,FS:8,DC:7</availability>
+		</model>
+		<model name='(Sealed)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -12884,20 +12884,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -12905,11 +12905,11 @@
 		<model name='PEN-2MAF'>
 			<availability>General:4</availability>
 		</model>
-		<model name='PEN-2H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PEN-3H'>
 			<availability>MOC:5,CC:4</availability>
+		</model>
+		<model name='PEN-2H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -12921,40 +12921,40 @@
 	</chassis>
 	<chassis name='Persepolis' unitType='Aero'>
 		<availability>CJF:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,OP:6,ROS:4,FWL:4,MSC:6,CP:4</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1'>
 			<availability>General:8</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12968,28 +12968,28 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:4,FS:4,MERC:4,CP:5,DC:4</availability>
-		<model name='(Prototype)'>
-			<availability>OP:1,LA:2</availability>
-		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Prototype)'>
+			<availability>OP:1,LA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:7,CW:8,CJF:7,RA:6,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='D'>
 			<availability>RD:4,General:5</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -12999,39 +12999,39 @@
 			<roles>recon</roles>
 			<availability>RD:7,General:6</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
 		<model name='C'>
 			<availability>RD:6,CDS:4,CNC:6,General:5,CP:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,CLAN:3,CP:5,MERC:3,FS:3,RA:5,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CDS:1,CNC:1,IS:3,CP:1,DC:3</availability>
-		</model>
 		<model name='7'>
 			<availability>RD:8,CDS:6,General:6,DC:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
-		</model>
-		<model name='3'>
-			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,CP:8,DC:4</availability>
 		</model>
 		<model name='6'>
 			<availability>RD:6,CDS:8,CP:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:3</availability>
+		<model name='3'>
+			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,CP:8,DC:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:8,CP:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:8,CP:8</availability>
+		<model name='(Standard)'>
+			<availability>CDS:1,CNC:1,IS:3,CP:1,DC:3</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk L' unitType='Mek'>
@@ -13045,61 +13045,61 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>RD:4,IS:7,FWL:8,CP:8,Periphery:6</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>OP:4,DC:4</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
-		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:6,TC:6</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
-		</model>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>PIR:1-</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:4,MSC:6,CP:4,BAN:1</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>RD:6,DC:8</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:3,MERC:4</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-4W'>
+			<availability>MOC:6,TC:6</availability>
+		</model>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8,CP:8</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>RD:4,ROS:2,DC:2</availability>
+		<model name='PXH-5L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>BAN:6,Periphery:1-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8,CP:8</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CC:4,OP:4,CLAN:3,FWL:4,MSC:5,MERC:4,DA:4,RCM:4,CP:4</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>PIR:1-</availability>
+		</model>
+		<model name='PXH-4L'>
+			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>RD:4,ROS:2,DC:2</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:4,MSC:6,CP:4,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>RD:6,DC:8</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Picaroon' unitType='Aero'>
@@ -13110,47 +13110,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,CNC:3,MH:1-,CP:3,CWIE:4,Periphery:2-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>Periphery:2</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,CNC:6,MERC:4,CP:6</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6,MOC:6</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -13158,11 +13158,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -13173,6 +13173,9 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:6,CDS:5,CP:5,RA:3,CWIE:3</availability>
+		<model name='2'>
+			<availability>CHH:8,CDS:8,CP:8</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4,CP:4</availability>
@@ -13182,9 +13185,6 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,CP:6,RA:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:8,CDS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -13205,12 +13205,12 @@
 		<model name='(Streak)'>
 			<availability>IS:6,TC:6,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>FWL:5,IS:5,CP:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
@@ -13246,39 +13246,39 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2,CP:2</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
+		</model>
 		<model name='(HV)'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:5,DA:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Stealth)'>
 			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:8,CC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4,CP:5</availability>
-		<model name='PGD-L3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PGD-L3'>
+			<availability>General:4</availability>
 		</model>
 		<model name='PGD-R3'>
 			<roles>ground_support</roles>
@@ -13293,42 +13293,42 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CDS:5,CP:5,RA:5,CWIE:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:4,CW:8,CNC:4,CP:4,CWIE:8</availability>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CWE:5,RD:3,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CWE:6,RD:6,CDS:9,CW:6,General:7,CP:9</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
+		<model name='H'>
+			<availability>CWE:5,RD:3,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CWE:6,RD:6,CDS:9,CW:6,General:7,CP:9</availability>
+		<model name='Prime'>
+			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -13348,9 +13348,6 @@
 	</chassis>
 	<chassis name='Prefect' unitType='Mek'>
 		<availability>ROS:4</availability>
-		<model name='PRF-3R'>
-			<availability>General:5</availability>
-		</model>
 		<model name='PRF-2R'>
 			<availability>General:4</availability>
 		</model>
@@ -13359,6 +13356,9 @@
 		</model>
 		<model name='PRF-1R'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PRF-3R'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Prey Seeker' unitType='Mek'>
@@ -13370,11 +13370,11 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Quad)'>
-			<availability>CHH:6+</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='(Quad)'>
+			<availability>CHH:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -13392,63 +13392,63 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Succession Wars)'>
-			<roles>support</roles>
-			<availability>Periphery:4</availability>
-		</model>
-		<model name='(ECM)'>
-			<roles>support</roles>
-			<availability>General:4,Periphery:4</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
-			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
-		</model>
-		<model name='(Security)'>
+		<model name='(3140 Upgrade)'>
 			<roles>apc</roles>
-			<availability>ROS:5</availability>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(RAF)'>
 			<roles>apc</roles>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='(3140 Upgrade)'>
+		<model name='(Succession Wars)'>
+			<roles>support</roles>
+			<availability>Periphery:4</availability>
+		</model>
+		<model name='(Security)'>
 			<roles>apc</roles>
-			<availability>ROS:4</availability>
+			<availability>ROS:5</availability>
+		</model>
+		<model name='(ECM)'>
+			<roles>support</roles>
+			<availability>General:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>General:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:6,MERC:3+,CP:7,RA:6,BAN:5,CWIE:7,CWE:7,MERC.WD:4,RD:5,CDS:7,CW:7,ROS:4+,CNC:7,CJF:4</availability>
-		<model name='H'>
-			<availability>CWE:6,CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:5,RD:3,CDS:5,CW:5,General:4,CP:5</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CWE:6,CHH:6,RD:3,CDS:7,CW:6,CNC:4,General:5,CP:5,CJF:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:4,CDS:5,CW:6,General:3,CP:5,CJF:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CWE:5,RD:5,CDS:8,CW:5,CNC:8,General:7,CP:8,CWIE:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CWE:6,CHH:6,RD:8,CDS:6,CW:6,CNC:7,General:8,CP:6,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CWE:6,CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,RD:3,CDS:5,CW:5,General:4,CP:5</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:4,CDS:5,CW:6,General:3,CP:5,CJF:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CWE:6,CHH:6,RD:3,CDS:7,CW:6,CNC:4,General:5,CP:5,CJF:6</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CWE:5,RD:5,CDS:8,CW:5,CNC:8,General:7,CP:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -13468,15 +13468,15 @@
 		<model name='[PPC] (RAF)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Quaestor Mobile Tactical Command HQ' unitType='Tank'>
@@ -13494,11 +13494,11 @@
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>Periphery.Deep:4,Periphery:6</availability>
@@ -13506,36 +13506,36 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:4,CC:5,OP:6,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,DTA:6,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4</availability>
-		<model name='QKD-5K'>
-			<availability>MERC:5,DC:4</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:6,FWL:8,CP:8</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='QKD-9M'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:5,ROS:3,DA:5,FS:3</availability>
+		<model name='QKD-5M'>
+			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
 		</model>
 		<model name='QKD-8K'>
 			<availability>RD:5,ROS:5,MERC:4,DC:8</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='QKD-9M'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:5,ROS:3,DA:5,FS:3</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+		<model name='QKD-C'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:6,FWL:8,CP:8</availability>
+		<model name='QKD-5K'>
+			<availability>MERC:5,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:4,ROS:6,FWL:4:3139,RCM:4,DA:4,MERC:4,CP:4</availability>
-		<model name='(GL)' mechanized='true'>
+		<model name='(David)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -13543,7 +13543,7 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(David)' mechanized='true'>
+		<model name='(GL)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -13557,15 +13557,15 @@
 	</chassis>
 	<chassis name='R10 Mechanized ICV' unitType='Tank' omni='IS'>
 		<availability>CC:5,OP:6,CLAN.IS:4,MERC:4,CP:4,CWIE:4,DTA:6,CWE:4,RF:6,CW:4,ROS:4,CNC:4,FWL:6,MSC:7,DA:6,RCM:6</availability>
+		<model name='(B)'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Prime)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='(A)'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(B)'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -13578,24 +13578,24 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:5</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden II Battle Armor' unitType='BattleArmor'>
@@ -13609,32 +13609,24 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:2,ROS:3,FS:3,MERC:3</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
-		</model>
-		<model name='MDG-1Ar'>
-			<availability>ROS:8,FS:4,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1Ar'>
+			<availability>ROS:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:6,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:5,CP:4,CDP:6,DC:4</availability>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV2'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4,CP:4</availability>
 		</model>
 		<model name='VV22'>
 			<roles>urban</roles>
@@ -13644,20 +13636,28 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='VV2'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4,CP:4</availability>
+		</model>
+		<model name='VV1 (MG)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
+		<model name='RPR-300'>
+			<availability>LA:6,ROS:6,MERC:4</availability>
+		</model>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
-		</model>
-		<model name='RPR-300S'>
-			<availability>LA:6</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:6,ROS:6,MERC:4</availability>
+		<model name='RPR-300S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -13666,15 +13666,11 @@
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-5X'>
+		<model name='RPT-2X2'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='RPT-2X2'>
+		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
@@ -13682,51 +13678,55 @@
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>DC:6</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='RTX1-OA'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
-		<model name='(MH)' mechanized='false'>
-			<availability>MH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
 		</model>
 		<model name='(LRM)' mechanized='false'>
 			<availability>General:4,MH:0</availability>
+		</model>
+		<model name='(MH)' mechanized='false'>
+			<availability>MH:8</availability>
 		</model>
 		<model name='(LRM) [MH]' mechanized='false'>
 			<availability>General:4</availability>
@@ -13741,14 +13741,6 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:5,MOC:2,FWL:2,MERC:4,DA:3,CP:2,TC:2</availability>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,TC:3</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:7,MOC:5</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
@@ -13757,21 +13749,29 @@
 			<roles>spotter</roles>
 			<availability>CC:1,MOC:1,MERC:1,DC:1,TC:1</availability>
 		</model>
+		<model name='RVN-4Lr'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:5</availability>
+		</model>
 		<model name='RVN-4L'>
 			<roles>spotter</roles>
 			<availability>CC:4,MOC:4,DA:6,TC:4</availability>
 		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>OP:4,RF:4,LA:6,ROS:4,FWL:2:3139,MH:4,MERC:4,FS:4,DA:4,CP:2</availability>
-		<model name='RZK-10T'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='RZK-10S'>
 			<availability>LA:6</availability>
@@ -13792,12 +13792,12 @@
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,CP:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -13808,19 +13808,15 @@
 		<model name='(Stealth)'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Revenant' unitType='Mek'>
 		<availability>ROS:2</availability>
-		<model name='UBM-2R'>
-			<roles>specops</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='UBM-2R7'>
 			<roles>specops</roles>
 			<availability>General:6</availability>
@@ -13829,17 +13825,29 @@
 			<roles>specops</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='UBM-2R2'>
+		<model name='UBM-2R'>
 			<roles>specops</roles>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='UBM-2R4'>
 			<roles>spotter,specops</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='UBM-2R2'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CWE:1,CHH:1,CW:1,General:8,CNC:1,CP:1</availability>
@@ -13848,27 +13856,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:1,OP:8,FS:2,CP:8,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8</availability>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:5,OP:6,FS:5,MERC:7,CP:6,DTA:6,RF:6,ROS:8,FWL:6,MSC:6,DA:6,RCM:6</availability>
+		<model name='F-100'>
+			<availability>FVC:2-,Periphery:2-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>MOC:5,CC:5,DTA:8,OP:8,ROS:6,FWL:8,MSC:8,MERC:8,CP:8,DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -13876,51 +13879,44 @@
 		<model name='F-700'>
 			<availability>CC:8,MOC:5,DTA:8,OP:8,RF:8,ROS:8,FWL:8,MSC:8,MERC:8,RCM:8,DA:8,CP:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>MOC:5,CC:5,DTA:8,OP:8,ROS:6,FWL:8,MSC:8,MERC:8,CP:8,DC:8</availability>
-		</model>
-		<model name='F-100'>
-			<availability>FVC:2-,Periphery:2-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:5,OP:6,FS:5,MERC:7,CP:6,DTA:6,RF:6,ROS:8,FWL:6,MSC:6,DA:6,RCM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:5,CNC:5,IS:3,CP:5,RA:5</availability>
-		<model name='8'>
-			<availability>CC:4,OP:4,RD:6,CDS:4,LA:4,IS:4,MSC:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:4,IS:4,CP:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:1,CNC:1,CP:1,RA:2</availability>
+		<model name='3'>
+			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:8,CP:8,DC:6</availability>
 		</model>
+		<model name='2'>
+			<availability>CNC:5,CP:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:1,CNC:1,CP:1,RA:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:4,IS:4,CP:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='8'>
+			<availability>CC:4,OP:4,RD:6,CDS:4,LA:4,IS:4,MSC:4,FS:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='6'>
 			<availability>CHH:4,CDS:6,CP:6</availability>
 		</model>
-		<model name='3'>
-			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CNC:5,CP:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:4,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
-		<model name='RFL-7M'>
-			<availability>MOC:4,OP:8,IS:4,CP:8,CDP:4,TC:4,DTA:8,RF:8,FWL:8,MSC:8,DA:8,RCM:8,DC:5</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='RFL-5D'>
 			<availability>FVC:3,LA:2,FS:2,MERC:3</availability>
+		</model>
+		<model name='RFL-7M'>
+			<availability>MOC:4,OP:8,IS:4,CP:8,CDP:4,TC:4,DTA:8,RF:8,FWL:8,MSC:8,DA:8,RCM:8,DC:5</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:2</availability>
@@ -13929,14 +13925,15 @@
 			<roles>fire_support</roles>
 			<availability>MOC:1-,PIR:1-,MH:1-</availability>
 		</model>
+		<model name='RFL-5M'>
+			<availability>CC:1,MOC:1,Periphery.MW:3,Periphery.ME:3,FWL:2,MH:3,MERC:1,CP:2,DC:1</availability>
+		</model>
 		<model name='C 2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='RFL-8D'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-9T'>
-			<availability>TC:6</availability>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='RFL-8X'>
 			<availability>ROS:4,MERC:4</availability>
@@ -13945,39 +13942,42 @@
 			<roles>fire_support</roles>
 			<availability>ROS:5,MERC:5</availability>
 		</model>
-		<model name='RFL-5M'>
-			<availability>CC:1,MOC:1,Periphery.MW:3,Periphery.ME:3,FWL:2,MH:3,MERC:1,CP:2,DC:1</availability>
+		<model name='RFL-8D'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-9T'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,ROS:6,CLAN:2,FS:5,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5,ROS:4,FS:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>CNC:4,FS:4,CP:4,DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:4</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
+		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>CNC:4,FS:4,CP:4,DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Roadrunner (Emerald Harrier)' unitType='Mek'>
@@ -13989,14 +13989,14 @@
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CHH:4,CNC:7,CP:7,RA:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>RA:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:4,CP:4,RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>RA:6</availability>
@@ -14004,34 +14004,31 @@
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>RD:6-</availability>
-		<model name='(Hybrid)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Hybrid)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rokurokubi' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='RK-4K'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RK-4X'>
 			<availability>General:2</availability>
 		</model>
 		<model name='RK-4T'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RK-4K'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>RA.OA:5,FVC:4,RF:4,LA:5,ROS:4,FS:3,MERC:2,CWIE:6,TC:6</availability>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
@@ -14042,6 +14039,9 @@
 			<roles>artillery,fire_support</roles>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
 		<availability>FS:5,MERC:3</availability>
@@ -14051,11 +14051,11 @@
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
 		<availability>DTA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='NH-3X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='NH-2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NH-3X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -14075,12 +14075,12 @@
 			<roles>recon</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -14093,29 +14093,29 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,CDS:4,CLAN:4,MERC:3+,CP:4,CJF:4,RA:5,BAN:5,CWIE:5,DC:4+</availability>
-		<model name='D'>
-			<availability>CWE:3,RD:3,CDS:8,CW:3,CNC:6,General:5,CP:7,CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:5,RD:3,CDS:8,CW:5,General:6,CP:8,CJF:4,CWIE:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CWE:6,RD:3,CDS:9,CW:6,General:6,CP:9,CJF:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:3,General:2</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CWE:8,RD:8,CDS:5,CW:8,CNC:8,General:7,CP:6,CJF:9</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
+		<model name='B'>
+			<availability>CWE:5,RD:3,CDS:8,CW:5,General:6,CP:8,CJF:4,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CNC:4,General:5,CP:5,CJF:4,RA:6,CWIE:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:3,RD:3,CDS:8,CW:3,CNC:6,General:5,CP:7,CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:6,General:5,RA:6,CWIE:5</availability>
@@ -14126,19 +14126,19 @@
 	</chassis>
 	<chassis name='Ryoken III-XP' unitType='Mek' omni='IS'>
 		<availability>CWE:2</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14147,20 +14147,20 @@
 		<model name='3'>
 			<availability>CHH:8,RD:4,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>RD:8,CDS:8,IS:8,CP:8</availability>
-		</model>
 		<model name='2'>
 			<availability>RD:6,ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RD:8,CDS:8,IS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
 		<availability>CNC:7,CP:7,DC:5</availability>
-		<model name='SM1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Telos)'>
 			<availability>CNC:2,DC:3</availability>
+		</model>
+		<model name='SM1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1A Tank Destroyer' unitType='Tank'>
@@ -14171,13 +14171,13 @@
 	</chassis>
 	<chassis name='SM2 Heavy Artillery Vehicle' unitType='Tank'>
 		<availability>DTA:4,OP:4,CDS:4,ROS:5,CNC:5,FWL:5,MSC:4,MERC:4,CP:4,CJF:4,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LTC)'>
 			<roles>artillery</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM3 Tank Destroyer' unitType='Tank'>
@@ -14192,13 +14192,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,CP:4,DC:8,Periphery:4</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:6,Periphery:6</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,CP:4,DC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -14209,14 +14209,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
-		<model name='SB-27'>
-			<availability>General:1-</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='SB-27'>
+			<availability>General:1-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
@@ -14228,17 +14228,8 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -14247,33 +14238,42 @@
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
 		<availability>FVC:4,ROS:4,FS:6,MERC:4</availability>
-		<model name='SGT-8R'>
-			<availability>FVC:8,FS:4</availability>
-		</model>
-		<model name='SGT-10X'>
-			<availability>ROS:6,FS:6,MERC:6</availability>
-		</model>
 		<model name='SGT-14D'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='SGT-8R'>
+			<availability>FVC:8,FS:4</availability>
 		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:6,FS:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittarii' unitType='Aero'>
 		<availability>ROS:8</availability>
-		<model name='SGT-2R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SGT-3R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='SGT-2R'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SGT-4R'>
 			<availability>General:4</availability>
@@ -14284,11 +14284,11 @@
 		<model name='S-4C'>
 			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
-		<model name='S-8'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
+		</model>
+		<model name='S-8'>
+			<availability>ROS:8,DC:8</availability>
 		</model>
 		<model name='S-7'>
 			<availability>ROS:6,CNC:6,CP:6,DC:6</availability>
@@ -14296,32 +14296,32 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,DC.AL:7,IS:4,FWL:4,MERC:4,FS:3,CJF:4,DC:5</availability>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
-		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>IS:8,DC:8</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Saladin Mk II HCV' unitType='Tank'>
 		<availability>CNC:4,FWL:4,MERC:4,CP:4,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(BC3)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CWE:6,CW:6,RA:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CWE:6,CW:6,RA:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -14330,14 +14330,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-7T'>
-			<roles>fire_support</roles>
-			<availability>LA:5</availability>
-		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -14346,9 +14338,17 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
 		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='PPR-7T'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
 		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
@@ -14357,44 +14357,44 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>LA:5,ROS:5</availability>
-		<model name='SL-27'>
-			<availability>IS:6,DC:6</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:2,RA.OA:5,Periphery.DD:4,FWL:1-,Periphery.OS:4,CP:1-,Periphery:2,TC:2,DC:2-</availability>
-		<model name='(MRM)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:2-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Mk II HCV' unitType='Tank'>
 		<availability>CNC:4,FWL:4,MERC:4,CP:4,DC:5</availability>
-		<model name='(BC3)'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BC3)'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sarath' unitType='Mek' omni='IS'>
 		<availability>RF:5-</availability>
+		<model name='SRTH-1O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='SRTH-1OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SRTH-1OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='SRTH-1O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -14419,17 +14419,17 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CNC:3,CP:3,RA:4</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CNC:4,CP:4,RA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CNC:4,CP:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XP'>
 			<availability>CNC:8,CP:8</availability>
@@ -14437,11 +14437,8 @@
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:4,CW:5</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
@@ -14449,8 +14446,11 @@
 		<model name='J'>
 			<availability>CWE:4,CHH:4,CW:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -14472,10 +14472,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -14483,6 +14479,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -14494,34 +14494,34 @@
 		<model name='(Primary)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(H)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(G)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(B)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(I)'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(C)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(J)'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(E)'>
 			<roles>artillery</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(I)'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(H)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(J)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(F)'>
 			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(B)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(G)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(A)'>
@@ -14541,62 +14541,62 @@
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:3</availability>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
+		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Schildkrote Line Tank' unitType='Tank'>
 		<availability>LA:4-,LA.pm:5,MERC:3-</availability>
-		<model name='(HPPC)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(HPPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,OP:4,RD:4,ROS:5,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:7</availability>
-		<model name='SCK-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCK-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SCK-OA'>
 			<roles>interceptor</roles>
@@ -14605,30 +14605,30 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>RA.OA:1,RD:2,CNC:2,CP:2,Periphery:2,RA:2</availability>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:6</availability>
+		<model name='(Armor)'>
+			<availability>RD:8,CNC:8,IS:6,CP:8,RA:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>RD:8,CNC:8,IS:6,CP:8,RA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>RA.OA:2-,Periphery.DD:2-,Periphery.OS:2-,Periphery:2-,DC:2-</availability>
+		<model name='(Standard)'>
+			<availability>General:2-</availability>
+		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2-</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:8,DC:8</availability>
@@ -14639,18 +14639,17 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(BC3)'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(3136 Upgrade)'>
 			<availability>CNC:4,FWL:4,MERC:4,CP:4,DC:4</availability>
+		</model>
+		<model name='(BC3)'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,LA:6,FWL:6,IS:7,Periphery.Deep:5,FS:6,CP:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(Minesweeper)'>
-			<roles>minesweeper</roles>
-			<availability>CC:4-,MOC:2-</availability>
+		<model name='(MRM)'>
+			<availability>IS:5,DC:5,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-</availability>
@@ -14661,39 +14660,40 @@
 		<model name='(SRM)'>
 			<availability>General:1-</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>IS:5,DC:5,Periphery:4</availability>
+		<model name='(Minesweeper)'>
+			<roles>minesweeper</roles>
+			<availability>CC:4-,MOC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2,FVC:2,LA:4,ROS:2,FWL:2,MERC:2,CP:2,DC:4,Periphery:3</availability>
-		<model name='SCP-1N'>
-			<availability>Periphery:2-</availability>
+		<model name='SCP-12S'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>IS:1,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='SCP-10M'>
-			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
+		<model name='SCP-10M'>
+			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Scourge' unitType='Mek'>
 		<availability>OP:4,RD:3,LA:4,FWL:4,IS:3,CP:4,Periphery:2</availability>
-		<model name='SCG-WF1'>
-			<availability>OP:8,LA:8,FWL:8,CP:8</availability>
-		</model>
 		<model name='SCG-WD1'>
 			<availability>OP:6,LA:6,General:8,FWL:6,CP:6</availability>
+		</model>
+		<model name='SCG-WF1'>
+			<availability>OP:8,LA:8,FWL:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -14711,41 +14711,41 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
+		<model name='3'>
+			<availability>CJF:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CWE:3,CHH:2,CW:3,CNC:5,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='X'>
 			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Fox Amphibious Armor' unitType='BattleArmor'>
@@ -14756,14 +14756,14 @@
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(SRM6)'>
 			<availability>General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:1</availability>
@@ -14777,13 +14777,13 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:3,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:8,FWL:4,IS:6,FS:8,CP:4</availability>
+		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sekhmet Assault Vehicle' unitType='Tank'>
@@ -14801,14 +14801,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,CW:1,LA:3,ROS:3,CJF:2,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -14822,16 +14822,16 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2</availability>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6</availability>
+		<model name='SYD-Z3A'>
+			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3</availability>
 		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3</availability>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6</availability>
 		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
@@ -14846,14 +14846,14 @@
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6,MOC:5</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -14875,12 +14875,21 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CDS:5,ROS:4+,CNC:7,MERC:3+,CP:6,CJF:5,RA:5</availability>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CWE:3,CW:3,General:6,RA:8</availability>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
@@ -14889,24 +14898,18 @@
 			<roles>recon</roles>
 			<availability>CWE:3,CW:3,General:6,RA:3</availability>
 		</model>
-		<model name='J'>
-			<availability>General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
+			<availability>CWE:3,CW:3,General:6,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>OP:3,CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3</availability>
-		<model name='8'>
-			<availability>CDS:4,LA:6,CNC:6,IS:4,CP:5,CWIE:6</availability>
+		<model name='6'>
+			<availability>CHH:8</availability>
+		</model>
+		<model name='5'>
+			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,CP:8,DC:8</availability>
 		</model>
 		<model name='9'>
 			<availability>ROS:5,MERC:3</availability>
@@ -14914,56 +14917,53 @@
 		<model name='2'>
 			<availability>RD:1</availability>
 		</model>
-		<model name='7'>
-			<availability>RA.OA:8,RA:8</availability>
+		<model name='8'>
+			<availability>CDS:4,LA:6,CNC:6,IS:4,CP:5,CWIE:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5,IS:6,CP:5,RA:6</availability>
 		</model>
+		<model name='7'>
+			<availability>RA.OA:8,RA:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CDS:5,CNC:5,IS:6,CP:5</availability>
-		</model>
-		<model name='5'>
-			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,CP:8,DC:8</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>RD:3,IS:3,Periphery.Deep:4,BAN:4,Periphery:6</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:5,FS:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,ROS:4,CLAN:4,FWL:2:3139,MSC:4,MERC:4,DA:4,CP:2,BAN:2</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>RD:4,DC:8</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>MOC:1-,MH:1-</availability>
 		</model>
-		<model name='SHD-2H'>
-			<availability>General:1-,Periphery:2-</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,ROS:4,CLAN:4,FWL:2:3139,MSC:4,MERC:4,DA:4,CP:2,BAN:2</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>RD:8,ROS:5,DC:4</availability>
-		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,CP:4,Periphery:4,DC:6</availability>
-		</model>
-		<model name='SHD-8L'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,OP:8,MERC:4,CP:7,CDP:3,TC:3,DTA:8,FVC:3,ROS:4,FWL:7:3139,MSC:8,RCM:8</availability>
-		</model>
-		<model name='SHD-9D'>
-			<availability>FS:6</availability>
 		</model>
 		<model name='SHD-5D'>
 			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SHD-3K'>
-			<availability>RD:4,DC:8</availability>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,OP:8,MERC:4,CP:7,CDP:3,TC:3,DTA:8,FVC:3,ROS:4,FWL:7:3139,MSC:8,RCM:8</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>General:1-,Periphery:2-</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>RD:8,ROS:5,DC:4</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='SHD-8L'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='SHD-2D2'>
+			<availability>FVC:5,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -14971,40 +14971,40 @@
 		<model name='(Flamer)'>
 			<availability>CDS:4,CP:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Interdictor)'>
 			<availability>CWE:4,CHH:4,RD:6,CDS:4,CW:4,ROS:8,CNC:4,CP:4,CJF:4,RA:4,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
 		<availability>MOC:8,FVC:4,PIR:4,IS:8,CDP:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MOC:8,IS:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>recon</roles>
 			<availability>FVC:8,PIR:8,IS:2,CDP:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MOC:8,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shen Long Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MOC:6</availability>
+		<model name='[Pop-Up Mine]' mechanized='false'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[David Light Gauss]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Interdictor]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Pop-Up Mine]' mechanized='false'>
-			<availability>General:5</availability>
-		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[David Light Gauss]' mechanized='false'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='false'>
 			<availability>General:8</availability>
@@ -15012,12 +15012,12 @@
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
 		<availability>CC:6</availability>
+		<model name='SHY-3B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SHY-5B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SHY-3B'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sheriff Infantry Support Tank' unitType='Tank'>
@@ -15041,14 +15041,14 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RD:2,RA:2</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shiro' unitType='Mek'>
@@ -15071,6 +15071,9 @@
 		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SHV-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
 		</model>
@@ -15080,37 +15083,34 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:4,DTA:6,OP:6,ROS:4,FWL:5,MSC:6,FS:3,RCM:4,CP:5,DC:3</availability>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
+		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKW-6H'>
+			<availability>General:5</availability>
 		</model>
 		<model name='SKW-8X'>
 			<roles>artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='SKW-6H'>
-			<availability>General:5</availability>
-		</model>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CWE:3,CHH:3,RD:4,CDS:4,CW:3,ROS:3,CNC:5,CP:4,CWIE:3,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,CP:6,DC:6</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CWE:6,CDS:4,CW:6,ROS:4,CNC:6,CP:5,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
+		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,CP:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -15133,10 +15133,10 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='2'>
+		<model name='3'>
 			<availability>General:4</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -15174,19 +15174,15 @@
 		<model name='(Flamer)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Heavy MG)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(SL)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Heavy MG)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Simurgh' unitType='Aero' omni='IS'>
 		<availability>ROS:7</availability>
-		<model name='SMG-OA'>
-			<roles>assault</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='SMG-O'>
 			<roles>assault</roles>
 			<availability>General:8</availability>
@@ -15195,14 +15191,18 @@
 			<roles>assault</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SMG-OA'>
+			<roles>assault</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,OP:5,ROS:3,FWL:4:3139,MSC:5,MERC:3,CP:4</availability>
-		<model name='SRC-5C'>
-			<availability>DTA:5,OP:5,ROS:5,FWL:5,MSC:5,CP:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>DTA:5,OP:5,ROS:5,FWL:5,MSC:5,CP:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>DTA:6,OP:6,ROS:6,FWL:6,MSC:6,CP:6</availability>
@@ -15229,42 +15229,42 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FVC:3,IS.pm:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:2-</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+		<model name='SL-15'>
+			<availability>ROS:0,FS:0,Periphery:2-</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>RA.OA:6,RD:6,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4</availability>
 		</model>
 		<model name='SL-15K'>
 			<availability>RD:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,FS:0,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>LA:1</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='(Huntsman)' mechanized='false'>
 			<availability>LA:4,FS:4,MERC:4</availability>
@@ -15298,11 +15298,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CP:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CNC:8,CP:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -15314,10 +15314,6 @@
 	</chassis>
 	<chassis name='Sokuryou' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='SKU-181 SurveyMech'>
-			<roles>support,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='SKU-197 SurveyMech'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -15325,6 +15321,10 @@
 		<model name='SKU-198 SurveyMech'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKU-181 SurveyMech'>
+			<roles>support,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -15362,26 +15362,26 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
-		<model name='SPR-6D'>
-			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
-		</model>
 		<model name='SPR-7D'>
 			<availability>ROS:5,FS:5,MERC:5</availability>
 		</model>
-		<model name='SPR-7Dr'>
-			<availability>ROS:3,FS:4,MERC:3</availability>
-		</model>
 		<model name='SPR-DH'>
 			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
+		</model>
+		<model name='SPR-6D'>
+			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
+		</model>
+		<model name='SPR-7Dr'>
+			<availability>ROS:3,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -15396,21 +15396,21 @@
 		<model name='SPR-5S'>
 			<availability>CC:4,LA:4,ROS:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8</availability>
 		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:7,MERC:4,CDP:7,RA:5</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(RA)' mechanized='true'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -15418,29 +15418,44 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:4,CP:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:4,CNC:4-,CP:4-</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:4,CNC:8,CP:8</availability>
 		</model>
-		<model name='2'>
-			<availability>ROS:6,CNC:4,CP:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:1,CC:2,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:6</availability>
+		<model name='SDR-10K'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2,CP:8</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='SDR-8X'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>Periphery:2-</availability>
 		</model>
 		<model name='SDR-7Kr'>
 			<availability>ROS:1,MERC:1,DC:1</availability>
 		</model>
-		<model name='SDR-10K'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SDR-7K'>
 			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
+		<model name='SDR-8Xr'>
+			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,CP:8,DC:6</availability>
@@ -15448,26 +15463,11 @@
 		<model name='SDR-7KC'>
 			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='SDR-8K'>
-			<availability>ROS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='SDR-8Xr'>
-			<availability>ROS:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>ROS:3,MERC:3,DC:4</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2,CP:8</availability>
-		</model>
-		<model name='SDR-8X'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
+		<model name='SDR-8K'>
+			<availability>ROS:4,MERC:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -15487,13 +15487,17 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:5,FVC:5,LA:7,ROS:7,IS:6,MH:4,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>IS:4,DC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -15502,10 +15506,6 @@
 		<model name='(Interdictor)'>
 			<roles>spotter</roles>
 			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,CP:4,DC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -15525,8 +15525,11 @@
 		<model name='STK-8S'>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		</model>
+		<model name='STK-6M'>
+			<availability>CC:5,MOC:5,OP:6,RF:6,ROS:6,FWL:6,MERC:6,DA:5,RCM:6,CP:6</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
@@ -15534,20 +15537,17 @@
 		<model name='STK-7D'>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>Periphery:2-</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,OP:3,RF:3,CLAN:8,FWL:3,MERC:3,DA:3,RCM:3,CP:3,BAN:2</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
-		</model>
-		<model name='STK-6M'>
-			<availability>CC:5,MOC:5,OP:6,RF:6,ROS:6,FWL:6,MERC:6,DA:5,RCM:6,CP:6</availability>
+		<model name='STK-3F'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CP:3,CJF:3,TC:4</availability>
@@ -15573,12 +15573,12 @@
 	</chassis>
 	<chassis name='Starslayer' unitType='Mek'>
 		<availability>MOC:4,CC:4,OP:4,RF:4,LA:6,ROS:4,FWL:2:3139,FS:4,DA:4,CP:2</availability>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='STY-3D'>
 			<roles>raider</roles>
 			<availability>MOC:4,CC:2,OP:2,LA:4,ROS:2,FWL:2,FS:2,MERC:4,CP:2</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
@@ -15587,6 +15587,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>LA:2,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
@@ -15595,28 +15599,24 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>FS:6,MERC:4</availability>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:6,LA:7,MERC:2</availability>
-		<model name='STM-OB'>
+		<model name='STM-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STM-OA'>
+		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15628,11 +15628,11 @@
 		<model name='STO-4B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-6S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -15647,33 +15647,29 @@
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,RD:1-,IS:7,MERC:7,Periphery:6,DC:4</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>BAN:8,Periphery:2-</availability>
-		</model>
-		<model name='STG-5G'>
-			<roles>recon</roles>
-			<availability>CC:5,OP:4,FVC:4,ROS:4,FWL:3:3139,MH:4,RCM:4,DA:4,FS:4,CP:3,CDP:5,TC:5</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
 		</model>
-		<model name='STG-3Gb'>
-			<roles>recon</roles>
-			<availability>CC:4,OP:6,CLAN:8,FWL:5,MSC:6,RCM:6,DA:6,MERC:4,CP:5,BAN:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
-		</model>
 		<model name='STG-6L'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:4,DA:4</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
+		<model name='STG-5G'>
+			<roles>recon</roles>
+			<availability>CC:5,OP:4,FVC:4,ROS:4,FWL:3:3139,MH:4,RCM:4,DA:4,FS:4,CP:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>CC:4,OP:6,CLAN:8,FWL:5,MSC:6,RCM:6,DA:6,MERC:4,CP:5,BAN:2</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>BAN:8,Periphery:2-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -15687,38 +15683,39 @@
 			<roles>recon</roles>
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,CP:6,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
-		<model name='F-95'>
-			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:7,MSC:6,MERC:5,RCM:6,DA:6,CP:7</availability>
-		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
-		</model>
-		<model name='F-92'>
-			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,IS:4,MH:4,CP:4</availability>
-		</model>
-		<model name='F-90'>
-			<availability>IS:2-,Periphery:2-</availability>
 		</model>
 		<model name='F-96R'>
 			<availability>DTA:4,OP:4,RF:4,LA:3,FWL:4,MSC:4,RCM:4,DA:4,CP:4</availability>
 		</model>
+		<model name='F-90'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='F-92'>
+			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,IS:4,MH:4,CP:4</availability>
+		</model>
+		<model name='F-95'>
+			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:7,MSC:6,MERC:5,RCM:6,DA:6,CP:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>RD:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -15726,11 +15723,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15742,63 +15742,69 @@
 	</chassis>
 	<chassis name='Storm Raider' unitType='Mek'>
 		<availability>RF:4,LA:4,ROS:3,MH:4,MERC:4,FS:4,Periphery:3</availability>
-		<model name='STM-R1'>
-			<availability>General:3</availability>
-		</model>
 		<model name='STM-R3'>
 			<availability>LA:8,MH:8,MERC:8</availability>
-		</model>
-		<model name='STM-R2'>
-			<availability>General:4</availability>
 		</model>
 		<model name='STM-R4'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
+		<model name='STM-R1'>
+			<availability>General:3</availability>
+		</model>
+		<model name='STM-R2'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:5,MOC:5,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:5,CP:5,DC:7</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SR1-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OM'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
-		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='SR1-OH'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,DC:1</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
 		</model>
@@ -15810,23 +15816,17 @@
 			<roles>fire_support</roles>
 			<availability>FVC:1-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
+		<model name='(SRM)'>
+			<availability>FVC:1-</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,ROS:3,FS.DMM:8,FS:3</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>FVC:1-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
@@ -15853,27 +15853,27 @@
 		<model name='STU-K5'>
 			<availability>FVC:2-,BAN:8,Periphery:2-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>ROS:6,FS:8,MERC:4</availability>
+		<model name='STU-D6'>
+			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>ROS:6,CLAN:8,FS:4,MERC:4,BAN:2</availability>
 		</model>
-		<model name='STU-D6'>
-			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
+		<model name='STU-D7'>
+			<availability>ROS:6,FS:8,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:2,CDS:2,RF:3,LA:2,ROS:3,CNC:2,FS:2,CP:2,CWIE:2</availability>
+		<model name='(Heavy Gauss)'>
+			<availability>RF:6,LA:6,CNC:6,CP:6,CWIE:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
-		</model>
-		<model name='(Heavy Gauss)'>
-			<availability>RF:6,LA:6,CNC:6,CP:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
@@ -15892,37 +15892,44 @@
 		<model name='E'>
 			<availability>CWE:5,RD:5,CW:5,CLAN:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:6,General:2</availability>
-		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:6,CW:6,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:6,General:2,CJF:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:6,General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CWE:5,CDS:3,CW:5,ROS:3,FS:5,MERC:2,CP:3</availability>
-		<model name='2'>
-			<availability>CDS:8,ROS:8,MERC:8,FS:8,CP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CWE:8,CDS:4,CW:8,CP:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:8,ROS:8,MERC:8,FS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OF'>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SD1-OE'>
 			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
@@ -15932,39 +15939,32 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
+		<model name='SD1-OF'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SD1-OG'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CWE:5,RD:3,CDS:4,CW:5,ROS:3,CNC:9,CP:7,CWIE:5</availability>
-		<model name='2'>
-			<availability>ROS:6,CNC:6,CP:6</availability>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:6,CNC:6,CP:6</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CNC:6,CP:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5,CP:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -15999,11 +15999,11 @@
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:5,LA:6,ROS:5,FWL:5,MH:4,FS:5,MERC:5,CP:5,TC:4</availability>
-		<model name='(Original)'>
-			<availability>LA:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<availability>LA:4,MERC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -16018,15 +16018,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -16034,19 +16034,15 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:2,CP:2,RA:4</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:8</availability>
@@ -16055,15 +16051,19 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>ROS:4,DC:6</availability>
+		<model name='TSH-8S'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Taihou Assault Dropship' unitType='Dropship'>
@@ -16087,11 +16087,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -16105,10 +16105,6 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DTA:6,OP:6,ROS:4,FWL:6,MSC:6,MERC:4,CP:6,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>MOC:6,CC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,ROS:6,MSC:8,MERC:6,DC:8</availability>
@@ -16117,21 +16113,21 @@
 			<roles>recon</roles>
 			<availability>ROS:5,DC:5</availability>
 		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
-		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,ROS:5,FWL:8,MSC:8,MERC:4,CP:8,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>MOC:6,CC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:4,MERC:2</availability>
-		<model name='TRG-2N'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='TRG-1N'>
 			<roles>recon</roles>
 			<availability>ROS:8</availability>
@@ -16140,29 +16136,33 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='TRG-2N'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,CP:4,DC:6</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='MIK-OE'>
+			<availability>General:5</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OE'>
-			<availability>General:5</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-OF'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -16174,77 +16174,77 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>DTA:8,OP:8,FWL.MM:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,MERC:4,CP:8</availability>
-		<model name='TMP-3M'>
-			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>RF:4,ROS:4,FWL:2:3139,MSC:4,MERC:4,CP:2</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>DTA:6,OP:6,ROS:6,FWL:6:3139,MSC:6,MERC:4,CP:6</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>ROS:2,FWL:2,MERC:2,CP:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>DTA:6,OP:6,ROS:6,FWL:6:3139,MSC:6,MERC:4,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar III' unitType='Mek' omni='IS'>
 		<availability>FS:5</availability>
-		<model name='TLR2-OC'>
+		<model name='TLR2-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='TLR2-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-OB'>
+		<model name='TLR2-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-O'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:4</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OR'>
-			<availability>General:3</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OI'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OE'>
+		<model name='TLR1-OF'>
 			<roles>spotter</roles>
-			<availability>General:3</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OF'>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OE'>
 			<roles>spotter</roles>
-			<availability>General:2</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OR'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tenshi' unitType='Mek' omni='IS'>
@@ -16255,11 +16255,11 @@
 		<model name='TN-10-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TN-10-OR'>
-			<availability>General:6</availability>
-		</model>
 		<model name='TN-10-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TN-10-OR'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -16271,15 +16271,15 @@
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>ROS:6,DC:4</availability>
+		<model name='TSN-C3M'>
+			<roles>recon,spotter</roles>
+			<availability>ROS:4,DC:4</availability>
+		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
 		<model name='TSN-1Cr'>
-			<roles>recon,spotter</roles>
-			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
@@ -16293,13 +16293,13 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CWE:1,CW:1,CJF:1,RA:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -16307,11 +16307,11 @@
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TNS-6S'>
-			<availability>LA:6,IS:4</availability>
-		</model>
 		<model name='TNS-4T'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='TNS-6S'>
+			<availability>LA:6,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -16330,8 +16330,18 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:1,CLAN:1,CP:1,RA:1,BAN:3,CWIE:2,CWE:1,MERC.WD:1,RD:1,CDS:1,CW:1,ROS:3+,CNC:2,CJF:4</availability>
+		<model name='AA'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CWE:4,RD:3,CDS:4,CW:4,CNC:5,General:6,CP:4,CJF:7,CWIE:5</availability>
 		</model>
 		<model name='G'>
 			<availability>CWE:6,CHH:4,RD:4,CDS:4,CW:6,CNC:4,General:2,CP:4,CJF:5,CWIE:5</availability>
@@ -16339,48 +16349,38 @@
 		<model name='D'>
 			<availability>CWE:8,RD:8,CW:8,CNC:6,General:5,CP:6,CWIE:6</availability>
 		</model>
-		<model name='AA'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CP:7,CJF:8,CWIE:6</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CWE:4,RD:3,CDS:4,CW:4,CNC:5,General:6,CP:4,CJF:7,CWIE:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CWE:6,RD:6,CDS:9,CW:6,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='HH'>
-			<availability>CWE:5,CHH:6,CDS:4,CW:5,CLAN:2,General:2,CP:4,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CWE:6,RD:6,CW:6,General:5,CJF:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5,CWIE:5</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:6,CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CP:7,CJF:8,CWIE:6</availability>
+		</model>
+		<model name='HH'>
+			<availability>CWE:5,CHH:6,CDS:4,CW:5,CLAN:2,General:2,CP:4,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
@@ -16389,14 +16389,14 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
@@ -16404,34 +16404,34 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:5</availability>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CP:2,RA:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:2,FVC:2,FWL:2,FS:2,MERC:2,CP:2,Periphery:2</availability>
+		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -16451,13 +16451,13 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>IS:4,Periphery:4</availability>
-		<model name='Angel'>
-			<roles>artillery</roles>
-			<availability>DTA:6,LA:4,ROS:4,FWL:5,FS:4,CP:5,DC:4</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:6,IS:6,CP:6</availability>
+		</model>
+		<model name='Angel'>
+			<roles>artillery</roles>
+			<availability>DTA:6,LA:4,ROS:4,FWL:5,FS:4,CP:5,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
@@ -16466,12 +16466,6 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:5,ROS:6,DC:4</availability>
-		<model name='TFT-A9'>
-			<availability>ROS:8,General:4</availability>
-		</model>
-		<model name='TFT-F11'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
@@ -16479,18 +16473,24 @@
 		<model name='TFT-L8'>
 			<availability>LA:8</availability>
 		</model>
+		<model name='TFT-F11'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='TFT-A9'>
+			<availability>ROS:8,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:6,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6,ROS:6,MERC:4</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:8,ROS:6,MERC:6</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6,ROS:6,MERC:4</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4,ROS:4</availability>
@@ -16498,51 +16498,51 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,RF:5,MERC:4,DA:5,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-1L'>
-			<availability>General:4</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-C4'>
 			<availability>CC:4,MOC:4,CC.LCC:6</availability>
+		</model>
+		<model name='THR-1L'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:8,CP:8,DC:4</availability>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Pulse Laser]' mechanized='true'>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
+		<model name='[Pulse Laser]' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird II Battle Armor' unitType='BattleArmor'>
@@ -16559,13 +16559,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:8</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -16580,38 +16580,44 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:4,LA:6,ROS:5,MH:4,FS:5,MERC:6,Periphery:2,TC:4,DC:3</availability>
-		<model name='TDR-1C'>
-			<availability>MOC:1-,TC:1-</availability>
-		</model>
-		<model name='TDR-60-RLA'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
-		</model>
-		<model name='TDR-9T'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:3,MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:3,MH:4,MERC:3,CP:3</availability>
+		</model>
+		<model name='TDR-17S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='TDR-60-RLA'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
 		</model>
 		<model name='TDR-9M'>
 			<availability>MOC:3,DTA:5,CC:3,OP:5,PIR:3,FWL:4,MH:3,MSC:5,DA:5,MERC:4,CP:4</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='TDR-9T'>
+			<availability>TC:5</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>MOC:1-,TC:1-</availability>
+		</model>
 		<model name='TDR-5Sb'>
 			<availability>TC:6</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:4,MERC:4</availability>
@@ -16622,21 +16628,9 @@
 		<model name='TDR-10S'>
 			<availability>LA:6,MERC:6</availability>
 		</model>
-		<model name='TDR-17S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:6,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC:6,CC.WHO:8</availability>
-		</model>
 		<model name='TSG-10L'>
 			<roles>spotter</roles>
 			<availability>CC:4</availability>
@@ -16644,9 +16638,15 @@
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
+		<model name='TSG-9DDC'>
+			<availability>CC:6,CC.WHO:8</availability>
+		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat II' unitType='Dropship'>
@@ -16663,11 +16663,11 @@
 	</chassis>
 	<chassis name='Tian-Zong' unitType='Mek'>
 		<availability>CC:6+,MOC:4+</availability>
-		<model name='TNZ-N1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='TNZ-N2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='TNZ-N1'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TNZ-N3'>
 			<availability>General:2</availability>
@@ -16696,13 +16696,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,RA:5</availability>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:8</availability>
+		</model>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2953)'>
 			<roles>asf_carrier</roles>
@@ -16720,15 +16720,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CNC:6,CP:4,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>DC:2-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,ROS:6,CNC:8,CP:8,DC:6</availability>
 		</model>
@@ -16736,21 +16727,30 @@
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>DC:2-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>DC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CWE:6,CHH:4,CW:6</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>urban</roles>
@@ -16759,8 +16759,8 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CWE:3,CW:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -16769,15 +16769,12 @@
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6,CW:6</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CWE:1,CW:1</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -16786,6 +16783,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -16797,14 +16797,10 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:1,MH:1,CP:1</availability>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Small Laser]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,CP:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
@@ -16816,6 +16812,10 @@
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
 		<availability>PIR:1-,MH:1-</availability>
@@ -16826,16 +16826,16 @@
 	</chassis>
 	<chassis name='Tortoise II' unitType='BattleArmor'>
 		<availability>ROS:2</availability>
-		<model name='(C3)' mechanized='false'>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)' mechanized='false'>
+		<model name='(SRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(aSRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRM)' mechanized='false'>
+		<model name='(C3)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -16861,11 +16861,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,CP:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
+		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
 		</model>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -16876,12 +16876,12 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
-		<model name='TR-12'>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='TR-12'>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -16911,16 +16911,16 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,CP:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>MOC:4-,Periphery:4-</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>RF:4,ROS:5,FWL:2:3139,MSC:4,MERC:4,CP:2</availability>
-		</model>
 		<model name='TBT-K7R'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TBT-XK7'>
+			<roles>fire_support</roles>
+			<availability>TC:6</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
@@ -16930,16 +16930,16 @@
 			<roles>fire_support</roles>
 			<availability>ROS:6,FWL:4:3139,MSC:6,MERC:5,CP:4</availability>
 		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>RF:4,ROS:5,FWL:2:3139,MSC:4,MERC:4,CP:2</availability>
+		</model>
 		<model name='TBT-9R'>
 			<availability>RF:6</availability>
 		</model>
-		<model name='TBT-9K'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='TBT-XK7'>
-			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>MOC:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -16953,28 +16953,28 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>MOC:8,CC:8,MH:4,TC:8</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:2,TC:2</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:6</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:2,TC:2</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:2,TC:2</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
@@ -16991,13 +16991,13 @@
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,CLAN:2,IS:9,Periphery.Deep:7,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>IS:6,DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -17005,14 +17005,14 @@
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
 		</model>
+		<model name='CMT-7T'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:5,CC:5,MERC:4,DA:4</availability>
-		</model>
-		<model name='CMT-7T'>
-			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -17051,19 +17051,19 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CWE:6+,CW:6+,ROS:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CWE:3,CW:3,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>General:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CWE:2,CW:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -17076,52 +17076,52 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CWE:2,CW:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>RD:4,CLAN:2</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:6,General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:6,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:5,CW:5,CNC:4,CP:4,CJF:7</availability>
+		<model name='C'>
+			<availability>CWE:7,CHH:7,CW:7,CNC:7,CP:7,CJF:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,CHH:6,CW:6,CNC:6,CP:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:9,RD:9,CW:9,General:7</availability>
+		</model>
 		<model name='A'>
 			<availability>CWE:7,CHH:7,CW:7,CNC:7,CP:7,CJF:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CWE:8,CHH:8,CW:8,CNC:8,CP:8,CJF:8</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,CHH:6,CW:6,CNC:6,CP:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,CHH:7,CW:7,CNC:7,CP:7,CJF:7</availability>
+		<model name='H'>
+			<availability>CWE:6,CHH:5,CW:6,CNC:5,CP:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:4,CHH:4,CW:4,CNC:4,CP:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:9,RD:9,CW:9,General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CWE:6,CHH:5,CW:6,CNC:5,CP:5,CJF:5</availability>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -17130,13 +17130,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -17148,17 +17148,20 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,CP:4,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -17166,18 +17169,33 @@
 			<roles>assault</roles>
 			<availability>RD:4,CHH:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,CHH:2,MERC.WD:1,CW:2,MERC:2+,CJF:3,RA:3,CWIE:2</availability>
-		<model name='F'>
-			<availability>CWE:4,CHH:6,RD:5,CDS:4,CW:4,CLAN:3,IS:1,CP:4,CJF:4</availability>
+		<model name='B'>
+			<availability>CWE:6,RD:5,CDS:8,CW:6,General:7,CP:8,CWIE:6</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:4,RD:1,CDS:2,CW:4,CNC:2,General:1,CP:2,CJF:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CWE:2,CHH:5,RD:2,CDS:4,CW:2,CNC:3,General:4,CP:3,CWIE:2</availability>
+		</model>
+		<model name='W'>
+			<roles>training</roles>
+			<availability>CWE:3,CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
+		<model name='I'>
+			<availability>General:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='R'>
 			<availability>General:6</availability>
@@ -17186,38 +17204,20 @@
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CWE:6,RD:2,CW:6,General:2,CWIE:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:6,RD:4,CDS:6,CW:6,General:5,CP:6,CJF:6,CWIE:6</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:5,CDS:8,CW:6,General:7,CP:8,CWIE:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>RD:8,CDS:9,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:4,RD:1,CDS:2,CW:4,CNC:2,General:1,CP:2,CJF:2,CWIE:4</availability>
+		<model name='E'>
+			<availability>CWE:4,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CWE:4,CHH:6,RD:5,CDS:4,CW:4,CLAN:3,IS:1,CP:4,CJF:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,IS:2,CP:5</availability>
 		</model>
-		<model name='W'>
-			<roles>training</roles>
-			<availability>CWE:3,CW:3,General:1,CWIE:2</availability>
-		</model>
-		<model name='I'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>CWE:6,CHH:6,RD:4,CDS:6,CW:6,General:5,CP:6,CJF:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Umbra' unitType='Aero'>
@@ -17229,11 +17229,11 @@
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CDS:4,CW:4,CP:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -17245,13 +17245,13 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:4</availability>
-		<model name='(3071)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(3071)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -17284,17 +17284,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='UM-R69'>
-			<roles>urban</roles>
-			<availability>FWL:6,IS:6,CP:6,Periphery:6</availability>
-		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:6,FS:6,DC:6</availability>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:4,Periphery:4</availability>
 		</model>
 		<model name='UM-R60L'>
 			<roles>urban</roles>
@@ -17304,31 +17297,38 @@
 			<roles>urban</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R68'>
 			<roles>urban</roles>
-			<availability>Periphery:2-</availability>
+			<availability>CC:6,FS:6,DC:6</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:4,MOC:4,FS.CMM:6,FWL:2:3139,MSC:4,FS:4,CP:2</availability>
 		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='UM-R63'>
 			<roles>urban</roles>
 			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:4,Periphery:4</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='UM-R69'>
+			<roles>urban</roles>
+			<availability>FWL:6,IS:6,CP:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursa' unitType='Mek'>
 		<availability>LA:6,ROS:5,MERC:5,CJF:5,CWIE:5</availability>
-		<model name='URA-2A'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='URA-2C'>
 			<availability>LA:4,ROS:4,CLAN:8,MERC:4</availability>
+		</model>
+		<model name='URA-2A'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -17344,10 +17344,6 @@
 			<deployedWith>IS</deployedWith>
 			<availability>RD:1</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>RD:1</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -17356,6 +17352,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>RD:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -17388,13 +17388,13 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:2,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
+		<model name='VLK-QD3'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:6,ROS:4,MERC:4</availability>
-		</model>
-		<model name='VLK-QD'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
@@ -17404,21 +17404,21 @@
 			<roles>recon,fire_support</roles>
 			<availability>FS:5,MERC:4</availability>
 		</model>
-		<model name='VLK-QD1'>
+		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QT2'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
-		<model name='VLK-QD3'>
-			<roles>recon,fire_support</roles>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QD4'>
 			<roles>recon,fire_support</roles>
 			<availability>ROS:6,FS:6</availability>
+		</model>
+		<model name='VLK-QD1'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -17433,38 +17433,38 @@
 		<model name='D'>
 			<availability>CWE:4,CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='E'>
-			<roles>recon</roles>
-			<availability>CWE:4,CW:4,CLAN:2,CJF:4</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='E'>
+			<roles>recon</roles>
+			<availability>CWE:4,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Mek' omni='IS'>
 		<availability>CC:5,MOC:4</availability>
-		<model name='LI-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='LI-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LI-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='LI-O'>
-			<availability>General:8</availability>
+		<model name='LI-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -17476,46 +17476,46 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CWE:4,CHH:5,CW:4,IS:10,CJF:4,Periphery:10</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
 		<model name='V9'>
 			<availability>LA:4,CLAN:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,DTA:5,RF:5,FWL:4:3139,DA:5,RCM:5,CP:4,CDP:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='V7'>
 			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,DTA:5,RF:5,FWL:4:3139,DA:5,RCM:5,CP:4,CDP:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='(Cell)'>
 			<availability>CC:6,LA:4,FWL:6,IS:4,FS:4,MERC:5,CP:6,DC:4,Periphery:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,TC:1,DC:4</availability>
-		<model name='(2682)'>
+		<model name='(3056)'>
 			<roles>asf_carrier</roles>
-			<availability>General:2</availability>
+			<availability>IS:4,FS:8</availability>
 		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:4,CC:4</availability>
 		</model>
-		<model name='(3056)'>
+		<model name='(2682)'>
 			<roles>asf_carrier</roles>
-			<availability>IS:4,FS:8</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -17535,51 +17535,51 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:4</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,FS:7,Periphery.OS:2,CP:2,Periphery:3,TC:2,DC:4</availability>
-		<model name='VTR-9B'>
-			<availability>Periphery:2-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:2</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
+		<model name='VTR-9Ka'>
+			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
 		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -17597,16 +17597,16 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>RD:7,ROS:6,MERC:5</availability>
+		<model name='VKG-3A'>
+			<roles>missile_artillery</roles>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
 		<model name='VKG-2G'>
 			<availability>RD:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-3A'>
-			<roles>missile_artillery</roles>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -17622,20 +17622,20 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:5,MERC:4,TC:6</availability>
-		<model name='VND-5L'>
-			<availability>CC:2,MOC:1,MERC:1</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:8,MOC:6</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:2,MOC:2,General:2,TC:2</availability>
 		</model>
+		<model name='VND-4L'>
+			<availability>CC:8,MOC:6</availability>
+		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
+		<model name='VND-5L'>
+			<availability>CC:2,MOC:1,MERC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -17661,49 +17661,49 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:6,RA:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CHH:5,CJF:3</availability>
+		<model name='5'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,CP:5,DC:6+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:6</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CNC:8,CP:8</availability>
-		</model>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -17719,32 +17719,24 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PIR:2,FS:1,DC:2</availability>
-		<model name='VNL-K75N'>
-			<availability>LA:8,FWL:8,FS:8,CP:8,DC:8</availability>
-		</model>
 		<model name='VNL-X71 (Yakuza)'>
 			<availability>PIR:8</availability>
+		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,FWL:8,FS:8,CP:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>General:4,FS:8,CDP:4</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>MOC:4,RD:4,LA:4,FWL:4,IS:1,CP:4,Periphery:4,TC:4</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>OP:6,FWL:4:3139,DA:6,RCM:6,CP:4</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:2-,General:2-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:2,PIR:2,IS:2,Periphery:2,TC:2</availability>
@@ -17753,9 +17745,17 @@
 			<roles>anti_infantry</roles>
 			<availability>FWL:8,MERC:3,CP:8,DC:3</availability>
 		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>FVC:2-,General:2-</availability>
+		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:6,RD:6,LA:6,ROS:6,MH:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>OP:6,FWL:4:3139,DA:6,RCM:6,CP:4</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -17770,63 +17770,63 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:4,RD:4,ROS:4+,CLAN:3,MERC:2+,CJF:3,BAN:5,CWIE:4,DC:3+</availability>
+		<model name='G'>
+			<availability>General:4</availability>
+		</model>
 		<model name='B'>
 			<availability>CWE:7,CDS:7,CW:7,General:6,CP:7,CJF:5</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:7,RD:4,CDS:7,CW:7,CNC:7,General:6,CP:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CNC:7,General:8,CP:7,CJF:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CP:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:4,CHH:5,CDS:3,CW:4,General:2,CP:3,CJF:4</availability>
+		<model name='H'>
+			<availability>CDS:5,CNC:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,CP:5,RA:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CP:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CWE:5,CHH:6,CDS:4,CW:5,CLAN:3,General:2,CP:4,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CHH:5,CDS:3,CW:4,General:2,CP:3,CJF:4</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CNC:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='G'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>CWE:7,RD:4,CDS:7,CW:7,CNC:7,General:6,CP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture Mk III (Mad Dog Mk III)' unitType='Mek' omni='Clan'>
 		<availability>RD:7,ROS:5,RA:7</availability>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture Mk IV (Mad Dog Mk IV)' unitType='Mek' omni='Clan'>
 		<availability>IS:4+,CLAN.IS:5</availability>
-		<model name='A'>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -17850,26 +17850,27 @@
 	</chassis>
 	<chassis name='Warg Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CW:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Reactive)' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:3,CLAN:7,IS:4,TC:3</availability>
-		<model name='9'>
-			<availability>CDS:6,CP:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4,CP:5</availability>
-		</model>
 		<model name='10'>
 			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
 		</model>
-		<model name='8'>
-			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
+		<model name='11'>
+			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
 		</model>
 		<model name='12'>
 			<availability>CDS:4,CP:4</availability>
@@ -17877,34 +17878,38 @@
 		<model name='6'>
 			<availability>RD:6,RA:6</availability>
 		</model>
-		<model name='7'>
-			<availability>RA:7</availability>
-		</model>
 		<model name='4'>
 			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,CNC:5,FS:4,CP:5,RA:5,CWIE:5,DC:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
+		<model name='7'>
+			<availability>RA:7</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>IS:3</availability>
+		<model name='5'>
+			<availability>CDS:5,IS:4,CP:5</availability>
 		</model>
-		<model name='11'>
-			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
+		<model name='8'>
+			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
+		</model>
+		<model name='9'>
+			<availability>CDS:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>LA:7,IS:6,FWL:7,CP:7,TC:8,Periphery:5</availability>
-		<model name='WHM-9S'>
-			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
+		<model name='WHM-5L'>
+			<availability>CC:6</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>RF:6,FWL:4,CP:4</availability>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:8,MERC:4</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
+		<model name='WHM-8D2'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:2,PIR:4,IS:2,MH:4,FS:2,MERC:3,CDP:4,TC:4</availability>
@@ -17912,47 +17917,42 @@
 		<model name='WHM-6R'>
 			<availability>BAN:8,Periphery:2-</availability>
 		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6,MOC:4</availability>
+		<model name='WHM-10T'>
+			<availability>FS:4,TC:8</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>RF:6,FWL:4,CP:4</availability>
 		</model>
 		<model name='WHM-11T'>
 			<availability>MOC:4,TC:6</availability>
 		</model>
-		<model name='WHM-8K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:6</availability>
+		<model name='WHM-6Rb'>
+			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
 		</model>
 		<model name='WHM-7M'>
 			<availability>CC:3,FVC:3,ROS:4,FWL:4,MERC:1,CP:4,Periphery:3</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
+		<model name='WHM-9S'>
+			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:8,MERC:4</availability>
+		<model name='WHM-4L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:4,TC:8</availability>
+		<model name='WHD-10CT'>
+			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:6</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:6</availability>
@@ -17960,21 +17960,21 @@
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+		<model name='H-9'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='H-7'>
 			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='H-10'>
-			<roles>apc</roles>
-			<availability>LA:4,CNC:8,FWL:4,CP:6,CWIE:8</availability>
-		</model>
-		<model name='H-8'>
-			<availability>RD:8,LA:3,FS.CH:8,ROS:6,IS:6,FWL:3,FS:6,CP:3,RA:8</availability>
 		</model>
 		<model name='H-7A'>
 			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:6</availability>
+		<model name='H-8'>
+			<availability>RD:8,LA:3,FS.CH:8,ROS:6,IS:6,FWL:3,FS:6,CP:3,RA:8</availability>
+		</model>
+		<model name='H-10'>
+			<roles>apc</roles>
+			<availability>LA:4,CNC:8,FWL:4,CP:6,CWIE:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -17986,15 +17986,9 @@
 	</chassis>
 	<chassis name='Warwolf' unitType='Mek' omni='Clan'>
 		<availability>CWE:2+,CW:2+</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -18002,68 +17996,74 @@
 		<model name='H'>
 			<availability>General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>IS:8,Periphery:6,RA:4</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
-		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:3,LA:3,MERC:2</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
-		</model>
-		<model name='WSP-3L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
-		</model>
-		<model name='WSP-3P'>
-			<availability>FVC:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:6,RA:8</availability>
 		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
+		</model>
+		<model name='WSP-3P'>
+			<availability>FVC:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='WSP-3K'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-3L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:5,FS:8,MERC:5,CDP:5,DC:4</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,CDP:4,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wendigo-VP' unitType='Mek' omni='Clan'>
 		<availability>CNC:2,FWL:1:3143,CP:2,DC:1</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wendigo' unitType='Mek' omni='Clan'>
@@ -18083,19 +18083,19 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CJF:1,RA:2</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>FVC:1,FS.CMM:1,MERC:1,DC:1,Periphery:1</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:8</availability>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -18104,26 +18104,23 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:6,MH:6,MERC:6,CDP:6,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:6,LA:5,CNC:2-,FWL:5,IS:4,CP:3-,MERC:5,DC:8</availability>
-		<model name='WGT-2LAW'>
+		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
-		</model>
-		<model name='WGT-4NC &apos;Dezgra&apos;'>
-			<availability>CNC:8,CP:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='WGT-2LAWC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-4NC &apos;Dezgra&apos;'>
+			<availability>CNC:8,CP:8</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>LA:4,FWL:4,IS:4,MERC:4,CP:4,DC:4</availability>
@@ -18134,33 +18131,36 @@
 		<model name='WGT-3SC'>
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
+		<model name='WGT-2LAW'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
 		<availability>LA:8</availability>
-		<model name='WKT-1S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WKT-2S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='WKT-1S'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:5,ROS.pm:8</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(TSEMP)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Support)'>
-			<roles>fire_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(XXL)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Support)'>
+			<roles>fire_support,spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LAC)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -18172,11 +18172,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>ROS:2,MERC:2,DC:5-</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>ROS:6</availability>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:6</availability>
 		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
@@ -18184,51 +18181,43 @@
 		<model name='WFT-C'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:6</availability>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,OP:3,MERC.KH:7,MERC:4,FS:1,CP:3,CWIE:5,DTA:3,MERC.WD:5,FVC:1,LA:7,ROS:5,FWL:3:3139,MH:4,MSC:3</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
-		</model>
-		<model name='WLF-1'>
-			<availability>Periphery.Deep:6,Periphery:8</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-3M'>
 			<availability>DTA:8,OP:8,FWL:8,MSC:8,CP:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
 		<model name='WLF-2H'>
 			<availability>LA:6,MERC:3,CWIE:4</availability>
 		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		<model name='WLF-1'>
+			<availability>Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,RD:2,LA:5,CNC:2,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
-		</model>
-		<model name='WVR-9D'>
-			<roles>spotter</roles>
-			<availability>FS:6,MERC:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>RD:5,ROS:4,CNC:4,MERC:3,CP:4</availability>
-		</model>
 		<model name='WVR-9W2'>
 			<availability>IS:4,DC:8</availability>
 		</model>
@@ -18236,48 +18225,59 @@
 			<roles>recon</roles>
 			<availability>RD:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:2-,PIR:2-,Periphery.ME:2-,MH:2-</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:4,DC:8</availability>
+		<model name='WVR-9D'>
+			<roles>spotter</roles>
+			<availability>FS:6,MERC:4</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>RD:5,ROS:4,CNC:4,MERC:3,CP:4</availability>
+		</model>
 		<model name='WVR-9M'>
 			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4,CP:6</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:5</availability>
+		</model>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:4,DC:8</availability>
+		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:5,LA:3,ROS:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:5</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:2-,PIR:2-,Periphery.ME:2-,MH:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:3,RD:5,CW:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -18291,16 +18291,19 @@
 	</chassis>
 	<chassis name='Wulfen' unitType='Mek' omni='Clan'>
 		<availability>CWE:4+,CW:4+</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='H'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
@@ -18308,9 +18311,6 @@
 		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Wurger Assault Craft' unitType='Small Craft'>
@@ -18322,19 +18322,19 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -18350,13 +18350,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,ROS:5,MSC:1,DA:1,RCM:1,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
-		</model>
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -18372,20 +18372,20 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,DA:4,Periphery:2,TC:4</availability>
+		<model name='XNT-4O'>
+			<availability>CC:6,MOC:6,LA:6</availability>
+		</model>
 		<model name='XNT-6O'>
 			<availability>CC:6,MOC:6,DA:8</availability>
+		</model>
+		<model name='XNT-7O'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='XNT-2O'>
 			<availability>General:1-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:6,MOC:6,LA:6,ROS:6,MERC:6</availability>
-		</model>
-		<model name='XNT-4O'>
-			<availability>CC:6,MOC:6,LA:6</availability>
-		</model>
-		<model name='XNT-7O'>
-			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -18397,14 +18397,14 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
+		<model name='2'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Xiphos Assault Battle Armor' unitType='BattleArmor'>
@@ -18412,10 +18412,10 @@
 		<model name='(C)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(A)' mechanized='false'>
+		<model name='(B)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(B)' mechanized='false'>
+		<model name='(A)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -18427,6 +18427,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:4,CDS:4,CNC:5,IS:5,CP:4,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='&apos;Spectre&apos;'>
 			<availability>General:3</availability>
 		</model>
@@ -18434,18 +18437,9 @@
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -18453,8 +18447,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:5</availability>
+		</model>
 		<model name='(PPC)'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -18490,18 +18490,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yun' unitType='Aero'>
@@ -18520,19 +18520,25 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>DC.GHO:2,CLAN:3,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>MERC:8,DC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank' omni='IS'>
 		<availability>ROS:3</availability>
+		<model name='(Omnidrone) C'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) Prime'>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Omnidrone) B'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
@@ -18540,12 +18546,6 @@
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) Prime'>
-			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
@@ -18567,38 +18567,38 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:5,ROS:3</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:4-</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:2-</availability>
 		</model>
+		<model name='ZEU-X4'>
+			<availability>LA:8</availability>
+		</model>
 		<model name='ZEU-X'>
 			<availability>LA:2-</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
-		</model>
-		<model name='ZEU-X4'>
-			<availability>LA:8</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,ROS:5,PIR:2,MH:2,FS:1-,MERC:5,CDP:2,TC:2</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:8,MERC:4</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -18622,29 +18622,29 @@
 	</chassis>
 	<chassis name='Zibler Fast Strike Tank' unitType='Tank' omni='IS'>
 		<availability>LA:6,ROS:5,IS:4,FS:7</availability>
-		<model name='(C)'>
+		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(B)'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='(C)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CWE:10,CW:10,ROS:6,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CWE:6,CW:6,ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CLAN:4,CJF:1</availability>
@@ -18661,19 +18661,19 @@
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>RD:2,LA:4,IS:2,Periphery:2</availability>
+		<model name='F'>
+			<roles>support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='Prime'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='E'>
-			<roles>support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -18684,7 +18684,7 @@
 		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
+		<model name='C'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -1156,38 +1156,35 @@
 	</chassis>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:4,RA.OA:4,LA:5,IS:4,FWL:4,FS:5,CP:4,Periphery:4,TC:4,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,LA:8,FWL:8,IS:6,FS:8,CP:8,TC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>Periphery:2</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,LA:8,FWL:8,IS:6,FS:8,CP:8,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achileus Light Battle Armor' unitType='BattleArmor'>
 		<availability>RF:4,FWL:4,DA:4,CP:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
-		<model name='(3088)'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
@@ -1196,16 +1193,19 @@
 			<roles>assault</roles>
 			<availability>CC:8,RF:8,FWL:8,IS:6,DA:8,CP:8,DC:4</availability>
 		</model>
+		<model name='(3088)'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>MERC.WD:1,CDS:1,ROS:1,CP:3,CJF:5,RA:5,CWIE:2</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>ROS:8,FWL:8</availability>
-		</model>
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>ROS:8,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Aegis Point Defense Suit' unitType='BattleArmor'>
@@ -1243,22 +1243,22 @@
 	</chassis>
 	<chassis name='Aesir Medium AA Vehicle' unitType='Tank'>
 		<availability>CWE:6,CHH:4,ROS:4,MERC:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>CHH:4,General:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<roles>anti_aircraft</roles>
 			<availability>CWE:4,CHH:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>CHH:4,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CJF:6</availability>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
@@ -1303,6 +1303,16 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
@@ -1310,51 +1320,41 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CP:4,DC:6</availability>
-		<model name='AKU-2XK'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='AKU-2XC'>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CP:5,DC:5</availability>
 		</model>
 		<model name='AKU-2X'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='AKU-1XJ'>
+			<availability>CP:5,DC:5</availability>
+		</model>
+		<model name='AKU-2XC'>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='AKU-2XK'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CWE:4,CDS:4,LA:6,ROS:5,FS:5,CP:4,CWIE:6,DC:3</availability>
-		<model name='Mk VI'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk VII'>
 			<availability>LA:4,FS:4</availability>
+		</model>
+		<model name='Mk VI'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
 		<availability>ROS:4,FWL:5,MERC:2,CP:5</availability>
-		<model name='ALB-3U'>
-			<availability>FWL:8,MERC:8,CP:8</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>FWL:6,CP:6</availability>
+		</model>
+		<model name='ALB-3U'>
+			<availability>FWL:8,MERC:8,CP:8</availability>
 		</model>
 		<model name='ALB-3Ur'>
 			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
@@ -1371,11 +1371,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
-		<model name='2'>
-			<availability>RD:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anat APC' unitType='Tank'>
@@ -1387,23 +1387,23 @@
 	</chassis>
 	<chassis name='Angerona Scout Suit' unitType='BattleArmor'>
 		<availability>ROS:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Recon)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Anhur Transport' unitType='VTOL'>
 		<availability>CHH:6,CLAN:2,RA:4</availability>
+		<model name='(BA)'>
+			<availability>CHH:6,RD:8,CWIE:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>apc,cargo</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(BA)'>
-			<availability>CHH:6,RD:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Anhur' unitType='VTOL'>
@@ -1414,20 +1414,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:8,CHH:3,LA:2,ROS:3,MERC:3,CWIE:2,BAN:2,RA:3</availability>
-		<model name='C 2'>
-			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
-		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:5,ROS:5,MERC:5,CWIE:5</availability>
 		</model>
-		<model name='ANH-2A'>
-			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		<model name='ANH-3A'>
+			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,IS:4,BAN:3</availability>
 		</model>
-		<model name='ANH-3A'>
-			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
+		<model name='ANH-2A'>
+			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
+		</model>
+		<model name='C 2'>
+			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1453,14 +1453,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:6,MOC:7,FVC:3,DA:3,TC:3</availability>
-		<model name='ABS-5Y'>
-			<availability>MOC:6,CC:6</availability>
+		<model name='ABS-3T'>
+			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-3R'>
 			<availability>General:4</availability>
-		</model>
-		<model name='ABS-3T'>
-			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-4C'>
 			<availability>CC:4,MOC:4</availability>
@@ -1473,53 +1470,52 @@
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
+		<model name='ABS-5Y'>
+			<availability>MOC:6,CC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>RF:6,ROS:4,FWL:6,MERC:4,DA:6,CP:6</availability>
+		<model name='ANV-5M'>
+			<availability>FWL:4,DA:4,CP:4</availability>
+		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>RF:5,FWL:5,DA:5,CP:5</availability>
 		</model>
-		<model name='ANV-5M'>
-			<availability>FWL:4,DA:4,CP:4</availability>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4,CP:4</availability>
+		</model>
+		<model name='ANV-5Q'>
+			<availability>RF:4,FWL:4,CP:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:2,MERC:2,CP:2</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>ROS:3,FWL:3,MERC:3,CP:3</availability>
 		</model>
-		<model name='ANV-5Q'>
-			<availability>RF:4,FWL:4,CP:4</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4,CP:4</availability>
-		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:2,MERC:2,CP:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
 		<availability>FWL:7,CP:7</availability>
-		<model name='ZU-J70'>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 		<model name='ZU-G60'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='ZU-J70'>
+			<availability>FWL:6,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:3,ROS:4,Periphery.ME:3,FWL:8,MH:4,MERC:4,CP:8,DC:6</availability>
-		<model name='APL-1R'>
-			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,MERC:3,CP:4,DC:3</availability>
-		</model>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,CP:4,DC:3</availability>
-		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>FWL:3,CP:3</availability>
+		</model>
+		<model name='APL-1R'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,MERC:3,CP:4,DC:3</availability>
 		</model>
 		<model name='APL-2S'>
 			<roles>fire_support</roles>
@@ -1528,6 +1524,10 @@
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='APL-3T'>
+			<roles>fire_support</roles>
+			<availability>FWL:4,CP:4,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -1549,14 +1549,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,MERC:4,FS:3,CP:4,DC:3</availability>
+		<model name='2'>
+			<availability>General:4</availability>
+		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1573,11 +1573,11 @@
 	</chassis>
 	<chassis name='Arcas' unitType='Mek'>
 		<availability>RD:6,CDS:3,ROS:3,CP:3</availability>
-		<model name='2'>
-			<availability>RD:3,ROS:3</availability>
-		</model>
 		<model name='3'>
 			<availability>RD:6</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:3,ROS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -1585,38 +1585,6 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,RD:4,LA:6,FWL:6,CP:6,Periphery:3,DC:5</availability>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:8,MOC:4</availability>
-		</model>
-		<model name='ARC-9W'>
-			<roles>fire_support</roles>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
-		</model>
-		<model name='ARC-9KC'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,TC:6,Periphery:4</availability>
-		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
@@ -1625,66 +1593,98 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,ROS:4,FWL:4,MERC:4,CP:4,DC:4</availability>
 		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,TC:6,Periphery:4</availability>
+		</model>
+		<model name='ARC-9W'>
+			<roles>fire_support</roles>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:4</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>RD:6,MERC:2</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>FVC:4,PIR:5,FWL:2,CP:2,Periphery:4</availability>
 		</model>
+		<model name='ARC-9KC'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='ARC-8M'>
 			<roles>fire_support</roles>
 			<availability>MOC:3,ROS:4,PIR:3,FWL:5,MH:3,MERC:4,CP:5</availability>
 		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>BAN:2,Periphery:2-</availability>
+		</model>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>RD:6,MERC:2</availability>
+		</model>
+		<model name='ARC-7L'>
+			<roles>fire_support</roles>
+			<availability>CC:8,MOC:4</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:5,ROS:4,MERC:2,CP:2-,CWIE:3-</availability>
-		<model name='AF1E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
+		<model name='AF1B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AF1B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AF1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:6,CWIE:7</availability>
-		<model name='A'>
-			<roles>fire_support</roles>
+		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
@@ -1696,20 +1696,20 @@
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
 		<availability>MERC.KH:3,RD:3,CP:4,CWIE:6</availability>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:1,ROS:2</availability>
-		<model name='A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:2</availability>
 		</model>
 		<model name='J'>
 			<availability>General:8</availability>
@@ -1717,11 +1717,11 @@
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Attack Craft' unitType='Small Craft'>
@@ -1733,11 +1733,11 @@
 	</chassis>
 	<chassis name='Ares Medium Tank' unitType='Tank'>
 		<availability>CWE:8,CLAN:6,CJF:4</availability>
-		<model name='(Plasma)'>
-			<availability>CWE:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Plasma)'>
+			<availability>CWE:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares' unitType='Mek' omni='IS'>
@@ -1745,15 +1745,15 @@
 		<model name='ARS-V1A Hera'>
 			<availability>General:7</availability>
 		</model>
-		<model name='ARS-V1 Zeus'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ARS-V1B Hades'>
 			<availability>General:7</availability>
 		</model>
 		<model name='ARS-V1C Aphrodite'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='ARS-V1 Zeus'>
+			<availability>General:8</availability>
 		</model>
 		<model name='ARS-V1D Hephaestus'>
 			<availability>General:7</availability>
@@ -1764,17 +1764,17 @@
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arion' unitType='Mek'>
@@ -1785,23 +1785,7 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
-		</model>
-		<model name='(Wheeled SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Hover LRM)'>
+		<model name='(Wheeled LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
@@ -1809,33 +1793,49 @@
 			<roles>apc,support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hover MG)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Tracked)'>
-			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
-		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
 		</model>
-		<model name='(Tracked LRM)'>
+		<model name='(Hover LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Wheeled SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
 		<model name='(Hover Sensors)'>
 			<roles>recon,apc</roles>
 			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Wheeled MG)'>
+			<roles>apc,support</roles>
+			<availability>PIR:3,General:2</availability>
+		</model>
+		<model name='(Hover SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Tracked MG)'>
+			<roles>apc,support</roles>
+			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1844,13 +1844,13 @@
 			<roles>assault</roles>
 			<availability>FS:2</availability>
 		</model>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Refit)'>
 			<roles>assault</roles>
 			<availability>ROS:8,FS:8</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arrow IV Assault Vehicle' unitType='Tank'>
@@ -1866,22 +1866,22 @@
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 		</model>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
 		<availability>ROS:5,DC:5</availability>
-		<model name='(3082)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(3062)'>
 			<roles>troop_carrier</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(3082)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -1900,11 +1900,11 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CWE:5,CHH:8,RD:6,CDS:5,ROS:4,CP:5,CJF:3,RA:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:8,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas III' unitType='Mek'>
@@ -1924,55 +1924,71 @@
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:3,CC:3,RA.OA:3,LA:6,CLAN:4,IS:3,FWL:3,FS:5,CP:3,Periphery:3,TC:3,DC:8</availability>
-		<model name='AS7-Dr'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>RF:4,LA:4,DC:4</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:4,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
-		</model>
 		<model name='AS7-K3'>
 			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:6</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:8,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>IS:4,DC:4</availability>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:6</availability>
 		</model>
 		<model name='AS7-D'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>MERC:2,DC:2</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:8,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:1,ROS:3,MERC:3</availability>
+		</model>
+		<model name='AS7-K4'>
+			<availability>RF:4,LA:4,DC:4</availability>
+		</model>
+		<model name='AS7-Dr'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S2'>
-			<availability>LA:1,ROS:3,MERC:3</availability>
+		<model name='AS7-C'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:4,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Gunship)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Tanker)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(CV)'>
 			<roles>asf_carrier</roles>
@@ -1982,31 +1998,15 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Gunship)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Tanker)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avalanche' unitType='Mek' omni='IS'>
 		<availability>CC:4,CDS:3,FWL:4,MERC:3,CP:3,DC:5</availability>
-		<model name='AVL-1OC'>
-			<availability>General:7</availability>
+		<model name='AVL-1OR'>
+			<availability>General:6,CLAN:8</availability>
 		</model>
 		<model name='AVL-1OA'>
 			<availability>General:7</availability>
@@ -2017,8 +2017,8 @@
 		<model name='AVL-1ON'>
 			<availability>General:6</availability>
 		</model>
-		<model name='AVL-1OR'>
-			<availability>General:6,CLAN:8</availability>
+		<model name='AVL-1OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AVL-1O'>
 			<availability>General:8</availability>
@@ -2036,65 +2036,65 @@
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:7,CP:9,RA:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6,CP:7</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5</availability>
-		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CWE:4,CLAN:2</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5</availability>
+		</model>
 		<model name='D'>
 			<availability>CWE:6,CLAN:4,CP:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6,CP:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:7,CP:9,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
 		<availability>RD:4,IS:4,CP:5,DC:6</availability>
-		<model name='AV1-OG'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
+		</model>
 		<model name='AV1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
+		</model>
+		<model name='AV1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OG'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AV1-OJ'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='AV1-OB'>
-			<availability>General:7</availability>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
@@ -2110,8 +2110,17 @@
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
+		<model name='AWS-9Ma'>
+			<availability>LA:2,ROS:2,FWL:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='AWS-9M'>
+			<availability>MOC:2,PIR:2,FWL:4,IS:2,MH:2,CP:4,TC:2,Periphery:4</availability>
+		</model>
 		<model name='AWS-11R'>
 			<availability>RF:5,FWL:4,CP:4</availability>
+		</model>
+		<model name='AWS-9Q'>
+			<availability>MOC:6,FWL:4,IS:6,MH:6,CP:4,TC:6,Periphery:4</availability>
 		</model>
 		<model name='AWS-10KM'>
 			<availability>ROS:4,FWL:4,CP:4,DC:6</availability>
@@ -2119,23 +2128,14 @@
 		<model name='AWS-8Q'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='AWS-9M'>
-			<availability>MOC:2,PIR:2,FWL:4,IS:2,MH:2,CP:4,TC:2,Periphery:4</availability>
-		</model>
-		<model name='AWS-9Q'>
-			<availability>MOC:6,FWL:4,IS:6,MH:6,CP:4,TC:6,Periphery:4</availability>
-		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:2,ROS:2,FWL:2,FS:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
 		<availability>RD:6,CDS:4,ROS:4,FS:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>RD:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -2146,86 +2146,82 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:1,LA:5,ROS:4,FS:1</availability>
+		<model name='AXM-4D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='AXM-3Sr'>
+			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='AXM-6T'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-4D'>
-			<availability>FS:6</availability>
+		<model name='AXM-1N'>
+			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
 		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='AXM-1N'>
-			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
-		</model>
-		<model name='AXM-3Sr'>
-			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CJF:5,RA:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
-		<model name='3 &apos;Devil&apos;'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='3 &apos;Devil&apos;'>
+			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CWE:6,MERC.WD:5,LA:4,ROS:5</availability>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:6,General:4</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:2,MERC:3</availability>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
@@ -2237,11 +2233,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
@@ -2249,15 +2241,23 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,IS:8</availability>
+		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,IS:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>General:2</availability>
@@ -2268,44 +2268,56 @@
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,LA:4,ROS:4,FWL:4,FS:4,MERC:8,DA:4,CP:4,Periphery:4</availability>
-		<model name='BNDR-01Ar'>
-			<availability>General:2</availability>
+		<model name='BNDR-01B'>
+			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='BNDR-01B'>
-			<availability>General:4,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1</availability>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2313,33 +2325,21 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='A'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank'>
@@ -2351,14 +2351,6 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,MERC:5</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:1</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
@@ -2371,14 +2363,6 @@
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='I'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
@@ -2387,48 +2371,64 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:1</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='I'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:4-,RA.OA:4-,FVC:2-,RF:2-,LA:2-,FWL:1-,MH:4-,MERC:1-,CP:1-,Periphery:7-,TC:4-</availability>
-		<model name='BNC-3Mr'>
-			<availability>MOC:6,FWL:6,CP:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='BNC-3MC'>
-			<availability>MOC:1-</availability>
-		</model>
-		<model name='BNC-7S'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BNC-9S2'>
-			<availability>RF:3,LA:5</availability>
-		</model>
 		<model name='BNC-9S'>
 			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>RF:1-</availability>
 		</model>
-		<model name='BNC-3E'>
-			<availability>Periphery:2-</availability>
+		<model name='BNC-5S'>
+			<availability>LA:2,MH:4,MERC:5</availability>
+		</model>
+		<model name='BNC-9S2'>
+			<availability>RF:3,LA:5</availability>
+		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:1-</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BNC-3S'>
 			<availability>Periphery:1-</availability>
 		</model>
-		<model name='BNC-5S'>
-			<availability>LA:2,MH:4,MERC:5</availability>
+		<model name='BNC-3E'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='BNC-6S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
+		</model>
+		<model name='BNC-3Mr'>
+			<availability>MOC:6,FWL:6,CP:6,CDP:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bardiche Heavy Strike Tank' unitType='Tank'>
@@ -2443,9 +2443,6 @@
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,ROS:4,MERC:4</availability>
-		<model name='BGS-1T'>
-			<availability>General:2</availability>
-		</model>
 		<model name='BGS-3T'>
 			<availability>LA:3,ROS:3,MERC:3</availability>
 		</model>
@@ -2454,6 +2451,9 @@
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='BGS-1T'>
+			<availability>General:2</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
@@ -2469,25 +2469,25 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
-		<model name='Prime'>
-			<roles>interceptor</roles>
-			<availability>General:7,CP:8,RA:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:2,CP:3,RA:6</availability>
-		</model>
-		<model name='A'>
-			<availability>RD:8,General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>CHH:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<roles>interceptor</roles>
+			<availability>General:7,CP:8,RA:8</availability>
+		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
 			<availability>General:1,RA:3</availability>
+		</model>
+		<model name='A'>
+			<availability>RD:8,General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:2,CP:3,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
@@ -2498,11 +2498,8 @@
 		<model name='H'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
@@ -2510,8 +2507,11 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2540,20 +2540,21 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
-		<model name='BLR-1Gc'>
-			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:4,CLAN:8,FWL:3,FS:4,MERC:4,CP:3,BAN:2,DC:4</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:2</availability>
+		<model name='BLR-10S'>
+			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
 		<model name='BLR-4S'>
 			<availability>LA:2,ROS:4,MERC:4</availability>
 		</model>
-		<model name='BLR-10S'>
-			<availability>LA:6,ROS:4,FS:4</availability>
+		<model name='BLR-K3'>
+			<roles>spotter</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:4,CLAN:8,FWL:3,FS:4,MERC:4,CP:3,BAN:2,DC:4</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:2</availability>
@@ -2561,35 +2562,34 @@
 		<model name='BLR-1G'>
 			<availability>BAN:8,Periphery:1-</availability>
 		</model>
+		<model name='BLR-3M'>
+			<availability>CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
+		<model name='BLR-6X'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BLR-M3'>
 			<roles>spotter</roles>
 			<availability>ROS:4,FWL:4,DA:5,MERC:4,CP:4</availability>
+		</model>
+		<model name='BLR-CM'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='BLR-1Gc'>
+			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>FWL:8,CP:8</availability>
 		</model>
 		<model name='BLR-K4'>
 			<availability>RD:4,ROS:4,DC:6</availability>
-		</model>
-		<model name='BLR-CM'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
-		</model>
-		<model name='BLR-4L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='BLR-K3'>
-			<roles>spotter</roles>
-			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2611,12 +2611,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='B'>
 			<roles>interceptor,ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,CLAN:2,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2631,14 +2631,14 @@
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>RD:6,ROS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
@@ -2655,28 +2655,28 @@
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:1,RA.OA:2,LA:1,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Kurita)'>
 			<availability>CLAN:6,IS:6,DC:8</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Flamer)'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:6,LA:4,ROS:7,FWL:6,MH:4,MERC:4,CP:6,TC:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2704,28 +2704,28 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>RD:6,ROS:6,CP:4</availability>
-		<model name='BEO-12'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='BEO-14'>
 			<roles>recon</roles>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='BEO-12'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>RF:5,LA:7,ROS:4,FS:3,MERC:3</availability>
-		<model name='BRZ-A3'>
-			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
-		</model>
-		<model name='BRZ-D4'>
-			<availability>LA:6</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>RF:4,LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:1</availability>
+		<model name='BRZ-D4'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BRZ-A3'>
+			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2733,12 +2733,12 @@
 		<model name='BSN-3K'>
 			<availability>General:8</availability>
 		</model>
+		<model name='BSN-5KC'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='BSN-4K'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='BSN-5KC'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishop Transport VTOL' unitType='VTOL'>
@@ -2750,63 +2750,69 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CWE:1,CHH:1,RD:1,ROS:4+,CJF:1,RA:1,BAN:2,CWIE:1</availability>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CWE:6,RD:4,General:6,CP:7,CJF:8</availability>
 		</model>
+		<model name='I'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:3,CHH:6,General:4,CP:5,CJF:6,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CDS:5,CLAN:4,General:2,CP:5</availability>
+		</model>
 		<model name='C'>
 			<availability>CWE:3,CHH:6,General:5,CJF:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CWE:5,RD:7,General:6,CJF:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CWE:2,RD:2,CDS:2,CLAN:1,General:2,CP:2,CJF:2,CWIE:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:3,CHH:6,General:4,CP:5,CJF:6,CWIE:5</availability>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='T'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CWE:5,RD:7,General:6,CJF:8</availability>
-		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,General:7,CP:8,CJF:9</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CDS:5,CLAN:4,General:2,CP:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='I'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,IS:5,FS:5,MERC:5,DC:8</availability>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
 		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BHKU-OG'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BHKU-OB'>
+		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
@@ -2816,23 +2822,17 @@
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
 		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:8,CDS:6,IS:5,MERC:6,CP:5,CWIE:6</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>General:4</availability>
@@ -2840,26 +2840,11 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
-		<model name='BL-6b-KNT'>
-			<availability>LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
-		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:3,FS:8</availability>
 		</model>
 		<model name='BLK-NT-2Y'>
 			<availability>FVC:4,ROS:6,IS:6,FS:6,CDP:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
-		</model>
-		<model name='BLK-NT-4D'>
-			<availability>CWE:6,CDS:6,ROS:6,FS:5,MERC:4,CP:5,CWIE:6</availability>
-		</model>
-		<model name='BLK-NT-3A'>
-			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
-		</model>
-		<model name='BL-12-KNT'>
-			<availability>ROS:3,FS:8</availability>
 		</model>
 		<model name='BLK-NT-3B'>
 			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
@@ -2867,35 +2852,50 @@
 		<model name='BLK-NT-5H'>
 			<availability>FWL:4,FS:5,MERC:4,CP:4,DC:4</availability>
 		</model>
+		<model name='BLK-NT-4D'>
+			<availability>CWE:6,CDS:6,ROS:6,FS:5,MERC:4,CP:5,CWIE:6</availability>
+		</model>
+		<model name='BLK-NT-3A'>
+			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
+		</model>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BL-6b-KNT'>
+			<availability>LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CJF:7</availability>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='H'>
+		<model name='E'>
 			<availability>CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>CJF:2</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
+		<model name='H'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='X'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -2911,80 +2911,80 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Wolf Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:6,CWIE:4</availability>
-		<model name='[LBX]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[ERSPL]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Mortar]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='[Heavy Mortar]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[LBX]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Heavy Flamer]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:2,RA.OA:3,FVC:4,FS:4,MERC:2,TC:2,Periphery:4</availability>
-		<model name='BJ-2r'>
-			<availability>FVC:6,FS:6,MERC:6</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>Periphery:1</availability>
 		</model>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
 		<model name='BJ-2'>
 			<availability>FVC:3,LA:4,FS:2,MERC:4</availability>
 		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='BJ-2r'>
+			<availability>FVC:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:2,ROS:4,FWL:5,IS:1,FS:6,MERC:3,DA:4,CP:5,DC:6</availability>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8,CP:8</availability>
-		</model>
 		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7,CP:7</availability>
-		</model>
-		<model name='BJ2-OB'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OU'>
+		<model name='BJ2-OX'>
 			<availability>General:2</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7,CP:7</availability>
 		</model>
 		<model name='BJ2-O'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OX'>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OD'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8,CP:8</availability>
+		</model>
+		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -2992,10 +2992,6 @@
 		<availability>ROS:8,FWL:2,FS:4,CP:2</availability>
 		<model name='BLD-7R'>
 			<availability>FWL:8,CP:8</availability>
-		</model>
-		<model name='BLD-XR'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,FS:8</availability>
 		</model>
 		<model name='BLD-XX'>
 			<roles>anti_aircraft</roles>
@@ -3007,21 +3003,22 @@
 		<model name='BLD-XS'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='BLD-XR'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
 		<availability>RF:4,LA:6,ROS:4,FWL:2,MERC:4,CP:2</availability>
-		<model name='BTZ-3F'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTZ-4F'>
 			<availability>RF:6,LA:6,ROS:6</availability>
+		</model>
+		<model name='BTZ-3F'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='&apos;Black Blizzard&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3029,20 +3026,23 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;Black Blizzard&apos;'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='G'>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
@@ -3054,17 +3054,17 @@
 		<model name='E'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CWE:9</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
@@ -3095,22 +3095,22 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:4</availability>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='A'>
+		<model name='Prime'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3121,13 +3121,13 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
-		<model name='BMB-05A'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RA.OA:8</availability>
-		</model>
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='BMB-05A'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RA.OA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3139,13 +3139,6 @@
 	</chassis>
 	<chassis name='Boreas' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -3153,26 +3146,33 @@
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bowman' unitType='Mek'>
 		<availability>CHH:4</availability>
-		<model name='3'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='4'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:2</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
@@ -3186,15 +3186,6 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-X3'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LDT-5'>
 			<availability>PIR:4</availability>
 		</model>
@@ -3203,6 +3194,15 @@
 		</model>
 		<model name='LDT-X1'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X3'>
+			<availability>PIR:4</availability>
+		</model>
+		<model name='LDT-1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LDT-X4'>
+			<availability>PIR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Broadsword' unitType='Dropship'>
@@ -3226,17 +3226,17 @@
 		<model name='(PPC 2)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(PPC)'>
-			<availability>General:4</availability>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,RA.OA:6,RD:6,IS:6,FS:6</availability>
+		</model>
+		<model name='(PPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3265,37 +3265,37 @@
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Bulldog Medium Tank' unitType='Tank'>
 		<availability>LA:3,ROS:4,FS:4,MERC:3,Periphery:1-,DC:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='(AC2)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
 		<availability>RF:7,FWL:6,DA:6,MERC:5,CP:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Buraq Fast Battle Armor' unitType='BattleArmor'>
@@ -3313,11 +3313,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,ROS:6,CP:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Bus' unitType='Small Craft'>
@@ -3329,17 +3329,17 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
-		<model name='BSW-S2r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='BSW-X2'>
+			<availability>LA:4,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BSW-X2'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='BSW-S2r'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BSW-X1'>
 			<availability>MERC:4</availability>
@@ -3363,17 +3363,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:4,LA:2,FS:2,MERC:2</availability>
-		<model name='CES-4R'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CES-3S'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='CES-3R'>
 			<availability>FVC:8,FS:1,MERC:1</availability>
 		</model>
 		<model name='CES-4S'>
 			<availability>LA:6,FS:6</availability>
+		</model>
+		<model name='CES-3S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='CES-4R'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Calliope' unitType='Mek'>
@@ -3424,13 +3424,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CWE:1,CHH:1,RD:2,CDS:3,CP:4,CJF:1,RA:3</availability>
-		<model name='(Merchant 2985)'>
-			<roles>cargo</roles>
-			<availability>RD:4,CDS:8,CP:8,CJF:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Merchant 2985)'>
+			<roles>cargo</roles>
+			<availability>RD:4,CDS:8,CP:8,CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3455,26 +3455,26 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
-		<model name='CTF-3D'>
-			<availability>FVC:3,MH:4,FS:2,MERC:4</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-5D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='CTF-3LL'>
 			<availability>CC:6,MOC:6,MERC:3,TC:6</availability>
 		</model>
-		<model name='CTF-4X'>
-			<availability>FVC:4,FS:4,MERC:3</availability>
+		<model name='CTF-3D'>
+			<availability>FVC:3,MH:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='CTF-1X'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
-		<model name='CTF-1X'>
-			<availability>Periphery:2-</availability>
+		<model name='CTF-4X'>
+			<availability>FVC:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult II' unitType='Mek'>
@@ -3490,81 +3490,81 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:4,FWL:3,MH:3,MERC:1,CP:2,DA:4,Periphery:2,TC:2,DC:6</availability>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K4'>
+		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>BAN:2</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='CPLT-C3'>
-			<roles>missile_artillery</roles>
-			<deployedWith>Raven</deployedWith>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,CDP:3,TC:3,DC:4</availability>
-		</model>
-		<model name='CPLT-C6'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FVC:3,CLAN:6,MERC:3,Periphery:3,DC:4</availability>
 		</model>
 		<model name='CPLT-C5A'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
 		</model>
-		<model name='CPLT-K2K'>
+		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
+		</model>
+		<model name='CPLT-C1b'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FVC:3,CLAN:6,MERC:3,Periphery:3,DC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,FWL:2,MERC:4,DA:4,CP:2</availability>
 		</model>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
+		</model>
+		<model name='CPLT-K4'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C3'>
+			<roles>missile_artillery</roles>
+			<deployedWith>Raven</deployedWith>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,CDP:3,TC:3,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CP:5,RA:5,DC:3+</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
@@ -3572,41 +3572,41 @@
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:6</availability>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cave Lion' unitType='Mek'>
@@ -3617,16 +3617,20 @@
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>RA:4</availability>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>RA:8</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek' omni='IS'>
 		<availability>ROS:3</availability>
-		<model name='CLR-03-OC'>
+		<model name='CLR-03-OD'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='CLR-03-OE'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3634,19 +3638,15 @@
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='CLR-03-O'>
-			<roles>spotter,specops</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='CLR-03-OD'>
-			<roles>specops</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='CLR-03-OA'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='CLR-03-OE'>
+		<model name='CLR-03-O'>
+			<roles>spotter,specops</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='CLR-03-OC'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3660,39 +3660,33 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CP:6,RA:5</availability>
-		<model name='3'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CP:8</availability>
+		</model>
+		<model name='3'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='Commando'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='Commando'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
-		<model name='CNT-1D'>
-			<availability>Periphery.HR:2,Periphery.OS:2,Periphery:2</availability>
-		</model>
-		<model name='CNT-2D'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
@@ -3700,24 +3694,23 @@
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
 		</model>
+		<model name='CNT-1D'>
+			<availability>Periphery.HR:2,Periphery.OS:2,Periphery:2</availability>
+		</model>
+		<model name='CNT-2D'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:4,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6</availability>
-		<model name='CN9-A'>
-			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:2,MERC:1,Periphery:4</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:3</availability>
+		<model name='CN9-Ar'>
+			<availability>IS:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CP:3,CDP:3</availability>
 		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
+		<model name='CN10-B'>
+			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-H'>
 			<availability>MH:1-</availability>
@@ -3725,21 +3718,37 @@
 		<model name='CN9-D4D'>
 			<availability>ROS:3,FWL:3,FS:3,MERC:3,CP:3</availability>
 		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3,Periphery:4</availability>
+		<model name='CN9-A'>
+			<deployedWith>Trebuchet</deployedWith>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CN9-D3'>
 			<availability>FVC:2,ROS:2,FS:1,MERC:1,CDP:3</availability>
 		</model>
-		<model name='CN10-B'>
-			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
+		<model name='CN9-D'>
+			<availability>FVC:2,MERC:1,Periphery:4</availability>
 		</model>
 		<model name='CN9-Da'>
 			<availability>FVC:4,ROS:2,FWL:2,MERC:2,FS:2,CP:2,Periphery:4</availability>
 		</model>
+		<model name='CN9-D5'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek' omni='IS'>
 		<availability>LA:6,ROS:6,FS:8,MERC:5</availability>
+		<model name='CN11-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='CN11-O'>
 			<availability>General:8</availability>
 		</model>
@@ -3747,15 +3756,6 @@
 			<availability>General:7</availability>
 		</model>
 		<model name='CN11-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OD'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3788,11 +3788,11 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
-		<model name='2'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='4'>
 			<roles>spotter</roles>
@@ -3813,21 +3813,21 @@
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
 		<availability>LA:4,ROS:4,FS:8,MERC:4,DC:4,TC:4</availability>
-		<model name='X'>
-			<availability>General:8</availability>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
+		</model>
+		<model name='XII'>
+			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 		<model name='XI'>
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
+		<model name='X'>
+			<availability>General:8</availability>
 		</model>
 		<model name='XIVs'>
 			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
-		</model>
-		<model name='XII'>
-			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
@@ -3835,6 +3835,10 @@
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
@@ -3844,115 +3848,111 @@
 			<roles>training</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:2,DC.GHO:2,RD:4,LA:1,ROS:2,DC:1</availability>
-		<model name='CHP-3N'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
+		<model name='C'>
+			<availability>CHH:6,RD:6,CLAN:8</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:1,RD:1,LA:2,MERC.SI:4,MERC:2,BAN:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,RD:6,CLAN:8</availability>
+		<model name='CHP-1N2'>
+			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
+		</model>
+		<model name='CHP-3N'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>RD:2,ROS:4,IS:3,MERC:2,BAN:4,Periphery:2</availability>
-		<model name='(Standard)'>
+		<model name='(CASE)'>
 			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>missile_artillery</roles>
-			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(SRM)'>
+			<roles>missile_artillery</roles>
+			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>MOC:1-,RA.OA:2-,FVC:1,RD:3-,LA:1-,ROS:2-,TC:1-,Periphery:1,DC:4-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='CGR-3K'>
+			<availability>MERC:1-,DC:2-</availability>
+		</model>
 		<model name='CGR-2A2'>
 			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SB &apos;Challenger&apos;'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='CGR-1A9'>
+			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CGR-SA5'>
 			<roles>urban</roles>
 			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CGR-3K'>
-			<availability>MERC:1-,DC:2-</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='CGR-C'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='CGR-1A9'>
-			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SB &apos;Challenger&apos;'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
-		<model name='CGR-1L'>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
-		<model name='F-13'>
-			<availability>CC:4,ROS:4,FWL:4,FS:4,CP:4,MERC:4</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,FVC:2,RF:2,FWL:2,MERC:2,DA:2,CP:2,Periphery:2</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>FVC:2,Periphery:2</availability>
-		</model>
 		<model name='F-10'>
 			<roles>recon</roles>
 			<availability>CC:1-,RF:1-,FWL:1-,MERC:1-,DA:1-,CP:1-,Periphery:1-</availability>
-		</model>
-		<model name='F-11'>
-			<availability>CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
 		</model>
 		<model name='OF-17A-R'>
 			<roles>recon</roles>
 			<availability>ROS:4,FWL:4,CP:4</availability>
 		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,FVC:2,RF:2,FWL:2,MERC:2,DA:2,CP:2,Periphery:2</availability>
+		</model>
 		<model name='F-14-S'>
 			<availability>RF:8,FWL:8,MH:4,MERC:5,DA:8,CP:8</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>FVC:2,Periphery:2</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
+		</model>
+		<model name='F-13'>
+			<availability>CC:4,ROS:4,FWL:4,FS:4,CP:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CDS:4,LA:3,ROS:5,FWL:3,FS:3,CP:4,DC:3</availability>
-		<model name='(BAP)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
@@ -3960,13 +3960,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BAP)'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>CDS:6,LA:6,ROS:6,FWL:5,FS:6,CP:5,DC:6</availability>
-		</model>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3977,63 +3977,63 @@
 	</chassis>
 	<chassis name='Chimera' unitType='Mek'>
 		<availability>FVC:4,RF:4,LA:6,ROS:4,FWL:4,MH:4,MERC:5,DA:4,CP:4,DC:5</availability>
-		<model name='CMA-C'>
-			<availability>:0,IS:4,DC:8</availability>
-		</model>
 		<model name='CMA-1S'>
 			<availability>General:8,FWL:0</availability>
+		</model>
+		<model name='CMA-C'>
+			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
-		<model name='CHP-W5'>
-			<availability>:0,BAN:3,Periphery:2-</availability>
-		</model>
-		<model name='CHP-W10'>
-			<availability>FVC:2,CDP:2,TC:2</availability>
-		</model>
-		<model name='CHP-W5b'>
-			<availability>CLAN:2,BAN:2</availability>
+		<model name='CHP-W7'>
+			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 		<model name='CHP-W7T'>
 			<availability>TC:8</availability>
 		</model>
+		<model name='CHP-W5b'>
+			<availability>CLAN:2,BAN:2</availability>
+		</model>
+		<model name='CHP-W10'>
+			<availability>FVC:2,CDP:2,TC:2</availability>
+		</model>
 		<model name='CHP-W8'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,BAN:3,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
 		<availability>CP:6,RA:8</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:1,RF:2,FWL:2,MERC:1,CP:2,CDP:2,Periphery:2</availability>
-		<model name='CDA-3G'>
-			<roles>recon</roles>
-			<availability>CC:6,FWL:4,MERC:6,CP:4</availability>
-		</model>
-		<model name='CDA-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:6,MERC:6,CP:8,Periphery:4</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
-		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:2,IS:4,CP:2</availability>
 		</model>
 		<model name='CDA-3P'>
 			<availability>RF:8,FWL:8,CP:8</availability>
+		</model>
+		<model name='CDA-3G'>
+			<roles>recon</roles>
+			<availability>CC:6,FWL:4,MERC:6,CP:4</availability>
+		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
+		</model>
+		<model name='CDA-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:6,MERC:6,CP:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -4070,20 +4070,20 @@
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
@@ -4100,23 +4100,23 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
@@ -4124,14 +4124,14 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
@@ -4148,32 +4148,32 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -4181,11 +4181,11 @@
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4194,14 +4194,14 @@
 			<roles>marine</roles>
 			<availability>RD:8</availability>
 		</model>
-		<model name='(Rabid)' mechanized='true'>
-			<availability>CWE:4,RD:4,CDS:4,CP:4,CWIE:4</availability>
+		<model name='(Volk)' mechanized='true'>
+			<availability>CWE:4</availability>
 		</model>
 		<model name='(Rache)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Volk)' mechanized='true'>
-			<availability>CWE:4</availability>
+		<model name='(Rabid)' mechanized='true'>
+			<availability>CWE:4,RD:4,CDS:4,CP:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
@@ -4209,20 +4209,20 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4234,10 +4234,6 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='V3'>
-			<roles>assault</roles>
-			<availability>LA:4,ROS:8,FS:4</availability>
-		</model>
 		<model name='Interceptor'>
 			<roles>assault</roles>
 			<availability>LA:3</availability>
@@ -4246,20 +4242,27 @@
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='V3'>
+			<roles>assault</roles>
+			<availability>LA:4,ROS:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
 		<availability>CWE:5,RD:5,CP:5,RA:3</availability>
-		<model name='2'>
-			<availability>RA:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:2,MOC:2,FVC:2,RF:2,LA:2,ROS:2,FS:2,MERC:1,DA:2,CDP:2,TC:2,Periphery:3</availability>
 		<model name='CLNT-2-3U'>
 			<availability>CC:2,General:6</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
@@ -4270,9 +4273,6 @@
 		</model>
 		<model name='CLNT-2-3UL'>
 			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
@@ -4323,51 +4323,45 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
-		<model name='COM-5S'>
-			<roles>recon</roles>
-			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
-		</model>
-		<model name='COM-2Dr'>
-			<roles>recon</roles>
-			<availability>LA:5,MERC:5,Periphery:5</availability>
-		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>LA:8,ROS:8</availability>
-		</model>
 		<model name='COM-8S'>
 			<availability>LA:7,MERC:4</availability>
+		</model>
+		<model name='COM-3A'>
+			<roles>recon</roles>
+			<availability>Periphery:1-</availability>
 		</model>
 		<model name='COM-1A'>
 			<roles>recon</roles>
 			<availability>FVC:1-,Periphery:1-</availability>
 		</model>
-		<model name='COM-3A'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>Periphery:1-</availability>
+			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
+		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:8</availability>
+		</model>
+		<model name='COM-5S'>
+			<roles>recon</roles>
+			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='COM-7B'>
+			<roles>recon</roles>
+			<availability>LA:8,ROS:8</availability>
+		</model>
+		<model name='COM-2Dr'>
+			<roles>recon</roles>
+			<availability>LA:5,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,FVC:2,LA:2,ROS:3,IS:2,FWL:2,FS:3,CP:2,TC:2,DC:2,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:8</availability>
-		</model>
 		<model name='(Upgrade) (Standard)'>
 			<availability>LA:8,FWL:6,MERC:6,CP:6</availability>
 		</model>
@@ -4376,6 +4370,12 @@
 		</model>
 		<model name='(Laser Upgrade)'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
@@ -4389,13 +4389,13 @@
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:6,Periphery:6</availability>
-		<model name='(2801)'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:6,IS:6,DC:8</availability>
+		</model>
+		<model name='(2801)'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condottiere Assault Craft' unitType='Small Craft'>
@@ -4414,13 +4414,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,BAN:3</availability>
-		<model name='(2602) (Mech)'>
-			<roles>mech_carrier,asf_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2602)'>
 			<roles>mech_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2602) (Mech)'>
+			<roles>mech_carrier,asf_carrier</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -4443,23 +4443,23 @@
 	</chassis>
 	<chassis name='Conquistador' unitType='Dropship'>
 		<availability>FS:6</availability>
-		<model name='(Avalon One)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Avalon One)'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>RD:3</availability>
-		<model name='(SRM)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LMG)' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
@@ -4496,20 +4496,20 @@
 		<model name='CRX-OC'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CRX-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='CRX-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='CRX-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CRX-OR'>
 			<availability>RA.OA:4,CLAN:8</availability>
+		</model>
+		<model name='CRX-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4520,20 +4520,20 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		<model name='CSR-V12'>
+			<availability>BAN:4,Periphery:2-</availability>
 		</model>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
 		</model>
 		<model name='CSR-V12b'>
 			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='CSR-V12'>
-			<availability>BAN:4,Periphery:2-</availability>
 		</model>
 		<model name='CSR-V18'>
 			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
@@ -4560,20 +4560,20 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='G'>
-			<availability>CHH:6,General:4</availability>
-		</model>
 		<model name='X 2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='X'>
+		<model name='X 3'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='XR'>
 			<availability>CJF:8</availability>
 		</model>
-		<model name='X 3'>
+		<model name='X'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
@@ -4581,19 +4581,15 @@
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='I'>
+		<model name='D'>
 			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<availability>CWE:3,CJF:3,CWIE:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -4601,12 +4597,16 @@
 		<model name='H'>
 			<availability>General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='I'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
@@ -4620,16 +4620,16 @@
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
 		<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
+		</model>
 		<model name='CRB-27b'>
 			<roles>raider</roles>
 			<availability>ROS:8,CLAN:4,FWL:8,MERC:8,CP:8,BAN:2,DC:6</availability>
 		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
-		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crane Heavy Transport' unitType='VTOL'>
@@ -4641,36 +4641,36 @@
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
 		<availability>CC:3,CDS:6,LA:4,ROS:4,FWL:4,FS:3,MERC:4,CP:5,CJF:6,CWIE:6,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:8,FWL:8,CLAN.IS:8,FS:8,CP:8</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,FWL:8,CLAN.IS:8,FS:8,CP:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CC:8,CDS:4,MERC:8,CP:4,DC:8</availability>
 		</model>
+		<model name='4'>
+			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CP:4,RA:4</availability>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4678,19 +4678,19 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:3,ROS:3,CLAN:4,CP:3,CJF:3,RA:3,CWIE:5</availability>
-		<model name='CRK-5004-1'>
-			<availability>ROS:6</availability>
+		<model name='CRK-5003-3'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='CRK-5005-1'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,BAN:8</availability>
 		</model>
-		<model name='CRK-5003-3'>
+		<model name='CRK-5004-1'>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
@@ -4711,33 +4711,37 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CDS:2,CP:2,RA:5,CWIE:2</availability>
-		<model name='A'>
-			<availability>General:5</availability>
+		<model name='U'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='U'>
-			<availability>CLAN:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crow Scout Helicopter' unitType='VTOL'>
 		<availability>CC:3,MOC:3,ROS:4,IS:2,FWL:3,MERC:3,CP:2,DC:4</availability>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,FWL:8,MERC:8,CP:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
@@ -4746,51 +4750,47 @@
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,FWL:8,MERC:8,CP:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CLAN:5,IS:6,Periphery:5</availability>
-		<model name='CRD-8S'>
-			<availability>LA:8,FS:4</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>BAN:1,Periphery:2-</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>MOC:4,FWL:8,MERC:4,CP:8,CDP:4,TC:4</availability>
-		</model>
 		<model name='CRD-7W'>
 			<availability>ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5,MH:4,MERC:2,CP:5</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:4,MERC:3</availability>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
 		</model>
 		<model name='CRD-5S'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='CRD-4L'>
 			<availability>CC:2,MOC:4</availability>
 		</model>
-		<model name='CRD-5K'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='CRD-8S'>
+			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='CRD-3R'>
+			<availability>BAN:1,Periphery:2-</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:4,MERC:3</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='CRD-2R'>
 			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,CP:5,BAN:2</availability>
 		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		<model name='CRD-5M'>
+			<availability>MOC:4,FWL:8,MERC:4,CP:8,CDP:4,TC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
 		<model name='CRD-4D'>
 			<availability>FVC:8,FS:8</availability>
@@ -4798,11 +4798,11 @@
 	</chassis>
 	<chassis name='Cuchulainn Support Armor' unitType='BattleArmor'>
 		<availability>CWE:3,MERC.KH:7,MERC.WD:6,LA:4,MERC:5,CWIE:7</availability>
-		<model name='(Clan Model)' mechanized='true'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(IS Model)' mechanized='true'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(Clan Model)' mechanized='true'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cuirass' unitType='Mek'>
@@ -4810,42 +4810,50 @@
 		<model name='CDR-1X'>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDR-2BC'>
-			<availability>General:6</availability>
-		</model>
 		<model name='CDR-2X'>
 			<availability>General:5</availability>
+		</model>
+		<model name='CDR-2BC'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cutlass' unitType='Aero'>
 		<availability>FS:8</availability>
+		<model name='CUT-01E'>
+			<availability>General:4</availability>
+		</model>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CUT-01E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,Periphery:2,TC:2,RA.OA:2,RD:4,LA:3,ROS:3,FWL:2,DC:5</availability>
-		<model name='CP-11-G'>
-			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
 		<model name='CP-11-A'>
 			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>General:2-</availability>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:4,DC:4</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
 		<model name='CP-11-B'>
 			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>RD:5,IS:5</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CP-11-G'>
+			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
@@ -4854,31 +4862,23 @@
 		<model name='CP-11-H'>
 			<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
 		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:4,DC:4</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>RD:5,IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:5,MERC.WD:3,ROS:3,CWIE:4</availability>
-		<model name='4'>
-			<availability>General:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
+		<model name='4'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyllaros' unitType='Mek'>
@@ -4897,25 +4897,25 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>MOC:4,CDP:4,TC:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4940,35 +4940,35 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1C'>
-			<availability>General:5</availability>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
+		</model>
+		<model name='DARO-1A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='DARO-1A'>
-			<availability>General:7</availability>
+		<model name='DARO-1C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='DAI-01r'>
 			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='DAI-01'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='DAI-03'>
 			<roles>fire_support</roles>
@@ -4988,14 +4988,14 @@
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
 		<availability>RD:5,ROS:5,DC:7</availability>
-		<model name='DMO-4K'>
-			<availability>DC:8</availability>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:2</availability>
 		</model>
 		<model name='DMO-2K'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:2</availability>
+		<model name='DMO-4K'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='DMO-5K'>
 			<roles>spotter</roles>
@@ -5004,39 +5004,39 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,LA:4+,ROS:4+,CJF:5,DC:4+</availability>
-		<model name='Prime'>
-			<availability>CWE:5,CDS:7,General:8,CP:7,CJF:9</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:2,CHH:2,RD:2,CLAN:1,General:2,CP:2,CJF:2</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		<model name='A'>
+			<availability>CWE:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:8,RD:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		<model name='Prime'>
+			<availability>CWE:5,CDS:7,General:8,CP:7,CJF:9</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:8,RD:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		</model>
 		<model name='C'>
 			<availability>CWE:5,CDS:5,General:4,CP:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:5,General:7,CJF:8,CWIE:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:2,CHH:2,RD:2,CLAN:1,General:2,CP:2,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -5055,31 +5055,31 @@
 	</chassis>
 	<chassis name='Dark Crow' unitType='Mek'>
 		<availability>RA:6</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:4,FS:6,MERC:4</availability>
-		<model name='DRT-6T'>
-			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
-		</model>
 		<model name='DRT-3S'>
 			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='DRT-6T'>
+			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
 		</model>
 		<model name='DRT-4S'>
 			<availability>LA:1,MH:4,MERC:4,FS:2</availability>
@@ -5087,11 +5087,14 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,General:5,CDP:3</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='(BAP)'>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
+		</model>
+		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
 		</model>
@@ -5103,62 +5106,59 @@
 			<roles>recon</roles>
 			<availability>FVC:2,FS:2,CDP:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(BAP)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
+			<availability>FVC:4,General:5,CDP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,RD:4,IS:3+,CJF:2,BAN:2</availability>
+		<model name='B'>
+			<availability>CWE:7,CHH:6,RD:7,CDS:6,General:5,CP:6,CWIE:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CDS:3,General:2,CP:3</availability>
+		</model>
+		<model name='K'>
+			<availability>RD:4,General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CHH:8,RD:8,CDS:7,General:6,CP:7,CWIE:7</availability>
+		</model>
 		<model name='H'>
 			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>RD:2,CDS:5,General:3,CP:5,CJF:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CDS:3,General:2,CP:3</availability>
+		<model name='D'>
+			<availability>CWE:8,CHH:8,RD:8,CDS:4,General:6,CP:6,CWIE:8</availability>
 		</model>
 		<model name='G'>
 			<availability>General:6</availability>
 		</model>
-		<model name='K'>
-			<availability>RD:4,General:2</availability>
+		<model name='F'>
+			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CWE:4,CHH:8,RD:4,CDS:6,General:5,CP:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:8,CHH:8,RD:8,CDS:4,General:6,CP:6,CWIE:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,RD:8,CDS:7,General:6,CP:7,CWIE:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:7,CHH:6,RD:7,CDS:6,General:5,CP:6,CWIE:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
 		<availability>RD:4,CDS:5,LA:3,ROS:4,IS:3,FS:3,CP:4,RA:4,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
+		<model name='2'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='3'>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='4'>
 			<availability>MERC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -5175,15 +5175,15 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
-		<model name='DFC-OA'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OD'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5198,11 +5198,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='DFN-3S'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DFN-3T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='DFN-3S'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -5216,11 +5216,15 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='S'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
@@ -5228,25 +5232,12 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='S'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
-		<model name='(Standard Mk. II)'>
-			<availability>Periphery:2</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,CWIE:4</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -5254,9 +5245,18 @@
 		<model name='(MRM)'>
 			<availability>FVC:4,DC:8,Periphery:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard Mk. II)'>
+			<availability>Periphery:2</availability>
+		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
 			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
@@ -5265,11 +5265,11 @@
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>LA:5,ROS:5,CWIE:5</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:4,CWIE:4</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>LA:5,ROS:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5285,13 +5285,13 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:6-</availability>
-		<model name='(Armor)'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Armor)'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -5309,20 +5309,20 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
+		<model name='DV-7D'>
+			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='DV-9D'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:1</availability>
+		</model>
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
 		</model>
 		<model name='DV-6M'>
 			<availability>CLAN:4,Periphery:2-</availability>
-		</model>
-		<model name='DV-9D'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='DV-6Mr'>
-			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Destrier Siege Vehicle' unitType='Tank'>
@@ -5343,11 +5343,11 @@
 		<model name='DVS-3'>
 			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
-		<model name='DVS-2'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='DVS-1D'>
 			<availability>FVC:8,TC:8</availability>
+		</model>
+		<model name='DVS-2'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5388,11 +5388,14 @@
 	</chassis>
 	<chassis name='Doloire' unitType='Mek' omni='IS'>
 		<availability>ROS:8,MERC:4</availability>
-		<model name='DLR-OC'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='DLR-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='DLR-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='DLR-OC'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-OA'>
@@ -5401,18 +5404,15 @@
 		<model name='DLR-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-O'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,RD:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5440,22 +5440,22 @@
 	</chassis>
 	<chassis name='Dragon II' unitType='Mek'>
 		<availability>DC:8</availability>
-		<model name='DRG-11R'>
-			<roles>missile_artillery</roles>
-			<availability>General:2+</availability>
-		</model>
 		<model name='DRG-11K'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='DRG-11R'>
+			<roles>missile_artillery</roles>
+			<availability>General:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:3,DC:2</availability>
-		<model name='DRG-7N'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
 		<model name='DRG-5N'>
 			<availability>Periphery.Deep:4,MERC:4,DC:4,Periphery:6</availability>
+		</model>
+		<model name='DRG-7N'>
+			<availability>MERC:8,DC:8</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>MERC:4,DC:4</availability>
@@ -5463,12 +5463,12 @@
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:2,CHH:3,RD:4,ROS:4+</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
+		<model name='Prime'>
+			<availability>RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:8,CDS:8,General:6,CP:8,CJF:8,CWIE:6</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>RD:5,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:6,RD:6,CDS:6,General:4,CP:5,CJF:6,CWIE:6</availability>
@@ -5476,26 +5476,26 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
-		</model>
 		<model name='H'>
 			<availability>CLAN:3,General:2,CP:5</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:7,CDS:6,General:5,CP:6,CJF:6</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>RD:5,General:2</availability>
+		<model name='A'>
+			<availability>RD:8,CDS:8,General:6,CP:8,CJF:8,CWIE:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:7,RD:7,CDS:8,General:6,CP:8,CJF:8,RA:7,CWIE:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CWE:7,RD:7,CDS:6,General:5,CP:6,CJF:6</availability>
+		</model>
 		<model name='I'>
+			<availability>General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,General:4,CP:5,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5514,11 +5514,11 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,ROS:2,FS:4</availability>
-		<model name='(Sealed)'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5530,11 +5530,11 @@
 	</chassis>
 	<chassis name='Duan Gung' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:4,TC:4</availability>
-		<model name='D9-G9'>
-			<availability>General:8</availability>
-		</model>
 		<model name='D9-G10'>
 			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='D9-G9'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Duat Military Transport' unitType='Dropship'>
@@ -5546,24 +5546,24 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='EGL-R6b'>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>General:2-</availability>
 		</model>
+		<model name='EGL-R6b'>
+			<availability>FWL:6,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL.MM:7,RF:6,FWL:6,MH:4,FWL.FO:7,MERC:4,DA:5,CP:6</availability>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
+		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
 		</model>
 		<model name='EGL-3M'>
 			<availability>FWL:5,CP:5</availability>
@@ -5574,10 +5574,6 @@
 		<model name='MEB-10'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='MEB-9'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='MEB-13'>
 			<roles>recon</roles>
@@ -5591,17 +5587,21 @@
 			<roles>recon</roles>
 			<availability>CC:6</availability>
 		</model>
+		<model name='MEB-9'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,Periphery:4-</availability>
 		<model name='EFT-7X'>
 			<availability>IS:8,MH:6</availability>
 		</model>
-		<model name='EFT-4J'>
-			<availability>MERC:1-,Periphery:8</availability>
-		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='EFT-4J'>
+			<availability>MERC:1-,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5612,29 +5612,29 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
-		</model>
 		<model name='EST-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='EST-OC'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CHH:4,RD:5,LA:3,ROS:3,FS:3,MERC:3,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>RD:8</availability>
-		</model>
 		<model name='&apos;HumHov&apos;'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RD:8</availability>
 		</model>
 		<model name='(Streak)'>
 			<roles>fire_support</roles>
@@ -5643,41 +5643,14 @@
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CHH:4,MERC.WD:4,CLAN:4,CP:4+</availability>
-		<model name='(Fire) [AP Gauss]' mechanized='true'>
-			<availability>CWE:2,CHH:2,CJF:4</availability>
-		</model>
-		<model name='(Space) [MicroPL]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:4</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Fire) [Flamer]' mechanized='true'>
-			<availability>CWE:2,CHH:2,CJF:4</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
 		<model name='[HMG]' mechanized='true'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [MicroPL]' mechanized='true'>
 			<availability>CWE:2,CHH:2,CJF:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[MicroPL]' mechanized='true'>
 			<availability>CLAN:6</availability>
@@ -5685,8 +5658,35 @@
 		<model name='(Headhunter)' mechanized='true'>
 			<availability>CWE:2,RD:2,CWIE:2</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Space) [MicroPL]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:4</availability>
+		</model>
+		<model name='(Fire) [AP Gauss]' mechanized='true'>
+			<availability>CWE:2,CHH:2,CJF:4</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [Flamer]' mechanized='true'>
+			<availability>CWE:2,CHH:2,CJF:4</availability>
+		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5697,31 +5697,27 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,FWL:4,MH:3,DC:4</availability>
-		<model name='EMP-6L'>
-			<availability>CC:3</availability>
-		</model>
-		<model name='EMP-7L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='EMP-6A'>
-			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
-		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 		<model name='EMP-8L'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
+		<model name='EMP-7L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='EMP-6L'>
+			<availability>CC:3</availability>
+		</model>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-6A'>
+			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
 		<availability>LA:5-,ROS:3-,MERC:3-</availability>
-		<model name='END-6J'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4</availability>
@@ -5733,32 +5729,36 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
+		<model name='END-6J'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:5,ROS:4,MERC:5,FS:7</availability>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='ENF-6H'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='ENF-6Ma'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='ENF-6T'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='ENF-6G'>
 			<availability>ROS:4,FS:1,MERC:4</availability>
-		</model>
-		<model name='ENF-7C3BS'>
-			<availability>FS:1</availability>
 		</model>
 		<model name='ENF-6NAIS'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='ENF-7C3BS'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='ENF-6H'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='ENF-7D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
@@ -5769,10 +5769,6 @@
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Standard)'>
-			<roles>support,engineer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC)'>
 			<roles>support,engineer</roles>
 			<availability>General:4</availability>
@@ -5781,28 +5777,36 @@
 			<roles>support,engineer</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support,engineer</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Enyo Strike Tank' unitType='Tank'>
 		<availability>CHH:7,RD:5,CJF:3,RA:4,CWIE:4</availability>
-		<model name='(ER Pulse)'>
-			<availability>CHH:8,RD:5</availability>
+		<model name='(LB-X) &apos;Sholef&apos;'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LB-X) &apos;Sholef&apos;'>
-			<availability>CHH:4</availability>
+		<model name='(ER Pulse)'>
+			<availability>CHH:8,RD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CWE:4+,CHH:6+,RD:3+,CDS:4+,CP:3+,CWIE:4+</availability>
+		<model name='A'>
+			<roles>apc,fire_support,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='A'>
-			<roles>apc,fire_support,spotter</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
@@ -5812,10 +5816,6 @@
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:9</availability>
@@ -5823,13 +5823,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CDS:2,ROS:1,CP:2,RA:1</availability>
-		<model name='(2862)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:8,DC:8</availability>
-		</model>
 		<model name='(2711)'>
 			<roles>destroyer</roles>
 			<availability>IS:8</availability>
+		</model>
+		<model name='(2862)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -5838,12 +5838,12 @@
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FS:4,MERC:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:4,FS:6</availability>
-		</model>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FS:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5868,13 +5868,13 @@
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
 		<availability>FWL:1,IS:1,CP:1</availability>
-		<model name='(Standard)'>
-			<roles>civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(HPG)'>
 			<roles>civilian</roles>
 			<availability>FWL:1,CP:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>civilian</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
@@ -5896,27 +5896,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MERC:4</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support) [King David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CC:5</availability>
-		</model>
-		<model name='(Support) [King David]' mechanized='true'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5931,12 +5931,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,CP:8</availability>
-		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,FWL:4,CP:4</availability>
+		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5947,11 +5947,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-9R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='FLC-8R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='FLC-9R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5963,13 +5963,13 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Standard)'>
-			<roles>cruiser</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cruiser</roles>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
@@ -5978,54 +5978,54 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='FEC-3C'>
+			<availability>General:4</availability>
+		</model>
 		<model name='FEC-5CM'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='FEC-3C'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='&apos;Longshot&apos;' mechanized='false'>
-			<availability>General:4</availability>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='&apos;Longshot&apos;' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
+		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir II Assault Battle Armor' unitType='BattleArmor'>
 		<availability>LA:6</availability>
-		<model name='(Med. Laser)' mechanized='false'>
+		<model name='(AI)' mechanized='false'>
+			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(AI)' mechanized='false'>
-			<roles>anti_infantry</roles>
+		<model name='(Med. Laser)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)' mechanized='false'>
@@ -6037,32 +6037,32 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,MERC.WD:4,MERC.KH:2+,CHH:1,RD:1,CJF:2,CWIE:4</availability>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,RD:6,CDS:7,General:4,CP:6,CJF:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:7,General:6,CP:5,CJF:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:6,CDS:7,General:5,CP:5,CJF:7,CWIE:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,CDS:5,CLAN:4,General:2,CP:5,CWIE:6</availability>
 		</model>
-		<model name='H'>
-			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CWE:3,CDS:6,General:4,CP:5,CWIE:3</availability>
+		</model>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,RD:6,CDS:7,General:4,CP:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:6,CDS:7,General:5,CP:5,CJF:7,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
@@ -6079,36 +6079,36 @@
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>LA:1,ROS:1,FS:2</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='&apos;Fermi&apos;'>
 			<roles>apc</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='(Armor) &apos;Wild Weasel&apos;'>
-			<roles>recon</roles>
-			<availability>LA:3,FWL:2,FS:5,CP:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:1</availability>
 		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='(Armor) &apos;Wild Weasel&apos;'>
+			<roles>recon</roles>
+			<availability>LA:3,FWL:2,FS:5,CP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
-		<model name='(Thumper)'>
-			<roles>artillery</roles>
-			<availability>General:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,IS:4</availability>
 		</model>
 		<model name='(Sniper)'>
 			<roles>artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,IS:4</availability>
+		<model name='(Thumper)'>
+			<roles>artillery</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Gun Infantry' unitType='Infantry'>
@@ -6120,59 +6120,11 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LBX20)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(UAC10)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6180,39 +6132,91 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC2)'>
+		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
+		<model name='(LBX20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(LBX5)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CP:3,CJF:7</availability>
-		<model name='F'>
-			<roles>anti_infantry</roles>
+		<model name='E'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:3</availability>
+		</model>
 		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:9</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:8</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
@@ -6227,19 +6231,15 @@
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-10D'>
-			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-10D'>
+			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='ALM-8D'>
 			<roles>recon,raider</roles>
@@ -6265,11 +6265,13 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:6,IS:5,Periphery.Deep:5,Periphery:7</availability>
-		<model name='FS9-S2'>
-			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
+		<model name='FS9-M3'>
+			<roles>spotter</roles>
+			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
 		</model>
-		<model name='FS9-M4'>
-			<availability>FVC:3,RF:4,LA:4,ROS:4,IS:4,MH:3,FS:4,DA:4,TC:3</availability>
+		<model name='FS9-S1'>
+			<roles>recon</roles>
+			<availability>LA:2,General:1,FS:1</availability>
 		</model>
 		<model name='FS9-M2'>
 			<roles>incendiary</roles>
@@ -6277,6 +6279,16 @@
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
+		</model>
+		<model name='FS9-S2'>
+			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
+		</model>
+		<model name='FS9-M4'>
+			<availability>FVC:3,RF:4,LA:4,ROS:4,IS:4,MH:3,FS:4,DA:4,TC:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
@@ -6289,77 +6301,62 @@
 		<model name='FS9-S3'>
 			<availability>LA:6,ROS:5,FWL:3,FS:3,MERC:3,CP:3</availability>
 		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
-		</model>
-		<model name='FS9-S1'>
-			<roles>recon</roles>
-			<availability>LA:2,General:1,FS:1</availability>
-		</model>
-		<model name='FS9-M3'>
-			<roles>spotter</roles>
-			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:2,LA:5,IS:2,FS:3,MERC:4,DC:7</availability>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OH'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='FS9-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:3,DC:3</availability>
-		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OH'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
 		<availability>CJF:4</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -6369,44 +6366,47 @@
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,ROS:2,CLAN:1,FWL:4,CP:2,CJF:2,DC:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,FWL:4,MERC.SI:5,CP:4,BAN:8</availability>
-		</model>
 		<model name='FLS-9M'>
 			<availability>FWL:7,CP:7</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,FWL:4,MERC.SI:5,CP:4,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:8,BAN:4,Periphery:10</availability>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
 			<availability>IS:4,BAN:6,Periphery:4</availability>
 		</model>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
+			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
+		</model>
 		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
-			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -6415,11 +6415,11 @@
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
 		</model>
-		<model name='FLE-20'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='FLE-17'>
 			<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
+		</model>
+		<model name='FLE-20'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6430,8 +6430,8 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -6443,20 +6443,20 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -6485,17 +6485,17 @@
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
 		<availability>ROS:3,FS:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(VSP)'>
-			<availability>General:4</availability>
+		<model name='(Interdictor)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:5</availability>
+		<model name='(VSP)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6533,10 +6533,6 @@
 	</chassis>
 	<chassis name='Fulcrum Heavy Hovertank' unitType='Tank'>
 		<availability>LA:8,ROS:5,FS:6,MERC:3,Periphery:2</availability>
-		<model name='II'>
-			<roles>spotter</roles>
-			<availability>LA:5,FS:3</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
@@ -6545,52 +6541,56 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='II'>
+			<roles>spotter</roles>
+			<availability>LA:5,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CWE:1,CHH:3,RD:3,ROS:5,FS:5,MERC:4,CJF:1</availability>
-		<model name='(Fury III)'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='(Fury IIIm)'>
-			<roles>spotter</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
-		</model>
-		<model name='(C3S)'>
-			<availability>ROS:5,FS:5</availability>
-		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
+		<model name='(Fury III)'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:8,FS:8,MERC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='(Fury IIIm)'>
+			<roles>spotter</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
 		<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
-		<model name='(3056)'>
-			<roles>vee_carrier,infantry_carrier</roles>
-			<availability>CC:5,RF:6,ROS:6,General:4,FWL:6,DA:6,CP:6</availability>
-		</model>
 		<model name='(2638)'>
 			<roles>vee_carrier,infantry_carrier</roles>
 			<availability>CC:2-,General:8</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>vee_carrier,infantry_carrier</roles>
+			<availability>CC:5,RF:6,ROS:6,General:4,FWL:6,DA:6,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Fusilier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:5,MERC:3</availability>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>FS:7</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
@@ -6606,10 +6606,6 @@
 	</chassis>
 	<chassis name='GD Infiltrator Suit' unitType='BattleArmor'>
 		<availability>MERC.KH:6,RF:4,LA:6,ROS:4,MERC:4</availability>
-		<model name='(Remote Sensors)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
@@ -6617,13 +6613,17 @@
 		<model name='(Firedrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Sensors)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Mines)' mechanized='true'>
 			<roles>minelayer</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Sensors)' mechanized='true'>
+		<model name='(Remote Sensors)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -6632,21 +6632,21 @@
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(ERSL)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(TDF)'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CWE:2,ROS:2,RA:2</availability>
-		<model name='2'>
-			<availability>CWE:6,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CWE:6,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6660,28 +6660,28 @@
 		<model name='GLT-10-0'>
 			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='GLT-7-0'>
-			<availability>General:8,FS:4</availability>
-		</model>
 		<model name='GLT-8-0'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
+		<model name='GLT-7-0'>
+			<availability>General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3,CP:3</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,CP:7,TC:5,DC:4,Periphery:4</availability>
 		</model>
 		<model name='GAL-200'>
 			<availability>MOC:1,LA:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,CP:7,TC:5,DC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
@@ -6689,45 +6689,45 @@
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='WD'>
+			<availability>MERC.WD:8-,CWIE:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
 		<model name='GAL-2GLS'>
 			<availability>IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='WD'>
-			<availability>MERC.WD:8-,CWIE:8</availability>
-		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Gambit' unitType='Mek'>
 		<availability>IS:5</availability>
+		<model name='GBT-1G'>
+			<availability>General:8</availability>
+		</model>
 		<model name='GBT-1L'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='GBT-1G'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:4,FS:6,MERC:4,CDP:4,TC:4</availability>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='GRM-01A2'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
 		</model>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRM-01A2'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Garrot Superheavy Transport' unitType='VTOL'>
@@ -6746,9 +6746,6 @@
 	</chassis>
 	<chassis name='Gauntlet' unitType='Mek' omni='IS'>
 		<availability>LA:8</availability>
-		<model name='GTL-1OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='GTL-1O'>
 			<availability>General:8</availability>
 		</model>
@@ -6758,23 +6755,23 @@
 		<model name='GTL-1OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='GTL-1OC'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
 		<availability>CHH:3,CLAN:1,IS:6,Periphery.Deep:4,CP:4,BAN:3,Periphery:6</availability>
-		<model name='(2531)'>
-			<roles>vee_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>vee_carrier</roles>
 			<availability>LA:8,ROS:6,General:4,FS:8</availability>
 		</model>
+		<model name='(2531)'>
+			<roles>vee_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
 		<availability>CC:2,MOC:2,IS:2,MERC:2,FS:2,CP:3,TC:2,FVC:2,LA:4,PIR:2,FWL:3,MH:2,DC:2</availability>
-		<model name='GST-50'>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 		<model name='GST-90'>
 			<availability>PIR:8,MERC:6</availability>
 		</model>
@@ -6784,55 +6781,58 @@
 		<model name='GST-11'>
 			<availability>General:4</availability>
 		</model>
+		<model name='GST-50'>
+			<availability>FWL:6,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:7</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,CDS:4,ROS:4+,CLAN:4,CP:4,CJF:3,BAN:4</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='G'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5,CP:7,CJF:7</availability>
-		</model>
-		<model name='K'>
-			<availability>CWE:5,CHH:6,RD:6,CDS:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CWE:7,RD:8,General:8,CJF:9,CWIE:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:5</availability>
+		<model name='A'>
+			<availability>CWE:8,RD:7,CDS:5,General:6,CP:5,CJF:5,CWIE:8</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:8,RD:7,CDS:5,General:6,CP:5,CJF:5,CWIE:8</availability>
+		<model name='B'>
+			<availability>RD:4,General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CWE:7,RD:8,General:8,CJF:9,CWIE:7</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CP:7,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,RD:5,CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
+		<model name='K'>
+			<availability>CWE:5,CHH:6,RD:6,CDS:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='D'>
 			<availability>CWE:3,RD:4,CDS:2,General:2,CP:2,CJF:2,CWIE:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='P'>
 			<availability>CWE:5,CHH:6,RD:6,CDS:5,CLAN:4,General:3,CP:5,CJF:5,CWIE:5</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,General:7</availability>
+		<model name='F'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6869,14 +6869,6 @@
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
 		<availability>ROS:5,FS:7</availability>
-		<model name='(Light Gauss)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>FS:6</availability>
@@ -6885,23 +6877,31 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:1</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6913,19 +6913,16 @@
 	</chassis>
 	<chassis name='Goblin Infantry Support Vehicle' unitType='Tank'>
 		<availability>FVC:5,LA:2,ROS:4,FS:2,MERC:4</availability>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,RD:7</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>RD:8</availability>
-		</model>
 		<model name='(Fast Assault)' mechanized='false'>
 			<availability>CHH:6</availability>
 		</model>
@@ -6936,40 +6933,43 @@
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>RD:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-4S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:6,FWL:5,MH:6,MERC:6,CP:5,CDP:6,TC:6</availability>
-		</model>
-		<model name='GOL-6M'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
-		</model>
-		<model name='GOL-3L'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:6,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,MH:8,Periphery:4</availability>
 		</model>
-		<model name='GOL-2H'>
+		<model name='GOL-3L'>
 			<roles>fire_support</roles>
-			<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
+			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='GOL-6M'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
+		<model name='GOL-4S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GOL-2H'>
+			<roles>fire_support</roles>
+			<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon Carrier' unitType='Dropship'>
@@ -6981,19 +6981,15 @@
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CP:4,RA:6</availability>
-		<model name='3'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CP:5,RA:5</availability>
+		</model>
+		<model name='3'>
+			<availability>RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>ROS:2,RA:7</availability>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>RA:4</availability>
@@ -7001,26 +6997,30 @@
 		<model name='RISC'>
 			<availability>ROS:8</availability>
 		</model>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>RA:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gossamer VTOL' unitType='VTOL'>
 		<availability>CDS:6,LA:6,ROS:6,FWL:6,FS:6,CP:5,RA:8-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CDS:4,ROS:7,CLAN:3,FWL:7,CP:5,MERC:4</availability>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
+		</model>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-600'>
 			<availability>ROS:8,FWL:6,CP:6</availability>
@@ -7034,17 +7034,20 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>RD:4,ROS:4,MERC:4,CP:5,DC:4</availability>
+		<model name='DRG-5K'>
+			<availability>RD:8,ROS:6,MERC:6,CP:8,DC:2</availability>
+		</model>
+		<model name='DRG-7K'>
+			<availability>ROS:6,MERC:4,DC:1</availability>
+		</model>
+		<model name='DRG-C'>
+			<availability>ROS:4,DC:2</availability>
+		</model>
 		<model name='DRG-10K'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='DRG-7KC'>
 			<availability>DC:8</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>RD:8,ROS:6,MERC:6,CP:8,DC:2</availability>
-		</model>
-		<model name='DRG-C'>
-			<availability>ROS:4,DC:2</availability>
 		</model>
 		<model name='DRG-9KC'>
 			<roles>spotter</roles>
@@ -7052,9 +7055,6 @@
 		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>ROS:6,MERC:4,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
@@ -7071,23 +7071,23 @@
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,IS:3,Periphery.Deep:4,MERC:7,Periphery:6,DC:4,TC:6</availability>
+		<model name='GHR-7P'>
+			<availability>LA:8,MERC:4</availability>
+		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
+		</model>
+		<model name='GHR-5H'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 		<model name='GHR-5J'>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>ROS:4,MERC:2,FS:2,DC:4</availability>
-		</model>
-		<model name='GHR-5H'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='GHR-7P'>
-			<availability>LA:8,MERC:4</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gravedigger' unitType='Mek'>
@@ -7117,14 +7117,14 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -7154,26 +7154,17 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer)[C3/HRR]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:6</availability>
+		<model name='[Flamer]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[LRR]' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[Flamer]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:4</availability>
+		<model name='(Hunter-Killer)[C3/HRR]' mechanized='false'>
+			<availability>FS:5</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
@@ -7182,16 +7173,25 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[Heavy Flamer]' mechanized='false'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:4,FS:5</availability>
-		<model name='B' mechanized='false'>
+		<model name='A' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A' mechanized='true'>
+		<model name='B' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D' mechanized='true'>
@@ -7204,20 +7204,23 @@
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CJF:6</availability>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>General:4</availability>
 		</model>
-		<model name='D'>
+		<model name='H'>
+			<availability>CHH:8,CLAN:5,IS:3</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:8,CLAN:5,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -7225,32 +7228,29 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
-		<model name='A'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:5,CDS:6,LA:3,IS:3,CP:6,CJF:2,CWIE:4,DC:4</availability>
-		<model name='4'>
-			<availability>CDS:6,IS:6,CP:7</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:8,IS:8,CP:6</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='6'>
-			<availability>ROS:4,CP:6,DC:6</availability>
+		<model name='7'>
+			<availability>ROS:4,CP:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:6,CP:4</availability>
 		</model>
-		<model name='7'>
-			<availability>ROS:4,CP:6</availability>
+		<model name='6'>
+			<availability>ROS:4,CP:6,DC:6</availability>
 		</model>
 		<model name='8'>
 			<availability>CWE:6,LA:6,ROS:4,CJF:6,CWIE:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:6,IS:6,CP:7</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CP:4</availability>
@@ -7258,51 +7258,51 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:1,RD:4,LA:7,ROS:5,IS:6,MERC:7,CP:2,TC:5,Periphery:4,DC:7</availability>
-		<model name='GRF-2N'>
-			<availability>CC:4,MOC:4,CLAN:6,FWL:4,MH:4,FS:4,MERC:4,CP:4,BAN:4,DC:4</availability>
-		</model>
-		<model name='GRF-5M'>
-			<availability>ROS:5,FWL:6,MERC:5,CP:6</availability>
-		</model>
-		<model name='GRF-3M'>
-			<availability>MOC:4,RF:6,LA:3,FWL:5,IS:4,MH:4,DA:6,CP:5,DC:1</availability>
+		<model name='GRF-1N'>
+			<availability>BAN:2,Periphery:2-</availability>
 		</model>
 		<model name='GRF-6S2'>
 			<availability>LA:5,FS:4,DC:4</availability>
 		</model>
-		<model name='GRF-4R'>
-			<availability>CC:4,RD:5,ROS:6,FWL:4,FS:4,CP:4,DC:4</availability>
-		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:3,ROS:2,DC:1</availability>
+		<model name='GRF-6S'>
+			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CP:8,DC:8</availability>
 		</model>
+		<model name='GRF-5M'>
+			<availability>ROS:5,FWL:6,MERC:5,CP:6</availability>
+		</model>
+		<model name='GRF-1DS'>
+			<availability>FVC:3,ROS:2,DC:1</availability>
+		</model>
+		<model name='GRF-3M'>
+			<availability>MOC:4,RF:6,LA:3,FWL:5,IS:4,MH:4,DA:6,CP:5,DC:1</availability>
+		</model>
 		<model name='GRF-4N'>
 			<availability>TC:6</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CC:4,RD:5,ROS:6,FWL:4,FS:4,CP:4,DC:4</availability>
 		</model>
 		<model name='GRF-5L'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>BAN:2,Periphery:2-</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
+		<model name='GRF-2N'>
+			<availability>CC:4,MOC:4,CLAN:6,FWL:4,MH:4,FS:4,MERC:4,CP:4,BAN:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -7321,11 +7321,11 @@
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3</availability>
-		</model>
 		<model name='B'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3</availability>
 		</model>
 		<model name='D'>
 			<availability>CC:3,MOC:3,RF:2,MERC:2</availability>
@@ -7333,30 +7333,30 @@
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.KH:4,MERC.WD:4,CHH:2-,LA:4,ROS:4,CP:2-,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>ROS:4,CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CWE:4,IS:8,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>ROS:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CHH:1,ROS:5,FWL:3,FS:4,CP:3,MERC:2,RA:1,Periphery:1</availability>
-		<model name='GLT-6WB3'>
+		<model name='GLT-8D'>
 			<roles>raider</roles>
-			<availability>ROS:3,FWL:4,MERC:3,CP:4</availability>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>NIOPS:0,Periphery:1-</availability>
 		</model>
-		<model name='GLT-8D'>
-			<roles>raider</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='GLT-6WB3'>
+			<roles>raider</roles>
+			<availability>ROS:3,FWL:4,MERC:3,CP:4</availability>
 		</model>
 		<model name='GLT-3N'>
 			<roles>raider</roles>
@@ -7365,11 +7365,11 @@
 	</chassis>
 	<chassis name='Gulltoppr OmniMonitor' unitType='Tank' omni='IS'>
 		<availability>MERC.KH:5,LA:4,CWIE:6</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(A)'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(B)'>
 			<roles>artillery,spotter</roles>
@@ -7378,15 +7378,15 @@
 	</chassis>
 	<chassis name='Gun' unitType='Mek' omni='IS'>
 		<availability>CC:6-,MOC:5,DA:4</availability>
-		<model name='GN-2O'>
-			<availability>General:8</availability>
+		<model name='GN-2OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='GN-2OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='GN-2OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='GN-2O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -7395,12 +7395,12 @@
 			<roles>spotter</roles>
 			<availability>LA:6,General:4,FS:6,DC:6</availability>
 		</model>
-		<model name='GUN-1ERD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GUN-2ERDr'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
+		</model>
+		<model name='GUN-1ERD'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunsmith' unitType='Mek'>
@@ -7411,12 +7411,12 @@
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6,ROS:4,FS:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurzil Support Tank' unitType='Tank'>
@@ -7449,9 +7449,9 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,IS:4,CP:5,DC:4,CWIE:4</availability>
-		<model name='HKO-1C'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>LA:4,DC:4</availability>
+			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CP:5,DC:4+</availability>
@@ -7459,20 +7459,20 @@
 		<model name='2'>
 			<availability>CDS:4,CP:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='HKO-1C'>
 			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
+			<availability>LA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>RA.OA:5,CHH:7,LA:3,ROS:4,CLAN:5,FS:3,MERC:3</availability>
-		<model name='(AAA)'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:8,RD:4,CDS:4,CP:4,RA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:8,RD:4,CDS:4,CP:4,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hadur Fast Support Vehicle' unitType='Tank'>
@@ -7491,60 +7491,55 @@
 	</chassis>
 	<chassis name='Hammer' unitType='Mek'>
 		<availability>FWL:6,MERC:5,CP:6</availability>
+		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
+			<roles>spotter</roles>
+			<availability>FWL:4,MERC:4,CP:4</availability>
+		</model>
 		<model name='HMR-3C &apos;Claw-Hammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:5,MERC:5,CP:5</availability>
-		</model>
-		<model name='HMR-3M'>
-			<roles>fire_support</roles>
-			<deployedWith>Anvil</deployedWith>
-			<availability>General:8</availability>
 		</model>
 		<model name='HMR-3S &apos;Slammer&apos;'>
 			<roles>fire_support</roles>
 			<deployedWith>Anvil</deployedWith>
 			<availability>FWL:6,MERC:6,CP:6</availability>
 		</model>
-		<model name='HMR-3P &apos;Pein-Hammer&apos;'>
-			<roles>spotter</roles>
-			<availability>FWL:4,MERC:4,CP:4</availability>
+		<model name='HMR-3M'>
+			<roles>fire_support</roles>
+			<deployedWith>Anvil</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:5,MERC:3</availability>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:6,MERC:6</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6E'>
-			<availability>General:6,MERC:6</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:5,CLAN:2,CP:3</availability>
-		<model name='HMR-HE'>
-			<availability>ROS:4</availability>
+		<model name='HMR-HDb'>
+			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
 		</model>
 		<model name='HMR-HD'>
 			<availability>General:8,CP:4</availability>
 		</model>
-		<model name='HMR-HDb'>
-			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
+		<model name='HMR-HE'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:4,ROS:3+,CP:4,CJF:4</availability>
-		<model name='B'>
-			<availability>General:6,CP:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
@@ -7554,17 +7549,22 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>General:8,CP:9</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6,CP:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>General:8,CP:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7582,11 +7582,11 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,FWL.pm:7,RF:7,LA:5,FWL:7,MH:5,MERC:5,CP:7,DA:7</availability>
-		<model name='(MML)'>
-			<availability>MOC:6,CC:6,RF:8,LA:6,FWL:8,DA:8,MERC:6,CP:8</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<availability>CC:6,MOC:6,RF:6,FWL:6,MH:6,DA:6,CP:6,MERC:5</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:6,CC:6,RF:8,LA:6,FWL:8,DA:8,MERC:6,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Harpagos' unitType='Mek'>
@@ -7597,14 +7597,14 @@
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Standard)'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hasek Mechanized Combat Vehicle' unitType='Tank'>
@@ -7616,14 +7616,14 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>ROS:4,MERC:2,DC:5</availability>
-		<model name='HTM-28T'>
-			<availability>ROS:4,DC:2</availability>
+		<model name='HTM-27T'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:8</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>MERC:2,DC:2</availability>
+		<model name='HTM-28T'>
+			<availability>ROS:4,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Godai' unitType='Mek'>
@@ -7659,43 +7659,43 @@
 		<model name='HCT-6S'>
 			<availability>LA:8,MERC:6</availability>
 		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='HCT-5D'>
 			<availability>CDP:1</availability>
 		</model>
-		<model name='HCT-6M'>
-			<availability>ROS:5,FWL:8,MERC:6,CP:8</availability>
-		</model>
-		<model name='HCT-7R'>
-			<availability>ROS:8</availability>
-		</model>
-		<model name='HCT-5S'>
-			<availability>FVC:3,LA:2,FS:2,MERC:4,DC:2,Periphery:4</availability>
-		</model>
 		<model name='HCT-5DD'>
 			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
 		</model>
+		<model name='HCT-5S'>
+			<availability>FVC:3,LA:2,FS:2,MERC:4,DC:2,Periphery:4</availability>
+		</model>
 		<model name='HCT-6D'>
 			<availability>ROS:4,FS:2,MERC:6</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-6M'>
+			<availability>ROS:5,FWL:8,MERC:6,CP:8</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		</model>
+		<model name='HCT-7R'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7707,34 +7707,34 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HA1-OE'>
-			<availability>General:5</availability>
+		<model name='HA1-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='HA1-OM'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='HA1-OE'>
+			<availability>General:5</availability>
+		</model>
+		<model name='HA1-OT'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HA1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OT'>
-			<availability>General:4</availability>
-		</model>
-		<model name='HA1-OF'>
-			<availability>General:4</availability>
-		</model>
-		<model name='HA1-OC'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Havoc' unitType='Mek'>
@@ -7745,11 +7745,11 @@
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
 		<availability>CC:2,RF:5,LA:3,FWL:5,IS:3,FS:4,DA:3,CP:5,DC:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Armor)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -7761,12 +7761,12 @@
 			<roles>artillery</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MML)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HawkWolf' unitType='Mek'>
@@ -7795,25 +7795,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,TC:6,Periphery:5</availability>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7825,11 +7825,11 @@
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
 		<availability>MOC:2+,RA.OA:2+,FWL:4+,IS:2+,DC:3+</availability>
-		<model name='DEST Heavy Response Platoon'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='Royal Gurkha Battalion'>
 			<availability>General:8,DC:4</availability>
+		</model>
+		<model name='DEST Heavy Response Platoon'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy LRM Carrier' unitType='Tank'>
@@ -7860,23 +7860,23 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor-U'>
+			<availability>ROS:2,FS:3,MERC:2</availability>
+		</model>
+		<model name='Meteor-G'>
+			<availability>General:3,FWL:4,CP:4</availability>
+		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='Meteor'>
 			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CP:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
-		</model>
-		<model name='Meteor-U'>
-			<availability>ROS:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
-		</model>
-		<model name='Meteor-G'>
-			<availability>General:3,FWL:4,CP:4</availability>
-		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7887,6 +7887,14 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:4,Periphery:6,TC:7</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -7894,33 +7902,25 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:4,TC:7,Periphery:6</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
@@ -7929,15 +7929,15 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
@@ -7955,11 +7955,11 @@
 		<model name='HEL-4A'>
 			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7991,14 +7991,22 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CP:5,CJF:2</availability>
+		<model name='C'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:6,CJF:3</availability>
+		</model>
 		<model name='B'>
 			<availability>General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:7,CJF:3</availability>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='G'>
 			<availability>General:6</availability>
@@ -8006,21 +8014,13 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:6,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
@@ -8028,12 +8028,12 @@
 			<roles>spotter</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
@@ -8054,36 +8054,36 @@
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
 		<availability>CHH:4</availability>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AP)'>
 			<roles>recon,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4+</availability>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<roles>recon,apc,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon,apc,spotter</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -8108,42 +8108,46 @@
 			<roles>recon</roles>
 			<availability>ROS:2-,MERC:2-</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>FWL:4,CP:4</availability>
-		</model>
-		<model name='HER-6D'>
-			<roles>recon</roles>
-			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5SA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:4,MERC:4,CP:4</availability>
-		</model>
-		<model name='HER-2S'>
-			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
+			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:6,FS:6,CP:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5Sr'>
+		<model name='HER-2S'>
 			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:4</availability>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:4,CP:4</availability>
+		</model>
+		<model name='HER-5SA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:4,MERC:4,CP:4</availability>
+		</model>
+		<model name='HER-6D'>
+			<roles>recon</roles>
+			<availability>FS.LG:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>DC.GHO:6,FWL:7,CP:7,MERC:5,DC:6</availability>
+		<model name='HER-3S'>
+			<roles>recon</roles>
+			<availability>FWL:1,CP:1</availability>
+		</model>
+		<model name='HER-4S'>
+			<roles>recon</roles>
+			<availability>FWL:4,CP:4</availability>
+		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:8</availability>
-		</model>
-		<model name='HER-3S'>
+		<model name='HER-3S1'>
 			<roles>recon</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
@@ -8151,31 +8155,27 @@
 			<roles>recon</roles>
 			<availability>FWL:6,MERC:6,CP:6,DC:8</availability>
 		</model>
-		<model name='HER-4S'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>FWL:4,CP:4</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:1,CP:1</availability>
+			<availability>CLAN:6,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
+		<model name='(LB-X)'>
+			<availability>CC:8,MOC:6,RF:6,DA:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CC:1,IS:1,Periphery:1</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:8,MOC:6,RF:6,DA:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CC:1,IS:1,Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hexareme HQ Hovercraft' unitType='Tank'>
@@ -8187,32 +8187,32 @@
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
 		<availability>LA:1,IS:1</availability>
+		<model name='(Cunnington)'>
+			<roles>spotter</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>LA:1,General:8</availability>
 		</model>
-		<model name='(Cunnington)'>
-			<roles>spotter</roles>
-			<availability>LA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CWE:6,CHH:6,RD:6,CDS:4,LA:3,ROS:4,CP:5,CJF:6</availability>
-		<model name='2'>
-			<availability>CWE:4</availability>
+		<model name='(Standard)'>
+			<availability>CWE:4,CDS:4,IS:8,CP:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CWE:4,CHH:8,RD:8,ROS:4,CJF:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CWE:4,CDS:4,IS:8,CP:4</availability>
+		<model name='2'>
+			<availability>CWE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:5,MOC:4,LA:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
-		<model name='HGN-734'>
-			<availability>LA:6,ROS:6,MERC:6</availability>
+		<model name='HGN-738'>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 		<model name='HGN-732b'>
 			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -8220,8 +8220,8 @@
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:8,ROS:8</availability>
+		<model name='HGN-734'>
+			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hippogriff' unitType='ProtoMek'>
@@ -8232,7 +8232,7 @@
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:5</availability>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8240,7 +8240,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8266,32 +8266,32 @@
 	</chassis>
 	<chassis name='Hitotsume Kozo' unitType='Mek'>
 		<availability>DC.GHO:7,DC:6</availability>
-		<model name='HKZ-1F'>
-			<availability>DC.GHO:6,General:4</availability>
-		</model>
 		<model name='HKZ-1P'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HKZ-1F'>
+			<availability>DC.GHO:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander III' unitType='Mek'>
 		<availability>LA:6,FS.CMM:8,FS:7,MERC:6</availability>
-		<model name='BZK-D2'>
-			<availability>LA:8,General:4</availability>
-		</model>
 		<model name='BZK-D3'>
 			<availability>General:4,MERC:8</availability>
 		</model>
 		<model name='BZK-D1'>
 			<availability>General:4,FS:8</availability>
 		</model>
+		<model name='BZK-D2'>
+			<availability>LA:8,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F7'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BZK-F5'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BZK-F7'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8308,15 +8308,15 @@
 		<model name='HNT-182'>
 			<availability>FVC:4,FS.PMM:4,FS.CMM:4,FS.DMM:4,FS.CrMM:4</availability>
 		</model>
-		<model name='HNT-181'>
-			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
+		<model name='HNT-171'>
+			<availability>FVC:8,FS:6,MERC:8</availability>
 		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='HNT-171'>
-			<availability>FVC:8,FS:6,MERC:8</availability>
+		<model name='HNT-181'>
+			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -8370,53 +8370,63 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
-		<model name='HBK-5SS'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='HBK-6S'>
-			<availability>LA:8,ROS:6,MERC:6</availability>
-		</model>
 		<model name='HBK-7R'>
 			<roles>spotter</roles>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
+		<model name='HBK-6S'>
+			<availability>LA:8,ROS:6,MERC:6</availability>
 		</model>
 		<model name='HBK-5H'>
 			<availability>FVC:3,MH:6,Periphery:4</availability>
 		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>Periphery:2-</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='HBK-5S'>
 			<availability>LA:3,ROS:3,MH:3,MERC:1,FS:3</availability>
 		</model>
-		<model name='HBK-6N'>
-			<availability>ROS:3,FWL:2,MH:4,MERC:3,CP:2,DC:3</availability>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='HBK-7S'>
 			<roles>spotter</roles>
 			<availability>LA:4</availability>
 		</model>
+		<model name='HBK-6N'>
+			<availability>ROS:3,FWL:2,MH:4,MERC:3,CP:2,DC:3</availability>
+		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
 		<availability>MERC.WD:3,RD:5,CDS:4,CLAN:3,CP:4,BAN:4</availability>
-		<model name='(2948) (LF)'>
-			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(2832)'>
 			<availability>MERC.WD:8,CLAN:4</availability>
+		</model>
+		<model name='(2948) (LF)'>
+			<availability>MERC.WD:2,CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,IS:3,MERC:3,FS:3,CP:2,Periphery:3,TC:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='(Amphibious)'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>RF:6,LA:8,ROS:6,FWL:4,FS:6,MERC:6,DA:6,CP:4</availability>
+		</model>
 		<model name='(ERLL)'>
 			<availability>LA:4,FS:4</availability>
 		</model>
@@ -8424,42 +8434,35 @@
 			<roles>fire_support</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>RF:6,LA:8,ROS:6,FWL:4,FS:6,MERC:6,DA:6,CP:4</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Amphibious)'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,CP:5,TC:6</availability>
+		<model name='HUR-WO-R4N'>
+			<roles>fire_support</roles>
+			<availability>CC:6</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:4,MOC:4,FWL:5,CP:5</availability>
+		</model>
 		<model name='HUR-WO-R4O'>
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:4,MOC:4,FWL:5,CP:5</availability>
-		</model>
-		<model name='HUR-WO-R4N'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,MERC:4,FS:4,CP:4,DC:4</availability>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:3+</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='HSCL-1-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:3+</availability>
+		</model>
+		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OD'>
@@ -8468,18 +8471,15 @@
 		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>ROS:2,CLAN:3</availability>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
+		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,MERC.SI:4,BAN:8</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8491,17 +8491,17 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CLAN:6,RA:6</availability>
-		<model name='(Algar)'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:8,CLAN:6,CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Algar)'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:8,CLAN:6,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
@@ -8522,8 +8522,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:2,MOC:8,LA:1,ROS:4,IS:8,FWL:3,MH:8,CP:3,TC:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8531,10 +8531,10 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
-		<model name='[SRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -8560,11 +8560,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:6,MERC.KH:8</availability>
-		</model>
 		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-4E'>
+			<availability>MERC.WD:6,MERC.KH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8589,23 +8589,23 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(BA)'>
 			<availability>CWE:6,CJF:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8614,17 +8614,17 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:4,LA:4,ROS:5,FWL:4,FS:4,CP:4,DC:4</availability>
-		<model name='(3115)'>
+		<model name='(SCC)'>
 			<roles>assault</roles>
-			<availability>ROS:6</availability>
+			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>CC:8,ROS:4,FWL:8,CP:8</availability>
 		</model>
-		<model name='(SCC)'>
+		<model name='(3115)'>
 			<roles>assault</roles>
-			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+			<availability>ROS:6</availability>
 		</model>
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
@@ -8633,40 +8633,40 @@
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
 		<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,TC:3,DC:6</availability>
-		<model name='(3056)'>
-			<roles>assault</roles>
-			<availability>RF:8,ROS:5,FWL:8,IS:4,DA:8,CP:8</availability>
-		</model>
 		<model name='(2655)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>assault</roles>
+			<availability>RF:8,ROS:5,FWL:8,IS:4,DA:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,CLAN:9,IS:7,Periphery.Deep:6,FS:9,CP:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,PIR:5,FWL:9</availability>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631 PPC)'>
+		<model name='(2850)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:5</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -8678,17 +8678,20 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CHH:6,LA:2,ROS:3,CLAN:4,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Gauss)'>
 			<roles>fire_support</roles>
 			<availability>CWE:4,CHH:8,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
+		<model name='2'>
+			<availability>RA:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
@@ -8696,12 +8699,14 @@
 			<roles>recon</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='2'>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='J-27 Ordnance Transport' unitType='Tank'>
 		<availability>MOC:4,RA.OA:4,CLAN:6,IS:6,MH:4,CP:6,Periphery:2,TC:4</availability>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -8711,11 +8716,6 @@
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8732,19 +8732,15 @@
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>RD:3,IS:4,TC:4,Periphery:4</availability>
-		<model name='(3082 Upgrade)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='(3082 Upgrade)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
 		<availability>CC:4,RD:6,LA:4,ROS:5,IS:4,FWL:4,FS:6,MERC:4,CJF:4,Periphery:4,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>RD:8,IS:3,Periphery:6</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>ROS:6,FS:6,CJF:8</availability>
@@ -8753,13 +8749,13 @@
 			<roles>fire_support</roles>
 			<availability>RD:4,IS:8,Periphery:8</availability>
 		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>RD:8,IS:3,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='JES III Missile Carrier' unitType='Tank'>
 		<availability>IS:5</availability>
-		<model name='(Thunderbolt)'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -8768,11 +8764,15 @@
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Speed)'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(Thunderbolt)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8817,19 +8817,15 @@
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
 		<availability>MOC:5,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5,MERC:6,CP:6</availability>
-		<model name='JA-KL-1532'>
-			<availability>FWL:2,Periphery.Deep:6,MERC:2,CP:2,Periphery:8</availability>
-		</model>
 		<model name='JA-KL-55'>
 			<availability>ROS:5,FWL:4,MERC:5,CP:4</availability>
+		</model>
+		<model name='JA-KL-1532'>
+			<availability>FWL:2,Periphery.Deep:6,MERC:2,CP:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackalope' unitType='Mek'>
 		<availability>ROS:6,MERC:4</availability>
-		<model name='JLP-BD'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='JLP-KW &apos;Wolpertinger&apos;'>
 			<roles>recon</roles>
 			<availability>General:3</availability>
@@ -8838,6 +8834,10 @@
 			<roles>recon</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='JLP-BD'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='JLP-KA'>
 			<roles>recon</roles>
 			<availability>General:3</availability>
@@ -8845,36 +8845,26 @@
 	</chassis>
 	<chassis name='Jade Hawk' unitType='Mek'>
 		<availability>MERC:5,CJF:5</availability>
+		<model name='(Standard)'>
+			<availability>CJF:8</availability>
+		</model>
+		<model name='JHK-03'>
+			<availability>MERC:8</availability>
+		</model>
 		<model name='2'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='JHK-04'>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='JHK-03'>
-			<availability>MERC:8</availability>
-		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CJF:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CWE:2,General:1</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:5,General:2,RA:4</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:4,CLAN:2,RA:6</availability>
@@ -8882,8 +8872,18 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:5,General:2,RA:4</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CWE:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8897,21 +8897,6 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
-		<model name='JM6-S'>
-			<roles>anti_aircraft</roles>
-			<availability>Periphery:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
-		</model>
-		<model name='JM7-D'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:3,MERC:6</availability>
-		</model>
-		<model name='JM6-DDa'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2,MERC:2</availability>
-		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
@@ -8920,35 +8905,69 @@
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,FS:4</availability>
 		</model>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
+		</model>
 		<model name='JM6-DGr'>
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,LA:2,ROS:2,FS:1,MERC:2,CDP:3,DC:2</availability>
 		</model>
-		<model name='JM7-C3BS'>
+		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:8</availability>
+			<availability>ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='JM6-DD'>
 			<roles>anti_aircraft</roles>
 			<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
 		</model>
+		<model name='JM7-G'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DDa'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-S'>
+			<roles>anti_aircraft</roles>
+			<availability>Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jaguar' unitType='Mek'>
 		<availability>LA:5,ROS:5,FS:4,CJF:4,CWIE:5</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,CWIE:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
+		<model name='JVN-10N'>
+			<roles>recon</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='JVN-11P'>
+			<availability>FVC:6</availability>
+		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
+		<model name='JVN-11B'>
+			<roles>recon</roles>
+			<availability>FVC:1,LA:1,ROS:1,FS:1,MERC:1,CDP:1</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 		<model name='JVN-10P'>
 			<roles>recon</roles>
 			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
@@ -8957,79 +8976,64 @@
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='JVN-10N'>
-			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
-		</model>
-		<model name='JVN-11P'>
-			<availability>FVC:6</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11B'>
-			<roles>recon</roles>
-			<availability>FVC:1,LA:1,ROS:1,FS:1,MERC:1,CDP:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6,CWIE:7</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='X'>
 			<availability>General:1,CJF:2,RA:2</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CWE:6,CDS:6,ROS:4,CP:7,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CWE:2,CP:3</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:8,IS:8,CP:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CWE:2,CP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:5,FS.DMM:5,MERC:4,Periphery.OS:5,FS:4,RA:4,DC:8,Periphery:3</availability>
-		<model name='JR7-C4'>
-			<roles>raider</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>ROS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>ROS:4,DC:8</availability>
+		</model>
+		<model name='JR7-C4'>
+			<roles>raider</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='JR7-K'>
 			<roles>raider</roles>
@@ -9039,17 +9043,9 @@
 			<roles>raider</roles>
 			<availability>MERC:4,FS:4,DC:2</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Hoist)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='JI-50 (MG)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -9057,6 +9053,10 @@
 		<model name='JI-50'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Hoist)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='JI-50 (Q-Vehicle)'>
 			<roles>support</roles>
@@ -9069,11 +9069,11 @@
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
-		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G8A'>
 			<availability>General:8</availability>
@@ -9098,26 +9098,26 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:5,Periphery:7</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
@@ -9135,29 +9135,45 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CJF:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:4,DC:5</availability>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 		<model name='C' mechanized='true'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>ROS:2,DC:2</availability>
 		</model>
 		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
@@ -9167,29 +9183,13 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='[ECM]' mechanized='true'>
+		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -9210,40 +9210,40 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
+		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Industrial Drill]' mechanized='false'>
+		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>RD:8</availability>
-		<model name='G'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='G'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -9255,39 +9255,39 @@
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
 		<availability>PIR:2,IS:2,Periphery:2,RA:2</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:2,MERC:2</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
-		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:4</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>FWL:5,IS:6,CP:5</availability>
 		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>MH:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,DC:6</availability>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:8,DC:8</availability>
 		</model>
 		<model name='CRK-5003-C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
-			<availability>DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kelswa Assault Tank' unitType='Tank'>
@@ -9298,6 +9298,13 @@
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
 		<availability>MERC.WD:2,LA:2,ROS:2,CLAN:2,FS:2,DC:1</availability>
+		<model name='(MedEvac)'>
+			<roles>support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
@@ -9305,18 +9312,11 @@
 		<model name='(ML)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
-		</model>
-		<model name='(MedEvac)'>
-			<roles>support</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kheper' unitType='Mek'>
@@ -9327,23 +9327,23 @@
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,FWL:4,MH:4,DC:4</availability>
-		<model name='KGC-001'>
-			<availability>LA:1,IS:3,MH:6</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
 		</model>
 		<model name='KGC-007'>
 			<availability>LA:2,ROS:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='KGC-008B'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 		</model>
+		<model name='KGC-001'>
+			<availability>LA:1,IS:3,MH:6</availability>
+		</model>
 		<model name='KGC-005r'>
 			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='KGC-008B'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='KGC-009'>
 			<availability>LA:8</availability>
@@ -9351,23 +9351,20 @@
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>RD:6,CDS:3,ROS:3+,CP:2,RA:3</availability>
-		<model name='C'>
-			<availability>RD:3,General:5</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='D'>
 			<availability>RD:5,General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:3,General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -9375,13 +9372,16 @@
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
 		<availability>CC:4,MOC:4,RD:4,ROS:8,IS:5,MERC:6,TC:4</availability>
-		<model name='(PPC)'>
+		<model name='(RAC)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(RAC)'>
+		<model name='(PPC)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -9390,41 +9390,41 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,ROS:6,MERC:2,DC:2</availability>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:5</availability>
-		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:2,DC.SL:4,ROS:3,CLAN:6,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='KTO-20'>
-			<availability>MERC:2,DC:2</availability>
 		</model>
 		<model name='KTO-19b'>
 			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
+		<model name='KTO-20'>
+			<availability>MERC:2,DC:2</availability>
+		</model>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:5</availability>
+		</model>
+		<model name='KTO-K'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9442,13 +9442,13 @@
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
 		<availability>DC:1</availability>
-		<model name='K-3N-KR4'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='K-3N-KR5'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='K-3N-KR4'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kite Reconnaissance Vehicle' unitType='Tank'>
@@ -9467,19 +9467,19 @@
 	</chassis>
 	<chassis name='Kodiak II' unitType='Mek'>
 		<availability>RD:6</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>RD:6,ROS:4,RA:5</availability>
-		<model name='5'>
-			<availability>RD:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
@@ -9488,11 +9488,11 @@
 		<model name='2'>
 			<availability>RD:5,ROS:6</availability>
 		</model>
+		<model name='5'>
+			<availability>RD:4</availability>
+		</model>
 		<model name='4'>
 			<availability>RD:4,ROS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Komodo' unitType='Mek'>
@@ -9501,35 +9501,35 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>General:8,DC:2</availability>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:1</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
+		<model name='KIM-2'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>General:8,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>FWL:5,MERC:4,CP:5</availability>
-		</model>
-		<model name='(Mortar)' mechanized='false'>
+		<model name='(AI Mk IIr)' mechanized='false'>
 			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk IIr)' mechanized='false'>
-			<availability>FWL:4,MERC:3,CP:4</availability>
-		</model>
 		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>FWL:5,MERC:4,CP:5</availability>
+		</model>
+		<model name='(Mortar)' mechanized='false'>
+			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Koroshiya' unitType='Aero'>
@@ -9540,56 +9540,32 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,ROS:3,MERC:4,CC.TG:6</availability>
-		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-5I'>
-			<availability>ROS:8,MERC:8</availability>
-		</model>
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8,MERC:4</availability>
-		</model>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:5</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-6L'>
 			<roles>artillery</roles>
 			<availability>CC:6,MOC:6</availability>
 		</model>
+		<model name='KSC-4I'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='KSC-5I'>
+			<availability>ROS:8,MERC:8</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:3,MERC.WD:3,CDS:3,IS:4+,CP:3,CJF:2,BAN:4,RA:3</availability>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>General:2,CP:3</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<availability>CWE:7,RD:8,CDS:3,General:4,CP:3</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>RD:6,CDS:9,General:8,CP:7</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CWE:4,RD:4,CDS:7,General:5,CP:7,CWIE:4</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
@@ -9599,14 +9575,38 @@
 			<roles>recon</roles>
 			<availability>CWE:7,RD:2,CDS:5,General:3,CP:3,CJF:2,CWIE:7</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<availability>CWE:7,RD:8,CDS:3,General:4,CP:3</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>General:2,CP:3</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CWE:4,RD:4,CDS:7,General:5,CP:7,CWIE:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:6,IS:5</availability>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9614,27 +9614,27 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
 		<availability>MERC:4</availability>
-		<model name='KTO-4A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='KTO-3A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='KTO-4A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>ROS:2,CJF:2,RA:2</availability>
-		<model name='4'>
-			<availability>ROS:8,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='4'>
+			<availability>ROS:8,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -9667,14 +9667,14 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>RD:4</availability>
-		<model name='4'>
-			<availability>General:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='4'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9709,12 +9709,6 @@
 	</chassis>
 	<chassis name='Lament' unitType='Mek'>
 		<availability>ROS:6</availability>
-		<model name='LMT-4RC'>
-			<availability>General:3</availability>
-		</model>
-		<model name='LMT-3C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='LMT-2R'>
 			<availability>General:8</availability>
 		</model>
@@ -9723,6 +9717,12 @@
 		</model>
 		<model name='LMT-2D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='LMT-3C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='LMT-4RC'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lamprey Transport Helicopter' unitType='VTOL'>
@@ -9741,33 +9741,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
-		<model name='LX-2A'>
-			<availability>RF:5,LA:5,ROS:5,FWL:5,MERC:5,DA:5,CP:5</availability>
-		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
 		<model name='LX-2'>
 			<availability>General:8</availability>
 		</model>
+		<model name='LX-2A'>
+			<availability>RF:5,LA:5,ROS:5,FWL:5,MERC:5,DA:5,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-4E'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:8,FS:8</availability>
 		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='LHU-4E'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9779,6 +9779,15 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
+		</model>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
 		<model name='LGN-2K'>
 			<roles>raider</roles>
 			<availability>ROS:6</availability>
@@ -9786,60 +9795,51 @@
 		<model name='LGN-2F'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
-		</model>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:4,FWL:6,MH:4,MERC:4,CP:6</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<roles>recon</roles>
+		<model name='(David)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(David)' mechanized='true'>
+		<model name='(MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(FireDrake)' mechanized='true'>
+		<model name='(Sensor)' mechanized='true'>
+			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(MG)' mechanized='true'>
+		<model name='(FireDrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,IS:7,Periphery.Deep:5,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(2581)'>
-			<roles>asf_carrier</roles>
-			<availability>General:5-</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>asf_carrier</roles>
 			<availability>CC:8,RF:8,LA:8,ROS:8,General:4,FWL:8,FS:8,DA:8,CP:8</availability>
 		</model>
+		<model name='(2581)'>
+			<roles>asf_carrier</roles>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>RF:8,LA:8,ROS:8,General:4,FWL:8,FS:8,DA:8,CP:8</availability>
-		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>RF:8,LA:8,ROS:8,General:4,FWL:8,FS:8,DA:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -9885,15 +9885,17 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
+		</model>
 		<model name='Owl'>
 			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
-		<model name='Angel'>
-			<roles>recon</roles>
-			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
-		</model>
 		<model name='Comet'>
 			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:2,LA:2</availability>
@@ -9901,11 +9903,9 @@
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
 		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Angel'>
+			<roles>recon</roles>
+			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9916,12 +9916,12 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(ERSL)'>
 			<availability>ROS:4</availability>
@@ -9929,53 +9929,53 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
-		<model name='LTN-G15'>
-			<availability>General:2-</availability>
+		<model name='LTN-G16D'>
+			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
 		</model>
-		<model name='LTN-G16D'>
-			<availability>ROS:6,FS:6,MERC:4</availability>
+		<model name='LTN-G16O'>
+			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G15'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='LTN-G16L'>
 			<availability>CC:6,MOC:6,RF:4,FWL:3,MERC:4,DA:6,CP:3</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16O'>
-			<availability>RA.OA:6,FVC:4,CDP:4</availability>
-		</model>
 		<model name='LTN-G16S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,MERC.KH:4+,CJF:4,RA:5,CWIE:6</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:6,CDS:4,General:5,CP:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,RD:6,General:7,CWIE:6</availability>
+		<model name='Prime'>
+			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CWE:4,CHH:4,RD:5,General:3,CP:3,CJF:2,CWIE:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:6,RD:6,General:7,CWIE:6</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
+		<model name='B'>
+			<availability>RD:6,CDS:4,General:5,CP:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='C'>
+			<availability>CWE:4,CHH:4,RD:5,General:3,CP:3,CJF:2,CWIE:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:7,General:5,CWIE:6</availability>
@@ -10006,10 +10006,6 @@
 	</chassis>
 	<chassis name='Lobo' unitType='Mek'>
 		<availability>CWE:6,CJF:3</availability>
-		<model name='2'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CWE:8</availability>
 		</model>
@@ -10017,167 +10013,171 @@
 			<roles>anti_infantry</roles>
 			<availability>CWE:2</availability>
 		</model>
+		<model name='2'>
+			<roles>anti_infantry</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CWE:7,CHH:6,RD:6,ROS:3,CJF:6,DC:3</availability>
-		<model name='6'>
-			<availability>CWE:6,RD:6</availability>
-		</model>
-		<model name='9'>
-			<availability>CJF:6</availability>
-		</model>
-		<model name='8'>
-			<availability>RD:6,ROS:5,DC:5</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:6,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CWE:5,CHH:5,LA:6,CJF:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CWE:4,CHH:4,RD:4,ROS:4</availability>
 		</model>
+		<model name='8'>
+			<availability>RD:6,ROS:5,DC:5</availability>
+		</model>
+		<model name='6'>
+			<availability>CWE:6,RD:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CWE:5,CHH:5,LA:6,CJF:6</availability>
+		</model>
+		<model name='7'>
+			<availability>CHH:6,ROS:2</availability>
+		</model>
+		<model name='9'>
+			<availability>CJF:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CLAN:2-,IS:6,Periphery:3</availability>
-		<model name='LCT-6M'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MERC:3,CP:4</availability>
-		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:4,FWL:5,CP:5</availability>
-		</model>
-		<model name='LCT-5T'>
-			<roles>recon,anti_infantry</roles>
-			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='LCT-5M3'>
 			<availability>ROS:5,FWL:4,CP:4</availability>
-		</model>
-		<model name='LCT-1Vb'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,CP:4,BAN:2</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
-		</model>
-		<model name='LCT-1V2'>
-			<roles>recon</roles>
-			<availability>PIR:4,MH:4,MERC:3</availability>
 		</model>
 		<model name='LCT-5W2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,ROS:6,CLAN:4,IS:4,FS:6,DC:6</availability>
 		</model>
-		<model name='LCT-5V'>
-			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		<model name='LCT-5M2'>
+			<availability>ROS:4,FWL:5,CP:5</availability>
 		</model>
-		<model name='LCT-3S'>
+		<model name='LCT-1Vb'>
 			<roles>recon</roles>
-			<availability>LA:8,MERC:6</availability>
+			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,CP:4,BAN:2</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4,MERC:3</availability>
 		</model>
 		<model name='LCT-3M'>
 			<roles>recon</roles>
 			<availability>MOC:2,RF:5,FWL:4,IS:2,MERC:4,DA:5,CP:4</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-3S'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>LA:8,MERC:6</availability>
+		</model>
+		<model name='LCT-5T'>
+			<roles>recon,anti_infantry</roles>
+			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
+		</model>
+		<model name='LCT-6M'>
+			<roles>recon</roles>
+			<availability>ROS:2,FWL:4,MERC:3,CP:4</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CWE:3,CHH:4,BAN:4,CWIE:3</availability>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:4,CP:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:4,CHH:6,RD:3,CDS:6,General:5,CP:6,CJF:7,CWIE:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>RD:8,General:8,CJF:9</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
+		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CWE:5,CHH:6,RD:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:5,General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:8,General:8,CJF:9</availability>
+		<model name='G'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki Mk II (Hel)' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:7,RD:5,MERC.WD:3,MERC.KH:3,CDS:5,CP:5,CJF:7,RA:5</availability>
-		<model name='B'>
-			<roles>artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<roles>artillery</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>CWE:1,CHH:3,MERC.WD:2,CDS:2,ROS:1,CP:2,RA:3</availability>
-		<model name='(2841)'>
-			<roles>destroyer</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2662)'>
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2841)'>
+			<roles>destroyer</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6</availability>
-		<model name='LGB-7V'>
+		<model name='LGB-14C'>
 			<roles>fire_support</roles>
-			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
-		</model>
-		<model name='LGB-8V'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CP:4</availability>
-		</model>
-		<model name='LGB-12R'>
-			<roles>fire_support</roles>
-			<availability>LA:4,ROS:8,FWL:2,FS:4,CP:2,DC:4</availability>
+			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CP:4,CDP:4,TC:4</availability>
 		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,ROS:6,FWL:6,FS:6,MERC:6,DA:6,CP:6,DC:6</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGB-12R'>
+			<roles>fire_support</roles>
+			<availability>LA:4,ROS:8,FWL:2,FS:4,CP:2,DC:4</availability>
+		</model>
+		<model name='LGB-8V'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CP:4</availability>
+		</model>
 		<model name='LGB-14C2'>
 			<roles>fire_support</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
@@ -10185,17 +10185,17 @@
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lu Wei Bing' unitType='Mek'>
@@ -10221,11 +10221,11 @@
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:4,MERC:6</availability>
-		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:4,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Luduan Scout Vehicle' unitType='Tank'>
@@ -10241,13 +10241,13 @@
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM1/A'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='LM4/C'>
 			<roles>support</roles>
 			<availability>LA:8</availability>
+		</model>
+		<model name='LM1/A'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='LM5/M'>
 			<availability>LA:1-</availability>
@@ -10266,24 +10266,24 @@
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,DC:5</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6</availability>
-		</model>
 		<model name='LNX-9C'>
 			<availability>ROS:8,MERC:6,DC:8</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6</availability>
 		</model>
 		<model name='LNX-9R'>
 			<availability>LA:8,MERC:6</availability>
@@ -10291,13 +10291,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,CP:3</availability>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -10345,19 +10345,12 @@
 		<model name='B'>
 			<availability>CWE:5,CHH:7,RD:4,CDS:7,General:6,CP:7,CJF:7,CWIE:5</availability>
 		</model>
-		<model name='F'>
-			<availability>CWE:5,CHH:5,RD:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:2,CHH:2,RD:2,CLAN:1,General:2,CP:2,CJF:3,CWIE:2</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>CWE:5,CHH:4,CLAN:5,General:5,CP:4,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='Prime'>
+			<availability>RD:7,CDS:8,General:8,CP:7,CJF:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,General:4,CP:3</availability>
@@ -10365,19 +10358,26 @@
 		<model name='A'>
 			<availability>CWE:7,RD:8,CDS:8,General:7,CP:8,CJF:8</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
+		<model name='F'>
+			<availability>CWE:5,CHH:5,RD:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:7,CDS:8,General:8,CP:7,CJF:8</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:2,CHH:2,RD:2,CLAN:1,General:2,CP:2,CJF:3,CWIE:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:7,RD:2,General:5,CJF:6,CWIE:7</availability>
 		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:6,LA:5,ROS:5,IS:4,CP:5,CWIE:4,DC:5</availability>
-		<model name='4'>
+		<model name='5'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -10385,25 +10385,31 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='5'>
+		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='2'>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,LA:4,CLAN:4,IS:4,FS:4,CP:5,CWIE:4,DC:4</availability>
-		<model name='Enhanced'>
-			<availability>CLAN:6,CP:4,CWIE:4</availability>
+		<model name='2'>
+			<availability>CWE:4,CDS:4,LA:4,IS:4,FS:4,CP:4,DC:4,CWIE:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CDS:5,CP:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='5'>
+			<availability>General:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CP:4</availability>
@@ -10411,14 +10417,8 @@
 		<model name='4'>
 			<availability>General:6</availability>
 		</model>
-		<model name='6'>
-			<availability>CDS:5,CP:5</availability>
-		</model>
-		<model name='2'>
-			<availability>CWE:4,CDS:4,LA:4,IS:4,FS:4,CP:4,DC:4,CWIE:4</availability>
-		</model>
-		<model name='5'>
-			<availability>General:6</availability>
+		<model name='Enhanced'>
+			<availability>CLAN:6,CP:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk IV (Savage Wolf)' unitType='Mek'>
@@ -10429,17 +10429,17 @@
 	</chassis>
 	<chassis name='Mad Cat Mk IV (Savage Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CDS:6,IS:4+,CLAN.IS:5,CP:6</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -10448,12 +10448,12 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MTR-7K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='MTR-7K'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='MTR-6E'>
 			<roles>recon,spotter</roles>
@@ -10462,18 +10462,18 @@
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:6,MOC:6,Periphery.MM:6,MERC:6,CP:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,DA:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Malice' unitType='Mek'>
@@ -10508,61 +10508,64 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:2,MERC.WD:4,CDS:4,CP:4,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='M'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:3,General:1</availability>
-		</model>
-		<model name='G'>
-			<availability>General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:7,General:8,CP:7,CJF:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CWE:8,RD:9,CDS:4,General:7,CP:6,CJF:9</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,CDS:4,General:5,CP:5,CJF:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:7,CDS:7,General:6,CP:7,CJF:5,CWIE:7</availability>
+		<model name='G'>
+			<availability>General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,RD:5,CDS:3,General:4,CP:4</availability>
 		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
 		<model name='T'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:7,RD:7,CDS:7,General:6,CP:7,CJF:5,CWIE:7</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,CDS:4,General:5,CP:5,CJF:2</availability>
+		</model>
+		<model name='M'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:3,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:4,RF:4,LA:4,ROS:4,MERC:4,CWIE:6</availability>
-		<model name='MNL-4S'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:4,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
 		</model>
+		<model name='MNL-4S'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
 		<availability>ROS:6</availability>
-		<model name='(Support)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Support)'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manteuffel Attack Tank' unitType='Tank' omni='IS'>
 		<availability>LA:6,ROS:4,FS:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
@@ -10570,43 +10573,40 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,RA.OA:4,LA:4,ROS:3,FWL:3,DC:5</availability>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,LA:8,ROS:8,FS:8,MERC:8</availability>
+		<model name='(HPPC)'>
+			<availability>CC:6,MOC:6,LA:6,ROS:6,FWL:6,FS:6,MERC:6,CP:6,DC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-,Periphery:2</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,FS:4,DC:4</availability>
 		</model>
-		<model name='(HPPC)'>
-			<availability>CC:6,MOC:6,LA:6,ROS:6,FWL:6,FS:6,MERC:6,CP:6,DC:6</availability>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,LA:8,ROS:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore II Heavy Tank' unitType='Tank'>
@@ -10617,11 +10617,11 @@
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
 		<availability>CC:3,LA:3,FWL:4,IS:3,FS:5,CP:4,DC:3</availability>
-		<model name='(ECCM)'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ECCM)'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder Battle Armor' unitType='BattleArmor'>
@@ -10637,109 +10637,109 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:6,RD:5,CP:4,CJF:5,RA:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,RD:2,CJF:2</availability>
+		<model name='4'>
+			<availability>RD:4,CP:6,RA:4</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:1,CWIE:6</availability>
 		</model>
-		<model name='6'>
-			<availability>CWE:6,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>RD:5,CJF:5</availability>
-		</model>
 		<model name='7'>
 			<availability>RD:6</availability>
 		</model>
-		<model name='2'>
-			<availability>RD:3,CJF:3</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,RD:2,CJF:2</availability>
 		</model>
-		<model name='4'>
-			<availability>RD:4,CP:6,RA:4</availability>
+		<model name='6'>
+			<availability>CWE:6,CJF:4</availability>
 		</model>
 		<model name='8'>
 			<availability>RD:1,CJF:1</availability>
 		</model>
+		<model name='2'>
+			<availability>RD:3,CJF:3</availability>
+		</model>
+		<model name='3'>
+			<availability>RD:5,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:6,MERC:4,CP:5,TC:4,MERC.WD:6,LA:1,ROS:6,PIR:4,FWL:5,MH:4,DC:5</availability>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:6</availability>
-		</model>
-		<model name='MAD-5A'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='MAD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		<model name='C'>
+			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='MAD-4L'>
 			<availability>CC:8,MOC:8</availability>
 		</model>
-		<model name='MAD-4S'>
-			<availability>LA:4,ROS:6,FS:2,MERC:8,CP:8</availability>
-		</model>
 		<model name='MAD-6S'>
 			<availability>LA:6</availability>
-		</model>
-		<model name='MAD-4K'>
-			<availability>DC:8</availability>
 		</model>
 		<model name='MAD-4H'>
 			<availability>PIR:4,MH:4,TC:4</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:6</availability>
+		<model name='MAD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='MAD-5A'>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:6</availability>
+		</model>
+		<model name='MAD-4S'>
+			<availability>LA:4,ROS:6,FS:2,MERC:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>FWL:8,MERC:3,DA:8,CP:8</availability>
-		</model>
-		<model name='MAD-9D'>
-			<availability>FS:6</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>RF:6,ROS:4,FWL:4,MERC:4,DA:6,CP:4,DC:4</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='MAD-5M'>
-			<availability>MOC:4,ROS:4,FWL:6,MERC:4,CP:6</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='MAD-3R'>
-			<availability>Periphery:2-,TC:2-</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
-		</model>
-		<model name='MAD-2R'>
-			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
+		<model name='MAD-7D'>
+			<availability>FS:8</availability>
 		</model>
 		<model name='MAD-5R'>
 			<availability>FS:4,MERC:3</availability>
 		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
+		</model>
+		<model name='MAD-9S'>
+			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-3R'>
+			<availability>Periphery:2-,TC:2-</availability>
+		</model>
+		<model name='MAD-5M'>
+			<availability>MOC:4,ROS:4,FWL:6,MERC:4,CP:6</availability>
+		</model>
 		<model name='MAD-5L'>
 			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-6L'>
+			<availability>CC:6,MOC:4</availability>
+		</model>
+		<model name='MAD-2R'>
+			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
+		</model>
+		<model name='MAD-9D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='MAD-5S'>
 			<availability>FVC:2,LA:2,MERC:2</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>FWL:8,MERC:3,DA:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -10755,11 +10755,11 @@
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:8,IS:5</availability>
-		<model name='M1'>
-			<availability>ROS:1,ROS.pm:8,General:8</availability>
-		</model>
 		<model name='M1A'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='M1'>
+			<availability>ROS:1,ROS.pm:8,General:8</availability>
 		</model>
 		<model name='M1J'>
 			<availability>General:6</availability>
@@ -10767,17 +10767,17 @@
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(XL)'>
-			<availability>CHH:4,RD:3,ROS:4</availability>
+		<model name='(ATM)'>
+			<availability>General:5,CJF:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CJF:2</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CHH:6,RD:4,CDS:4,ROS:4,CP:4</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>CHH:4,RD:3,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10791,14 +10791,14 @@
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
+		<model name='MHL-2L'>
+			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		</model>
 		<model name='MHL-3MC'>
 			<availability>MOC:6</availability>
 		</model>
 		<model name='MHL-6MC'>
 			<availability>MOC:6,CC:4</availability>
-		</model>
-		<model name='MHL-2L'>
-			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
@@ -10813,11 +10813,8 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,RD:3,CDS:3,MERC:3+,CP:2,CJF:3,RA:1,BAN:3</availability>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
+		<model name='C'>
+			<availability>CWE:6,RD:6,CDS:5,General:4,CP:5</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
@@ -10825,8 +10822,14 @@
 		<model name='A'>
 			<availability>RD:5,CDS:8,General:5,CP:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CWE:6,RD:6,CDS:5,General:4,CP:5</availability>
+		<model name='D'>
+			<availability>RD:5,CDS:5,General:4,CP:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CDS:9,General:8,CP:9</availability>
@@ -10834,57 +10837,54 @@
 		<model name='B'>
 			<availability>CDS:8,General:5,CP:8</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:5,CDS:5,General:4,CP:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>MERC:5,DC:7</availability>
-		<model name='MAL-1R'>
-			<availability>MERC:6</availability>
+		<model name='MAL-3R'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='MAL-C'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='MAL-3R'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='MAL-1K'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='MAL-1R'>
+			<availability>MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(Fusion)'>
+		<model name='(MG)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>TC:6</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
+		<model name='(Fusion)'>
+			<roles>apc</roles>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
 		<availability>General:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(LRT)'>
 			<availability>General:4</availability>
@@ -10892,19 +10892,19 @@
 		<model name='(LB-X)'>
 			<availability>FWL:6,CP:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Company Command)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
@@ -10924,13 +10924,13 @@
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
 		<availability>RA:1,CWIE:1</availability>
-		<model name='(2652)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2851)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2652)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='MechBuster' unitType='Conventional Fighter'>
@@ -10960,39 +10960,36 @@
 	</chassis>
 	<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
 		<availability>IS:5,Periphery:5</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
@@ -11004,33 +11001,36 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Rifle AA)'>
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -11065,26 +11065,22 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5</availability>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='MS1-OG'>
 			<availability>General:4</availability>
+		</model>
+		<model name='MS1-OA'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -11092,13 +11088,17 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OA'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mengqin' unitType='Aero'>
@@ -11139,25 +11139,25 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Dropship'>
 		<availability>RF:4,FWL:6,CP:6</availability>
-		<model name='R1'>
-			<roles>assault</roles>
-			<availability>RF:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>assault</roles>
 			<availability>FWL:8,CP:8</availability>
 		</model>
+		<model name='R1'>
+			<roles>assault</roles>
+			<availability>RF:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1A'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='MLN-1C'>
 			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
+		</model>
+		<model name='MLN-1A'>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -11166,6 +11166,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Targeting Computer)'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Gauss) &apos;Sandblaster&apos;'>
 			<roles>urban</roles>
@@ -11177,22 +11182,17 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Targeting Computer)'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CHH:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='XP'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='XP'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='P2'>
 			<availability>CHH:6</availability>
@@ -11221,22 +11221,18 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		<model name='MLR-B2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MLR-BX'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='MLR-B2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,CP:5+,DC:5+</availability>
-		<model name='(ICE)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>support</roles>
-			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
@@ -11246,11 +11242,15 @@
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LL)'>
+			<roles>support</roles>
+			<availability>CC:8,General:4,MERC:2,DC:8</availability>
+		</model>
+		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
@@ -11291,24 +11291,24 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>LA:5,ROS:5,MERC:4</availability>
-		<model name='MON-268'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3,ROS:3,MERC:3</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
+		<model name='MON-268'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3,ROS:3,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>DC.GHO:3,RD:4,ROS:5,MERC:3,FS:3,DC:4</availability>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>NIOPS:0,Periphery:8</availability>
-		</model>
 		<model name='MON-76'>
 			<roles>recon</roles>
 			<availability>RD:6,ROS:6,MERC:6,FS:6,DC:6</availability>
+		</model>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>NIOPS:0,Periphery:8</availability>
 		</model>
 		<model name='MON-86'>
 			<roles>recon</roles>
@@ -11317,11 +11317,11 @@
 	</chassis>
 	<chassis name='Mongrel' unitType='Mek'>
 		<availability>CWE:3,RD:6,CHH:5,LA:4,MERC:5,CWIE:6</availability>
-		<model name='MGL-T2'>
-			<availability>CLAN:8,IS:4</availability>
-		</model>
 		<model name='MGL-T1'>
 			<availability>CWE:4,RD:4,IS:8,CWIE:4</availability>
+		</model>
+		<model name='MGL-T2'>
+			<availability>CLAN:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -11332,11 +11332,11 @@
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:3,IS:2</availability>
-		<model name='(2839)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2839)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
@@ -11347,23 +11347,23 @@
 	</chassis>
 	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
-		<model name='MR-1SE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MR-1SC'>
-			<availability>General:7</availability>
+		<model name='MR-1SE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='MR-1SA'>
 			<roles>interceptor,ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SC'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -11392,25 +11392,25 @@
 			<roles>recon</roles>
 			<availability>CP:4,DC:4</availability>
 		</model>
-		<model name='4'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
 		<availability>CLAN:5,IS:4</availability>
-		<model name='(HAG)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mortar Carrier' unitType='Tank'>
@@ -11446,7 +11446,10 @@
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
@@ -11459,17 +11462,14 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -11495,29 +11495,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:8</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -11540,6 +11540,14 @@
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:4,MERC.WD:4,RD:3,CDS:4,General:2,CP:4</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CWE:6,CHH:6,CDS:6,General:5,CP:6,CWIE:6</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery</roles>
+			<availability>CWE:4,CHH:3,MERC.WD:4,RD:3,CDS:4,General:2,CP:4,CWIE:4</availability>
+		</model>
 		<model name='A'>
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:3,RD:3,CDS:4,General:2,CP:4,CWIE:4</availability>
@@ -11547,14 +11555,6 @@
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8,CP:9</availability>
-		</model>
-		<model name='C'>
-			<roles>missile_artillery</roles>
-			<availability>CWE:4,CHH:3,MERC.WD:4,RD:3,CDS:4,General:2,CP:4,CWIE:4</availability>
-		</model>
-		<model name='B'>
-			<roles>missile_artillery</roles>
-			<availability>CWE:6,CHH:6,CDS:6,General:5,CP:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nagasawa' unitType='Dropship'>
@@ -11566,13 +11566,13 @@
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3A'>
 			<roles>fire_support,spotter</roles>
@@ -11592,11 +11592,11 @@
 	</chassis>
 	<chassis name='Narukami Heavy Tank' unitType='Tank'>
 		<availability>DC:8</availability>
-		<model name='NK-1C'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NK-BC3'>
 			<availability>General:4</availability>
+		</model>
+		<model name='NK-1C'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Neanderthal' unitType='Mek'>
@@ -11623,11 +11623,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRT)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(LRT)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(SRT)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11639,29 +11639,29 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='H'>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -11681,6 +11681,9 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='NSR-K7'>
+			<availability>General:2</availability>
+		</model>
 		<model name='NSR-K1'>
 			<availability>General:6</availability>
 		</model>
@@ -11689,9 +11692,6 @@
 		</model>
 		<model name='NSR-KC'>
 			<availability>General:4</availability>
-		</model>
-		<model name='NSR-K7'>
-			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Wolf' unitType='Mek'>
@@ -11709,15 +11709,15 @@
 	</chassis>
 	<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
 		<availability>CWE:2,CHH:2,RD:2,ROS:5,CWIE:2</availability>
+		<model name='(LAC)'>
+			<roles>spotter</roles>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<roles>spotter</roles>
-			<availability>ROS:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
@@ -11726,32 +11726,32 @@
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,RF:5,LA:8,ROS:6,FWL:4,FS:7,MERC:6,CP:4</availability>
+		<model name='NGS-6T'>
+			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='NGS-5T'>
+			<availability>RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
+		</model>
 		<model name='NGS-4S'>
 			<availability>:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 		</model>
 		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='NGS-6T'>
-			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
-		</model>
-		<model name='NGS-5T'>
-			<availability>RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
-		</model>
 		<model name='NGS-6S'>
 			<availability>LA:8,ROS:6,MERC:4</availability>
-		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
 		<availability>LA:6,ROS:5,FS:6,MERC:3</availability>
-		<model name='NSR-9FC'>
-			<availability>LA:5,FS:5,MERC:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9FC'>
+			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
 		<model name='NSR-9SS'>
 			<availability>LA:4,MERC:2,FS:4</availability>
@@ -11768,11 +11768,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-3'>
-			<availability>General:2</availability>
-		</model>
 		<model name='NJT-4'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='NJT-3'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11784,65 +11784,65 @@
 	</chassis>
 	<chassis name='Nisos Attack WIGE' unitType='Tank'>
 		<availability>CC:6,MOC:6,LA:4,DA:6,MERC:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>RD:4,DC.LV:8,DC.SL:2,LA:3,ROS:5,MERC:3,DC:8</availability>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>RD:4,ROS:6,MERC:4,DC:4</availability>
 		</model>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>ROS:3+,CP:8</availability>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CP:4</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CP:4</availability>
-		</model>
-		<model name='F'>
-			<availability>ROS:6</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CP:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CDS:4,ROS:4,CP:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='F'>
+			<availability>ROS:6</availability>
 		</model>
 		<model name='H'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11854,38 +11854,38 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:6,ROS:4+,CP:7,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='H'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='E'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='I'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='E'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
@@ -11902,36 +11902,36 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>RD:4,LA:4,ROS:6,MERC:4,FS:4,DC:5</availability>
-		<model name='NX-110'>
+		<model name='NX-80C'>
 			<roles>recon</roles>
-			<availability>DC:5</availability>
+			<availability>ROS:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='NX-90'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NX-100'>
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='NX-80C'>
+		<model name='NX-90'>
 			<roles>recon</roles>
-			<availability>ROS:3,MERC:3,DC:3</availability>
+			<availability>DC:4</availability>
+		</model>
+		<model name='NX-110'>
+			<roles>recon</roles>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M12'>
 			<roles>missile_artillery,spotter</roles>
@@ -11940,14 +11940,14 @@
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>RD:4,CDS:4,ROS:3,CP:5,DC:3</availability>
+		<model name='4'>
+			<availability>CP:3,DC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CP:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CP:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -11969,11 +11969,11 @@
 	</chassis>
 	<chassis name='Ogre Battle Armor' unitType='BattleArmor'>
 		<availability>RF:6,LA:4,DA:4</availability>
-		<model name='(Interdictor)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Interdictor)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Okinawa' unitType='Dropship'>
@@ -11994,11 +11994,11 @@
 	</chassis>
 	<chassis name='Onager' unitType='Mek'>
 		<availability>CJF:4</availability>
-		<model name='2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oni Battle Armor' unitType='BattleArmor'>
@@ -12027,30 +12027,30 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
-		<model name='HEAT'>
-			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:4,IS:4,CP:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:6,IS:6</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-,Periphery:4</availability>
 		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:4,IS:4,CP:8</availability>
+		<model name='(Sealed)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(MML)'>
+			<availability>MOC:6,IS:6</availability>
+		</model>
+		<model name='HEAT'>
+			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
+		</model>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Oo-Suzumebachi' unitType='Small Craft'>
@@ -12062,14 +12062,14 @@
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4</availability>
@@ -12083,12 +12083,8 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
-		<model name='ON3-M'>
-			<roles>spotter</roles>
-			<availability>CC:6,FWL:6,MERC:5,CP:6</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
 		</model>
 		<model name='ON1-MC'>
 			<availability>FS:2,MERC:2,DC:4</availability>
@@ -12096,20 +12092,24 @@
 		<model name='ON1-MB'>
 			<availability>CC:2,MOC:2,ROS:4,FWL:4,DA:4,MERC:2,CP:4,DC:2</availability>
 		</model>
-		<model name='ON1-K'>
-			<availability>CLAN:2-,Periphery:2-</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
-		</model>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MERC:2,FS:2,CP:4</availability>
+		<model name='ON3-M'>
+			<roles>spotter</roles>
+			<availability>CC:6,FWL:6,MERC:5,CP:6</availability>
 		</model>
 		<model name='ON2-M'>
 			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3,CP:4</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>CLAN:2-,Periphery:2-</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:8</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MERC:2,FS:2,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -12130,14 +12130,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-5D'>
-			<availability>FS:6</availability>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
+		<model name='OSR-5D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -12145,55 +12145,55 @@
 		<model name='OSP-26'>
 			<availability>CC:4,ROS:8</availability>
 		</model>
-		<model name='OSP-36'>
-			<availability>ROS:5</availability>
-		</model>
 		<model name='OSP-25'>
 			<availability>General:6</availability>
+		</model>
+		<model name='OSP-36'>
+			<availability>ROS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,ROS:4,IS:4,TC:4,DC:5,Periphery:2</availability>
-		<model name='OSR-4K'>
-			<availability>ROS:4,MERC:4,DC:6</availability>
-		</model>
 		<model name='OSR-5C'>
 			<availability>TC:6</availability>
+		</model>
+		<model name='OSR-4L'>
+			<availability>CC:8,MOC:4</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='OSR-2D'>
+			<availability>ROS:6,IS:4,Periphery:4</availability>
+		</model>
+		<model name='OSR-4K'>
+			<availability>ROS:4,MERC:4,DC:6</availability>
+		</model>
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:3</availability>
 		</model>
-		<model name='OSR-2D'>
-			<availability>ROS:6,IS:4,Periphery:4</availability>
-		</model>
 		<model name='OSR-4C'>
 			<availability>TC:6,Periphery:5</availability>
-		</model>
-		<model name='OSR-4L'>
-			<availability>CC:8,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
@@ -12201,6 +12201,10 @@
 		<model name='OTT-7K'>
 			<roles>recon,spotter</roles>
 			<availability>FVC:8,IS:8,DC:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
@@ -12210,36 +12214,32 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:4,RF:5,LA:8,ROS:5,FWL:5,MERC:5,FS:4,CP:5,DC:4</availability>
 		</model>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>RF:5,ROS:4,FWL:5,FS:5,MERC:3,CP:5</availability>
 		<model name='OTL-7M'>
 			<availability>ROS:6,FWL:6,MERC:4,CP:6</availability>
 		</model>
-		<model name='OTL-9M'>
-			<availability>ROS:4,FWL:6,CP:6</availability>
-		</model>
 		<model name='OTL-8D'>
 			<availability>FS:8</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:2,MERC:4,CP:2</availability>
 		</model>
 		<model name='OTL-8M'>
 			<availability>RF:8,FWL:6,MERC:3,CP:6</availability>
 		</model>
-		<model name='OTL-9R'>
-			<availability>ROS:6,FWL:4,MERC:5,CP:4</availability>
+		<model name='OTL-5M'>
+			<availability>FWL:2,MERC:4,CP:2</availability>
+		</model>
+		<model name='OTL-9M'>
+			<availability>ROS:4,FWL:6,CP:6</availability>
+		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='OTL-5D'>
 			<availability>FVC:3,Periphery.HR:4,PIR:3,FS:2,Periphery:4</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>ROS:6,FWL:4,MERC:5,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -12250,10 +12250,6 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CWE:4,CHH:8</availability>
-		<model name='(3070)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:4</availability>
@@ -12261,6 +12257,10 @@
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
 			<availability>CHH:3</availability>
+		</model>
+		<model name='(3070)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -12272,24 +12272,32 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
-		<model name='(3056)'>
-			<roles>mech_carrier</roles>
-			<availability>LA:8,IS:6,FS:8</availability>
-		</model>
 		<model name='A3A'>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='A3'>
-			<roles>assault</roles>
-			<availability>FS:3</availability>
+		<model name='(3056)'>
+			<roles>mech_carrier</roles>
+			<availability>LA:8,IS:6,FS:8</availability>
 		</model>
 		<model name='(2762)'>
 			<roles>mech_carrier</roles>
 			<availability>General:2,BAN:1</availability>
 		</model>
+		<model name='A3'>
+			<roles>assault</roles>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,FWL:4,FS:2,MERC:2,CP:4,DC:6</availability>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2,CLAN:6</availability>
+		</model>
+		<model name='OW-1F'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -12297,6 +12305,14 @@
 		<model name='OW-1C'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1G'>
 			<roles>recon,spotter</roles>
@@ -12310,22 +12326,6 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2,CLAN:6</availability>
-		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1F'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='PAB-28 Sniper Suit' unitType='BattleArmor'>
 		<availability>FS:6,MERC:4</availability>
@@ -12336,29 +12336,29 @@
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
 		<availability>CHH:5,LA:5,ROS:5,MERC:3,CWIE:8,DC:3</availability>
-		<model name='3'>
-			<availability>CHH:4,ROS:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='3'>
+			<availability>CHH:4,ROS:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CDS:4,CP:4,CWIE:7</availability>
-		<model name='2'>
-			<availability>CDS:5,CP:5,CWIE:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CWIE:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:5,CP:5,CWIE:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -12367,21 +12367,21 @@
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery:5</availability>
 		</model>
-		<model name='PKR-T5 (ICE)'>
-			<roles>recon,raider</roles>
-			<availability>CC:1,PIR:2,General:1,FWL:1,MERC:1,FS:2,CP:1,Periphery:3,DC:1</availability>
-		</model>
 		<model name='PKR-T5 (SRM2)'>
 			<roles>recon,raider,apc</roles>
 			<availability>CC:5,MOC:5</availability>
 		</model>
-		<model name='PKR-T5 (ML)'>
-			<roles>recon,raider</roles>
-			<availability>FWL.pm:4,DA:3-</availability>
-		</model>
 		<model name='&apos;Gespenst&apos;'>
 			<roles>recon,specops</roles>
 			<availability>LA:2</availability>
+		</model>
+		<model name='PKR-T5 (ICE)'>
+			<roles>recon,raider</roles>
+			<availability>CC:1,PIR:2,General:1,FWL:1,MERC:1,FS:2,CP:1,Periphery:3,DC:1</availability>
+		</model>
+		<model name='PKR-T5 (ML)'>
+			<roles>recon,raider</roles>
+			<availability>FWL.pm:4,DA:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Anti-Missile Tank' unitType='Tank'>
@@ -12400,17 +12400,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>LA:3,ROS:3,FWL.OG:3,FWL.OH:3,FWL.FO:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>LA:3,ROS:3,FWL.OG:3,FWL.OH:3,FWL.FO:3,FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Paladin Defense System' unitType='Tank'>
@@ -12429,6 +12429,9 @@
 	</chassis>
 	<chassis name='Pandion Combat WiGE' unitType='Tank'>
 		<availability>LA:3,ROS:3,FWL:3,FS:6,MERC:3,CP:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -12437,35 +12440,28 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,RD:4,ROS:2,FS.DMM:4,MERC:2,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='PNT-10K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,TC:2,DC:2</availability>
 		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
-		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
 		</model>
 		<model name='PNT-12KC'>
 			<roles>raider</roles>
@@ -12475,13 +12471,17 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>RD:4,DC:8</availability>
+		</model>
+		<model name='PNT-12K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -12497,13 +12497,13 @@
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:8</availability>
-		<model name='2'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<roles>recon,spotter</roles>
@@ -12512,60 +12512,60 @@
 	</chassis>
 	<chassis name='Partisan AA Vehicle' unitType='Tank'>
 		<availability>MOC:7,FWL:6,IS:4,DA:6,CP:6</availability>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(3134 Upgrade)'>
 			<roles>anti_aircraft</roles>
 			<availability>FWL:6,CP:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,IS:5,FS:8,CP:5,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Quad RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:5,Periphery:5</availability>
-		</model>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='(Cell)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Company Command)'>
 			<roles>spotter,anti_aircraft</roles>
 			<availability>ROS:2,FS:2</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>IS:5,Periphery:5</availability>
+		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
+		<model name='(Cell)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Quad RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
 			<availability>Periphery:2-</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>Periphery:2-</availability>
-		</model>
-		<model name='(C3)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12576,10 +12576,6 @@
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
 		<availability>RF:6</availability>
-		<model name='PKM-2D'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PKM-2C'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
@@ -12587,6 +12583,10 @@
 		<model name='PKM-2E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='PKM-2D'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -12598,11 +12598,11 @@
 	</chassis>
 	<chassis name='Patron MilitiaMech' unitType='Mek'>
 		<availability>FWL.pm:4,DA.pm:4,RF.pm:4,IS.pm:2</availability>
-		<model name='PTN-2M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PTN-2'>
 			<availability>FWL:1,DA:1</availability>
+		</model>
+		<model name='PTN-2M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
@@ -12632,21 +12632,21 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:8</availability>
 		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
-		</model>
 		<model name='X-Pulse'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(MRM)'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='(3058 Upgrade)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,FS:8,DC:7</availability>
+		</model>
+		<model name='(Sealed)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -12658,20 +12658,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-6M'>
-			<availability>LA:5,FS:5</availability>
 		</model>
 		<model name='PTR-6T'>
 			<availability>FS.DBG:8,FS:4</availability>
 		</model>
+		<model name='PTR-6M'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -12679,11 +12679,11 @@
 		<model name='PEN-2MAF'>
 			<availability>General:4</availability>
 		</model>
-		<model name='PEN-2H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PEN-3H'>
 			<availability>MOC:6,CC:5</availability>
+		</model>
+		<model name='PEN-2H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -12695,40 +12695,40 @@
 	</chassis>
 	<chassis name='Persepolis' unitType='Aero'>
 		<availability>CJF:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>ROS:4,FWL:5,CP:5</availability>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1D'>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1W'>
+			<availability>General:2</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1'>
 			<availability>General:8</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1W'>
-			<availability>General:2</availability>
-		</model>
-		<model name='P1E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12742,28 +12742,28 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:4,FS:4,MERC:4,CP:5,DC:4</availability>
-		<model name='(Prototype)'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Prototype)'>
+			<availability>LA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:7,CJF:7,RA:6,CWIE:8</availability>
-		<model name='A'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='D'>
 			<availability>RD:4,General:5</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon,spotter</roles>
@@ -12773,39 +12773,39 @@
 			<roles>recon</roles>
 			<availability>RD:7,General:6</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
 		<model name='C'>
 			<availability>RD:6,CDS:4,General:5,CP:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,CDS:5,RF:3,LA:3,ROS:4,CLAN:3,CP:5,MERC:3,FS:3,RA:5,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>IS:3,CP:1,DC:3</availability>
-		</model>
 		<model name='7'>
 			<availability>RD:8,CDS:6,General:6,DC:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,RF:4,LA:4,ROS:4,FS:4,MERC:4,CP:8,DC:4</availability>
 		</model>
 		<model name='6'>
 			<availability>RD:6,CDS:8,CP:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:2</availability>
+		<model name='3'>
+			<availability>CDS:8,RF:4,LA:4,ROS:4,FS:4,MERC:4,CP:8,DC:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:8,CP:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:8,CP:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:3,CP:1,DC:3</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk L' unitType='Mek'>
@@ -12819,57 +12819,57 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>RD:4,IS:7,FWL:8,CP:8,Periphery:6</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
 		<model name='PXH-7K'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='PXH-7S'>
-			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
-		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:6,TC:6</availability>
-		</model>
-		<model name='PXH-4L'>
-			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:5,CP:5,BAN:1</availability>
-		</model>
-		<model name='PXH-6D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>RD:6,DC:8</availability>
 		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:4</availability>
 		</model>
-		<model name='PXH-3M'>
+		<model name='PXH-4W'>
+			<availability>MOC:6,TC:6</availability>
+		</model>
+		<model name='PXH-3D'>
 			<roles>recon</roles>
-			<availability>RF:8,FWL:8,IS:4,DA:8,CP:8</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>RD:4,ROS:2,DC:2</availability>
+		<model name='PXH-5L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
 		<model name='PXH-1'>
 			<roles>recon</roles>
 			<availability>BAN:6,Periphery:1-</availability>
 		</model>
+		<model name='PXH-7S'>
+			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>RF:8,FWL:8,IS:4,DA:8,CP:8</availability>
+		</model>
 		<model name='PXH-1c (Special)'>
 			<roles>recon</roles>
 			<availability>CC:4,CLAN:3,FWL:4,MERC:4,DA:4,CP:4</availability>
 		</model>
-		<model name='PXH-3D'>
+		<model name='PXH-4L'>
+			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>RD:4,ROS:2,DC:2</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>CLAN:5,FWL:5,CP:5,BAN:1</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>RD:6,DC:8</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Picaroon' unitType='Aero'>
@@ -12880,47 +12880,47 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,MH:1-,CP:3,CWIE:4,Periphery:2-</availability>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(RAC) &apos;Assault Pike&apos;'>
-			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>Periphery:2</availability>
 		</model>
+		<model name='(RAC) &apos;Assault Pike&apos;'>
+			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
+		</model>
 		<model name='(AC5)'>
+			<availability>MOC:2</availability>
+		</model>
+		<model name='(Missile)'>
 			<availability>MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,MERC:4,CP:6</availability>
+		<model name='PLG-4Z'>
+			<availability>CC:6,MOC:6</availability>
+		</model>
 		<model name='PLG-5Z'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='PLG-3Z'>
+			<availability>General:8</availability>
 		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='PLG-4Z'>
-			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='PLG-3Z'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12928,11 +12928,11 @@
 		<model name='2'>
 			<availability>CJF:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -12943,6 +12943,9 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:6,CDS:5,CP:5,RA:3,CWIE:3</availability>
+		<model name='2'>
+			<availability>CHH:8,CDS:8,CP:8</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4,CP:4</availability>
@@ -12952,9 +12955,6 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,CP:6,RA:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:8,CDS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -12975,12 +12975,12 @@
 		<model name='(Streak)'>
 			<availability>IS:6,TC:6,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
 			<availability>FWL:5,IS:5,CP:5,TC:3,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
@@ -13009,39 +13009,39 @@
 		<model name='(Light Gauss)'>
 			<availability>FWL:2,CP:2</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
+		</model>
 		<model name='(HV)'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>CC:4,MOC:4,MERC:4,DA:4,CDP:4,TC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:5,DA:5</availability>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Stealth)'>
 			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:8,CC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
-		<model name='PGD-L3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PGD-L3'>
+			<availability>General:4</availability>
 		</model>
 		<model name='PGD-R3'>
 			<roles>ground_support</roles>
@@ -13056,42 +13056,42 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CDS:5,CP:5,RA:5,CWIE:1</availability>
-		<model name='(2611)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2875)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2611)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:4,CP:4,CWIE:8</availability>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CWE:5,RD:3,CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CWE:6,RD:6,CDS:9,General:7,CP:9</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='H'>
+			<availability>CWE:5,RD:3,CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CWE:6,RD:6,CDS:9,General:7,CP:9</availability>
+		<model name='Prime'>
+			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -13111,9 +13111,6 @@
 	</chassis>
 	<chassis name='Prefect' unitType='Mek'>
 		<availability>ROS:4</availability>
-		<model name='PRF-3R'>
-			<availability>General:5</availability>
-		</model>
 		<model name='PRF-2R'>
 			<availability>General:4</availability>
 		</model>
@@ -13122,6 +13119,9 @@
 		</model>
 		<model name='PRF-1R'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PRF-3R'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Prey Seeker' unitType='Mek'>
@@ -13133,11 +13133,11 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Quad)'>
-			<availability>CHH:6+</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='(Quad)'>
+			<availability>CHH:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -13155,63 +13155,63 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Succession Wars)'>
-			<roles>support</roles>
-			<availability>Periphery:4</availability>
-		</model>
-		<model name='(ECM)'>
-			<roles>support</roles>
-			<availability>General:4,Periphery:4</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>support</roles>
-			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
-		</model>
-		<model name='(Security)'>
+		<model name='(3140 Upgrade)'>
 			<roles>apc</roles>
-			<availability>ROS:6</availability>
+			<availability>ROS:5</availability>
 		</model>
 		<model name='(RAF)'>
 			<roles>apc</roles>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='(3140 Upgrade)'>
+		<model name='(Succession Wars)'>
+			<roles>support</roles>
+			<availability>Periphery:4</availability>
+		</model>
+		<model name='(Security)'>
 			<roles>apc</roles>
-			<availability>ROS:5</availability>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='(ECM)'>
+			<roles>support</roles>
+			<availability>General:4,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>support</roles>
 			<availability>General:8,CLAN:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CWE:7,MERC.WD:4,RD:5,CDS:7,ROS:4+,CLAN:6,MERC:3+,CP:7,CJF:4,RA:6,BAN:5,CWIE:7</availability>
-		<model name='H'>
-			<availability>CWE:6,CHH:6,CLAN:4,General:3,CJF:6</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:5,RD:3,CDS:5,General:4,CP:5</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>CWE:6,CHH:6,RD:3,CDS:7,General:5,CP:5,CJF:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:4,CDS:5,General:3,CP:5,CJF:4</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CWE:5,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CWE:6,CHH:6,RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CWE:6,CHH:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,RD:3,CDS:5,General:4,CP:5</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:4,CDS:5,General:3,CP:5,CJF:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CWE:6,CHH:6,RD:3,CDS:7,General:5,CP:5,CJF:6</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CWE:5,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -13231,15 +13231,15 @@
 		<model name='[PPC] (RAF)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='[Laser] (RAF)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Quaestor Mobile Tactical Command HQ' unitType='Tank'>
@@ -13257,11 +13257,11 @@
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
-		<model name='QUA-51T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='QUA-51P'>
 			<availability>Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='QUA-51T'>
+			<availability>General:8</availability>
 		</model>
 		<model name='QUA-51M'>
 			<availability>Periphery.Deep:4,Periphery:6</availability>
@@ -13269,36 +13269,36 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
-		<model name='QKD-5K'>
-			<availability>MERC:5,DC:4</availability>
+		<model name='QKD-5Mr'>
+			<availability>General:6,FWL:8,CP:8</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='QKD-9M'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:5,ROS:4,DA:5,FS:4</availability>
+		<model name='QKD-5M'>
+			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
 		</model>
 		<model name='QKD-8K'>
 			<availability>RD:5,ROS:5,MERC:4,DC:8</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='QKD-9M'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:5,ROS:4,DA:5,FS:4</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+		<model name='QKD-C'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:6,FWL:8,CP:8</availability>
+		<model name='QKD-5K'>
+			<availability>MERC:5,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:6,FWL:4,MERC:4,CP:4</availability>
-		<model name='(GL)' mechanized='true'>
+		<model name='(David)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -13306,7 +13306,7 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(David)' mechanized='true'>
+		<model name='(GL)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -13320,15 +13320,15 @@
 	</chassis>
 	<chassis name='R10 Mechanized ICV' unitType='Tank' omni='IS'>
 		<availability>CC:5,CWE:5,RF:6,ROS:4,FWL:6,CLAN.IS:4,MERC:4,DA:6,CP:4,CWIE:4</availability>
+		<model name='(B)'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Prime)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='(A)'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(B)'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -13341,24 +13341,24 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
+		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden II Battle Armor' unitType='BattleArmor'>
@@ -13372,32 +13372,24 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:2,ROS:3,FS:3,MERC:3</availability>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
-		</model>
-		<model name='MDG-1Ar'>
-			<availability>ROS:8,FS:4,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1Ar'>
+			<availability>ROS:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:6,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:5,CP:4,CDP:6,DC:4</availability>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV2'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4,CP:4</availability>
 		</model>
 		<model name='VV22'>
 			<roles>urban</roles>
@@ -13407,20 +13399,28 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='VV2'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,FWL:4,MERC:4,FS:4,CP:4</availability>
+		</model>
+		<model name='VV1 (MG)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
+		<model name='RPR-300'>
+			<availability>LA:6,ROS:6,MERC:4</availability>
+		</model>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
-		</model>
-		<model name='RPR-300S'>
-			<availability>LA:6</availability>
 		</model>
 		<model name='RPR-100b'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:6,ROS:6,MERC:4</availability>
+		<model name='RPR-300S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
@@ -13429,15 +13429,11 @@
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-5X'>
+		<model name='RPT-2X2'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='RPT-2X2'>
+		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
@@ -13445,51 +13441,55 @@
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>DC:6</availability>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OR'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='RTX1-OC'>
+		<model name='RTX1-OD'>
+			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OG'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RTX1-OR'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='RTX1-OB'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
 		<model name='RTX1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='RTX1-OB'>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OA'>
 			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='RTX1-OA'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OD'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
-		<model name='(MH)' mechanized='false'>
-			<availability>MH:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
 		</model>
 		<model name='(LRM)' mechanized='false'>
 			<availability>General:4,MH:0</availability>
+		</model>
+		<model name='(MH)' mechanized='false'>
+			<availability>MH:8</availability>
 		</model>
 		<model name='(LRM) [MH]' mechanized='false'>
 			<availability>General:4</availability>
@@ -13504,14 +13504,6 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:6,MOC:2,FWL:2,MERC:2,DA:4,CP:2,TC:2</availability>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,TC:3</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:7,MOC:6</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
@@ -13520,21 +13512,29 @@
 			<roles>spotter</roles>
 			<availability>CC:1,MOC:1,MERC:1,DC:1,TC:1</availability>
 		</model>
+		<model name='RVN-4Lr'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:6</availability>
+		</model>
 		<model name='RVN-4L'>
 			<roles>spotter</roles>
 			<availability>CC:4,MOC:4,DA:6,TC:4</availability>
 		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>RF:4,LA:6,ROS:4,FWL:2,MH:4,MERC:4,FS:4,DA:4,CP:2</availability>
-		<model name='RZK-10T'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RZK-9S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10T'>
+			<availability>LA:4</availability>
 		</model>
 		<model name='RZK-10S'>
 			<availability>LA:6</availability>
@@ -13555,12 +13555,12 @@
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
 		<availability>CC:9,MOC:6,CDS:5,Periphery.CM:5,Periphery.ME:5,FWL:5,CP:5,TC:6</availability>
+		<model name='(RAC)'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -13571,19 +13571,15 @@
 		<model name='(Stealth)'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Revenant' unitType='Mek'>
 		<availability>ROS:3</availability>
-		<model name='UBM-2R'>
-			<roles>specops</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='UBM-2R7'>
 			<roles>specops</roles>
 			<availability>General:6</availability>
@@ -13592,17 +13588,29 @@
 			<roles>specops</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='UBM-2R2'>
+		<model name='UBM-2R'>
 			<roles>specops</roles>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='UBM-2R4'>
 			<roles>spotter,specops</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='UBM-2R2'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>fire_support</roles>
+			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CWE:1,CHH:1,General:8,CP:1</availability>
@@ -13611,27 +13619,22 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SL)'>
-			<roles>fire_support</roles>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(ML)'>
 			<roles>fire_support</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(SL)'>
 			<roles>fire_support</roles>
-			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:5,RF:6,ROS:8,FWL:6,FS:5,MERC:7,DA:6,CP:6</availability>
+		<model name='F-100'>
+			<availability>FVC:2-,Periphery:2-</availability>
+		</model>
+		<model name='F-700b'>
+			<availability>MOC:5,CC:5,ROS:6,FWL:8,MERC:8,CP:8,DC:8</availability>
 		</model>
 		<model name='F-100a'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -13639,48 +13642,41 @@
 		<model name='F-700'>
 			<availability>CC:8,MOC:5,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8</availability>
 		</model>
-		<model name='F-700b'>
-			<availability>MOC:5,CC:5,ROS:6,FWL:8,MERC:8,CP:8,DC:8</availability>
-		</model>
-		<model name='F-100'>
-			<availability>FVC:2-,Periphery:2-</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:5,RF:6,ROS:8,FWL:6,FS:5,MERC:7,DA:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:5,IS:3,CP:5,RA:5</availability>
-		<model name='8'>
-			<availability>CC:4,RD:6,CDS:4,LA:4,IS:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:4,IS:4,CP:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:1,CP:1,RA:2</availability>
+		<model name='3'>
+			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CP:8,DC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:1,CP:1,RA:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:4,IS:4,CP:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='8'>
+			<availability>CC:4,RD:6,CDS:4,LA:4,IS:4,FS:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='6'>
 			<availability>CHH:4,CDS:6,CP:6</availability>
 		</model>
-		<model name='3'>
-			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:4,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
-		<model name='RFL-7M'>
-			<availability>MOC:4,RF:8,FWL:8,IS:4,DA:8,CP:8,CDP:4,DC:5,TC:4</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='RFL-5D'>
 			<availability>FVC:3,LA:1,FS:2,MERC:2</availability>
+		</model>
+		<model name='RFL-7M'>
+			<availability>MOC:4,RF:8,FWL:8,IS:4,DA:8,CP:8,CDP:4,DC:5,TC:4</availability>
 		</model>
 		<model name='RFL-3Cr'>
 			<availability>FS:2</availability>
@@ -13689,14 +13685,15 @@
 			<roles>fire_support</roles>
 			<availability>MOC:1-,PIR:1-,MH:1-</availability>
 		</model>
+		<model name='RFL-5M'>
+			<availability>Periphery.MW:3,Periphery.ME:3,FWL:1,MH:3,CP:1</availability>
+		</model>
 		<model name='C 2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='RFL-8D'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-9T'>
-			<availability>TC:6</availability>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='RFL-8X'>
 			<availability>ROS:4,MERC:4</availability>
@@ -13705,39 +13702,42 @@
 			<roles>fire_support</roles>
 			<availability>ROS:5,MERC:5</availability>
 		</model>
-		<model name='RFL-5M'>
-			<availability>Periphery.MW:3,Periphery.ME:3,FWL:1,MH:3,CP:1</availability>
+		<model name='RFL-8D'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-9T'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,ROS:6,CLAN:2,FS:5,DC:5</availability>
-		<model name='(Standard)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>LA:5,ROS:4,FS:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>FS:4,CP:4,DC:5</availability>
-		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:4</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
 		<model name='(SPL)'>
 			<roles>apc</roles>
 			<availability>FVC:4,IS:4</availability>
+		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>FS:4,CP:4,DC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Roadrunner (Emerald Harrier)' unitType='Mek'>
@@ -13749,14 +13749,14 @@
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CHH:4,CP:7,RA:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='2'>
 			<availability>RA:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CP:4,RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='4'>
 			<availability>RA:6</availability>
@@ -13764,34 +13764,31 @@
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>RD:6-</availability>
-		<model name='(Hybrid)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Hybrid)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rokurokubi' unitType='Mek'>
 		<availability>DC:8</availability>
-		<model name='RK-4K'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RK-4X'>
 			<availability>General:2</availability>
 		</model>
 		<model name='RK-4T'>
 			<availability>General:4</availability>
 		</model>
+		<model name='RK-4K'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>RA.OA:5,FVC:4,RF:4,LA:5,ROS:4,FS:3,MERC:2,CWIE:6,TC:6</availability>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
@@ -13802,6 +13799,9 @@
 			<roles>artillery,fire_support</roles>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
 		<availability>FS:5,MERC:3</availability>
@@ -13811,11 +13811,11 @@
 	</chassis>
 	<chassis name='Rook' unitType='Mek'>
 		<availability>ROS:4,FWL:5,FS:4,MERC:4,CP:5</availability>
-		<model name='NH-3X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='NH-2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NH-3X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rose (Bara no Ryu)' unitType='Dropship'>
@@ -13835,12 +13835,12 @@
 			<roles>recon</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='false'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Firedrake)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='false'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13853,29 +13853,29 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,CDS:4,CLAN:4,MERC:3+,CP:4,CJF:4,RA:5,BAN:5,CWIE:5,DC:4+</availability>
-		<model name='D'>
-			<availability>CWE:3,RD:3,CDS:8,General:5,CP:7,CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:5,RD:3,CDS:8,General:6,CP:8,CJF:4,CWIE:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CWE:6,RD:3,CDS:9,General:6,CP:9,CJF:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:3,General:2</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CWE:8,RD:8,CDS:5,General:7,CP:6,CJF:9</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
+		<model name='B'>
+			<availability>CWE:5,RD:3,CDS:8,General:6,CP:8,CJF:4,CWIE:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,General:5,CP:5,CJF:4,RA:6,CWIE:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:3,RD:3,CDS:8,General:5,CP:7,CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:6,General:5,RA:6,CWIE:5</availability>
@@ -13886,19 +13886,19 @@
 	</chassis>
 	<chassis name='Ryoken III-XP' unitType='Mek' omni='IS'>
 		<availability>CWE:3</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -13907,20 +13907,20 @@
 		<model name='3'>
 			<availability>CHH:8,RD:4,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>RD:8,CDS:8,IS:8,CP:8</availability>
-		</model>
 		<model name='2'>
 			<availability>RD:6,ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RD:8,CDS:8,IS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
 		<availability>CP:7,DC:5</availability>
-		<model name='SM1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Telos)'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='SM1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1A Tank Destroyer' unitType='Tank'>
@@ -13931,13 +13931,13 @@
 	</chassis>
 	<chassis name='SM2 Heavy Artillery Vehicle' unitType='Tank'>
 		<availability>ROS:5,FWL:5,MERC:4,CP:5,DC:6</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LTC)'>
 			<roles>artillery</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SM3 Tank Destroyer' unitType='Tank'>
@@ -13952,13 +13952,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,CP:4,DC:8,Periphery:4</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:6,Periphery:6</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,CP:4,DC:8,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13969,14 +13969,14 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
-		<model name='SB-27'>
-			<availability>General:1-</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='SB-27'>
+			<availability>General:1-</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
@@ -13988,17 +13988,8 @@
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -14007,33 +13998,42 @@
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='X'>
 			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
 		<availability>FVC:4,ROS:4,FS:6,MERC:4</availability>
-		<model name='SGT-8R'>
-			<availability>FVC:8,FS:4</availability>
-		</model>
-		<model name='SGT-10X'>
-			<availability>ROS:6,FS:6,MERC:6</availability>
-		</model>
 		<model name='SGT-14D'>
 			<availability>FS:5</availability>
+		</model>
+		<model name='SGT-8R'>
+			<availability>FVC:8,FS:4</availability>
 		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:6,FS:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittarii' unitType='Aero'>
 		<availability>ROS:8</availability>
-		<model name='SGT-2R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SGT-3R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='SGT-2R'>
+			<availability>General:8</availability>
 		</model>
 		<model name='SGT-4R'>
 			<availability>General:6</availability>
@@ -14044,11 +14044,11 @@
 		<model name='S-4C'>
 			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
-		<model name='S-8'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
+		</model>
+		<model name='S-8'>
+			<availability>ROS:8,DC:8</availability>
 		</model>
 		<model name='S-7'>
 			<availability>CP:6,DC:4</availability>
@@ -14056,32 +14056,32 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,DC.AL:7,IS:4,FWL:4,MERC:4,FS:3,CJF:4,DC:5</availability>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
-		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>IS:8,DC:8</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Saladin Mk II HCV' unitType='Tank'>
 		<availability>FWL:5,MERC:5,CP:4,DC:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(BC3)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Laser)' mechanized='true'>
-			<availability>CWE:6,RA:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Laser)' mechanized='true'>
+			<availability>CWE:6,RA:6</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
@@ -14090,14 +14090,6 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-7T'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -14106,9 +14098,17 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
 		</model>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
 		<model name='PPR-5S'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='PPR-7T'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
@@ -14117,44 +14117,44 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>LA:5,ROS:5</availability>
-		<model name='SL-27'>
-			<availability>IS:6,DC:6</availability>
-		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='SL-27'>
+			<availability>IS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
 		<availability>MOC:2,RA.OA:5,Periphery.DD:4,Periphery.OS:4,Periphery:2,TC:2,DC:1-</availability>
-		<model name='(MRM)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:2-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Mk II HCV' unitType='Tank'>
 		<availability>FWL:5,MERC:5,CP:4,DC:7</availability>
-		<model name='(BC3)'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(BC3)'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sarath' unitType='Mek' omni='IS'>
 		<availability>RF:5-</availability>
+		<model name='SRTH-1O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='SRTH-1OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SRTH-1OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='SRTH-1O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -14179,26 +14179,23 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CP:3,RA:4</availability>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CP:4,RA:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CP:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:4</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
@@ -14206,8 +14203,11 @@
 		<model name='J'>
 			<availability>CWE:4,CHH:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
@@ -14229,10 +14229,6 @@
 	</chassis>
 	<chassis name='Saxon APC' unitType='Tank'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='(Laser)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(HQ)'>
 			<roles>apc,support,spotter</roles>
 			<availability>General:2</availability>
@@ -14240,6 +14236,10 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(MASH)'>
 			<roles>apc,support</roles>
@@ -14251,34 +14251,34 @@
 		<model name='(Primary)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(H)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(G)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(B)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(I)'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(C)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(J)'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(E)'>
 			<roles>artillery</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(I)'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(H)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(J)'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(F)'>
 			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(B)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(G)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(A)'>
@@ -14298,62 +14298,62 @@
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:4</availability>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
+		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Schildkrote Line Tank' unitType='Tank'>
 		<availability>LA:4-,LA.pm:6,MERC:3-</availability>
-		<model name='(HPPC)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(HPPC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>RD:4,ROS:5,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>fire_support,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:8</availability>
-		<model name='SCK-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCK-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SCK-OA'>
 			<roles>interceptor</roles>
@@ -14362,30 +14362,30 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>RA.OA:1,RD:2,CP:2,Periphery:2,RA:2</availability>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:6</availability>
+		<model name='(Armor)'>
+			<availability>RD:8,IS:6,CP:8,RA:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(Armor)'>
-			<availability>RD:8,IS:6,CP:8,RA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
 		<availability>RA.OA:2-,Periphery.DD:2-,Periphery.OS:2-,Periphery:2-,DC:2-</availability>
+		<model name='(Standard)'>
+			<availability>General:2-</availability>
+		</model>
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2-</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:8,DC:8</availability>
@@ -14396,18 +14396,17 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(BC3)'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(3136 Upgrade)'>
 			<availability>FWL:6,MERC:6,CP:5,DC:6</availability>
+		</model>
+		<model name='(BC3)'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,LA:6,FWL:6,IS:7,Periphery.Deep:5,FS:6,CP:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(Minesweeper)'>
-			<roles>minesweeper</roles>
-			<availability>CC:4-,MOC:2-</availability>
+		<model name='(MRM)'>
+			<availability>IS:5,DC:5,Periphery:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-</availability>
@@ -14418,39 +14417,40 @@
 		<model name='(SRM)'>
 			<availability>General:1-</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>IS:5,DC:5,Periphery:4</availability>
+		<model name='(Minesweeper)'>
+			<roles>minesweeper</roles>
+			<availability>CC:4-,MOC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
 		<availability>CC:2,FVC:2,LA:4,ROS:2,FWL:2,MERC:2,CP:2,DC:4,Periphery:3</availability>
-		<model name='SCP-1N'>
-			<availability>Periphery:2-</availability>
+		<model name='SCP-12S'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='SCP-1N'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='SCP-1O'>
 			<availability>IS:1,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='SCP-10M'>
-			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
+		<model name='SCP-10M'>
+			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Scourge' unitType='Mek'>
 		<availability>RD:3,LA:5,FWL:5,IS:4,CP:5,Periphery:3</availability>
-		<model name='SCG-WF1'>
-			<availability>LA:8,FWL:8,CP:8</availability>
-		</model>
 		<model name='SCG-WD1'>
 			<availability>LA:6,General:8,FWL:6,CP:6</availability>
+		</model>
+		<model name='SCG-WF1'>
+			<availability>LA:8,FWL:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -14468,41 +14468,41 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
+		<model name='3'>
+			<availability>CJF:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
 		<availability>CWE:3,CHH:2,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
 		</model>
 		<model name='E'>
 			<availability>General:4</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='X'>
 			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Fox Amphibious Armor' unitType='BattleArmor'>
@@ -14513,14 +14513,14 @@
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(SRM6)'>
 			<availability>General:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:1</availability>
@@ -14534,13 +14534,13 @@
 	</chassis>
 	<chassis name='Seeker' unitType='Dropship'>
 		<availability>CC:3,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:3,DC:4</availability>
-		<model name='(2815)'>
-			<roles>vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3054)'>
 			<roles>vee_carrier</roles>
 			<availability>CC:4,LA:8,FWL:4,IS:6,FS:8,CP:4</availability>
+		</model>
+		<model name='(2815)'>
+			<roles>vee_carrier</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sekhmet Assault Vehicle' unitType='Tank'>
@@ -14558,14 +14558,14 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,ROS:3,CJF:2,DC:2</availability>
-		<model name='STN-3L'>
-			<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-3L'>
+			<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -14579,16 +14579,16 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6</availability>
+		<model name='SYD-Z3A'>
+			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3</availability>
 		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3</availability>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6</availability>
 		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
@@ -14599,14 +14599,14 @@
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
 		<availability>CC:6,MOC:5</availability>
+		<model name='SYU-4B'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SYU-2B'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='SYU-6B'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -14628,12 +14628,21 @@
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CDS:5,ROS:4+,MERC:3+,CP:6,CJF:5,RA:5</availability>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CWE:3,General:6,RA:8</availability>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
@@ -14642,75 +14651,66 @@
 			<roles>recon</roles>
 			<availability>CWE:3,General:6,RA:3</availability>
 		</model>
-		<model name='J'>
-			<availability>General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
+		<model name='B'>
 			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
+			<availability>CWE:3,General:6,RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
-		<model name='8'>
-			<availability>CDS:4,LA:6,IS:4,CP:5,CWIE:6</availability>
-		</model>
-		<model name='9'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='7'>
-			<availability>RA.OA:8,RA:8</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:5,IS:6,CP:5,RA:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:5,IS:6,CP:5</availability>
+		<model name='6'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='5'>
 			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,CP:8,DC:8</availability>
 		</model>
-		<model name='6'>
-			<availability>CHH:8</availability>
+		<model name='9'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:4,LA:6,IS:4,CP:5,CWIE:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:5,IS:6,CP:5,RA:6</availability>
+		</model>
+		<model name='7'>
+			<availability>RA.OA:8,RA:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:5,IS:6,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>RD:3,IS:3,Periphery.Deep:4,BAN:4,Periphery:6</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:5,FS:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:1-,Periphery:2-</availability>
-		</model>
 		<model name='SHD-2Hb'>
 			<availability>CC:4,MOC:4,ROS:4,CLAN:4,FWL:4,MERC:4,DA:4,CP:4,BAN:2</availability>
 		</model>
-		<model name='SHD-12C'>
-			<availability>RD:8,ROS:5,DC:4</availability>
+		<model name='SHD-3K'>
+			<availability>RD:4,DC:8</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,CP:4,Periphery:4,DC:6</availability>
 		</model>
-		<model name='SHD-8L'>
-			<availability>CC:8</availability>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
 		</model>
 		<model name='SHD-7M'>
 			<availability>CC:4,MOC:3,FVC:3,ROS:4,FWL:8,MERC:4,CP:8,CDP:3,TC:3</availability>
 		</model>
+		<model name='SHD-2H'>
+			<availability>General:1-,Periphery:2-</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>RD:8,ROS:5,DC:4</availability>
+		</model>
 		<model name='SHD-9D'>
 			<availability>FS:6</availability>
 		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
+		<model name='SHD-8L'>
+			<availability>CC:8</availability>
 		</model>
-		<model name='SHD-3K'>
-			<availability>RD:4,DC:8</availability>
+		<model name='SHD-2D2'>
+			<availability>FVC:5,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -14718,40 +14718,40 @@
 		<model name='(Flamer)'>
 			<availability>CDS:4,CP:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Interdictor)'>
 			<availability>CWE:4,CHH:4,RD:6,CDS:4,ROS:8,CP:4,CJF:4,RA:4,CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
 		<availability>MOC:8,FVC:4,PIR:4,IS:8,CDP:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MOC:8,IS:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>recon</roles>
 			<availability>FVC:8,PIR:8,IS:1,CDP:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MOC:8,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shen Long Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MOC:6</availability>
+		<model name='[Pop-Up Mine]' mechanized='false'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[David Light Gauss]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Interdictor]' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[Pop-Up Mine]' mechanized='false'>
-			<availability>General:5</availability>
-		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[David Light Gauss]' mechanized='false'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='false'>
 			<availability>General:8</availability>
@@ -14759,12 +14759,12 @@
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
 		<availability>CC:6</availability>
+		<model name='SHY-3B'>
+			<availability>General:3</availability>
+		</model>
 		<model name='SHY-5B'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='SHY-3B'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sheriff Infantry Support Tank' unitType='Tank'>
@@ -14788,14 +14788,14 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-18'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
-		</model>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RD:2,RA:2</availability>
+		</model>
+		<model name='SL-18'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shiro' unitType='Mek'>
@@ -14818,6 +14818,9 @@
 		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SHV-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
 		</model>
@@ -14827,37 +14830,34 @@
 		<model name='SHV-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:4,ROS:4,FWL:6,FS:3,CP:6,DC:3</availability>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
+		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKW-6H'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SKW-8X'>
 			<roles>artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='SKW-6H'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CWE:3,CHH:3,RD:4,CDS:4,ROS:3,CP:4,CWIE:3,DC:3</availability>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CP:6,DC:6</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CWE:6,CDS:4,ROS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CP:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -14880,10 +14880,10 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='2'>
+		<model name='3'>
 			<availability>General:4</availability>
 		</model>
-		<model name='3'>
+		<model name='2'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -14921,19 +14921,15 @@
 		<model name='(Flamer)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Heavy MG)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(SL)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Heavy MG)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Simurgh' unitType='Aero' omni='IS'>
 		<availability>ROS:8</availability>
-		<model name='SMG-OA'>
-			<roles>assault</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='SMG-O'>
 			<roles>assault</roles>
 			<availability>General:8</availability>
@@ -14942,14 +14938,18 @@
 			<roles>assault</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SMG-OA'>
+			<roles>assault</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>CC:3,ROS:3,FWL:4,MERC:3,CP:4</availability>
-		<model name='SRC-5C'>
-			<availability>ROS:5,FWL:5,CP:5</availability>
-		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-5C'>
+			<availability>ROS:5,FWL:5,CP:5</availability>
 		</model>
 		<model name='SRC-6C'>
 			<availability>ROS:6,FWL:6,CP:6</availability>
@@ -14976,42 +14976,42 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:1-</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FVC:3,IS.pm:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:1-</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+		<model name='SL-15'>
+			<availability>ROS:0,FS:0,Periphery:2-</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>RA.OA:6,RD:6,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4</availability>
 		</model>
 		<model name='SL-15K'>
 			<availability>RD:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,FS:0,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>LA:1</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='(Huntsman)' mechanized='false'>
 			<availability>LA:4,FS:4,MERC:4</availability>
@@ -15045,11 +15045,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CP:4,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CP:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -15061,10 +15061,6 @@
 	</chassis>
 	<chassis name='Sokuryou' unitType='Mek'>
 		<availability>DC:2</availability>
-		<model name='SKU-181 SurveyMech'>
-			<roles>support,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='SKU-197 SurveyMech'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
@@ -15072,6 +15068,10 @@
 		<model name='SKU-198 SurveyMech'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKU-181 SurveyMech'>
+			<roles>support,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -15109,26 +15109,26 @@
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
-		<model name='SPR-6D'>
-			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
-		</model>
 		<model name='SPR-7D'>
 			<availability>ROS:5,FS:5,MERC:5</availability>
 		</model>
-		<model name='SPR-7Dr'>
-			<availability>ROS:4,FS:5,MERC:4</availability>
-		</model>
 		<model name='SPR-DH'>
 			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
+		</model>
+		<model name='SPR-6D'>
+			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
+		</model>
+		<model name='SPR-7Dr'>
+			<availability>ROS:4,FS:5,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -15143,21 +15143,21 @@
 		<model name='SPR-5S'>
 			<availability>CC:4,LA:4,ROS:4,CC.MAC:8,FS:4</availability>
 		</model>
+		<model name='SPR-ST'>
+			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
+		</model>
 		<model name='SPR-5F'>
 			<roles>recon</roles>
 			<availability>IS:8</availability>
 		</model>
-		<model name='SPR-ST'>
-			<availability>CC:4,LA:4,ROS:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:8,MERC:4,CDP:8,RA:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='(RA)' mechanized='true'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -15165,29 +15165,44 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CP:4</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:4,CP:4-</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:4,CP:8</availability>
 		</model>
-		<model name='2'>
-			<availability>ROS:6,CP:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:1,CC:2,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:6</availability>
+		<model name='SDR-10K'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2,CP:8</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
+		<model name='SDR-8X'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
 		<model name='SDR-5V'>
 			<availability>Periphery:2-</availability>
 		</model>
 		<model name='SDR-7Kr'>
 			<availability>ROS:1,MERC:1,DC:1</availability>
 		</model>
-		<model name='SDR-10K'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SDR-7K'>
 			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
+		<model name='SDR-8Xr'>
+			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,CP:8,DC:6</availability>
@@ -15195,26 +15210,11 @@
 		<model name='SDR-7KC'>
 			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='SDR-8K'>
-			<availability>ROS:4,MERC:4,DC:6</availability>
-		</model>
-		<model name='SDR-8Xr'>
-			<availability>ROS:6,MERC:6,DC:6</availability>
-		</model>
 		<model name='SDR-7K2'>
 			<availability>ROS:3,MERC:3,DC:4</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2,CP:8</availability>
-		</model>
-		<model name='SDR-8X'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
+		<model name='SDR-8K'>
+			<availability>ROS:4,MERC:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -15234,13 +15234,17 @@
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:5,FVC:5,LA:7,ROS:7,IS:6,MH:4,FS:7,DC:7</availability>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>IS:4,DC:6</availability>
-		</model>
 		<model name='(Troop Transport)'>
 			<roles>recon,apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>IS:4,DC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -15249,10 +15253,6 @@
 		<model name='(Interdictor)'>
 			<roles>spotter</roles>
 			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,CP:4,DC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -15272,8 +15272,11 @@
 		<model name='STK-8S'>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		</model>
+		<model name='STK-6M'>
+			<availability>CC:5,MOC:5,RF:6,ROS:6,FWL:6,MERC:6,DA:5,CP:6</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
@@ -15281,20 +15284,17 @@
 		<model name='STK-7D'>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='STK-3F'>
-			<availability>Periphery:2-</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,RF:3,CLAN:8,FWL:3,MERC:3,DA:3,CP:3,BAN:2</availability>
 		</model>
-		<model name='STK-3H'>
-			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
-		</model>
-		<model name='STK-6M'>
-			<availability>CC:5,MOC:5,RF:6,ROS:6,FWL:6,MERC:6,DA:5,CP:6</availability>
+		<model name='STK-3F'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CP:3,CJF:3,TC:4</availability>
@@ -15320,12 +15320,12 @@
 	</chassis>
 	<chassis name='Starslayer' unitType='Mek'>
 		<availability>MOC:4,CC:4,RF:4,LA:6,ROS:4,FWL:2,FS:4,DA:4,CP:2</availability>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='STY-3D'>
 			<roles>raider</roles>
 			<availability>MOC:4,CC:2,LA:4,ROS:2,FWL:2,FS:2,MERC:4,CP:2</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
@@ -15334,6 +15334,10 @@
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
 		<availability>LA:1,FS.CMM:9,FS:8,MERC:4</availability>
+		<model name='STH-2D'>
+			<roles>recon</roles>
+			<availability>FS:6,MERC:4</availability>
+		</model>
 		<model name='STH-2D2'>
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
@@ -15342,28 +15346,24 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D'>
+		<model name='STH-2D1'>
 			<roles>recon</roles>
-			<availability>FS:6,MERC:4</availability>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-3S'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
-		<model name='STM-OB'>
+		<model name='STM-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STM-OA'>
+		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15375,11 +15375,11 @@
 		<model name='STO-4B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-6S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -15394,33 +15394,29 @@
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,RD:1-,IS:7,MERC:7,Periphery:6,DC:4</availability>
-		<model name='STG-3R'>
-			<roles>recon</roles>
-			<availability>BAN:8,Periphery:2-</availability>
-		</model>
-		<model name='STG-5G'>
-			<roles>recon</roles>
-			<availability>CC:5,FVC:4,ROS:4,FWL:4,MH:4,DA:4,FS:4,CP:4,CDP:5,TC:5</availability>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
 		</model>
-		<model name='STG-3Gb'>
-			<roles>recon</roles>
-			<availability>CC:4,CLAN:8,FWL:5,DA:6,MERC:4,CP:5,BAN:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
-		</model>
 		<model name='STG-6L'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:4,DA:4</availability>
 		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
+		<model name='STG-5G'>
+			<roles>recon</roles>
+			<availability>CC:5,FVC:4,ROS:4,FWL:4,MH:4,DA:4,FS:4,CP:4,CDP:5,TC:5</availability>
+		</model>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>CC:4,CLAN:8,FWL:5,DA:6,MERC:4,CP:5,BAN:2</availability>
+		</model>
+		<model name='STG-3R'>
+			<roles>recon</roles>
+			<availability>BAN:8,Periphery:2-</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
@@ -15434,38 +15430,39 @@
 			<roles>recon</roles>
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
-		<model name='F-95'>
-			<availability>CC:5,RF:6,LA:5,ROS:5,FWL:6,MERC:5,DA:6,CP:6</availability>
-		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
-		</model>
-		<model name='F-92'>
-			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,IS:4,MH:4,CP:4</availability>
-		</model>
-		<model name='F-90'>
-			<availability>IS:2-,Periphery:2-</availability>
 		</model>
 		<model name='F-96R'>
 			<availability>RF:5,LA:4,FWL:5,DA:5,CP:5</availability>
 		</model>
+		<model name='F-90'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='F-92'>
+			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,IS:4,MH:4,CP:4</availability>
+		</model>
+		<model name='F-95'>
+			<availability>CC:5,RF:6,LA:5,ROS:5,FWL:6,MERC:5,DA:6,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>RD:3</availability>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>:0,General:8</availability>
@@ -15473,11 +15470,14 @@
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>:0,CLAN:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15489,63 +15489,69 @@
 	</chassis>
 	<chassis name='Storm Raider' unitType='Mek'>
 		<availability>RF:4,LA:4,ROS:3,MH:4,MERC:4,FS:4,Periphery:3</availability>
-		<model name='STM-R1'>
-			<availability>General:3</availability>
-		</model>
 		<model name='STM-R3'>
 			<availability>LA:8,MH:8,MERC:8</availability>
-		</model>
-		<model name='STM-R2'>
-			<availability>General:4</availability>
 		</model>
 		<model name='STM-R4'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
+		<model name='STM-R1'>
+			<availability>General:3</availability>
+		</model>
+		<model name='STM-R2'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:5,MOC:5,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:5,CP:5,DC:7</availability>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SR1-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OM'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SR1-OR'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
-		<model name='SR1-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OH'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
-		<model name='SR1-OE'>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OR'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='SR1-OH'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SR1-OD'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OF'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,DC:1</availability>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(3061 Upgrade)'>
+			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='(Narc)'>
 			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
 		</model>
@@ -15557,23 +15563,17 @@
 			<roles>fire_support</roles>
 			<availability>FVC:1-</availability>
 		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
+		<model name='(SRM)'>
+			<availability>FVC:1-</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,ROS:3,FS.DMM:8,FS:3</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>FVC:1-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:6,LA:6,ROS:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(3061 Upgrade)'>
-			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:6,LA:6,ROS:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
@@ -15600,27 +15600,27 @@
 		<model name='STU-K5'>
 			<availability>FVC:2-,BAN:8,Periphery:2-</availability>
 		</model>
-		<model name='STU-D7'>
-			<availability>ROS:6,FS:8,MERC:4</availability>
+		<model name='STU-D6'>
+			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>ROS:6,CLAN:8,FS:4,MERC:4,BAN:2</availability>
 		</model>
-		<model name='STU-D6'>
-			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
+		<model name='STU-D7'>
+			<availability>ROS:6,FS:8,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:2,CDS:2,RF:3,LA:2,ROS:3,FS:2,CP:2,CWIE:2</availability>
+		<model name='(Heavy Gauss)'>
+			<availability>RF:6,LA:6,CP:6,CWIE:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Heavy Gauss)'>
-			<availability>RF:6,LA:6,CP:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
@@ -15639,37 +15639,44 @@
 		<model name='E'>
 			<availability>CWE:5,RD:5,CLAN:2</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:6,General:2</availability>
-		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:6,General:2</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:6,General:2,CJF:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:6,General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CWE:5,CDS:3,ROS:3,FS:5,MERC:2,CP:3</availability>
-		<model name='2'>
-			<availability>CDS:8,ROS:8,MERC:8,FS:8,CP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CWE:8,CDS:4,CP:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:8,ROS:8,MERC:8,FS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OF'>
+		<model name='SD1-OA'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SD1-OE'>
 			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
@@ -15679,39 +15686,32 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='SD1-OC'>
+			<availability>General:6,DC:7</availability>
+		</model>
+		<model name='SD1-OF'>
+			<availability>General:4</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='SD1-OA'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
 		</model>
-		<model name='SD1-OC'>
-			<availability>General:6,DC:7</availability>
-		</model>
-		<model name='SD1-OE'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SD1-OG'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CWE:5,RD:3,CDS:4,ROS:3,CP:7,CWIE:5</availability>
-		<model name='2'>
-			<availability>ROS:6,CP:6</availability>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='3'>
 			<availability>ROS:6,CP:6</availability>
 		</model>
+		<model name='2'>
+			<availability>ROS:6,CP:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,CP:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -15746,11 +15746,11 @@
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:5,LA:6,ROS:5,FWL:5,MH:4,FS:5,MERC:5,CP:5,TC:4</availability>
-		<model name='(Original)'>
-			<availability>LA:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<availability>LA:4,MERC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -15765,15 +15765,15 @@
 			<deployedWith>solo</deployedWith>
 			<availability>CC:3</availability>
 		</model>
-		<model name='(ICE)'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ICE)'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -15781,19 +15781,15 @@
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SWF-606R'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
+		</model>
+		<model name='SWF-606R'>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:2,CP:2,RA:4</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:8</availability>
@@ -15802,15 +15798,19 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
 		<availability>ROS:4,DC:6</availability>
+		<model name='TSH-8S'>
+			<availability>ROS:6,DC:6</availability>
+		</model>
 		<model name='TSH-7S'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSH-8S'>
-			<availability>ROS:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Taihou Assault Dropship' unitType='Dropship'>
@@ -15834,11 +15834,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Flamer)'>
-			<availability>MOC:4,CC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>MOC:4,CC:4</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -15852,10 +15852,6 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,ROS:4,FWL:6,MERC:4,CP:6,DC:6</availability>
-		<model name='ZPH-2A'>
-			<roles>recon</roles>
-			<availability>MOC:6,CC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
-		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>ROS:6,MERC:6,DC:8</availability>
@@ -15864,21 +15860,21 @@
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
 		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:2,MOC:2,ROS:2,FWL:2,MERC:2,CP:2,DC:2</availability>
-		</model>
 		<model name='ZPH-3A'>
 			<roles>recon</roles>
 			<availability>ROS:5,FWL:8,MERC:4,CP:8,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:2,MOC:2,ROS:2,FWL:2,MERC:2,CP:2,DC:2</availability>
+		</model>
+		<model name='ZPH-2A'>
+			<roles>recon</roles>
+			<availability>MOC:6,CC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:4,MERC:2</availability>
-		<model name='TRG-2N'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='TRG-1N'>
 			<roles>recon</roles>
 			<availability>ROS:8</availability>
@@ -15887,29 +15883,33 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='TRG-2N'>
+			<roles>recon</roles>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:4,ROS:4,CP:4,DC:6</availability>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='MIK-OE'>
+			<availability>General:5</availability>
+		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OE'>
-			<availability>General:5</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-OF'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -15921,77 +15921,77 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MERC:4,CP:8</availability>
-		<model name='TMP-3M'>
-			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
-		</model>
 		<model name='TMP-3MA'>
 			<availability>RF:4,ROS:4,FWL:4,MERC:4,CP:4</availability>
-		</model>
-		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
-			<availability>ROS:6,FWL:6,MERC:4,CP:6</availability>
 		</model>
 		<model name='TMP-3G'>
 			<availability>ROS:2,FWL:2,MERC:2,CP:2</availability>
 		</model>
+		<model name='TMP-3M'>
+			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
+		</model>
+		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
+			<availability>ROS:6,FWL:6,MERC:4,CP:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Templar III' unitType='Mek' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='TLR2-OC'>
+		<model name='TLR2-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='TLR2-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-OB'>
+		<model name='TLR2-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-O'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
 		<availability>FS:4</availability>
-		<model name='TLR1-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='TLR1-OR'>
-			<availability>General:3</availability>
-		</model>
-		<model name='TLR1-OC'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OI'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OE'>
+		<model name='TLR1-OF'>
 			<roles>spotter</roles>
-			<availability>General:3</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OF'>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OE'>
 			<roles>spotter</roles>
-			<availability>General:2</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OG'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='TLR1-OD'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OR'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tenshi' unitType='Mek' omni='IS'>
@@ -16002,11 +16002,11 @@
 		<model name='TN-10-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TN-10-OR'>
-			<availability>General:6</availability>
-		</model>
 		<model name='TN-10-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TN-10-OR'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -16018,15 +16018,15 @@
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>ROS:6,DC:4</availability>
+		<model name='TSN-C3M'>
+			<roles>recon,spotter</roles>
+			<availability>ROS:4,DC:4</availability>
+		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
 		<model name='TSN-1Cr'>
-			<roles>recon,spotter</roles>
-			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
@@ -16040,13 +16040,13 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CWE:1,CJF:1,RA:1</availability>
-		<model name='(2618)'>
-			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2835)'>
 			<roles>battleship</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2618)'>
+			<roles>battleship</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
@@ -16054,11 +16054,11 @@
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TNS-6S'>
-			<availability>LA:6,IS:4</availability>
-		</model>
 		<model name='TNS-4T'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='TNS-6S'>
+			<availability>LA:6,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -16077,8 +16077,18 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CWE:1,CHH:1,MERC.WD:1,RD:1,CDS:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
+		<model name='AA'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CWE:4,RD:3,CDS:4,General:6,CP:4,CJF:7,CWIE:5</availability>
 		</model>
 		<model name='G'>
 			<availability>CWE:6,CHH:4,RD:4,CDS:4,General:2,CP:4,CJF:5,CWIE:5</availability>
@@ -16086,48 +16096,38 @@
 		<model name='D'>
 			<availability>CWE:8,RD:8,General:5,CP:6,CWIE:6</availability>
 		</model>
-		<model name='AA'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:8,RD:4,CDS:8,General:7,CP:7,CJF:8,CWIE:6</availability>
-		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CWE:4,RD:3,CDS:4,General:6,CP:4,CJF:7,CWIE:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CWE:6,RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='HH'>
-			<availability>CWE:5,CHH:6,CDS:4,CLAN:2,General:2,CP:4,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CWE:6,RD:6,General:5,CJF:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5,CWIE:5</availability>
 		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:6,CHH:8,RD:4,CDS:8,General:7,CP:7,CJF:8,CWIE:6</availability>
+		</model>
+		<model name='HH'>
+			<availability>CWE:5,CHH:6,CDS:4,CLAN:2,General:2,CP:4,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,BAN:5</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Clan)'>
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
@@ -16136,14 +16136,14 @@
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
@@ -16151,34 +16151,34 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:5</availability>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CP:2,RA:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:2,FVC:2,FWL:2,FS:2,MERC:2,CP:2,Periphery:2</availability>
+		</model>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
@@ -16198,13 +16198,13 @@
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
 		<availability>IS:4,Periphery:4</availability>
-		<model name='Angel'>
-			<roles>artillery</roles>
-			<availability>LA:4,ROS:4,FWL:5,FS:4,CP:5,DC:4</availability>
-		</model>
 		<model name='TAV-1'>
 			<roles>artillery</roles>
 			<availability>FWL:6,IS:6,CP:6</availability>
+		</model>
+		<model name='Angel'>
+			<roles>artillery</roles>
+			<availability>LA:4,ROS:4,FWL:5,FS:4,CP:5,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
@@ -16213,12 +16213,6 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:5,ROS:6,DC:4</availability>
-		<model name='TFT-A9'>
-			<availability>ROS:8,General:4</availability>
-		</model>
-		<model name='TFT-F11'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
@@ -16226,18 +16220,24 @@
 		<model name='TFT-L8'>
 			<availability>LA:8</availability>
 		</model>
+		<model name='TFT-F11'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='TFT-A9'>
+			<availability>ROS:8,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:6,MERC:4</availability>
-		<model name='TDK-7KMA'>
-			<roles>missile_artillery</roles>
-			<availability>LA:6,ROS:6,MERC:4</availability>
-		</model>
 		<model name='TDK-7S'>
 			<availability>LA:8,ROS:6,MERC:6</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7KMA'>
+			<roles>missile_artillery</roles>
+			<availability>LA:6,ROS:6,MERC:4</availability>
 		</model>
 		<model name='TDK-7Y'>
 			<availability>LA:4,ROS:4</availability>
@@ -16245,51 +16245,51 @@
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
 		<availability>CHH:5</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='2 &apos;Fire Stallion&apos;'>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,RF:5,MERC:4,DA:5,TC:4</availability>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-1L'>
-			<availability>General:4</availability>
-		</model>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-C4'>
 			<availability>CC:4,MOC:4,CC.LCC:6</availability>
+		</model>
+		<model name='THR-1L'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CP:8,DC:4</availability>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
-		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Pulse Laser]' mechanized='true'>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[ER Laser]' mechanized='true'>
+		<model name='[Pulse Laser]' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird II Battle Armor' unitType='BattleArmor'>
@@ -16306,13 +16306,13 @@
 		<model name='TRB-D50'>
 			<availability>TC:8</availability>
 		</model>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
 		</model>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -16327,38 +16327,44 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:4,LA:6,ROS:5,MH:4,FS:5,MERC:6,Periphery:2,TC:4,DC:3</availability>
-		<model name='TDR-1C'>
-			<availability>MOC:1-,TC:1-</availability>
-		</model>
-		<model name='TDR-60-RLA'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
-		</model>
-		<model name='TDR-9T'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:2,MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MH:4,MERC:2,CP:2</availability>
+		</model>
+		<model name='TDR-17S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='TDR-60-RLA'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
 		</model>
 		<model name='TDR-9M'>
 			<availability>MOC:3,CC:3,PIR:3,FWL:5,MH:3,DA:5,MERC:4,CP:5</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='TDR-9T'>
+			<availability>TC:5</availability>
+		</model>
+		<model name='TDR-1C'>
+			<availability>MOC:1-,TC:1-</availability>
+		</model>
 		<model name='TDR-5Sb'>
 			<availability>TC:6</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:4,MERC:4</availability>
@@ -16369,21 +16375,9 @@
 		<model name='TDR-10S'>
 			<availability>LA:6,MERC:6</availability>
 		</model>
-		<model name='TDR-17S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:6,MOC:3,TC:3</availability>
-		<model name='TSG-9J'>
-			<availability>General:5</availability>
-		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC:6,CC.WHO:8</availability>
-		</model>
 		<model name='TSG-10L'>
 			<roles>spotter</roles>
 			<availability>CC:6</availability>
@@ -16391,9 +16385,15 @@
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
+		<model name='TSG-9DDC'>
+			<availability>CC:6,CC.WHO:8</availability>
+		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='TSG-9J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat II' unitType='Dropship'>
@@ -16410,11 +16410,11 @@
 	</chassis>
 	<chassis name='Tian-Zong' unitType='Mek'>
 		<availability>CC:6+,MOC:5+</availability>
-		<model name='TNZ-N1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='TNZ-N2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='TNZ-N1'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TNZ-N3'>
 			<availability>General:3</availability>
@@ -16443,13 +16443,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,RA:5</availability>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:8</availability>
+		</model>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(2953)'>
 			<roles>asf_carrier</roles>
@@ -16467,15 +16467,6 @@
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CP:5,DC:8</availability>
-		<model name='TKG-151'>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>ROS:8,DC:8</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>CDS:8,ROS:6,CP:8,DC:6</availability>
 		</model>
@@ -16483,21 +16474,30 @@
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='TKG-151'>
+			<availability>DC:1-</availability>
+		</model>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
+		</model>
 		<model name='TKG-150'>
 			<availability>DC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CWE:6,CHH:4</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>urban</roles>
@@ -16506,8 +16506,8 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CWE:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
@@ -16516,15 +16516,12 @@
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
 		<availability>CWE:1</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
@@ -16533,6 +16530,9 @@
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -16544,14 +16544,10 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:1,MH:1,CP:1</availability>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Small Laser]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,CP:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
@@ -16563,19 +16559,23 @@
 		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tortoise II' unitType='BattleArmor'>
 		<availability>ROS:3</availability>
-		<model name='(C3)' mechanized='false'>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)' mechanized='false'>
+		<model name='(SRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(aSRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(SRM)' mechanized='false'>
+		<model name='(C3)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -16601,11 +16601,11 @@
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
-		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
+		</model>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
 		</model>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -16616,12 +16616,12 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
-		<model name='TR-12'>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='TR-12'>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -16651,16 +16651,16 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,CP:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>MOC:4-,Periphery:4-</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>RF:4,ROS:5,FWL:4,MERC:4,CP:4</availability>
-		</model>
 		<model name='TBT-K7R'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TBT-XK7'>
+			<roles>fire_support</roles>
+			<availability>TC:6</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
@@ -16670,16 +16670,16 @@
 			<roles>fire_support</roles>
 			<availability>ROS:6,FWL:4,MERC:5,CP:4</availability>
 		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>RF:4,ROS:5,FWL:4,MERC:4,CP:4</availability>
+		</model>
 		<model name='TBT-9R'>
 			<availability>RF:8</availability>
 		</model>
-		<model name='TBT-9K'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='TBT-XK7'>
-			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>MOC:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -16693,28 +16693,28 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>MOC:8,CC:8,MH:4,TC:8</availability>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(Asterion)[MRR]' mechanized='true'>
-			<availability>MH:2,TC:2</availability>
-		</model>
-		<model name='(Ying Long)(Plasma)' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
-		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
 			<availability>TC:6</availability>
+		</model>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Theseus RL)[LRR]' mechanized='true'>
 			<availability>MOC:6</availability>
 		</model>
+		<model name='(Ying Long)(Plasma)' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
 		<model name='(Asterion)[PPC]' mechanized='true'>
 			<availability>MH:2,TC:2</availability>
 		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+		<model name='(Asterion)[MRR]' mechanized='true'>
+			<availability>MH:2,TC:2</availability>
+		</model>
+		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
@@ -16731,13 +16731,13 @@
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
 		<availability>CHH:5,CLAN:2,IS:9,Periphery.Deep:7,BAN:7,Periphery:9</availability>
-		<model name='(2593)'>
-			<roles>vee_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3057)'>
 			<roles>vee_carrier</roles>
 			<availability>IS:6,DC:8</availability>
+		</model>
+		<model name='(2593)'>
+			<roles>vee_carrier</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
@@ -16745,14 +16745,14 @@
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
 		</model>
+		<model name='CMT-7T'>
+			<availability>CC:6</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:5,CC:5,MERC:4,DA:4</availability>
-		</model>
-		<model name='CMT-7T'>
-			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -16791,19 +16791,19 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CWE:6+,ROS:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='3'>
 			<availability>CWE:3,ROS:2</availability>
-		</model>
-		<model name='4'>
-			<availability>General:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CWE:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -16816,52 +16816,52 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>RD:4,CLAN:2</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:6,General:2</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:6,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:5,CP:4,CJF:7</availability>
+		<model name='C'>
+			<availability>CWE:7,CHH:7,CP:7,CJF:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,CHH:6,CP:6,CJF:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:9,RD:9,General:7</availability>
+		</model>
 		<model name='A'>
 			<availability>CWE:7,CHH:7,CP:7,CJF:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CWE:8,CHH:8,CP:8,CJF:8</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,CHH:6,CP:6,CJF:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,CHH:7,CP:7,CJF:7</availability>
+		<model name='H'>
+			<availability>CWE:6,CHH:5,CP:5,CJF:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CWE:4,CHH:4,CP:4,CJF:4</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:9,RD:9,General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CWE:6,CHH:5,CP:5,CJF:5</availability>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -16870,13 +16870,13 @@
 			<roles>urban</roles>
 			<availability>General:4,FS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -16888,17 +16888,20 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,CP:4,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -16906,18 +16909,33 @@
 			<roles>assault</roles>
 			<availability>RD:4,CHH:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,CHH:2,MERC.WD:1,MERC:2+,CJF:3,RA:3,CWIE:2</availability>
-		<model name='F'>
-			<availability>CWE:4,CHH:6,RD:5,CDS:4,CLAN:3,IS:1,CP:4,CJF:4</availability>
+		<model name='B'>
+			<availability>CWE:6,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:4,RD:1,CDS:2,General:1,CP:2,CJF:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>CWE:2,CHH:5,RD:2,CDS:4,General:4,CP:3,CWIE:2</availability>
+		</model>
+		<model name='W'>
+			<roles>training</roles>
+			<availability>CWE:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
+		<model name='I'>
+			<availability>General:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='R'>
 			<availability>General:6</availability>
@@ -16926,38 +16944,20 @@
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CWE:6,RD:2,General:2,CWIE:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CDS:4,General:2,CP:4,CWIE:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:6,RD:4,CDS:6,General:5,CP:6,CJF:6,CWIE:6</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>RD:8,CDS:9,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:4,RD:1,CDS:2,General:1,CP:2,CJF:2,CWIE:4</availability>
+		<model name='E'>
+			<availability>CWE:4,CDS:4,General:2,CP:4,CWIE:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CWE:4,CHH:6,RD:5,CDS:4,CLAN:3,IS:1,CP:4,CJF:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,IS:2,CP:5</availability>
 		</model>
-		<model name='W'>
-			<roles>training</roles>
-			<availability>CWE:3,General:1,CWIE:2</availability>
-		</model>
-		<model name='I'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>CWE:6,CHH:6,RD:4,CDS:6,General:5,CP:6,CJF:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Umbra' unitType='Aero'>
@@ -16969,11 +16969,11 @@
 	</chassis>
 	<chassis name='Undine Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CDS:4,CP:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -16985,13 +16985,13 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:4</availability>
-		<model name='(3071)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(3071)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -17024,17 +17024,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='UM-R69'>
-			<roles>urban</roles>
-			<availability>FWL:6,IS:6,CP:6,Periphery:6</availability>
-		</model>
-		<model name='UM-R68'>
-			<roles>urban</roles>
-			<availability>CC:6,FS:6,DC:6</availability>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:4,Periphery:4</availability>
 		</model>
 		<model name='UM-R60L'>
 			<roles>urban</roles>
@@ -17044,31 +17037,38 @@
 			<roles>urban</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R68'>
 			<roles>urban</roles>
-			<availability>Periphery:2-</availability>
+			<availability>CC:6,FS:6,DC:6</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:4,MOC:4,FS.CMM:6,FWL:4,FS:4,CP:4</availability>
 		</model>
+		<model name='UM-R60'>
+			<roles>urban</roles>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='UM-R63'>
 			<roles>urban</roles>
 			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:4,Periphery:4</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='UM-R69'>
+			<roles>urban</roles>
+			<availability>FWL:6,IS:6,CP:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursa' unitType='Mek'>
 		<availability>LA:7,ROS:5,MERC:6,CJF:5,CWIE:5</availability>
-		<model name='URA-2A'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='URA-2C'>
 			<availability>LA:4,ROS:4,CLAN:8,MERC:4</availability>
+		</model>
+		<model name='URA-2A'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -17084,10 +17084,6 @@
 			<deployedWith>IS</deployedWith>
 			<availability>RD:1</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>RD:1</availability>
-		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
@@ -17096,6 +17092,10 @@
 		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>RD:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -17128,13 +17128,13 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:2,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
+		<model name='VLK-QD3'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:6,ROS:4,MERC:4</availability>
-		</model>
-		<model name='VLK-QD'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
@@ -17144,21 +17144,21 @@
 			<roles>recon,fire_support</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
-		<model name='VLK-QD1'>
+		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QT2'>
 			<roles>recon</roles>
 			<availability>TC:8</availability>
 		</model>
-		<model name='VLK-QD3'>
-			<roles>recon,fire_support</roles>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QD4'>
 			<roles>recon,fire_support</roles>
 			<availability>ROS:6,FS:6</availability>
+		</model>
+		<model name='VLK-QD1'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,ROS:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
@@ -17173,38 +17173,38 @@
 		<model name='D'>
 			<availability>CWE:4,CHH:6,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='E'>
-			<roles>recon</roles>
-			<availability>CWE:4,CLAN:2,CJF:4</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='E'>
+			<roles>recon</roles>
+			<availability>CWE:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5</availability>
-		<model name='LI-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='LI-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LI-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='LI-O'>
-			<availability>General:8</availability>
+		<model name='LI-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -17216,46 +17216,46 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CWE:4,CHH:5,IS:10,CJF:4,Periphery:10</availability>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
 		<model name='V9'>
 			<availability>LA:4,CLAN:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>CC:5,MOC:5,RF:5,FWL:4,DA:5,CP:4,CDP:5,TC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='V7'>
 			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
 		</model>
+		<model name='(LB-X)'>
+			<availability>CC:5,MOC:5,RF:5,FWL:4,DA:5,CP:4,CDP:5,TC:5</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='(Cell)'>
 			<availability>CC:6,LA:4,FWL:6,IS:4,FS:4,MERC:5,CP:6,DC:4,Periphery:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,TC:1,DC:4</availability>
-		<model name='(2682)'>
+		<model name='(3056)'>
 			<roles>asf_carrier</roles>
-			<availability>General:2</availability>
+			<availability>IS:4,FS:8</availability>
 		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:4,CC:4</availability>
 		</model>
-		<model name='(3056)'>
+		<model name='(2682)'>
 			<roles>asf_carrier</roles>
-			<availability>IS:4,FS:8</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -17275,51 +17275,51 @@
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:4</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,FS:7,Periphery.OS:2,CP:2,Periphery:3,TC:2,DC:4</availability>
-		<model name='VTR-9B'>
-			<availability>Periphery:2-</availability>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-Cr'>
 			<availability>FS:1,DC:2</availability>
 		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
+		<model name='VTR-9Ka'>
+			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
 		</model>
-		<model name='VTR-C'>
-			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-9B'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -17337,16 +17337,16 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>RD:7,ROS:6,MERC:5</availability>
+		<model name='VKG-3A'>
+			<roles>missile_artillery</roles>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
 		<model name='VKG-2G'>
 			<availability>RD:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-3A'>
-			<roles>missile_artillery</roles>
-			<availability>ROS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -17362,20 +17362,20 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:5,MERC:4,TC:6</availability>
-		<model name='VND-5L'>
-			<availability>CC:2,MOC:1,MERC:1</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:8,MOC:6</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:2,MOC:2,General:2,TC:2</availability>
 		</model>
+		<model name='VND-4L'>
+			<availability>CC:8,MOC:6</availability>
+		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
+		<model name='VND-5L'>
+			<availability>CC:2,MOC:1,MERC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -17401,49 +17401,49 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:6,RA:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CHH:5,CJF:3</availability>
+		<model name='5'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CJF:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CP:5,DC:6+</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>DC:8</availability>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:6</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>DC:8</availability>
+		</model>
 		<model name='(Nova Cat)' mechanized='true'>
 			<availability>CP:8</availability>
-		</model>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -17459,32 +17459,24 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PIR:2,FS:1,DC:2</availability>
-		<model name='VNL-K75N'>
-			<availability>LA:8,FWL:8,FS:8,CP:8,DC:8</availability>
-		</model>
 		<model name='VNL-X71 (Yakuza)'>
 			<availability>PIR:8</availability>
+		</model>
+		<model name='VNL-K75N'>
+			<availability>LA:8,FWL:8,FS:8,CP:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-8N'>
 			<availability>General:4,FS:8,CDP:4</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>MOC:4,RD:4,LA:4,FWL:4,IS:1,CP:4,Periphery:4,TC:4</availability>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>FWL:4,DA:6,CP:4</availability>
-		</model>
-		<model name='VL-2T'>
-			<roles>anti_infantry</roles>
-			<availability>FVC:2-,General:2-</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,FVC:2,PIR:2,IS:2,Periphery:2,TC:2</availability>
@@ -17493,9 +17485,17 @@
 			<roles>anti_infantry</roles>
 			<availability>FWL:8,MERC:3,CP:8,DC:3</availability>
 		</model>
+		<model name='VL-2T'>
+			<roles>anti_infantry</roles>
+			<availability>FVC:2-,General:2-</availability>
+		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:6,RD:6,LA:6,ROS:6,MH:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>FWL:4,DA:6,CP:4</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -17510,63 +17510,63 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:4,RD:4,ROS:4+,CLAN:3,MERC:2+,CJF:3,BAN:5,CWIE:4,DC:3+</availability>
+		<model name='G'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>CWE:7,CDS:7,General:6,CP:7,CJF:5</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:7,RD:4,CDS:7,General:6,CP:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,General:8,CP:7,CJF:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:5,RD:3,CDS:7,General:5,CP:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:4,CHH:5,CDS:3,General:2,CP:3,CJF:4</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,CP:5,RA:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:5,RD:3,CDS:7,General:5,CP:7</availability>
+		</model>
 		<model name='F'>
 			<availability>CWE:5,CHH:6,CDS:4,CLAN:3,General:2,CP:4,CJF:5</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CHH:5,CDS:3,General:2,CP:3,CJF:4</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='G'>
-			<availability>General:6</availability>
+		<model name='A'>
+			<availability>CWE:7,RD:4,CDS:7,General:6,CP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture Mk III (Mad Dog Mk III)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,ROS:5,RA:8</availability>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture Mk IV (Mad Dog Mk IV)' unitType='Mek' omni='Clan'>
 		<availability>IS:5+,CLAN.IS:7</availability>
-		<model name='A'>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
@@ -17590,26 +17590,27 @@
 	</chassis>
 	<chassis name='Warg Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Reactive)' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:3,CLAN:7,IS:4,TC:3</availability>
-		<model name='9'>
-			<availability>CDS:6,CP:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4,CP:5</availability>
-		</model>
 		<model name='10'>
 			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
 		</model>
-		<model name='8'>
-			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
+		<model name='11'>
+			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>IS:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
 		</model>
 		<model name='12'>
 			<availability>CDS:5,CP:5</availability>
@@ -17617,34 +17618,38 @@
 		<model name='6'>
 			<availability>RD:6,RA:6</availability>
 		</model>
-		<model name='7'>
-			<availability>RA:7</availability>
-		</model>
 		<model name='4'>
 			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,FS:4,CP:5,RA:5,CWIE:5,DC:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
+		<model name='7'>
+			<availability>RA:7</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>IS:3</availability>
+		<model name='5'>
+			<availability>CDS:5,IS:4,CP:5</availability>
 		</model>
-		<model name='11'>
-			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
+		<model name='8'>
+			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
+		</model>
+		<model name='9'>
+			<availability>CDS:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>LA:6,IS:6,FWL:6,CP:6,TC:8,Periphery:5</availability>
-		<model name='WHM-9S'>
-			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
+		<model name='WHM-5L'>
+			<availability>CC:6</availability>
 		</model>
-		<model name='WHM-8M'>
-			<availability>RF:6,FWL:4,CP:4</availability>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:8,MERC:4</availability>
 		</model>
-		<model name='WHM-7K'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
+		<model name='WHM-8D2'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
 		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:2,PIR:4,IS:2,MH:4,FS:2,MERC:3,CDP:4,TC:4</availability>
@@ -17652,47 +17657,42 @@
 		<model name='WHM-6R'>
 			<availability>BAN:8,Periphery:2-</availability>
 		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6,MOC:4</availability>
+		<model name='WHM-10T'>
+			<availability>FS:4,TC:8</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>RF:6,FWL:4,CP:4</availability>
 		</model>
 		<model name='WHM-11T'>
 			<availability>MOC:4,TC:6</availability>
 		</model>
-		<model name='WHM-8K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:4,LA:4,ROS:4</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:6</availability>
+		<model name='WHM-6Rb'>
+			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
 		</model>
 		<model name='WHM-7M'>
 			<availability>CC:3,FVC:3,ROS:4,FWL:4,CP:4,Periphery:3</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
+		<model name='WHM-9S'>
+			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:8,MERC:4</availability>
+		<model name='WHM-4L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:4,TC:8</availability>
+		<model name='WHD-10CT'>
+			<availability>CC:4,LA:4,ROS:4</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
+		<model name='WHM-7K'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:6</availability>
-		<model name='BLR-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BLR-2G'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BLR-2D'>
+			<availability>General:8</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:6</availability>
@@ -17700,21 +17700,21 @@
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,MH:6,DC:4</availability>
+		<model name='H-9'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='H-7'>
 			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='H-10'>
-			<roles>apc</roles>
-			<availability>LA:4,FWL:4,CP:6,CWIE:8</availability>
-		</model>
-		<model name='H-8'>
-			<availability>RD:8,LA:3,FS.CH:8,ROS:6,IS:6,FWL:3,FS:6,CP:3,RA:8</availability>
 		</model>
 		<model name='H-7A'>
 			<availability>IS:1-,Periphery:1-</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:6</availability>
+		<model name='H-8'>
+			<availability>RD:8,LA:3,FS.CH:8,ROS:6,IS:6,FWL:3,FS:6,CP:3,RA:8</availability>
+		</model>
+		<model name='H-10'>
+			<roles>apc</roles>
+			<availability>LA:4,FWL:4,CP:6,CWIE:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -17726,15 +17726,9 @@
 	</chassis>
 	<chassis name='Warwolf' unitType='Mek' omni='Clan'>
 		<availability>CWE:3+</availability>
-		<model name='C'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
@@ -17742,68 +17736,74 @@
 		<model name='H'>
 			<availability>General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>IS:8,Periphery:6,RA:4</availability>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
-		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:2,LA:3,MERC:2</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
-		</model>
-		<model name='WSP-3L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
-		</model>
-		<model name='WSP-3P'>
-			<availability>FVC:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:6,RA:8</availability>
 		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
+		</model>
+		<model name='WSP-3P'>
+			<availability>FVC:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='WSP-3K'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-3L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
 		<availability>MOC:4,FVC:5,FS:8,MERC:5,CDP:5,DC:4</availability>
-		<model name='WTC-4M'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WTC-4DM'>
 			<availability>FVC:6,FS:6,CDP:4,DC:4</availability>
+		</model>
+		<model name='WTC-4M'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wendigo-VP' unitType='Mek' omni='Clan'>
 		<availability>FWL:1,CP:1,DC:1</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wendigo' unitType='Mek' omni='Clan'>
@@ -17823,19 +17823,19 @@
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
 		<availability>CJF:1,RA:2</availability>
-		<model name='(2606)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2901)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2606)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Whitworth' unitType='Mek'>
 		<availability>FVC:1,FS.CMM:1,MERC:1,DC:1,Periphery:1</availability>
-		<model name='WTH-3'>
-			<availability>FS.CMM:8</availability>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
 		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
@@ -17844,23 +17844,20 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:6,MH:6,MERC:6,CDP:6,TC:6</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
-		</model>
 		<model name='WTH-K'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='WTH-3'>
+			<availability>FS.CMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:6,LA:5,FWL:5,IS:4,CP:3-,MERC:5,DC:8</availability>
-		<model name='WGT-2LAW'>
+		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>ROS:5,DC:6</availability>
-		</model>
-		<model name='WGT-2LAWC3'>
-			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>LA:4,FWL:4,IS:4,MERC:4,CP:4,DC:4</availability>
@@ -17871,33 +17868,36 @@
 		<model name='WGT-3SC'>
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
+		<model name='WGT-2LAW'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
 		<availability>LA:8</availability>
-		<model name='WKT-1S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='WKT-2S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='WKT-1S'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:5,ROS.pm:8</availability>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(TSEMP)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Support)'>
-			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(XXL)'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Support)'>
+			<roles>fire_support,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(LAC)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -17909,11 +17909,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>ROS:2,MERC:2,DC:5-</availability>
-		<model name='WFT-2'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-B'>
-			<availability>ROS:6</availability>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:6</availability>
 		</model>
 		<model name='WFT-1'>
 			<availability>General:4</availability>
@@ -17921,51 +17918,43 @@
 		<model name='WFT-C'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:6</availability>
+		<model name='WFT-2'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WFT-B'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,MERC.WD:5,FVC:1,LA:7,ROS:5,FWL:3,MH:4,MERC:4,FS:1,CP:3,CWIE:5</availability>
-		<model name='WLF-4WA'>
-			<roles>ew_support</roles>
-			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
-		</model>
-		<model name='WLF-1'>
-			<availability>Periphery.Deep:6,Periphery:8</availability>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-3M'>
 			<availability>FWL:8,CP:8</availability>
 		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
 		<model name='WLF-2H'>
 			<availability>LA:6,MERC:3,CWIE:4</availability>
 		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		<model name='WLF-1'>
+			<availability>Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='WLF-4WA'>
+			<roles>ew_support</roles>
+			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,RD:2,LA:5,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
-		</model>
-		<model name='WVR-9D'>
-			<roles>spotter</roles>
-			<availability>FS:6,MERC:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>RD:5,ROS:4,MERC:3,CP:4</availability>
-		</model>
 		<model name='WVR-9W2'>
 			<availability>IS:4,DC:8</availability>
 		</model>
@@ -17973,48 +17962,59 @@
 			<roles>recon</roles>
 			<availability>RD:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:2-,PIR:2-,Periphery.ME:2-,MH:2-</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:4,DC:8</availability>
+		<model name='WVR-9D'>
+			<roles>spotter</roles>
+			<availability>FS:6,MERC:4</availability>
 		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>RD:5,ROS:4,MERC:3,CP:4</availability>
+		</model>
 		<model name='WVR-9M'>
 			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4,CP:6</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:6</availability>
+		</model>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:4,DC:8</availability>
+		</model>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
 		</model>
 		<model name='WVR-7D'>
 			<roles>recon</roles>
 			<availability>FVC:4,LA:2,ROS:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:6</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:2-,PIR:2-,Periphery.ME:2-,MH:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,RD:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -18028,16 +18028,19 @@
 	</chassis>
 	<chassis name='Wulfen' unitType='Mek' omni='Clan'>
 		<availability>CWE:6+</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='H'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
@@ -18045,9 +18048,6 @@
 		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Wurger Assault Craft' unitType='Small Craft'>
@@ -18059,19 +18059,19 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -18087,13 +18087,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>DC.GHO:2,CC:1,FVC:2,RF:1,ROS:5,IS:1,FS:7,MERC:5,DA:1,DC:6</availability>
-		<model name='WVE-5N'>
-			<roles>urban</roles>
-			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
-		</model>
 		<model name='WVE-9N'>
 			<roles>urban</roles>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='WVE-5N'>
+			<roles>urban</roles>
+			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -18109,20 +18109,20 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,DA:4,Periphery:2,TC:4</availability>
+		<model name='XNT-4O'>
+			<availability>CC:6,MOC:6,LA:6</availability>
+		</model>
 		<model name='XNT-6O'>
 			<availability>CC:6,MOC:6,DA:8</availability>
+		</model>
+		<model name='XNT-7O'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='XNT-2O'>
 			<availability>General:1-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:6,MOC:6,LA:6,ROS:6,MERC:6</availability>
-		</model>
-		<model name='XNT-4O'>
-			<availability>CC:6,MOC:6,LA:6</availability>
-		</model>
-		<model name='XNT-7O'>
-			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -18134,14 +18134,14 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
+		<model name='2'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Xiphos Assault Battle Armor' unitType='BattleArmor'>
@@ -18149,10 +18149,10 @@
 		<model name='(C)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(A)' mechanized='false'>
+		<model name='(B)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(B)' mechanized='false'>
+		<model name='(A)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -18164,6 +18164,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:4,CDS:4,IS:5,CP:4,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='&apos;Spectre&apos;'>
 			<availability>General:3</availability>
 		</model>
@@ -18171,18 +18174,9 @@
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2,FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -18190,8 +18184,14 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:5</availability>
+		</model>
 		<model name='(PPC)'>
 			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
@@ -18227,18 +18227,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H9G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='Y-H10G'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Y-H9G'>
+			<availability>General:8</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yun' unitType='Aero'>
@@ -18257,19 +18257,25 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>DC.GHO:2,CLAN:3,MERC:4,DC:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<deployedWith>Chaparral</deployedWith>
-			<availability>CHH:6,CLAN:4,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
 			<availability>MERC:8,DC:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<deployedWith>Chaparral</deployedWith>
+			<availability>CHH:6,CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank' omni='IS'>
 		<availability>ROS:3</availability>
+		<model name='(Omnidrone) C'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) Prime'>
+			<availability>ROS:6</availability>
+		</model>
 		<model name='(Omnidrone) B'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
@@ -18277,12 +18283,6 @@
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='(Omnidrone) Prime'>
-			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
@@ -18304,38 +18304,38 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:7,ROS:3</availability>
-		<model name='ZEU-X2'>
-			<availability>LA:3-</availability>
+		<model name='ZEU-9WD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:2-</availability>
 		</model>
+		<model name='ZEU-X4'>
+			<availability>LA:8</availability>
+		</model>
 		<model name='ZEU-X'>
 			<availability>LA:2-</availability>
 		</model>
-		<model name='ZEU-9WD'>
-			<availability>General:4</availability>
-		</model>
-		<model name='ZEU-X4'>
-			<availability>LA:8</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,ROS:5,PIR:2,MH:2,FS:1-,MERC:5,CDP:2,TC:2</availability>
-		<model name='ZEU-9S'>
-			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:8,MERC:4</availability>
 		</model>
 		<model name='ZEU-6S'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-9S'>
+			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -18359,29 +18359,29 @@
 	</chassis>
 	<chassis name='Zibler Fast Strike Tank' unitType='Tank' omni='IS'>
 		<availability>LA:6,ROS:5,IS:4,FS:8</availability>
-		<model name='(C)'>
+		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(B)'>
-			<availability>General:7</availability>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
+		<model name='(C)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CWE:10,ROS:6,CLAN:9</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(ATM)'>
 			<availability>CWE:6,ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>CHH:5,CLAN:4,CJF:1</availability>
@@ -18398,19 +18398,19 @@
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>RD:2,LA:4,IS:2,Periphery:2</availability>
+		<model name='F'>
+			<roles>support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='Prime'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='E'>
-			<roles>support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
@@ -18421,7 +18421,7 @@
 		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
+		<model name='C'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>

--- a/megamek/data/mechfiles/mechs/LAMS/Wasp LAM Mk I WSP-100.mtf
+++ b/megamek/data/mechfiles/mechs/LAMS/Wasp LAM Mk I WSP-100.mtf
@@ -3,32 +3,33 @@ Wasp LAM Mk I
 WSP-100
 
 Config:LAM
-TechBase:Inner Sphere
-Era:2690
-Source:TRO3085
-Rules Level:3
+techbase:Inner Sphere
+era:2690
+source:TRO3085
+rules level:3
 
-Mass:30
-Engine:150 Fusion Engine(IS)
-Structure:IS Standard
-Myomer:Standard
+mass:30
+engine:150 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+lam:Standard
 
-Heat Sinks:10 Single
-Walk MP:5
-Jump MP:4
+heat sinks:10 Single
+walk mp:5
+jump mp:4
 
-Armor:Standard(Inner Sphere)
-LA Armor:5
-RA Armor:5
-LT Armor:8
-RT Armor:8
-CT Armor:9
-HD Armor:8
-LL Armor:7
-RL Armor:7
-RTL Armor:2
-RTR Armor:2
-RTC Armor:3
+armor:Standard(Inner Sphere)
+LA armor:5
+RA armor:5
+LT armor:8
+RT armor:8
+CT armor:9
+HD armor:8
+LL armor:7
+RL armor:7
+RTL armor:2
+RTR armor:2
+RTC armor:3
 
 Weapons:2
 Medium Laser, Right Arm
@@ -80,11 +81,11 @@ Right Torso:
 Landing Gear
 Avionics
 Heat Sink
-Cargo (1 ton)
-Cargo (1 ton)
-Cargo (1 ton)
-Cargo (1 ton)
-Cargo (1 ton)
+Bomb Bay
+Bomb Bay
+Bomb Bay
+Bomb Bay
+Bomb Bay
 -Empty-
 -Empty-
 -Empty-


### PR DESCRIPTION
Investigating relative rarity of LAMs based on a forum report, the Stinger and Wasp LAMs in 3067 show up as being more common than actual Stingers and Wasps, which doesn't seem right. Toned that down.

Also, gave the Wasp Mk I WSP-100 actual bomb bays instead of cargo bays.

A note on the force generator changes: I only changed rarities for Wasp and Stinger LAMs, but, for some reason, the RAT generator editor insists on arbitrarily re-ordering the XML elements in the files each time they are saved. I'll take a look at that some other time.