### PR TITLE
implement ECHO maneuvers for dropships/warships

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2933,6 +2933,7 @@ WeaponAttackAction.Dropping=dropping
 WeaponAttackAction.DualCockpit=dual cockpit
 WeaponAttackAction.ECCM=ECCM
 WeaponAttackAction.AeEvading=attacker is evading
+WeaponAttackAction.LargeCraftEcho=large craft performing ECHO maneuver
 WeaponAttackAction.FcsDamage=fcs damage
 WeaponAttackAction.FireThruCover=firing through cover
 WeaponAttackAction.GroundedAero=grounded aero

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -1894,5 +1894,64 @@ public class Dropship extends SmallCraft {
             specialAbilities.put(BattleForceSPA.CRW, (int)Math.round(getNCrew() / 60.0));
         }
     }
+    
+    @Override
+    public boolean canChangeSecondaryFacing() {
+    	// flying dropships can execute the "ECHO" maneuver (stratops 113), aka a torso twist, 
+    	// if they have the MP for it
+    	return isAirborne() && !isEvading() && (mpUsed <= getRunMP() - 2);
+    }
+
+    /**
+     * Can this dropship "torso twist" in the given direction?
+     */
+    @Override
+    public boolean isValidSecondaryFacing(int dir) {
+        int rotate = dir - getFacing();
+        if (canChangeSecondaryFacing()) {
+            return (rotate == 0) || (rotate == 1) || (rotate == -1)
+                    || (rotate == -5) || (rotate == 5);
+        }
+        return rotate == 0;
+    }
+
+    /**
+     * Return the nearest valid direction to "torso twist" in
+     */
+    @Override
+    public int clipSecondaryFacing(int dir) {
+        if (isValidSecondaryFacing(dir)) {
+            return dir;
+        }
+        
+        // can't twist without enough MP
+        if (!canChangeSecondaryFacing()) {
+            return getFacing();
+        }
+        // otherwise, twist once in the appropriate direction
+        final int rotate = (dir + (6 - getFacing())) % 6;
+
+        return rotate >= 3 ? (getFacing() + 5) % 6 : (getFacing() + 1) % 6;
+    }
+    
+    @Override
+    public void newRound(int roundNumber) {
+    	super.newRound(roundNumber);
+    	
+    	if(getGame().useVectorMove()) {
+    		setFacing(getSecondaryFacing());
+    	}
+    	
+    	setSecondaryFacing(getFacing());
+    }
+    
+    /**
+     * Utility function that handles situations where a facing change
+     * has some kind of permanent effect on the entity.
+     */
+    @Override
+    public void postProcessFacingChange() {
+    	mpUsed += 2;
+    }
 
 }

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -1897,11 +1897,11 @@ public class Dropship extends SmallCraft {
     
     @Override
     public boolean canChangeSecondaryFacing() {
-    	// flying dropships can execute the "ECHO" maneuver (stratops 113), aka a torso twist, 
-    	// if they have the MP for it
-    	return isAirborne() && !isEvading() && (mpUsed <= getRunMP() - 2);
+        // flying dropships can execute the "ECHO" maneuver (stratops 113), aka a torso twist, 
+        // if they have the MP for it
+        return isAirborne() && !isEvading() && (mpUsed <= getRunMP() - 2);
     }
-
+    
     /**
      * Can this dropship "torso twist" in the given direction?
      */
@@ -1914,7 +1914,7 @@ public class Dropship extends SmallCraft {
         }
         return rotate == 0;
     }
-
+    
     /**
      * Return the nearest valid direction to "torso twist" in
      */
@@ -1928,21 +1928,22 @@ public class Dropship extends SmallCraft {
         if (!canChangeSecondaryFacing()) {
             return getFacing();
         }
+        
         // otherwise, twist once in the appropriate direction
         final int rotate = (dir + (6 - getFacing())) % 6;
-
+        
         return rotate >= 3 ? (getFacing() + 5) % 6 : (getFacing() + 1) % 6;
     }
     
     @Override
     public void newRound(int roundNumber) {
-    	super.newRound(roundNumber);
-    	
-    	if(getGame().useVectorMove()) {
-    		setFacing(getSecondaryFacing());
-    	}
-    	
-    	setSecondaryFacing(getFacing());
+        super.newRound(roundNumber);
+        
+        if (getGame().useVectorMove()) {
+            setFacing(getSecondaryFacing());
+        }
+        
+        setSecondaryFacing(getFacing());
     }
     
     /**
@@ -1951,7 +1952,6 @@ public class Dropship extends SmallCraft {
      */
     @Override
     public void postProcessFacingChange() {
-    	mpUsed += 2;
+        mpUsed += 2;
     }
-
 }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2529,6 +2529,14 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             game.processGameEvent(new GameEntityChangeEvent(this, this));
         }
     }
+    
+    /**
+     * Utility function that handles situations where a facing change
+     * imparts some kind of permanent effect to the entity.
+     */
+    public void postProcessFacingChange() {
+    	
+    }
 
     /**
      * Can this entity change secondary facing at all?

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -568,13 +568,13 @@ public class Warship extends Jumpship {
     
     @Override
     public boolean canChangeSecondaryFacing() {
-    	// flying dropships can execute the "ECHO" maneuver (stratops 113), aka a torso twist, 
-    	// if they have the MP for it
-    	return isAirborne() && !isEvading() && (mpUsed <= getRunMP() - 2);
+        // flying warships can execute the "ECHO" maneuver (stratops 113), aka a torso twist, 
+        // if they have the MP for it
+        return isAirborne() && !isEvading() && (mpUsed <= getRunMP() - 2);
     }
-
+    
     /**
-     * Can this dropship "torso twist" in the given direction?
+     * Can this warship "torso twist" in the given direction?
      */
     @Override
     public boolean isValidSecondaryFacing(int dir) {
@@ -585,7 +585,7 @@ public class Warship extends Jumpship {
         }
         return rotate == 0;
     }
-
+    
     /**
      * Return the nearest valid direction to "torso twist" in
      */
@@ -599,9 +599,10 @@ public class Warship extends Jumpship {
         if (!canChangeSecondaryFacing()) {
             return getFacing();
         }
+        
         // otherwise, twist once in the appropriate direction
         final int rotate = (dir + (6 - getFacing())) % 6;
-
+        
         return rotate >= 3 ? (getFacing() + 5) % 6 : (getFacing() + 1) % 6;
     }
     
@@ -610,13 +611,13 @@ public class Warship extends Jumpship {
      */
     @Override
     public void newRound(int roundNumber) {
-    	super.newRound(roundNumber);
-    	
-    	if(getGame().useVectorMove()) {
-    		setFacing(getSecondaryFacing());
-    	}
-    	
-    	setSecondaryFacing(getFacing());
+        super.newRound(roundNumber);
+        
+        if (getGame().useVectorMove()) {
+            setFacing(getSecondaryFacing());
+        }
+        
+        setSecondaryFacing(getFacing());
     }
     
     /**
@@ -625,6 +626,6 @@ public class Warship extends Jumpship {
      */
     @Override
     public void postProcessFacingChange() {
-    	mpUsed += 2;
+        mpUsed += 2;
     }
 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3751,16 +3751,16 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
             
             // stratops page 113: ECHO maneuvers for large craft
-            if ((aero instanceof Warship || aero instanceof Dropship) &&
-            		aero.getFacing() != aero.getSecondaryFacing()) {
-            	// if we're computing this for an "attack preview", then we add 2 MP to 
-            	// the mp used, as we haven't used the MP yet. If we're actually processing
-            	// the attack, then the entity will be marked as 'done' and we have already added
-            	// the 2 MP, so we don't need to double-count it
-            	int extraMP = aero.isDone() ? 0 : 2;
-            	boolean willUseRunMP = aero.mpUsed + extraMP > aero.getWalkMP();
-            	int mod = willUseRunMP ? 2 : 1;
-            	toHit.addModifier(mod, Messages.getString("WeaponAttackAction.LargeCraftEcho"));
+            if (((aero instanceof Warship) || (aero instanceof Dropship)) &&
+                    (aero.getFacing() != aero.getSecondaryFacing())) {
+                // if we're computing this for an "attack preview", then we add 2 MP to 
+                // the mp used, as we haven't used the MP yet. If we're actually processing
+                // the attack, then the entity will be marked as 'done' and we have already added
+                // the 2 MP, so we don't need to double-count it
+                int extraMP = aero.isDone() ? 0 : 2;
+                boolean willUseRunMP = aero.mpUsed + extraMP > aero.getWalkMP();
+                int mod = willUseRunMP ? 2 : 1;
+                toHit.addModifier(mod, Messages.getString("WeaponAttackAction.LargeCraftEcho"));
             }
 
             // check for particular kinds of weapons in weapon bays

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -73,6 +73,7 @@ import megamek.common.Terrains;
 import megamek.common.ToHitData;
 import megamek.common.TripodMech;
 import megamek.common.VTOL;
+import megamek.common.Warship;
 import megamek.common.WeaponType;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.DiveBombAttack;
@@ -3747,6 +3748,19 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                             || wtype.getAtClass() == WeaponType.CLASS_AR10
                             || wtype.getAtClass() == WeaponType.CLASS_TELE_MISSILE))) {
                 toHit.addModifier(+2, Messages.getString("WeaponAttackAction.AeEvading"));
+            }
+            
+            // stratops page 113: ECHO maneuvers for large craft
+            if ((aero instanceof Warship || aero instanceof Dropship) &&
+            		aero.getFacing() != aero.getSecondaryFacing()) {
+            	// if we're computing this for an "attack preview", then we add 2 MP to 
+            	// the mp used, as we haven't used the MP yet. If we're actually processing
+            	// the attack, then the entity will be marked as 'done' and we have already added
+            	// the 2 MP, so we don't need to double-count it
+            	int extraMP = aero.isDone() ? 0 : 2;
+            	boolean willUseRunMP = aero.mpUsed + extraMP > aero.getWalkMP();
+            	int mod = willUseRunMP ? 2 : 1;
+            	toHit.addModifier(mod, Messages.getString("WeaponAttackAction.LargeCraftEcho"));
             }
 
             // check for particular kinds of weapons in weapon bays

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -14353,6 +14353,7 @@ public class Server implements Runnable {
                 TorsoTwistAction tta = (TorsoTwistAction) ea;
                 if (entity.canChangeSecondaryFacing()) {
                     entity.setSecondaryFacing(tta.getFacing());
+                    entity.postProcessFacingChange();
                 }
             } else if (ea instanceof FlipArmsAction) {
                 FlipArmsAction faa = (FlipArmsAction) ea;

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -23,7 +23,7 @@ public class ServerHelper {
      * @param isPlatoon Whether the target unit is a platoon.
      * @param ammoExplosion Whether we're considering a "big boom" ammo explosion from tacops.
      * @param ignoreInfantryDoubleDamage Whether we should ignore double damage to infantry.
-     * @return
+     * @return Whether the infantry unit can be considered to be "in the open"
      */
     public static boolean infantryInOpen(Entity te, IHex te_hex, IGame game, 
             boolean isPlatoon, boolean ammoExplosion, boolean ignoreInfantryDoubleDamage) {


### PR DESCRIPTION
This implements the ECHO rules on stratops page 113, which basically allows dropships and warships to "torso twist", at the cost of taking a penalty on their attack rolls.