### PR TITLE
Fix units getting stuck when jumping into water and getting hull down result

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -12300,6 +12300,8 @@ public class Server implements Runnable {
                 || (entity.isHullDown() && !entity.canGoHullDown())) {
                 addReport(doEntityFall(entity, roll));
             } else {
+                ServerHelper.sinkToBottom(entity);
+                
                 r = new Report(2317);
                 r.subject = entity.getId();
                 r.add(entity.getDisplayName());
@@ -21126,6 +21128,8 @@ public class Server implements Runnable {
                             entity.setHullDown(true);
                         }
                         if (entity.isHullDown() && entity.canGoHullDown()) {
+                            ServerHelper.sinkToBottom(entity);
+                            
                             r = new Report(2317);
                             r.subject = entity.getId();
                             r.add(entity.getDisplayName());

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -395,4 +395,22 @@ public class ServerHelper {
             vPhaseReport.addAll(s.destroyEntity(entity, "pilot death", true));
         }
     }
+    
+    /**
+     * Helper function that causes an entity to sink to the bottom of the water
+     * hex it's currently in.
+     */
+    public static void sinkToBottom(Entity entity) {
+        IHex fallHex = entity.getGame().getBoard().getHex(entity.getPosition());
+        int waterDepth = 0;
+        
+        // we're going hull down, we still sink to the bottom if appropriate
+        if (fallHex.containsTerrain(Terrains.WATER)) {
+            // *Only* use this if there actually is water in the hex, otherwise
+            // we get ITerrain.LEVEL_NONE, i.e. Integer.minValue...
+            waterDepth = fallHex.terrainLevel(Terrains.WATER);
+        }
+        
+        entity.setElevation(-waterDepth);
+    }
 }

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -401,16 +401,24 @@ public class ServerHelper {
      * hex it's currently in.
      */
     public static void sinkToBottom(Entity entity) {
+        if((entity == null) || !entity.getGame().getBoard().contains(entity.getPosition())) {
+            return;
+        }
+        
         IHex fallHex = entity.getGame().getBoard().getHex(entity.getPosition());
         int waterDepth = 0;
         
         // we're going hull down, we still sink to the bottom if appropriate
         if (fallHex.containsTerrain(Terrains.WATER)) {
-            // *Only* use this if there actually is water in the hex, otherwise
-            // we get ITerrain.LEVEL_NONE, i.e. Integer.minValue...
-            waterDepth = fallHex.terrainLevel(Terrains.WATER);
+            boolean hexHasBridge = fallHex.containsTerrain(Terrains.BRIDGE_CF);
+            boolean entityOnTopOfBridge = hexHasBridge && (entity.getElevation() == fallHex.ceiling());
+            
+            if (!entityOnTopOfBridge) {
+                // *Only* use this if there actually is water in the hex, otherwise
+                // we get ITerrain.LEVEL_NONE, i.e. Integer.minValue...
+                waterDepth = fallHex.terrainLevel(Terrains.WATER);
+                entity.setElevation(-waterDepth);
+            }
         }
-        
-        entity.setElevation(-waterDepth);
     }
 }


### PR DESCRIPTION
Finally fixes #705 

When a unit goes hull down, it's set as 'hull down', but none of the other fall behaviors occur - including elevation adjustment for sinking to the bottom. This PR addresses the issue.