### PR TITLE
Fix #2172 - Whitelist LinkedList for deserialization

### DIFF
--- a/megamek/resources/megamek/serialkiller.xml
+++ b/megamek/resources/megamek/serialkiller.xml
@@ -34,6 +34,7 @@
         <regexp>java\.util\.HashSet$</regexp>
         <regexp>java\.util\.Hashtable$</regexp>
         <regexp>java\.util\.LinkedHashSet$</regexp>
+        <regexp>java\.util\.LinkedList$</regexp>
         <regexp>java\.util\.TreeSet$</regexp>
         <regexp>java\.util\.Vector$</regexp>
         <regexp>\[Ljava\.lang\.Object;$</regexp>


### PR DESCRIPTION
This PR fixes #2172 by whitelisting java.lang.LinkedList for deserialization. 