### PR TITLE
Recolor movement in tooltip for dark themes

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -348,15 +348,15 @@ BoardView1.Tooltip.Evade=<BR><I><FONT COLOR=RED>(Evading)</FONT></I>
 BoardView1.Tooltip.TakingCover=<BR><I><FONT COLOR=RED>(Taking Cover)</FONT></I>
 BoardView1.Tooltip.Charging=<BR><I><FONT COLOR=RED>(Charging)</FONT></I>
 BoardView1.Tooltip.DFA=<BR><I><FONT COLOR=RED>(Death from Above)</FONT></I>
-BoardView1.Tooltip.AeroVelocity=<I><FONT COLOR=#400040>Current Velocity: {0}</FONT></I>
+BoardView1.Tooltip.AeroVelocity=<I><FONT COLOR=#A030A0>Current Velocity: {0}</FONT></I>
 BoardView1.Tooltip.Heat0=<FONT COLOR=#008000><I>Heat: 0</I></FONT>
 BoardView1.Tooltip.Heat=<FONT COLOR=#FF0000><I>Heat: {0}</I></FONT>
 BoardView1.Tooltip.Jammed=<FONT COLOR=#FF0000>Jammed by Enemy ECM</FONT>
 BoardView1.Tooltip.Clan=C-
-BoardView1.Tooltip.NotYetMoved=<FONT COLOR=#400040><I>Has not yet moved</I></FONT>
-BoardView1.Tooltip.NoMove=<FONT COLOR=#400040><I>Did not move (Mod: {0})</I></FONT>
+BoardView1.Tooltip.NotYetMoved=<FONT COLOR=#A030A0><I>Has not yet moved</I></FONT>
+BoardView1.Tooltip.NoMove=<FONT COLOR=#A030A0><I>Did not move (Mod: {0})</I></FONT>
 BoardView1.Tooltip.Arrow=<FONT COLOR=#{0}>&#10145; </FONT>
-BoardView1.Tooltip.MovementF=<FONT COLOR=#400040><I>{0} {1} (Mod: {2})</I></FONT>
+BoardView1.Tooltip.MovementF=<FONT COLOR=#A030A0><I>{0} {1} (Mod: {2})</I></FONT>
 BoardView1.Tooltip.Weapon=&nbsp;{1}{2}
 BoardView1.Tooltip.WeaponN=&nbsp;<B>{0} x</B>  {1}{2}
 BoardView1.Tooltip.TurretLocked=<I><FONT COLOR=RED>Turret locked!</FONT><I>

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -954,29 +954,8 @@ class EntitySprite extends Sprite {
                     
                 // Unit did move
                 } else {
-                    // Colored arrow
-                    // get the color resource
-                    String guipName = "AdvancedMoveDefaultColor";
-                    if ((entity.moved == EntityMovementType.MOVE_RUN)
-                            || (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
-                            || (entity.moved == EntityMovementType.MOVE_OVER_THRUST)) 
-                        guipName = "AdvancedMoveRunColor";
-                    else if (entity.moved == EntityMovementType.MOVE_SPRINT
-                            || entity.moved == EntityMovementType.MOVE_VTOL_SPRINT) 
-                        guipName = "AdvancedMoveSprintColor";
-                    else if (entity.moved == EntityMovementType.MOVE_JUMP) 
-                        guipName = "AdvancedMoveJumpColor";
-
-                    // HTML color String from Preferences
-                    String moveTypeColor = Integer
-                            .toHexString(GUIPreferences.getInstance()
-                                    .getColor(guipName).getRGB() & 0xFFFFFF);
-
-                    // Arrow
-                    addToTT("Arrow", BR, moveTypeColor);
-
                     // Actual movement and modifier
-                    addToTT("MovementF", NOBR,
+                    addToTT("MovementF", BR,
                             entity.getMovementString(entity.moved),
                             entity.delta_distance,
                             tmm);


### PR DESCRIPTION
As the title says. Changed the color of the movement text to a lighter color that will work with both light and dark UI LookandFeels.

![image](https://user-images.githubusercontent.com/17069663/88464020-973e4900-ceb7-11ea-928b-177f3618dad3.png)
![image](https://user-images.githubusercontent.com/17069663/88464026-a1f8de00-ceb7-11ea-83e2-47bd47d71578.png)

Also removed the arrow because in some UI LookandFeels the arrow character didn't work and showed an empty box instead.

Resolves #2047 