### PR TITLE
Fixed null pointer exception causing bot to break

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1151,7 +1151,7 @@ public class Client implements IClientCommandHandler {
     private void cacheImgTag(Entity entity){
 
         if(entity == null) {
-            System.out.println("Null entity reference in cacheImgTag()");
+            MegaMek.getLogger().error(this, "Null entity reference");
             return;
         }
 

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1184,14 +1184,12 @@ public class Client implements IClientCommandHandler {
      * Gets the current mech image
      */
     private Image getTargetImage(Entity e){
-        if(bv == null){
-            return  null;
-        }else {
-            if (e.isDestroyed()) {
-                return bv.getTilesetManager().wreckMarkerFor(e, -1);
-            } else {
-                return bv.getTilesetManager().imageFor(e);
-            }
+        if (bv == null) {
+            return null;
+        } else if (e.isDestroyed()) {
+            return bv.getTilesetManager().wreckMarkerFor(e, -1);
+        } else {
+            return bv.getTilesetManager().imageFor(e);
         }
     }
 

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1157,7 +1157,8 @@ public class Client implements IClientCommandHandler {
 
         if (imgCache == null) {
             imgCache = new Hashtable<>();
-        }else if (imgCache.containsKey(entity.getId())) {//remove images that should be refreshed
+        } else if (imgCache.containsKey(entity.getId())) {
+            //remove images that should be refreshed
             imgCache.remove(entity.getId());
         }
 

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1162,7 +1162,8 @@ public class Client implements IClientCommandHandler {
             imgCache.remove(entity.getId());
         }
 
-        if(getTargetImage(entity) != null){//convert image to base64, add to to <img> tag and store in cache
+        if (getTargetImage(entity) != null) {
+            //convert image to base64, add to to <img> tag and store in cache
             Image image = ImageUtil.getScaledImage(getTargetImage(entity), 56, 48);
             try {
                 String base64Text;

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1151,33 +1151,29 @@ public class Client implements IClientCommandHandler {
     private void cacheImgTag(Entity entity){
 
         if(entity == null) {
-            System.out.println("Null entity reference");
+            System.out.println("Null entity reference in cacheImgTag()");
             return;
         }
 
         if (imgCache == null) {
             imgCache = new Hashtable<>();
-        }else if (imgCache.containsKey(entity.getId())) {
-            //remove images that should be regenerated
+        }else if (imgCache.containsKey(entity.getId())) {//remove images that should be refreshed
             imgCache.remove(entity.getId());
         }
 
-        //convert to base64, add to to <img> tag and store in cache
-        if (!imgCache.containsKey(entity.getId())) {
-            Image image = ImageUtil.getScaledImage(getTargetImage(entity),  56, 48);
-            if(image!=null) {
-                try {
-                    String base64Text;
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    ImageIO.write((RenderedImage) image, "png", baos);
-                    baos.flush();
-                    base64Text = Base64.getEncoder().encodeToString(baos.toByteArray());
-                    baos.close();
-                    String img = "<img src='data:image/png;base64," + base64Text + "'>";
-                    imgCache.put(entity.getId(), img);
-                } catch (final IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
+        if(getTargetImage(entity) != null){//convert image to base64, add to to <img> tag and store in cache
+            Image image = ImageUtil.getScaledImage(getTargetImage(entity), 56, 48);
+            try {
+                String base64Text;
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ImageIO.write((RenderedImage) image, "png", baos);
+                baos.flush();
+                base64Text = Base64.getEncoder().encodeToString(baos.toByteArray());
+                baos.close();
+                String img = "<img src='data:image/png;base64," + base64Text + "'>";
+                imgCache.put(entity.getId(), img);
+            } catch (final IOException ioe) {
+                throw new UncheckedIOException(ioe);
             }
         }
     }
@@ -1186,10 +1182,14 @@ public class Client implements IClientCommandHandler {
      * Gets the current mech image
      */
     private Image getTargetImage(Entity e){
-        if(e.isDestroyed()) {
-            return bv.getTilesetManager().wreckMarkerFor(e, -1);
+        if(bv == null){
+            return  null;
         }else {
-            return bv.getTilesetManager().imageFor(e);
+            if (e.isDestroyed()) {
+                return bv.getTilesetManager().wreckMarkerFor(e, -1);
+            } else {
+                return bv.getTilesetManager().imageFor(e);
+            }
         }
     }
 


### PR DESCRIPTION
Fix for #2150. In some instances, the BoardView for the client is being called before it gets initialized. So I just added a null check to fix the error. I also refactored the null check prior to trying to encode an image to better protect from a potential null reference. I didn't notice any other problems, but if more issues arise in regards to PR #2135 then just notify me and I'll take a look at them too.