### PR TITLE
Standardizing the Entity Image between MegaMek and MekHQ

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
@@ -23,6 +23,7 @@ import java.awt.image.*;
 import java.io.File;
 import java.util.Iterator;
 
+import megamek.MegaMek;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.ImageFileFactory;
 import megamek.common.*;
@@ -221,6 +222,24 @@ public class EntityImage {
         return icon;
     }
 
+    public Image loadPreviewImage() {
+        if (base == null) {
+            return null;
+        }
+
+        base = applyColor(getBase());
+
+        // Add damage scars and smoke/fire; not to Infantry
+        if (!isInfantry && GUIPreferences.getInstance().getShowDamageDecal()) {
+            base = applyDamageDecal(getBase());
+            // No smoke in the lobby
+            if (!isPreview) {
+                base = applyDamageSmoke(getBase());
+            }
+        }
+        return getBase();
+    }
+
     /** Applies the unit individual or player color or camo to the icon. */
     private Image applyColor(Image image) {
         if (image == null) {
@@ -355,11 +374,9 @@ public class EntityImage {
         return result;
     }
 
-    /** Inititates the PixelGrabber for the given image and int array. */
-    private void grabImagePixels(Image img, int[] pixels) 
-    throws InterruptedException, RuntimeException {
-        PixelGrabber pg = new PixelGrabber(img, 0, 0, IMG_WIDTH,
-                IMG_HEIGHT, pixels, 0, IMG_WIDTH);
+    /** Initiates the PixelGrabber for the given image and int array. */
+    private void grabImagePixels(Image img, int[] pixels) throws InterruptedException, RuntimeException {
+        PixelGrabber pg = new PixelGrabber(img, 0, 0, IMG_WIDTH, IMG_HEIGHT, pixels, 0, IMG_WIDTH);
         pg.grabPixels();
         if ((pg.getStatus() & ImageObserver.ABORT) != 0) {
             throw new RuntimeException("ImageObserver aborted.");
@@ -370,22 +387,23 @@ public class EntityImage {
     private Image getDamageDecal(Entity entity, int pos) {
         try {
             switch (entity.getDamageLevel()) {
-            case Entity.DMG_LIGHT:
-                return getIM(PATH_LIGHT, entity.getShortName(), pos);
-            case Entity.DMG_MODERATE:
-                return getIM(PATH_MODERATE, entity.getShortName(), pos);
-            case Entity.DMG_HEAVY:
-                return getIM(PATH_HEAVY, entity.getShortName(), pos);
-            case Entity.DMG_CRIPPLED:
-                return getIM(PATH_CRIPPLED, entity.getShortName(), pos);
-            default: // DMG_NONE:
-                return null;
+                case Entity.DMG_LIGHT:
+                    return getIM(PATH_LIGHT, entity.getShortName(), pos);
+                case Entity.DMG_MODERATE:
+                    return getIM(PATH_MODERATE, entity.getShortName(), pos);
+                case Entity.DMG_HEAVY:
+                    return getIM(PATH_HEAVY, entity.getShortName(), pos);
+                case Entity.DMG_CRIPPLED:
+                    return getIM(PATH_CRIPPLED, entity.getShortName(), pos);
+                default: // DMG_NONE:
+                    return null;
             }
         } catch (Exception e) {
-            DefaultMmLogger.getInstance().error(getClass(), "getDamageDecal()", 
+            MegaMek.getLogger().error(getClass(), "getDamageDecal()",
                     "Could not load decal image.");
-            e.printStackTrace();
+            MegaMek.getLogger().error(getClass(), "getDamageDecal", e);
         }
+
         return null;
     }
     
@@ -399,7 +417,7 @@ public class EntityImage {
                 return dmgEmpty;
             }
 
-            String path = "";
+            String path;
             if (pos > -1) {
                 // Multi-hex units get their own overlays
                 path = dmgLevel == Entity.DMG_HEAVY ? PATH_SMOKEMULTI : PATH_FIREMULTI;
@@ -437,7 +455,7 @@ public class EntityImage {
         for (int i = 0; i <= img; i++) {
             n = iter.next();
         }
-        return (Image)DecalImages.getItem(cat, n);
+        return (Image) DecalImages.getItem(cat, n);
     }
     
     /** Returns the size of the collection of an iterator. Local helper function for DirectoryItems. */
@@ -446,6 +464,4 @@ public class EntityImage {
         for (;iter.hasNext();iter.next(), result++);
         return result;
     }
-
-
 }


### PR DESCRIPTION
This adds the one method that separated the two to MML to ensure consistency between MekHQ and MegaMek.