### PR TITLE
grounded LAMs have to follow mech rules

### DIFF
--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -1031,7 +1031,7 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
 
     @Override
     public boolean canFall(boolean gyroLegDamage) {
-        return getConversionMode() != CONV_MODE_FIGHTER && !isAirborneVTOLorWIGE();
+        return getConversionMode() != CONV_MODE_FIGHTER && !isAirborneVTOLorWIGE() && super.canFall(gyroLegDamage);
     }
     
     private static final TechAdvancement[] TA_LAM = {


### PR DESCRIPTION
canFall() was always reporting true for grounded LAMs, even when they're prone.

Fixes #2146 