### PR TITLE
Accept risk and remove serialkiller when loading mech summary

### DIFF
--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -37,7 +37,6 @@ import megamek.common.loaders.EntityLoadingException;
 import megamek.common.logging.*;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.*;
-import org.nibblesec.tools.SerialKiller;
 
 /**
  * Cache of the Mech summary information. Implemented as Singleton so a client
@@ -205,7 +204,7 @@ public class MechSummaryCache {
                     lLastCheck = unit_cache_path.lastModified();
                     InputStream istream = new BufferedInputStream(
                             new FileInputStream(unit_cache_path));
-                    ObjectInputStream fin = new SerialKiller(istream, getClass().getResource("./megamek/serialkiller.xml").toString());
+                    ObjectInputStream fin = new ObjectInputStream(istream);
                     Integer num_units = (Integer) fin.readObject();
                     for (int i = 0; i < num_units; i++) {
                         if (interrupted) {


### PR DESCRIPTION
This should fix [MekHQ #1969](https://github.com/MegaMek/mekhq/issues/1969) by removing serialkiller in the context of loading mech summary files, since attacks in that context would require getting malicious mech files onto the system. I believe that vector is relatively low risk compared to deserializing objects over the wire.