### PR TITLE
data corrections

### DIFF
--- a/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Dual).blk
+++ b/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Dual).blk
@@ -21,7 +21,7 @@ GunEmplacement
 </UnitType>
 
 <Name>
-Small Pulse Laser Turret
+Micro Pulse Laser Turret
 </Name>
 
 <Model>
@@ -29,7 +29,7 @@ Small Pulse Laser Turret
 </Model>
 
 <Year>
-2609
+3059
 </Year>
 
 <Type>
@@ -43,6 +43,6 @@ IS Level 3
 </Turret>
 
 <Guns Equipment>
-ISSmallPulseLaser
-ISSmallPulseLaser
+CLMicroPulseLaser
+CLMicroPulseLaser
 </Guns Equipment>

--- a/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Quad).blk
+++ b/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Quad).blk
@@ -19,7 +19,7 @@ GunEmplacement
 </UnitType>
 
 <Name>
-Small Pulse Laser Turret
+Micro Pulse Laser Turret
 </Name>
 
 <Model>
@@ -27,7 +27,7 @@ Small Pulse Laser Turret
 </Model>
 
 <Year>
-2609
+3059
 </Year>
 
 <Type>
@@ -39,8 +39,8 @@ IS Level 3
 </Turret>
 
 <Guns Equipment>
-ISSmallPulseLaser
-ISSmallPulseLaser
-ISSmallPulseLaser
-ISSmallPulseLaser
+CLMicroPulseLaser
+CLMicroPulseLaser
+CLMicroPulseLaser
+CLMicroPulseLaser
 </Guns Equipment>

--- a/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Single).blk
+++ b/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Single).blk
@@ -19,7 +19,7 @@ GunEmplacement
 </UnitType>
 
 <Name>
-Small Pulse Laser Turret
+Micro Pulse Laser Turret
 </Name>
 
 <Model>
@@ -27,7 +27,7 @@ Small Pulse Laser Turret
 </Model>
 
 <Year>
-2609
+3059
 </Year>
 
 <Type>
@@ -39,5 +39,5 @@ IS Level 3
 </Turret>
 
 <Guns Equipment>
-ISSmallPulseLaser
+CLMicroPulseLaser
 </Guns Equipment>

--- a/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Triple).blk
+++ b/megamek/data/mechfiles/ge/Clan/Laser/Pulse/CLPulseMicro Turret (Triple).blk
@@ -19,7 +19,7 @@ GunEmplacement
 </UnitType>
 
 <Name>
-Small Pulse Laser Turret
+Micro Pulse Laser Turret
 </Name>
 
 <Model>
@@ -27,7 +27,7 @@ Small Pulse Laser Turret
 </Model>
 
 <Year>
-2609
+3059
 </Year>
 
 <Type>
@@ -39,7 +39,7 @@ IS Level 3
 </Turret>
 
 <Guns Equipment>
-ISSmallPulseLaser
-ISSmallPulseLaser
-ISSmallPulseLaser
+CLMicroPulseLaser
+CLMicroPulseLaser
+CLMicroPulseLaser
 </Guns Equipment>

--- a/megamek/data/mechfiles/mechs/LAMS/Pwwka S-PW-1LAM.mtf
+++ b/megamek/data/mechfiles/mechs/LAMS/Pwwka S-PW-1LAM.mtf
@@ -17,8 +17,6 @@ cockpit:Small Cockpit
 gyro:Standard Gyro
 
 heat sinks:10 Double
-nocrit:Standard:None
-nocrit:Standard:None
 walk mp:6
 jump mp:6
 
@@ -108,7 +106,7 @@ Fusion Engine
 Fusion Engine
 Fusion Engine
 Landing Gear
-Cargo (1 ton)
+Bomb Bay
 
 Head:
 Life Support

--- a/megamek/data/mechfiles/mechs/LAMS/Screamer LAM SCR-1X-LAM.mtf
+++ b/megamek/data/mechfiles/mechs/LAMS/Screamer LAM SCR-1X-LAM.mtf
@@ -3,32 +3,33 @@ Screamer LAM
 SCR-1X-LAM
 
 Config:LAM
-TechBase:Inner Sphere
-Era:2774
-Source:XTRO Gunslingers - Star League
-Rules Level:2
+techbase:Inner Sphere
+era:2774
+source:XTRO Gunslingers - Star League
+rules level:2
 
-Mass:55
-Engine:275 Fusion Engine(IS)
-Structure:IS Standard
-Myomer:Standard
+mass:55
+engine:275 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+lam:Standard
 
-Heat Sinks:10 Double
-Walk MP:5
-Jump MP:4
+heat sinks:10 Double
+walk mp:5
+jump mp:4
 
-Armor:Standard(Inner Sphere)
-LA Armor:14
-RA Armor:14
-LT Armor:18
-RT Armor:18
-CT Armor:21
-HD Armor:9
-LL Armor:17
-RL Armor:17
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:14
+RA armor:14
+LT armor:18
+RT armor:18
+CT armor:21
+HD armor:9
+LL armor:17
+RL armor:17
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
 Weapons:1
 ER PPC, Right Arm
@@ -66,8 +67,8 @@ Landing Gear
 Avionics
 Jump Jet
 Jump Jet
-Cargo (1 ton)
-Cargo (1 ton)
+Bomb Bay
+Bomb Bay
 -Empty-
 -Empty-
 -Empty-
@@ -80,8 +81,8 @@ Landing Gear
 Avionics
 Jump Jet
 Jump Jet
-Cargo (1 ton)
-Cargo (1 ton)
+Bomb Bay
+Bomb Bay
 -Empty-
 -Empty-
 -Empty-

--- a/megamek/data/mechfiles/mechs/LAMS/Yurei S-YR-1LAM.mtf
+++ b/megamek/data/mechfiles/mechs/LAMS/Yurei S-YR-1LAM.mtf
@@ -17,8 +17,6 @@ cockpit:Small Cockpit
 gyro:Standard Gyro
 
 heat sinks:10 Double
-nocrit:Standard:None
-nocrit:Standard:None
 walk mp:5
 jump mp:5
 
@@ -90,7 +88,7 @@ Jump Jet
 ISDoubleHeatSink
 ISDoubleHeatSink
 ISDoubleHeatSink
-Cargo (1 ton)
+Bomb Bay
 CLCASEII
 -Empty-
 -Empty-

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -12983,8 +12983,6 @@ public class AmmoType extends EquipmentType {
         ammo.name = "Machine Gun Ammo";
         ammo.shortName = "Machine Gun";
         ammo.setInternalName("Clan Machine Gun Ammo - Proto");
-        ammo.addLookupName("CLMG Ammo");
-        ammo.addLookupName("Clan Machine Gun Ammo");
         ammo.damagePerShot = 1;
         ammo.rackSize = 2;
         ammo.ammoType = AmmoType.T_MG;

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -40,6 +40,21 @@ public class GunEmplacement extends Tank {
     private static int[] CRITICAL_SLOTS = new int[] { 0 };
     private static String[] LOCATION_ABBRS = { "GUN" };
     private static String[] LOCATION_NAMES = { "GUNS" };
+        
+    private static final TechAdvancement TA_GUN_EMPLACEMENT = new TechAdvancement(TECH_BASE_ALL)
+            .setAdvancement(DATE_PS, DATE_PS, DATE_PS)
+            .setTechRating(RATING_B).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
+            .setStaticTechLevel(SimpleTechLevel.INTRO);
+    
+    public static final TechAdvancement TA_LIGHT_BUILDING = new TechAdvancement(TECH_BASE_ALL)
+            .setAdvancement(DATE_PS, DATE_PS, DATE_PS)
+            .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
+            .setStaticTechLevel(SimpleTechLevel.INTRO);
+    
+    @Override
+    public TechAdvancement getConstructionTechAdvancement() {
+        return TA_GUN_EMPLACEMENT;
+    }
 
     public GunEmplacement() {
         initializeInternal(IArmorState.ARMOR_NA, LOC_GUNS);
@@ -58,6 +73,14 @@ public class GunEmplacement extends Tank {
 
     @Override
     public boolean isImmobile() {
+        return true;
+    }
+    
+    /**
+     * Our gun emplacements do not support dual turrets at this time
+     */
+    @Override
+    public boolean hasNoDualTurret() {
         return true;
     }
 

--- a/megamek/src/megamek/common/weapons/lasers/CLERLaserMicro.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERLaserMicro.java
@@ -57,7 +57,7 @@ public class CLERLaserMicro extends LaserWeapon {
         	.setIntroLevel(false)
         	.setUnofficial(false)
             .setTechRating(RATING_F)
-            .setAvailability(RATING_X, RATING_X, RATING_C, RATING_C)
+            .setAvailability(RATING_X, RATING_X, RATING_D, RATING_C)
             .setClanAdvancement(3059, 3060, 3061, DATE_NONE, DATE_NONE)
             .setClanApproximate(true, false, false,false, false)
             .setPrototypeFactions(F_CSJ)

--- a/megamek/src/megamek/common/weapons/lasers/CLPulseLaserMicro.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLPulseLaserMicro.java
@@ -61,7 +61,7 @@ public class CLPulseLaserMicro extends PulseLaserWeapon {
         	.setIntroLevel(false)
         	.setUnofficial(false)
             .setTechRating(RATING_F)
-            .setAvailability(RATING_X, RATING_X, RATING_C, RATING_C)
+            .setAvailability(RATING_X, RATING_X, RATING_D, RATING_C)
             .setClanAdvancement(3059, 3060, 3061, DATE_NONE, DATE_NONE)
             .setClanApproximate(true, false, false,false, false)
             .setPrototypeFactions(F_CSJ)


### PR DESCRIPTION
List of changes:
- gave the WoB LAMs actual bomb bays instead of cargo bays
- corrected tech ratings on some weapons per IntOps tech advancement table
- more aggressive "no dual turret" change to gun emplacements to ensure correct tech rating, "base" tech rating of turrets is different from vehicles
- protomech MG ammo had the same alias as standard MG ammo, so it would often show up in place of standard MG ammo when reading .blk files

There are still some issues with tech level calculation for turrets, but those will be for another PR.