### PR TITLE
mtf fixes for Level 1 Rifleman RFL-2N and Swordsman SWD-2

### DIFF
--- a/megamek/data/mechfiles/mechs/XTRs/Primitives IV/Rifleman RFL-2N.mtf
+++ b/megamek/data/mechfiles/mechs/XTRs/Primitives IV/Rifleman RFL-2N.mtf
@@ -9,15 +9,15 @@ Source:XTRO Primitives IV - Age of War
 Rules Level:1
 
 Mass:50
-Engine:200 Fusion Engine(IS)
-Structure:IS Standard
+Engine:200 Fusion Engine
+Structure:Standard
 Myomer:Standard
 
 Heat Sinks:16 Single
 Walk MP:4
 Jump MP:0
 
-Armor:Standard(IS/Clan)
+Armor:Standard(Inner Sphere)
 LA Armor:15
 RA Armor:15
 LT Armor:15

--- a/megamek/data/mechfiles/mechs/XTRs/Primitives IV/Swordsman SWD-2.mtf
+++ b/megamek/data/mechfiles/mechs/XTRs/Primitives IV/Swordsman SWD-2.mtf
@@ -9,15 +9,15 @@ Source:XTRO Primitives IV - Age of War
 Rules Level:1
 
 Mass:40
-Engine:160 Fusion Engine(IS)
-Structure:IS Standard
+Engine:160 Fusion Engine
+Structure:Standard
 Myomer:Standard
 
 Heat Sinks:10 Single
 Walk MP:4
 Jump MP:0
 
-Armor:Standard(IS/Clan)
+Armor:Standard(Inner Sphere)
 LA Armor:10
 RA Armor:10
 LT Armor:14


### PR DESCRIPTION
Update for PR #2234 

Just noticed MegaMek now complains about Rifleman RFL-2N and Swordsman SWD-2 being level 1. Looks like level 1 units need to use the simplified mtf syntax.