### PR TITLE
on phase change, update gun emplacements

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -5356,8 +5356,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 default:
             }
             for (Entity en: game.getEntitiesVector()) {
-                if (en.getDamageLevel() != Entity.DMG_NONE && 
-                        (en.damageThisRound != 0 || en instanceof GunEmplacement)) {
+                if ((en.getDamageLevel() != Entity.DMG_NONE) && 
+                        ((en.damageThisRound != 0) || (en instanceof GunEmplacement))) {
                     tileManager.reloadImage(en);
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -113,6 +113,7 @@ import megamek.common.ECMInfo;
 import megamek.common.Entity;
 import megamek.common.EntityVisibilityUtils;
 import megamek.common.Flare;
+import megamek.common.GunEmplacement;
 import megamek.common.IBoard;
 import megamek.common.IGame;
 import megamek.common.IGame.Phase;
@@ -5355,7 +5356,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 default:
             }
             for (Entity en: game.getEntitiesVector()) {
-                if (en.getDamageLevel() != Entity.DMG_NONE && en.damageThisRound != 0) {
+                if (en.getDamageLevel() != Entity.DMG_NONE && 
+                        (en.damageThisRound != 0 || en instanceof GunEmplacement)) {
                     tileManager.reloadImage(en);
                 }
             }


### PR DESCRIPTION
Because gun emplacements don't actually take damage, there's no 'entity update' when they take a crit during weapons fire. They do get updated during a phase change, so we'll refresh the sprite at that point to avoid extra network chattiness (it's possible that an emplacement gets crit during the movement phase, but fairly unlikely).