### PR TITLE
Bot friendly fire reduction

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2399,30 +2399,6 @@ public class FireControl {
     }
 
     /**
-     * Utility function that returns true if an attack on the building in the given coordinates
-     * will result in damage to friendly units.
-     */
-    public static boolean friendlyFireCheck(Entity shooter, IGame game, Coords position, boolean includeMobileUnits) {
-        Building building = game.getBoard().getBuildingAt(position);
-        
-        // no building, no problem
-        if (building == null) {
-            return false;
-        }
-        
-        // check if there are any entities in the building that meet the following criteria:
-        // - is friendly
-        // - if we care only about mobile units, has no MP 
-        for(Entity entity : game.getEntitiesVector(position, true)) {
-            if(!entity.isEnemyOf(shooter) && (includeMobileUnits || (entity.getWalkMP(true, false) == 0))) {
-                return true;
-            }
-        }
-        
-        return false;
-    }
-    
-    /**
      * This is it. Calculate the 'best' possible firing plan for this entity.
      * Overload this function if you think you can do better.
      *

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -27,6 +27,7 @@ import java.util.Vector;
 import megamek.common.AmmoType;
 import megamek.common.BattleArmor;
 import megamek.common.BombType;
+import megamek.common.Building;
 import megamek.common.BuildingTarget;
 import megamek.common.Compute;
 import megamek.common.Coords;
@@ -2397,6 +2398,30 @@ public class FireControl {
         return targetableEnemyList;
     }
 
+    /**
+     * Utility function that returns true if an attack on the building in the given coordinates
+     * will result in damage to friendly units.
+     */
+    public static boolean friendlyFireCheck(Entity shooter, IGame game, Coords position, boolean includeMobileUnits) {
+        Building building = game.getBoard().getBuildingAt(position);
+        
+        // no building, no problem
+        if (building == null) {
+            return false;
+        }
+        
+        // check if there are any entities in the building that meet the following criteria:
+        // - is friendly
+        // - if we care only about mobile units, has no MP 
+        for(Entity entity : game.getEntitiesVector(position, true)) {
+            if(!entity.isEnemyOf(shooter) && (includeMobileUnits || (entity.getWalkMP(true, false) == 0))) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
     /**
      * This is it. Calculate the 'best' possible firing plan for this entity.
      * Overload this function if you think you can do better.

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -27,7 +27,6 @@ import java.util.Vector;
 import megamek.common.AmmoType;
 import megamek.common.BattleArmor;
 import megamek.common.BombType;
-import megamek.common.Building;
 import megamek.common.BuildingTarget;
 import megamek.common.Compute;
 import megamek.common.Coords;

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import megamek.client.bot.princess.AeroPathUtil;
+import megamek.client.bot.princess.FireControl;
 import megamek.common.BulldozerMovePath;
 import megamek.common.Coords;
 import megamek.common.Entity;
@@ -227,6 +228,12 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         if (irreversibleJumpDown && 
                 !clusterTracker.coordinatesShareCluster(child.getEntity(), child.getFinalCoords(), destinationCoords,
                         mli.destHexElevation, destHexElevation)) {
+            return;
+        }
+        
+        // let's avoid pathing through buildings containing our immobile units - 
+        // they're not going to get out of the way and we can probably do better than killing our own guys
+        if(!child.isJumping() && FireControl.friendlyFireCheck(child.getEntity(), child.getGame(), child.getFinalCoords(), false)) {
             return;
         }
         

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -42,9 +42,9 @@ import megamek.common.Terrains;
  */
 public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
 
-    Comparator<BulldozerMovePath> movePathComparator;
-    int maximumCost = Integer.MAX_VALUE;
-    Map<Coords, Boolean> friendlyFireCheckResults = new HashMap<>();
+    private Comparator<BulldozerMovePath> movePathComparator;
+    private int maximumCost = Integer.MAX_VALUE;
+    private Map<Coords, Boolean> friendlyFireCheckResults = new HashMap<>();
     
     /**
      * Uses an A* search to find the "optimal" path to the destination coordinates.
@@ -65,7 +65,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         
         // if we're calculating a jump path and the entity has jump mp and can jump, start off with a jump
         // if we're trying to calc a jump path and the entity does not have jump mp, we're done
-        if(jump && (startPath.getCachedEntityState().getJumpMPWithTerrain() > 0) &&
+        if (jump && (startPath.getCachedEntityState().getJumpMPWithTerrain() > 0) &&
                 !entity.isProne() && !entity.isHullDown() && 
                 (entity.getGame().getPlanetaryConditions().getWindStrength() != PlanetaryConditions.WI_TORNADO_F4)) {
             startPath.addStep(MoveStepType.START_JUMP);
@@ -235,11 +235,11 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         
         // let's avoid pathing through buildings containing our immobile units - 
         // they're not going to get out of the way and we can probably do better than killing our own guys
-        if(!child.isJumping() && friendlyFireCheck(child.getEntity(), child.getGame(), child.getFinalCoords(), false)) {
+        if (!child.isJumping() && friendlyFireCheck(child.getEntity(), child.getGame(), child.getFinalCoords(), false)) {
             return;
         }
         
-        if((!shortestPathsToCoords.containsKey(child.getFinalCoords()) ||
+        if ((!shortestPathsToCoords.containsKey(child.getFinalCoords()) ||
                 // shorter path to these coordinates
                 (movePathComparator.compare(shortestPathsToCoords.get(child.getFinalCoords()), child) > 0)) &&
                 // legal or needs leveling or jumping and not off-board
@@ -255,8 +255,8 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * Utility function that returns true if an attack on the building in the given coordinates
      * will result in damage to friendly units. Computation is cached as it is somewhat expensive to perform for each possible path node.
      */
-    public boolean friendlyFireCheck(Entity shooter, IGame game, Coords position, boolean includeMobileUnits) {
-        if(friendlyFireCheckResults.containsKey(position)) {
+    private boolean friendlyFireCheck(Entity shooter, IGame game, Coords position, boolean includeMobileUnits) {
+        if (friendlyFireCheckResults.containsKey(position)) {
             return friendlyFireCheckResults.get(position);
         }
         
@@ -271,8 +271,8 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         // check if there are any entities in the building that meet the following criteria:
         // - is friendly
         // - if we care only about mobile units, has no MP 
-        for(Entity entity : game.getEntitiesVector(position, true)) {
-            if(!entity.isEnemyOf(shooter) && (includeMobileUnits || (entity.getWalkMP(true, false) == 0))) {
+        for (Entity entity : game.getEntitiesVector(position, true)) {
+            if (!entity.isEnemyOf(shooter) && (includeMobileUnits || (entity.getWalkMP(true, false) == 0))) {
                 friendlyFireCheckResults.put(position, true);
                 return true;
             }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -33720,10 +33720,8 @@ public class Server implements Runnable {
                                 step, moveType));
                     }
                 } else if (moveType == EntityMovementType.MOVE_JUMP) {
-                    getLogger().error(getClass(), METHOD_NAME, "gravity move check jump: "
+                    getLogger().debug(getClass(), METHOD_NAME, "gravity move check jump: "
                             + step.getMpUsed() + "/" + cachedMaxMPExpenditure);
-                    // TODO : Don't know if this still needs to be here after updating for new logging system.
-                    System.err.flush();
                     int origWalkMP = entity.getWalkMP(false, false);
                     int gravWalkMP = entity.getWalkMP();
                     if (step.getMpUsed() > cachedMaxMPExpenditure) {


### PR DESCRIPTION
Doesn't happen very often, but I've seen the bot blow up buildings containing its own turrets to try to get to the other side. Mostly this happens after you've considerably reduced the building CF. This PR addresses that by preventing the long-range pathfinder from pathing through buildings containing immobile units. 

Initial version was abominably slow for some reason, but adding a caching mechanism speeded things up nicely.