### PR TITLE
Support vehicle tech rating

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1319,6 +1319,17 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
         ctl.addComponent(EquipmentType.getStructureTechAdvancement(structureType,
                 TechConstants.isClan(structureTechLevel)));
+        /* TM, p. 122 gives general eras for each tech rating, but not specific dates.
+         * Besides that, there are many canon units with higher tech ratings than should
+         * be possible in their era, so we're just going to add a stub to get the tech rating right
+         * for cost purposes. */
+        if (isSupportVehicle()) {
+            ctl.addComponent(new TechAdvancement(TECH_BASE_ALL).setTechRating(getEngineTechRating()));
+            ctl.addComponent(new TechAdvancement(TECH_BASE_ALL).setTechRating(getStructuralTechRating()));
+            if (!hasPatchworkArmor() && (getArmorType(firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD)) {
+                ctl.addComponent(new TechAdvancement(TECH_BASE_ALL).setTechRating(getArmorTechRating()));
+            }
+        }
     }
 
     public int getRecoveryTurn() {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1324,10 +1324,11 @@ public abstract class Entity extends TurnOrdered implements Transporter,
          * be possible in their era, so we're just going to add a stub to get the tech rating right
          * for cost purposes. */
         if (isSupportVehicle()) {
-            ctl.addComponent(new TechAdvancement(TECH_BASE_ALL).setTechRating(getEngineTechRating()));
-            ctl.addComponent(new TechAdvancement(TECH_BASE_ALL).setTechRating(getStructuralTechRating()));
+            TechAdvancement blank = new TechAdvancement(getConstructionTechAdvancement());
+            ctl.addComponent(blank.setTechRating(getEngineTechRating()));
+            ctl.addComponent(blank.setTechRating(getStructuralTechRating()));
             if (!hasPatchworkArmor() && (getArmorType(firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD)) {
-                ctl.addComponent(new TechAdvancement(TECH_BASE_ALL).setTechRating(getArmorTechRating()));
+                ctl.addComponent(blank.setTechRating(getArmorTechRating()));
             }
         }
     }


### PR DESCRIPTION
The engine, structure, and armor tech ratings are stored as individual flags rather than as equipment with a full tech advancement record, and are being left out of the overall unit tech rating calculation. This is used as part of the cost calculation.

Fixes MegaMek/megameklab#713