### PR TITLE
Keyboard Shortcuts Overlay

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -752,6 +752,7 @@ CommonMenuBar.viewGameOptions=Game Options
 CommonMenuBar.viewLOSSetting=LOS Setting
 CommonMenuBar.viewMekDisplay=Unit Display
 CommonMenuBar.viewAccessibilityWindow=Accessibility Window
+CommonMenuBar.viewKeyboardShortcuts=Show Keyboard Shortcuts
 CommonMenuBar.ViewMenu=View
 CommonMenuBar.viewMiniMap=Mini Map
 CommonMenuBar.viewPlayerList=Player List
@@ -1326,6 +1327,13 @@ KeyBinds.cmdNames.prevMode=Previous Weapon Mode
 KeyBinds.cmdDesc.prevMode=Selects the previous mode for the selected weapon the unit display weapon list.
 KeyBinds.cmdNames.toggleDrawLabels=Toggle Unit Labels
 KeyBinds.cmdDesc.toggleDrawLabels=Toggles between displaying and not displaying unit labels
+KeyBinds.cmdNames.toggleKeyBindDisplay=Toggle Shortcut Key Display
+KeyBinds.cmdDesc.toggleKeyBindDisplay=Toggles the map overlay showing various key shortcuts
+
+#Key Bindings Overlay
+KeyBindingsDisplay.fixedBinds=Toggle Unit Display and Minimap: Mouse Button 4\nZoom: Ctrl + Mouse Wheel\nTurn / Torso twist: Shift + Left-Click\nLine of Sight tool: Ctrl + Left-Click (two hexes)\nRuler tool: Alt + Left-Click (two hexes)
+KeyBindingsDisplay.heading=#FFFFFFKeyboard Shortcuts
+
 
 #LOS / Ruler tool
 LOSDialog.inFirstHex=In first hex:

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-   This is the default key binding for MegaMek.  
-   Key code numeric values are defined in awt.event.KeyEvent.
-   See: http://docs.oracle.com/javase/7/docs/api/constant-values.html#java.awt.event.KeyEvent.CHAR_UNDEFINED
-   The modifier numeric value is a mask that determines what modifier keys are pressed (ie; ctrl, shift, etc). 
-   These are defined at the same webpage, however they should be combined using bitwise ors.
-   Commands are strings used to represent the possible actions MegaMek recognizes.
-   These are defined and listed in megamek.client.ui.swing.util.KeyBindCommand
- -->
 <KeyBindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="keyBindingSchema.xsl">
     <KeyBind>
          <command>scrollN</command> <!-- W -->
@@ -108,29 +99,29 @@
     </KeyBind>
 
     <KeyBind>
-         <command>nextUnit</command> <!-- Ctrl-N -->
-        <keyCode>78</keyCode>
-        <modifier>2</modifier>
-        <isRepeatable>false</isRepeatable>
-    </KeyBind>
-
-    <KeyBind>
-         <command>prevUnit</command> <!-- Shift-Q -->
-        <keyCode>81</keyCode>
-        <modifier>1</modifier>
-        <isRepeatable>false</isRepeatable>
-    </KeyBind>
-
-    <KeyBind>
-         <command>nextTarget</command> <!-- C -->
-        <keyCode>67</keyCode>
+         <command>nextUnit</command> <!-- Tab -->
+        <keyCode>9</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTarget</command> <!-- Z -->
-        <keyCode>90</keyCode>
+         <command>prevUnit</command> <!-- Shift-Tab -->
+        <keyCode>9</keyCode>
+        <modifier>1</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+         <command>nextTarget</command> <!-- NumPad + -->
+        <keyCode>107</keyCode>
+        <modifier>0</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+         <command>prevTarget</command> <!-- NumPad - -->
+        <keyCode>109</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
@@ -283,15 +274,15 @@
     </KeyBind>
 
     <KeyBind>
-         <command>prevMode</command> <!-- Shift-Tab -->
-        <keyCode>9</keyCode>
-        <modifier>1</modifier>
+         <command>prevMode</command> <!-- Number Sign -->
+        <keyCode>520</keyCode>
+        <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextMode</command> <!-- Tab -->
-        <keyCode>9</keyCode>
+         <command>nextMode</command> <!-- Number Sign -->
+        <keyCode>520</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
@@ -299,6 +290,13 @@
     <KeyBind>
          <command>toggleDrawLabels</command> <!-- Ctrl-Y -->
         <keyCode>89</keyCode>
+        <modifier>2</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+         <command>toggleKeyBindDisplay</command> <!-- Ctrl-K -->
+        <keyCode>75</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>

--- a/megamek/src/megamek/client/ui/IDisplayable.java
+++ b/megamek/src/megamek/client/ui/IDisplayable.java
@@ -1,8 +1,8 @@
 /*
  * MegaMek -
  * Copyright (C) 2000,2001,2002,2003,2004,2005,2006 Ben Mazur (bmazur@sev.org)
- *
  * This file (C) 2008 Jörg Walter <j.walter@syntax-k.de>
+ * MegaMek - Copyright (C) 2020 - The MegaMek Team  
  *
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the Free
@@ -23,33 +23,101 @@ import java.awt.Point;
 import java.awt.Rectangle;
 
 /**
- *
- * An object that is displayed over the part of the IBoardView
- * that is currently visible
+ * Used for Boardview overlays that don't move when the map is scrolled
+ * (such as the chat window). Use BoardView1.addDisplayable() to 
+ * add it to the boardview.
+ * 
  * @author jwalt
  */
 public interface IDisplayable {
 
-    public boolean isBeingDragged();
+    /** 
+     * Returns true when this IDisplayable is being dragged or resized
+     * using mouse movement. This will prevent the boardview from reacting to 
+     * this mouse action. 
+     * The default for this method will always return false.
+     */
+    default public boolean isBeingDragged() {
+        return false;
+    };
 
-    public boolean isDragged(Point point, Dimension backSize);
+    /** 
+     * Returns true when this IDisplayable is dragged or resized
+     * using mouse dragging. This will prevent the boardview from reacting to 
+     * this mouse action. 
+     * The default for this method will always return false.
+     */
+    default public boolean isDragged(Point point, Dimension backSize) {
+        return false;
+    };
+    
+    /** 
+     * Returns true when the mouse position point is considered "within" 
+     * this IDisplayable. This is called when a mouse button is pressed.
+     * The default for this method will always return false.
+     */
+    default public boolean isHit(Point point, Dimension size) {
+        return false;
+    };
 
-    public boolean isHit(Point point, Dimension size);
+    /** 
+     * Returns true when the mouse position point is considered "within" 
+     * this IDisplayable. This is called when the mouse or mouse wheel is moved.
+     * backSize is the pixel size of the boardview.
+     * The default for this method will always return false. 
+     */
+    default public boolean isMouseOver(Point point, Dimension backSize) {
+        return false;
+    };
 
-    public boolean isMouseOver(Point point, Dimension backSize);
-
-    public boolean isReleased();
+    default public boolean isReleased() {
+        return false;
+    };
 
     /**
-     * Draw this IDisplayable
-     * @param graph -           the <code>Graphics</code> to draw on
+     * Draw this IDisplayable to the Graphics graph, which is the boardview
+     * graphics. The currently visible part of the boardview is given by
+     * the Rectangle rect, so the upper left corner of the visible
+     * boardview is rect.x, rect.y.
      */
     public void draw(Graphics graph, Rectangle rect);
 
-    public boolean isSliding();
+    /** 
+     * Return true while sliding.
+     * "Sliding" means that this IDisplayable is in the process of
+     * opening, closing moving or fading. The boardview will repaint
+     * at some fps while an IDisplayable is sliding.  
+     * The default for this method will always return false. 
+     */
+    default public boolean isSliding() {
+        return false;
+    };
 
-    public void setIdleTime(long l, boolean b);
+    /**
+     * The boardview calls this to pass on the elapsed time elTime to the 
+     * IDisplayable. when add is true, elTime is usually the elapsed
+     * time since the last call to setIdleTime and should be added to 
+     * a stored elapsed time. 
+     * When add is false, elTime should replace the previously stored elapsed
+     * time (this is usually used with elTime = 0 to reset the elapsed time).
+     * Can be used to make this IDisplayable "slide" after some elapsed
+     * time, see slide().
+     * See ChatterBox2 for examples. 
+     * The default for this method will do nothing.
+     */
+    default public void setIdleTime(long elTime, boolean add) { };
 
-    public boolean slide();
+    /** 
+     * Conducts a frame update when sliding.
+     * "Sliding" means that this IDisplayable is in the process of
+     * opening, closing moving or fading. The boardview will repaint
+     * at some fps while an IDisplayable is sliding. 
+     * Return true as long as the slide process is not finished.
+     * See ChatterBox2 and KeyBindingsOverlay for examples.
+     * The default for this method will always return false.
+     */
+    default public boolean slide() {
+        return false;
+    };
 
 }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -164,6 +164,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
     //region view menu
     public static final String VIEW_MEK_DISPLAY = "viewMekDisplay"; //$NON-NLS-1$
     public static final String VIEW_ACCESSIBILITY_WINDOW = "viewAccessibilityWindow"; //$NON-NLS-1$
+    public static final String VIEW_KEYBINDS_OVERLAY = "viewKeyboardShortcuts";
     public static final String VIEW_MINI_MAP = "viewMiniMap"; //$NON-NLS-1$
     public static final String VIEW_UNIT_OVERVIEW = "viewUnitOverview"; //$NON-NLS-1$
     public static final String VIEW_ZOOM_IN = "viewZoomIn"; //$NON-NLS-1$
@@ -839,6 +840,9 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
                 break;
             case VIEW_ACCESSIBILITY_WINDOW:
                 toggleAccessibilityWindow();
+                break;
+            case VIEW_KEYBINDS_OVERLAY:
+                bv.toggleKeybindsOverlay();
                 break;
             case VIEW_MINI_MAP:
                 toggleMap();

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -89,6 +89,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
     private JMenuItem viewMiniMap;
     private JMenuItem viewMekDisplay;
     private JMenuItem viewAccessibilityWindow;
+    private JCheckBoxMenuItem viewKeybindsOverlay;
     private JMenuItem viewZoomIn;
     private JMenuItem viewZoomOut;
     private JMenuItem viewResetWindowPositions;
@@ -351,6 +352,13 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
         viewAccessibilityWindow.addActionListener(this);
         viewAccessibilityWindow.setActionCommand(ClientGUI.VIEW_ACCESSIBILITY_WINDOW);
         menu.add(viewAccessibilityWindow);
+        
+        viewKeybindsOverlay = new JCheckBoxMenuItem(Messages.getString("CommonMenuBar.viewKeyboardShortcuts"));
+        viewKeybindsOverlay.addActionListener(this);
+        viewKeybindsOverlay.setState(GUIPreferences.getInstance().getBoolean(GUIPreferences.SHOW_KEYBINDS_OVERLAY));
+        viewKeybindsOverlay.setActionCommand(ClientGUI.VIEW_KEYBINDS_OVERLAY);
+        menu.add(viewKeybindsOverlay);
+        viewKeybindsOverlay.setEnabled(false);
         
         viewResetWindowPositions = new JMenuItem(Messages.getString("CommonMenuBar.viewResetWindowPos")); //$NON-NLS-1$
         viewResetWindowPositions.addActionListener(this);
@@ -907,6 +915,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             viewMiniMap.setEnabled(true);
             viewZoomIn.setEnabled(true);
             viewZoomOut.setEnabled(true);
+            viewKeybindsOverlay.setEnabled(true);
         }
         // If we don't have a board we can't view the mini map.
         else {
@@ -917,6 +926,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             viewMiniMap.setEnabled(false);
             viewZoomIn.setEnabled(false);
             viewZoomOut.setEnabled(false);
+            viewKeybindsOverlay.setEnabled(false);
         }
 
         // If we have a unit list, and if we are in the lounge,
@@ -1450,6 +1460,8 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             toggleIsometric.setSelected((Boolean)e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.SHOW_FIELD_OF_FIRE)) {
             toggleFieldOfFire.setSelected((Boolean)e.getNewValue());
+        } else if (e.getName().equals(GUIPreferences.SHOW_KEYBINDS_OVERLAY)) {
+            viewKeybindsOverlay.setSelected((Boolean)e.getNewValue());
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -214,6 +214,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ALLY_UNIT_COLOR = "AllyUnitColor";
     public static final String MY_UNIT_COLOR = "MyUnitColor";
     public static final String ENEMY_UNIT_COLOR = "EnemyUnitColor";
+    public static final String SHOW_KEYBINDS_OVERLAY = "ShowKeybindsOverlay";
     
     // RAT dialog preferences
     public static String RAT_TECH_LEVEL = "RATTechLevel";
@@ -413,6 +414,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ENEMY_UNIT_COLOR, new Color(220, 20, 20));
         setDefault(MY_UNIT_COLOR, new Color(20, 220, 20));
         setDefault(UNIT_LABEL_BORDER_TEAM, true);
+        setDefault(SHOW_KEYBINDS_OVERLAY, true);
         
     }
 

--- a/megamek/src/megamek/client/ui/swing/OffBoardTargetOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/OffBoardTargetOverlay.java
@@ -174,16 +174,6 @@ public class OffBoardTargetOverlay implements IDisplayable {
     }
     
     @Override
-    public boolean isBeingDragged() {
-        return false;
-    }
-
-    @Override
-    public boolean isDragged(Point point, Dimension backSize) {
-        return false;
-    }
-
-    @Override
     public boolean isHit(Point point, Dimension size) {
         Point actualPoint = point;
         actualPoint.x = (int) (point.getX() + clientgui.getBoardView().getDisplayablesRect().getX());
@@ -200,11 +190,6 @@ public class OffBoardTargetOverlay implements IDisplayable {
             }
         }
                 
-        return false;
-    }
-
-    @Override
-    public boolean isMouseOver(Point point, Dimension backSize) {
         return false;
     }
 
@@ -305,20 +290,6 @@ public class OffBoardTargetOverlay implements IDisplayable {
         }
     }
 
-    @Override
-    public boolean isSliding() {
-        return false;
-    }
-
-    @Override
-    public void setIdleTime(long l, boolean b) {
-    }
-
-    @Override
-    public boolean slide() {
-        return false;
-    }
-    
     /**
      * Worker function that handles a click on a 'counterbattery fire' overlay button.
      * Possibly shows a target selection popup

--- a/megamek/src/megamek/client/ui/swing/UnitOverview.java
+++ b/megamek/src/megamek/client/ui/swing/UnitOverview.java
@@ -218,9 +218,6 @@ public class UnitOverview implements IDisplayable {
 
     }
 
-    public void setIdleTime(long timeIdle, boolean add) {
-    }
-
     public boolean isHit(Point p, Dimension size) {
         if (!visible) {
             return false;
@@ -279,18 +276,6 @@ public class UnitOverview implements IDisplayable {
         return false;
     }
 
-    public boolean isMouseOver(Point p, Dimension size) {
-        return false;
-    }
-
-    public boolean isSliding() {
-        return false;
-    }
-
-    public boolean slide() {
-        return false;
-    }
-
     public boolean isDragged(Point p, Dimension size) {
         int x = p.x;
         int y = p.y;
@@ -303,10 +288,6 @@ public class UnitOverview implements IDisplayable {
         } else {
             return true;
         }
-    }
-
-    public boolean isBeingDragged() {
-        return false;
     }
 
     public boolean isReleased() {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -503,6 +503,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
     /** Stores the correct tooltip dismiss delay so it can be restored when exiting the boardview */
     private int dismissDelay = ToolTipManager.sharedInstance().getDismissDelay();
+    
+    /** A map overlay showing some important keybinds. */ 
+    KeyBindingsOverlay keybindOverlay;
 
 
     /**
@@ -520,6 +523,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
         game.addGameListener(gameListener);
         game.getBoard().addBoardListener(this);
+        
+        keybindOverlay = new KeyBindingsOverlay(game, clientgui);
+        addDisplayable(keybindOverlay);
         ourTask = scheduleRedrawTimer();// call only once
         clearSprites();
         addMouseListener(this);
@@ -625,8 +631,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     return;
                 }
 
-                for (int i = 0; i < displayables.size(); i++) {
-                    IDisplayable disp = displayables.get(i);
+                for (IDisplayable disp: displayables) {
                     if (disp.isBeingDragged()) {
                         return;
                     }
@@ -636,7 +641,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                             .getViewport().getSize().getHeight());
                     Dimension drawDimension = new Dimension();
                     drawDimension.setSize(width, height);
-                    disp.isMouseOver(point, drawDimension);
+                    if (disp.isMouseOver(point, drawDimension)) {
+                        refreshDisplayables();
+                    }
                 }
             }
 
@@ -1024,6 +1031,25 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     }
 
                 });
+        
+        // Register the action for TOGGLE_CHAT
+        controller.registerCommandAction(KeyCommandBind.TOGGLE_KEYBIND_DISPLAY.cmd,
+                new CommandAction() {
+
+                    @Override
+                    public boolean shouldPerformAction() {
+                        if (shouldIgnoreKeyCommands()) {
+                            return false;
+                        } else {
+                            return true;
+                        }
+                    }
+
+                    @Override
+                    public void performAction() {
+                        toggleKeybindsOverlay();
+                    }
+                });
     }
 
     private boolean shouldIgnoreKeyCommands() {
@@ -1382,8 +1408,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         displayablesRect.y = -getY();
         displayablesRect.width = scrollpane.getViewport().getViewRect().width;
         displayablesRect.height = scrollpane.getViewport().getViewRect().height;
-        for (int i = 0; i < displayables.size(); i++) {
-            IDisplayable disp = displayables.get(i);
+        for (IDisplayable disp: displayables) {
             disp.draw(g, displayablesRect);
         }
 
@@ -6814,5 +6839,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     
     public Rectangle getDisplayablesRect() {
         return displayablesRect;
+    }
+    
+    public void toggleKeybindsOverlay() {
+        keybindOverlay.setVisible(!keybindOverlay.isVisible());
+        repaint();
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
@@ -1,0 +1,319 @@
+/*  
+* MegaMek - Copyright (C) 2020 - The MegaMek Team  
+*  
+* This program is free software; you can redistribute it and/or modify it under  
+* the terms of the GNU General Public License as published by the Free Software  
+* Foundation; either version 2 of the License, or (at your option) any later  
+* version.  
+*  
+* This program is distributed in the hope that it will be useful, but WITHOUT  
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
+* details.  
+*/  
+package megamek.client.ui.swing.boardview;
+
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Composite;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Rectangle;
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import megamek.client.ui.IDisplayable;
+import megamek.client.ui.Messages;
+import megamek.client.ui.swing.ClientGUI;
+import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.KeyCommandBind;
+import megamek.common.IGame;
+import megamek.common.IGame.Phase;
+import megamek.common.event.GameListener;
+import megamek.common.event.GameListenerAdapter;
+import megamek.common.event.GamePhaseChangeEvent;
+import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.util.ImageUtil;
+
+/** 
+ * An overlay for the Boardview that displays a selection of keybinds
+ * for the current game situation 
+ * 
+ * @author SJuliez
+ */
+public class KeyBindingsOverlay implements IDisplayable {
+
+    private static final Font FONT = new Font("SansSerif", Font.PLAIN, 13); //$NON-NLS-1$
+    private static final int DIST_TOP = 30;
+    private static final int DIST_SIDE = 30;
+    private static final int PADDING_X = 10;
+    private static final int PADDING_Y = 5;
+    private static final Color TEXT_COLOR = new Color(200, 250, 200);
+    private static final Color SHADOW_COLOR = Color.DARK_GRAY;
+    private static final Color BG_COLOR = new Color(80, 80, 80, 120);
+    private static final float FADE_SPEED = 0.2f;
+    
+    /** The keybinds to be shown during the firing phases (incl. physical etc.) */
+    private static final List<KeyCommandBind> BINDS_FIRE = Arrays.asList(
+            KeyCommandBind.NEXT_WEAPON,
+            KeyCommandBind.PREV_WEAPON,
+            KeyCommandBind.FIELD_FIRE,
+            KeyCommandBind.NEXT_TARGET,
+            KeyCommandBind.NEXT_TARGET_VALID,
+            KeyCommandBind.NEXT_TARGET_NOALLIES,
+            KeyCommandBind.NEXT_TARGET_VALID_NO_ALLIES
+            );
+
+    /** The keybinds to be shown during the movement phase */
+    private static final List<KeyCommandBind> BINDS_MOVE = Arrays.asList(
+            KeyCommandBind.MOVE_ENVELOPE,
+            KeyCommandBind.TOGGLE_MOVEMODE,
+            KeyCommandBind.TOGGLE_CONVERSIONMODE
+            );
+
+    /** The keybinds to be shown in all phases during the local player's turn */
+    private static final List<KeyCommandBind> BINDS_MY_TURN = Arrays.asList(
+            KeyCommandBind.CANCEL, 
+            KeyCommandBind.DONE, 
+            KeyCommandBind.NEXT_UNIT,
+            KeyCommandBind.PREV_UNIT,
+            KeyCommandBind.CENTER_ON_SELECTED
+            );
+
+    /** The keybinds to be shown in all phases during any player's turn */
+    private static final List<KeyCommandBind> BINDS_ANY_TURN = Arrays.asList(
+            KeyCommandBind.TOGGLE_KEYBIND_DISPLAY,
+            KeyCommandBind.TOGGLE_CHAT,
+            KeyCommandBind.TOGGLE_ISO,
+            KeyCommandBind.TOGGLE_DRAW_LABELS
+            );
+
+    private static final List<String> ADDTL_BINDS = Arrays.asList(
+            Messages.getString("KeyBindingsDisplay.fixedBinds").split("\n"));
+
+    ClientGUI clientGui;
+
+    /** True when the overlay is displayed or fading in. */
+    private boolean visible;
+    /** True indicates the strings should be redrawn. */
+    private boolean changed = true;
+    /** The cached image for this Display. */
+    Image displayImage;
+    /** The current game phase. */
+    Phase currentPhase;
+    /** True while fading in this overlay. */
+    private boolean fadingIn = false;
+    /** True while fading out this overlay. */
+    private boolean fadingOut = false;
+    /** The transparency of the overlay. Only used while fading in/out. */
+    private float alpha = 1;
+
+    /** 
+     * An overlay for the Boardview that displays a selection of keybinds
+     * for the current game situation. 
+     */
+    public KeyBindingsOverlay(IGame game, ClientGUI cg) {
+        visible = GUIPreferences.getInstance().getBoolean(GUIPreferences.SHOW_KEYBINDS_OVERLAY);
+        currentPhase = game.getPhase();
+        game.addGameListener(gameListener);
+        clientGui = cg;
+    }
+
+    public void draw(Graphics graph, Rectangle clipBounds) {
+        if (!visible && !isSliding()) {
+            return;
+        }
+        
+        // At startup, phase and turn change and when the keybinds change, 
+        // the cached image is (re)created
+        if (changed) {
+            changed = false;
+            
+            // calculate the size from the text lines, font and padding
+            graph.setFont(FONT);
+            FontMetrics fm = graph.getFontMetrics(FONT);
+            ArrayList<String> allLines = assembleTextLines(); 
+            Rectangle r = getSize(graph, allLines, fm);
+            r = new Rectangle(r.width + 2 * PADDING_X, r.height + 2 * PADDING_Y);
+            
+            displayImage = ImageUtil.createAcceleratedImage(r.width, r.height);
+            Graphics intGraph = displayImage.getGraphics();
+            GUIPreferences.AntiAliasifSet(intGraph);
+
+            // draw a semi-transparent background rectangle 
+            intGraph.setColor(BG_COLOR);
+            intGraph.fillRoundRect(0, 0, r.width, r.height, PADDING_X, PADDING_X);
+            
+            // The coordinates to write the texts to
+            int x = PADDING_X;
+            int y = PADDING_Y + fm.getAscent();
+            
+            // write the strings
+            for (String line: allLines) {
+                drawShadowedString(intGraph, line, x, y);
+                y += fm.getHeight();
+            }
+        }
+        
+        // draw the cached image to the boardview
+        // uses Composite to draw the image with variable transparency
+        if (alpha < 1) {
+            // Save the former composite and set an alpha blending composite
+            Composite saveComp = ((Graphics2D)graph).getComposite();
+            int type = AlphaComposite.SRC_OVER;
+            ((Graphics2D)graph).setComposite(AlphaComposite.getInstance(type, alpha));
+            graph.drawImage(displayImage, clipBounds.x + DIST_SIDE, clipBounds.y + DIST_TOP, null);
+            ((Graphics2D)graph).setComposite(saveComp);
+        } else {
+            graph.drawImage(displayImage, clipBounds.x + DIST_SIDE, clipBounds.y + DIST_TOP, null);
+        }
+    }
+
+    /** Calculates the pixel size of the display from the necessary text lines. */ 
+    private Rectangle getSize(Graphics graph, ArrayList<String> lines, FontMetrics fm) {
+        int width = 0;
+        for (String line: lines) {
+            if (fm.stringWidth(line) > width) {
+                width = fm.stringWidth(line);
+            }
+        }
+        int height = fm.getHeight() * lines.size();
+        return new Rectangle(width, height);
+    }
+    
+    /** Returns an ArrayList of all text lines to be shown. */
+    private ArrayList<String> assembleTextLines() {
+        ArrayList<String> result = new ArrayList<String>();
+        
+        result.add(Messages.getString("KeyBindingsDisplay.heading"));
+
+        // Most of the keybinds are only active during the local player's turn 
+        if (clientGui.getClient().isMyTurn()) {
+            List<KeyCommandBind> listForPhase = new ArrayList<>();
+            switch (currentPhase) {
+            case PHASE_MOVEMENT:
+                listForPhase = BINDS_MOVE;
+                break;
+            case PHASE_FIRING:
+            case PHASE_OFFBOARD:
+            case PHASE_PHYSICAL:
+                listForPhase = BINDS_FIRE;
+                break;
+            default:
+            }
+
+            result.addAll(convertToStrings(listForPhase));
+            result.addAll(convertToStrings(BINDS_MY_TURN));
+        }
+
+        result.addAll(convertToStrings(BINDS_ANY_TURN));
+        result.addAll(ADDTL_BINDS);
+        return result;
+    }
+    
+    /** Converts a list of KeyCommandBinds to a list of formatted strings. */
+    private List<String> convertToStrings(List<KeyCommandBind> kcbs) {
+        ArrayList<String> result = new ArrayList<String>();
+        for (KeyCommandBind kcb: kcbs) {
+            String label = Messages.getString("KeyBinds.cmdNames." + kcb.cmd);
+            String mod = KeyEvent.getKeyModifiersText(kcb.modifiers);
+            String key = KeyEvent.getKeyText(kcb.key);
+            result.add(label + ": " + (mod.isBlank() ? "" : mod + "+") + key);
+        }
+        return result;
+    }
+    
+    /** 
+     * Draws the String s to the Graphics graph  at position x,y 
+     * with a shadow. If the string starts with #789ABC then 789ABC 
+     * is converted to a color to write the rest of the text,
+     * otherwise TEXT_COLOR is used.
+     */
+    private void drawShadowedString(Graphics graph, String s, int x, int y) {
+        Color textColor = TEXT_COLOR;
+        // Extract a color code from the start of the string
+        // used to display headlines if it's there
+        if (s.startsWith("#") && s.length() > 7) {
+            try {
+                int red = Integer.parseInt(s.substring(1,3), 16);
+                int grn = Integer.parseInt(s.substring(3,5), 16);
+                int blu = Integer.parseInt(s.substring(5,7), 16);
+                textColor = new Color(red, grn, blu);
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+            }
+            s = s.substring(7);
+        }
+        graph.setColor(SHADOW_COLOR);
+        graph.drawString(s, x + 1, y + 1);
+        graph.setColor(textColor);
+        graph.drawString(s, x, y);
+    }
+    
+    /** 
+     * Activates or deactivates the overlay, fading it in or out.
+     * Also saves the visibility to the GUIPreferences so 
+     * MegaMek remembers it. 
+     * */
+    public void setVisible(boolean vis) {
+        visible = vis;
+        GUIPreferences.getInstance().setValue(GUIPreferences.SHOW_KEYBINDS_OVERLAY, vis);
+        if (vis) {
+            fadingIn = true;
+            fadingOut = false;
+        } else {
+            fadingIn = false;
+            fadingOut = true;
+        }
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+    
+    @Override
+    public boolean isSliding() {
+        return fadingOut || fadingIn;
+    }
+    
+    @Override
+    public boolean slide() {
+        if (fadingIn) {
+            alpha += FADE_SPEED;
+            if (alpha > 1) {
+                alpha = 1;
+                fadingIn = false;
+            }
+            return true;
+        } else if (fadingOut) {
+            alpha -= FADE_SPEED;
+            if (alpha < 0) {
+                alpha = 0;
+                fadingOut = false;
+            }
+            return true;
+        }
+        return false;
+    }
+    
+    /** Detects phase and turn changes to display only relevant keybinds. */
+    private GameListener gameListener = new GameListenerAdapter() {
+        @Override
+        public void gamePhaseChange(GamePhaseChangeEvent e) {
+            currentPhase = e.getNewPhase();
+            changed = true;
+        }
+        
+        @Override
+        public void gameTurnChange(GameTurnChangeEvent e) {
+            // The active player has changed
+            changed = true;
+        }
+    };
+
+}

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -49,7 +49,7 @@ public enum KeyCommandBind {
     NEXT_WEAPON("nextWeapon", false, KeyEvent.VK_E, 0), // Default: E
     PREV_WEAPON("prevWeapon", false, KeyEvent.VK_Q, 0), // Default: Q
     NEXT_UNIT("nextUnit", false, KeyEvent.VK_E, InputEvent.SHIFT_MASK), // Default: Shift-E
-    PREV_UNIT("prevUnit", false, KeyEvent.VK_Q, InputEvent.SHIFT_MASK), // Default: Shift0Q
+    PREV_UNIT("prevUnit", false, KeyEvent.VK_Q, InputEvent.SHIFT_MASK), // Default: Shift-Q
     NEXT_TARGET("nextTarget", false, KeyEvent.VK_C, 0), // Default: C
     PREV_TARGET("prevTarget", false, KeyEvent.VK_Z, 0), // Default: Z
     NEXT_TARGET_VALID("nextTargetValid", false, KeyEvent.VK_C, InputEvent.SHIFT_MASK), // Default: Shift-C
@@ -79,7 +79,8 @@ public enum KeyCommandBind {
     TOGGLE_CONVERSIONMODE("toggleConversion", false, KeyEvent.VK_M, 0), // Default: M
     PREV_MODE("prevMode", false, KeyEvent.VK_TAB, InputEvent.CTRL_MASK), // Default: Tab
     NEXT_MODE("nextMode", false, KeyEvent.VK_TAB, 0), // Default: Tab
-    TOGGLE_DRAW_LABELS("toggleDrawLabels", false, KeyEvent.VK_Y, 0); // Default: Y
+    TOGGLE_DRAW_LABELS("toggleDrawLabels", false, KeyEvent.VK_Y, 0), // Default: Y
+    TOGGLE_KEYBIND_DISPLAY("toggleKeyBindDisplay", false, KeyEvent.VK_K, InputEvent.CTRL_MASK); // Default: Ctrl-K
 
 
     /**


### PR DESCRIPTION
Adds an overlay to the board showing various keyboard shortcuts. I didnt even know that "Next Valid Target (No Allies)" existed, so I figure other people might not know either. The overlay has a menu item and a shortcut (Ctrl-K) to toggle it and it will remember when it's turned off.
The shortcuts shown change with the phase and active player.

Updated the IDisplayable interface with default methods and comments. 

I seem to have committed a change to the default keybinds xml therefore this is currently draft.

Movement Phase:
![image](https://user-images.githubusercontent.com/17069663/90486887-f3546000-e139-11ea-87f8-516622b6c92a.png)
Firing Phase:
![image](https://user-images.githubusercontent.com/17069663/90486919-fd765e80-e139-11ea-847c-532b4cf6cae3.png)
Other player's turn:
![image](https://user-images.githubusercontent.com/17069663/90487061-36163800-e13a-11ea-8e46-78cbbf01a954.png)
Menu item:
![image](https://user-images.githubusercontent.com/17069663/90487168-5fcf5f00-e13a-11ea-8dab-137e23f02683.png)
