### PR TITLE
fix NPE when attempting to roll initiative for player with no units

### DIFF
--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -526,7 +526,7 @@ public final class Player extends TurnOrdered implements IPlayer {
     public int getCommandBonus() {
         int commandb = 0;
         
-        if(game == null) {
+        if (game == null) {
             return 0;
         }
         

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -525,6 +525,11 @@ public final class Player extends TurnOrdered implements IPlayer {
     @Override
     public int getCommandBonus() {
         int commandb = 0;
+        
+        if(game == null) {
+            return 0;
+        }
+        
         for (Entity entity : game.getEntitiesVector()) {
             if ((null != entity.getOwner())
                     && entity.getOwner().equals(this)


### PR DESCRIPTION
This prevents an NPE when attempting to roll individual initiative for units belonging to a player that isn't in the game? I'm not really sure how it got into this state. 

Fixes #2115 , the second issue (first one was already fixed)