### PR TITLE
Fix array size initial value.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -172,7 +172,9 @@ public class TestSmallCraft extends TestAero {
      *           allotment
      */
     public static double[] extraSlotCost(SmallCraft sc) {
-        int arcs = sc.isSpheroid()? 7 : 5;
+        // Arcs/locations include the hull. Spheroids have two arcs in each side location;
+        // the indices for the side aft arcs are after the virtual wings location.
+        final int arcs = sc.isSpheroid() ? 8 : 5;
         int[] weaponsPerArc = new int[arcs];
         double[] weaponTonnage = new double[arcs];
         boolean hasNC3 = sc.hasWorkingMisc(MiscType.F_NAVAL_C3);


### PR DESCRIPTION
Fixes a bug introduced by #2070. The starting index of the virtual locations for the spheroid aft side firing arcs was inconsistent, and in settling on the larger value I didn't change the size of the array that collects the weapon count.