### PR TITLE
fix npe when displaying summary/TRO for gun emplacements

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/gunemplacement.ftl
+++ b/megamek/resources/megamek/common/templates/tro/gunemplacement.ftl
@@ -1,0 +1,51 @@
+${fullName}
+
+<#if includeFluff>
+<#include "fluff.ftl">
+</#if>
+
+Type: ${chassis}
+Technology Base: ${techBase} 
+Movement Type: ${moveType}
+Tonnage: ${tonnage}
+Battle Value: ${battleValue}
+
+${formatBasicDataRow("Equipment", "", "Mass")}
+${formatBasicDataRow("Internal Structure", "", isMass)}
+${formatBasicDataRow("Heat Sinks:", hsCount, hsMass)}
+${formatBasicDataRow("Control Equipment:", "", controlMass)}
+<#if liftMass gt 0>
+${formatBasicDataRow("Lift Equipment:", "", liftMass)}
+</#if>
+${formatBasicDataRow("Power Amplifier:", "", amplifierMass)}
+<#if hasTurret2>
+${formatBasicDataRow("Rear Turret:", "", turretMass)}
+${formatBasicDataRow("Front Turret:", "", turretMass2)}
+<#elseif hasTurret>
+${formatBasicDataRow("Turret:", "", turretMass)}
+</#if>
+
+
+<#if isOmni>
+Fixed Equipment
+	<#if fixedTonnage gt 0>
+${formatBasicDataRow("Location", "Fixed", "Tonnage")}	
+	<#list fixedEquipment as row>
+		<#if row.equipment != "None">
+${formatBasicDataRow(row.location, row.equipment, row.tonnage)}
+		</#if>
+	</#list>
+	<#else>
+None
+	</#if>
+</#if>
+
+Weapons
+${formatEquipmentRow("and Ammo", "Location", "Tonnage")}	
+<#list equipment as eq>
+${formatEquipmentRow(eq.name, eq.location, eq.tonnage)}
+</#list>
+	
+<#if quirks??>
+Features the following design quirks: ${quirks}
+</#if>

--- a/megamek/resources/megamek/common/templates/tro/gunemplacement.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/gunemplacement.ftlh
@@ -1,0 +1,65 @@
+<html>
+<head>
+  <title>${fullName}</title>
+</head>
+<body>
+  <div style="font:12pt monospaced">
+  <font size="+1"><b>${fullName}</b></font>
+<#if includeFluff>
+<#include "fluff.ftlh">
+</#if>
+  
+	<p>
+	<b>Type:</b> ${chassis}<br/>
+	<b>Technology Base:</b> ${techBase}<br/> 
+	<b>Tonnage:</b> ${tonnage}<br/>
+	<b>Battle Value:</b> ${battleValue}<br/>
+	</p>
+	
+	<table>
+	<tr><th>Equipment</th><th/><th>Mass</th></tr>
+	<tr><td>Heat Sinks:</td><td align="center">${hsCount}</td><td align="center">${hsMass}</td></tr>
+	<tr><td>Control Equipment:</td><td></td><td align="center">${controlMass}</td</tr>
+<#if liftMass gt 0>
+	<tr><td>Lift Equipment:</td><td></td><td align="center">${liftMass}</td</tr>
+</#if>
+	<tr><td>Power Amplifier:</td><td></td><td align="center">${amplifierMass}</td</tr>
+<#if hasTurret2>
+	<tr><td>Rear Turret:</td><td></td><td align="center">${turretMass}</td</tr>
+	<tr><td>Front Turret:</td><td></td><td align="center">${turretMass2}</td</tr>
+<#elseif hasTurret>
+	<tr><td>Turret:</td><td></td><td align="center">${turretMass}</td</tr>
+</#if>
+	</table>
+	
+	<#if isOmni>
+	<b>Fixed Equipment</b><br/>
+		<#if fixedTonnage gt 0>
+			<table>
+			<tr><td><i>Location</i></td><td align="center"><i>Fixed</i></td><td align="center"><i>Tonnage</i></td></tr>
+			<#list fixedEquipment as row>
+				<#if row.equipment != "None">
+			<tr><td>${row.location}</td><td align="center">${row.equipment}</td><td align="center">${row.tonnage}</td></tr>
+				</#if>
+			</#list>
+			</table>
+		<#else>
+			None
+		</#if>
+	</#if>
+	
+	<table>
+		<tr><th align="left">Weapons<br/>and Ammo</th><th>Location</th><th>Critical</th><th>Tonnage</th></tr>
+		<#list equipment as eq>
+			<tr><td>${eq.name}</td><td align="center">${eq.location}</td><td align="center">${eq.slots}</td><td align="center">${eq.tonnage}</td></tr>
+		</#list>
+	</table>
+	
+	<#if quirks??>
+		<p>
+		Features the following design quirks: ${quirks}
+		</p>
+	</#if>
+	</div>
+</body>
+</html>

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1372,6 +1372,11 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
 
     public boolean isClanArmor(int loc) {
+        // if the location does not exist, it does not have clan armor
+        if (loc >= locations()) {
+            return false;
+        }
+        
         if (getArmorTechLevel(loc) == TechConstants.T_TECH_UNKNOWN) {
             return isClan();
         }

--- a/megamek/src/megamek/common/templates/VehicleTROView.java
+++ b/megamek/src/megamek/common/templates/VehicleTROView.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import megamek.common.Entity;
 import megamek.common.EntityFluff;
+import megamek.common.GunEmplacement;
 import megamek.common.Messages;
 import megamek.common.Mounted;
 import megamek.common.SuperHeavyTank;
@@ -44,6 +45,13 @@ public class VehicleTROView extends TROView {
 
     @Override
     protected String getTemplateFileName(boolean html) {
+        if(tank instanceof GunEmplacement) {
+            if (html) {
+                return "gunemplacement.ftlh";
+            }
+            return "gunemplacement.ftl";
+        }
+        
         if (html) {
             return "vehicle.ftlh";
         }

--- a/megamek/src/megamek/common/templates/VehicleTROView.java
+++ b/megamek/src/megamek/common/templates/VehicleTROView.java
@@ -45,11 +45,12 @@ public class VehicleTROView extends TROView {
 
     @Override
     protected String getTemplateFileName(boolean html) {
-        if(tank instanceof GunEmplacement) {
+        if (tank instanceof GunEmplacement) {
             if (html) {
                 return "gunemplacement.ftlh";
+            } else {
+                return "gunemplacement.ftl";
             }
-            return "gunemplacement.ftl";
         }
         
         if (html) {


### PR DESCRIPTION
This fixes #2022 in two ways:

1) isClanArmor no longer throws an exception if passed an invalid location, returning false instead
2) Created new TRO templates for gun emplacements which omit armor and structure information and selectively use those for the TRO display.