### PR TITLE
Check for unallocated equipment in larger aerospace units during validation

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -757,7 +757,8 @@ public class TestAdvancedAerospace extends TestAero {
         correct &= correctCrew(buff);
         correct &= correctGravDecks(buff);
         correct &= correctBays(buff);
-        
+        correct &= correctCriticals(buff);
+
         return correct;
     }
 
@@ -1177,7 +1178,7 @@ public class TestAdvancedAerospace extends TestAero {
                 buff.append(" requires ").append(extra[i]).append(" tons of additional fire control.\n");
             }
         }
-        return true;
+        return super.correctCriticals(buff);
     }
     
     @Override

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -747,7 +747,7 @@ public class TestAero extends TestEntity {
     public List<Mounted> checkCriticalSlotsForEquipment(Entity entity) {
         List<Mounted> unallocated = new ArrayList<>();
         for (Mounted m : entity.getEquipment()) {
-            if ((m.getLocation() == Entity.LOC_NONE) && !m.isOneShotAmmo() && m.getCriticals() > 0) {
+            if ((m.getLocation() == Entity.LOC_NONE) && !m.isOneShotAmmo() && (m.getCriticals() > 0)) {
                 unallocated.add(m);
             }
         }

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -836,33 +836,34 @@ public class TestAero extends TestEntity {
                 numWeapons[m.getLocation()]++;
             }
         }
-        
-        int[] availSpace = availableSpace(aero);
-        if (availSpace == null){
-            buff.append("Invalid armor type! Armor: ")
-                    .append(EquipmentType.armorNames[aero.getArmorType(Aero.LOC_NOSE)]);
-            buff.append("\n");
-            return false;
-        }       
-        
-        if (numBombs > aero.getMaxBombPoints()){
-            buff.append("Invalid number of bombs! Unit can mount ").append(aero.getMaxBombPoints())
-                    .append(" but ").append(numBombs).append("are present!");
-            buff.append("\n");
-            return false;
-        }
-        
-        String[] locNames = aero.getLocationNames();
-        int loc = Aero.LOC_AFT;
-        while (loc >= 0){
-            correct &= !(numWeapons[loc] > availSpace[loc]);
-            if (numWeapons[loc] > availSpace[loc]){
-                buff.append(locNames[loc]).append(" has ").append(numWeapons[loc])
-                        .append(" weapons but it can only fit ").append(availSpace[loc]).append(" weapons!");
+
+        if (aero.isFighter()) {
+            int[] availSpace = availableSpace(aero);
+            if (availSpace == null) {
+                buff.append("Invalid armor type! Armor: ")
+                        .append(EquipmentType.armorNames[aero.getArmorType(Aero.LOC_NOSE)]);
                 buff.append("\n");
+                return false;
             }
-            loc--;
-        }        
+            if (numBombs > aero.getMaxBombPoints()) {
+                buff.append("Invalid number of bombs! Unit can mount ").append(aero.getMaxBombPoints())
+                        .append(" but ").append(numBombs).append("are present!");
+                buff.append("\n");
+                return false;
+            }
+
+            String[] locNames = aero.getLocationNames();
+            int loc = Aero.LOC_AFT;
+            while (loc >= 0) {
+                correct &= !(numWeapons[loc] > availSpace[loc]);
+                if (numWeapons[loc] > availSpace[loc]) {
+                    buff.append(locNames[loc]).append(" has ").append(numWeapons[loc])
+                            .append(" weapons but it can only fit ").append(availSpace[loc]).append(" weapons!");
+                    buff.append("\n");
+                }
+                loc--;
+            }
+        }
         
         return correct;
     }

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -593,6 +593,7 @@ public class TestSmallCraft extends TestAero {
         correct &= !hasIllegalEquipmentCombinations(buff);
         correct &= correctHeatSinks(buff);
         correct &= correctCrew(buff);
+        correct &= correctCriticals(buff);
         
         return correct;
     }
@@ -878,7 +879,7 @@ public class TestSmallCraft extends TestAero {
                 buff.append(" requires ").append(extra[i]).append(" tons of additional fire control.\n");
             }
         }
-        return true;
+        return super.correctCriticals(buff);
     }
     
     @Override


### PR DESCRIPTION
Call parent method in TestAero to insure all equipment other than one-shot ammo has been assigned a location. Clean up in TestAero, including removing code that was copied from TestMech that has no bearing on aerospace units.

Fixes MegaMek/megameklab#712