### PR TITLE
add doubles to list of allowed things to serialize

### DIFF
--- a/megamek/resources/megamek/serialkiller.xml
+++ b/megamek/resources/megamek/serialkiller.xml
@@ -14,6 +14,7 @@
         <regexp>java\.lang\.Boolean$</regexp>
         <regexp>java\.lang\.Enum$</regexp>
         <regexp>java\.lang\.Integer$</regexp>
+        <regexp>java\.lang\.Double$</regexp>
         <regexp>java\.lang\.Number$</regexp>
         <regexp>java\.lang\.StringBuffer$</regexp>
         <regexp>java\.util\.ArrayList$</regexp>


### PR DESCRIPTION
This was preventing starting a megamek scenario from mekhq, as mekhq apparently passes doubles.

From a security perspective, there's no reason to prevent serialization/deserialization of doubles.