### PR TITLE
mek mortars correctly do 1/2 damage to reactive armor(?)

### DIFF
--- a/megamek/src/megamek/common/weapons/MekMortarHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarHandler.java
@@ -17,6 +17,7 @@ import java.util.Vector;
 
 import megamek.common.BattleArmor;
 import megamek.common.Compute;
+import megamek.common.HitData;
 import megamek.common.IGame;
 import megamek.common.Infantry;
 import megamek.common.Report;
@@ -44,6 +45,7 @@ public class MekMortarHandler extends AmmoWeaponHandler {
      */
     public MekMortarHandler(ToHitData t, WeaponAttackAction w, IGame g, Server s) {
         super(t, w, g, s);
+        generalDamageType = HitData.DAMAGE_MISSILE;
     }
 
     /*


### PR DESCRIPTION
Fixes #2074 by setting the mek mortar's "general damage type" to missile so that reactive armor catches it.

Don't have my copy of TacOps handy, so I'll sit on this until I get to it tomorrow night to confirm that this is the right way to handle the situation.