### PR TITLE
Extra combat crew seat for tanks

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1542,6 +1542,7 @@ MechView.BayPersonnel=Bay Personnel
 MechView.Passengers=Passengers
 MechView.Marines=Marines
 MechView.BAMarines=BA Marines
+MechView.ExtraCrewSeats=Extra Crew Seats:\ 
 MechView.DropshipCollar.NONE=No docking collar
 MechView.DropshipCollar.NO_BOOM=No K-F Boom
 MechView.DropshipCollar.PROTOTYPE_BOOM=Prototype K-F Boom

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7011,7 +7011,7 @@ public class Compute {
             }
             return crew + (int) Math.ceil(crew / 6.0);
         } else if (entity instanceof Tank) {
-            return (int) Math.ceil(entity.getWeight() / 15.0);
+            return (int) Math.ceil(entity.getWeight() / 15.0) + ((Tank) entity).getExtraCrewSeats();
         } else if (entity instanceof BattleArmor) {
             int ntroopers = 0;
             for (int trooper = 1; trooper < entity.locations(); trooper++) {

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -1014,6 +1014,10 @@ public class MechView {
             }
             retVal.add(crewTable);
         }
+        if (isVehicle && ((Tank) entity).getExtraCrewSeats() > 0) {
+            retVal.add(new SingleLine(Messages.getString("MechView.ExtraCrewSeats")
+                    + ((Tank) entity).getExtraCrewSeats()));
+        }
         return retVal;
     }
 

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2725,7 +2725,7 @@ public class Tank extends Entity {
         costs[i++] = 2000 * Math.max(0, sinks - freeHeatSinks);
         costs[i++] = turretWeight * 5000;
 
-        costs[i++] = getWeaponsAndEquipmentCost(ignoreAmmo);
+        costs[i++] = getWeaponsAndEquipmentCost(ignoreAmmo) + getExtraCrewSeats() * 100;
 
         if (!isSupportVehicle()) {
             double diveTonnage;

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -45,6 +45,8 @@ public class BLKFile {
     public static final int EXTERNAL = 13;
     
     private static final String COMSTAR_BAY = "c*";
+
+    static final String BLK_EXTRA_SEATS = "extra_seats";
     
     /**
      * If a vehicular grenade launcher does not have a facing provided, assign a default facing.
@@ -962,6 +964,9 @@ public class BLKFile {
             }
             if (!t.isSupportVehicle() && t.isTrailer()) {
                 blk.writeBlockData("trailer", 1);
+            }
+            if (tank.getExtraCrewSeats() > 0) {
+                blk.writeBlockData(BLK_EXTRA_SEATS, tank.getExtraCrewSeats());
             }
         }
         

--- a/megamek/src/megamek/common/loaders/BLKTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKTankFile.java
@@ -137,6 +137,9 @@ public class BLKTankFile extends BLKFile implements IMechLoader {
         t.setMovementMode(nMotion);
 
         addTransports(t);
+        if (dataFile.exists(BLK_EXTRA_SEATS)) {
+            t.setExtraCrewSeats(dataFile.getDataAsInt(BLK_EXTRA_SEATS)[0]);
+        }
 
         int engineCode = BLKFile.FUSION;
         if (dataFile.exists("engine_type")) {

--- a/megamek/src/megamek/common/templates/VehicleTROView.java
+++ b/megamek/src/megamek/common/templates/VehicleTROView.java
@@ -14,6 +14,7 @@
 package megamek.common.templates;
 
 import java.text.NumberFormat;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -52,7 +53,7 @@ public class VehicleTROView extends TROView {
                 return "gunemplacement.ftl";
             }
         }
-        
+
         if (html) {
             return "vehicle.ftlh";
         }
@@ -62,14 +63,14 @@ public class VehicleTROView extends TROView {
     @SuppressWarnings("unchecked")
     @Override
     protected void initModel(EntityVerifier verifier) {
-        setModelData("formatArmorRow", new FormatTableRowMethod(new int[] { 20, 10, 10 },
-                new Justification[] { Justification.LEFT, Justification.CENTER, Justification.CENTER }));
+        setModelData("formatArmorRow", new FormatTableRowMethod(new int[]{20, 10, 10},
+                new Justification[]{Justification.LEFT, Justification.CENTER, Justification.CENTER}));
         addBasicData(tank);
         addArmorAndStructure();
         final int nameWidth = addEquipment(tank);
         setModelData("formatEquipmentRow",
-                new FormatTableRowMethod(new int[] { nameWidth, 12, 12 }, new Justification[] { Justification.LEFT,
-                        Justification.CENTER, Justification.CENTER, Justification.CENTER, Justification.CENTER }));
+                new FormatTableRowMethod(new int[]{nameWidth, 12, 12}, new Justification[]{Justification.LEFT,
+                        Justification.CENTER, Justification.CENTER, Justification.CENTER, Justification.CENTER}));
         addFluff();
         setModelData("isOmni", tank.isOmni());
         setModelData("isVTOL", tank.hasETypeFlag(Entity.ETYPE_VTOL));
@@ -129,13 +130,13 @@ public class VehicleTROView extends TROView {
         }
     }
 
-    private static final int[][] TANK_ARMOR_LOCS = { { Tank.LOC_FRONT }, { Tank.LOC_RIGHT, Tank.LOC_LEFT },
-            { Tank.LOC_REAR }, { Tank.LOC_TURRET }, { Tank.LOC_TURRET_2 }, { VTOL.LOC_ROTOR } };
+    private static final int[][] TANK_ARMOR_LOCS = {{Tank.LOC_FRONT}, {Tank.LOC_RIGHT, Tank.LOC_LEFT},
+            {Tank.LOC_REAR}, {Tank.LOC_TURRET}, {Tank.LOC_TURRET_2}, {VTOL.LOC_ROTOR}};
 
-    private static final int[][] SH_TANK_ARMOR_LOCS = { { SuperHeavyTank.LOC_FRONT },
-            { SuperHeavyTank.LOC_FRONTRIGHT, SuperHeavyTank.LOC_FRONTLEFT },
-            { SuperHeavyTank.LOC_REARRIGHT, SuperHeavyTank.LOC_REARLEFT }, { SuperHeavyTank.LOC_REAR },
-            { SuperHeavyTank.LOC_TURRET }, { SuperHeavyTank.LOC_TURRET_2 } };
+    private static final int[][] SH_TANK_ARMOR_LOCS = {{SuperHeavyTank.LOC_FRONT},
+            {SuperHeavyTank.LOC_FRONTRIGHT, SuperHeavyTank.LOC_FRONTLEFT},
+            {SuperHeavyTank.LOC_REARRIGHT, SuperHeavyTank.LOC_REARLEFT}, {SuperHeavyTank.LOC_REAR},
+            {SuperHeavyTank.LOC_TURRET}, {SuperHeavyTank.LOC_TURRET_2}};
 
     private void addArmorAndStructure() {
         if (tank.hasETypeFlag(Entity.ETYPE_SUPER_HEAVY_TANK)) {
@@ -163,5 +164,25 @@ public class VehicleTROView extends TROView {
             return Messages.getString("TROView.Sponson");
         }
         return entity.getLocationName(mounted.getLocation());
+    }
+
+    @Override
+    protected int addEquipment(Entity entity, boolean includeAmmo) {
+        int retVal = super.addEquipment(entity, includeAmmo);
+        if (tank.getExtraCrewSeats() > 0) {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> list = (List<Map<String, Object>>) getModelData("equipment");
+            Map<String, Object> seatEntry = new HashMap<>();
+            if (tank.getExtraCrewSeats() > 1) {
+                seatEntry.put("name", String.format("%d Extra Crew Seats", tank.getExtraCrewSeats()));
+            } else {
+                seatEntry.put("name", "Extra Combat Seat");
+            }
+            seatEntry.put("location", tank.getLocationName(Tank.LOC_BODY));
+            seatEntry.put("tonnage", tank.getExtraCrewSeats() * 0.5);
+            seatEntry.put("slots", tank.getExtraCrewSeats());
+            list.add(seatEntry);
+        }
+        return retVal;
     }
 }


### PR DESCRIPTION
The Tank class has had a field for extra combat crew seats (TM, 236)  for longer than I've been around, but other than calculating the weight and slot cost, it hasn't done anything. I've added it to the crew size calculations, added a block to save it in the unit file, and added entries on the summaries. Also apparently some automatic IDE reformatting.

This handles the MM part of MegaMek/megameklab#693