### PR TITLE
fix path enumerator NPEs for destroyed entities

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -179,6 +179,16 @@ public class PathEnumerator {
             // Clear out any already calculated paths.
             getUnitPaths().remove(mover.getId());
             getLongRangePaths().remove(mover.getId());
+            
+            // if the entity does not exist in the game for any reason, let's cut out safely
+            // otherwise, we'll run into problems calculating paths
+            if(getGame().getEntity(mover.getId()) == null) {
+                // clean up orphaned entries in local storage
+                getUnitMovableAreas().remove(mover.getId());
+                getUnitPotentialLocations().remove(mover.getId());
+                getLastKnownLocations().remove(mover.getId());
+                return;
+            }
 
             // Start constructing the new list of paths.
             List<MovePath> paths = new ArrayList<>();

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -182,7 +182,7 @@ public class PathEnumerator {
             
             // if the entity does not exist in the game for any reason, let's cut out safely
             // otherwise, we'll run into problems calculating paths
-            if(getGame().getEntity(mover.getId()) == null) {
+            if (getGame().getEntity(mover.getId()) == null) {
                 // clean up orphaned entries in local storage
                 getUnitMovableAreas().remove(mover.getId());
                 getUnitPotentialLocations().remove(mover.getId());


### PR DESCRIPTION
Occasionally, a unit will get destroyed while the path enumerator is still calculating movement possibilities for it. Since that happens in a separate thread, the underlying game object gets updated and a call to "getEntity(id)" returns null, but the entity object having its moves calculated is still present, leading to NPEs.

This *should* fix that problem (it's difficult to reproduce since it goes away if you kick the bot and have it reconnect) by double checking that the entity is actually in the game before starting path calculations. It also cleans up orphaned entries for that entity in the various lookup tables.

Fixes #1807 