### PR TITLE
fix tech level calculation for gun emplacements

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKGunEmplacementFile.java
+++ b/megamek/src/megamek/common/loaders/BLKGunEmplacementFile.java
@@ -64,6 +64,9 @@ public class BLKGunEmplacementFile extends BLKFile implements IMechLoader {
                 e.setHasNoTurret(true);
             }
         }
+        
+        // our gun emplacements do not support dual turrets at this time
+        e.setHasNoDualTurret(true);
 
         loadEquipment(e, "Guns", GunEmplacement.LOC_GUNS);
         e.setArmorTonnage(e.getArmorWeight());


### PR DESCRIPTION
For some reason, the "has no dual turret" property defaults to false. It's set explicitly when loading tanks, but not when loading gun emplacements, which throws off their tech progression calculation.