### PR TITLE
Correct binary laser cannon SR AV.

### DIFF
--- a/megamek/src/megamek/common/weapons/lasers/ISBinaryLaserCannon.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISBinaryLaserCannon.java
@@ -1,8 +1,4 @@
-package megamek.common.weapons.lasers;
-
-import megamek.common.SimpleTechLevel;
-
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
  *  This program is free software; you can redistribute it and/or modify it
@@ -15,6 +11,10 @@ import megamek.common.SimpleTechLevel;
  *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  *  for more details.
  */
+package megamek.common.weapons.lasers;
+
+import megamek.common.SimpleTechLevel;
+
 /*
  * Created on Sep 12, 2004
  *
@@ -53,7 +53,7 @@ public class ISBinaryLaserCannon extends LaserWeapon {
         criticals = 4;
         bv = 222;
         cost = 200000;
-        shortAV = 16;
+        shortAV = 12;
         medAV = 12;
         maxRange = RANGE_MED;
         rulesRefs = "319,TO";


### PR DESCRIPTION
Blazers do 12 damage. 16 is the heat value.

Also moved the copyright/license text to the top of the file.

Fixes #2122 