### PR TITLE
FIx heavy vibro claw name string

### DIFF
--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -97,8 +97,8 @@ public class BattleArmor extends Infantry {
         "BA Manipulator Adaptation [Mine Clearance Equipment]", "BA Manipulators [Battle Claw]",
         "BA Manipulator Adaptation [Magnetic Battle Claw]", "BA Manipulator Adaptation [Vibro-Claw]",
         "BA Manipulators [Heavy Battle Claw]", "BA Manipulator Adaptation [Heavy Magnetic Battle Claw]",
-        "BA Manipulator Adaptation [Heavy Vibro-Claw", "BA Manipulators [Salvage Arm]", "BA Manipulators [Cargo Lifter]",
-    "BA Manipulators [Industrial Drill]" };
+        "BA Manipulator Adaptation [Heavy Vibro-Claw]", "BA Manipulators [Salvage Arm]", "BA Manipulators [Cargo Lifter]",
+        "BA Manipulators [Industrial Drill]" };
 
     public static final int CHASSIS_TYPE_BIPED = 0;
     public static final int CHASSIS_TYPE_QUAD = 1;


### PR DESCRIPTION
Adds the missing final bracket.

Fixes MegaMek/megameklab#708