### PR TITLE
Skip equipment in LOC_NONE in BA TRO display.

### DIFF
--- a/megamek/src/megamek/common/templates/BattleArmorTROView.java
+++ b/megamek/src/megamek/common/templates/BattleArmorTROView.java
@@ -145,7 +145,8 @@ public class BattleArmorTROView extends TROView {
         Map<String, Object> row;
         int nameWidth = 30;
         for (final Mounted m : ba.getEquipment()) {
-            if (m.isAPMMounted() || (m.getType() instanceof InfantryAttack) || (m.getType() == armor)) {
+            if (m.isAPMMounted() || (m.getType() instanceof InfantryAttack)
+                    || (m.getType() == armor) || (m.getLocation() == BattleArmor.LOC_NONE)) {
                 continue;
             }
             if ((m.getType() instanceof MiscType) && m.getType().hasFlag(MiscType.F_BA_MANIPULATOR)) {


### PR DESCRIPTION
Something I missed in #2120. The TRO display for BA does not skip equipment in LOC_NONE, resulting in JJ, VTOL, and UMU showing up again in the equipment list.