### PR TITLE
Skip negative armor test for patchwork

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -716,7 +716,8 @@ public class TestMech extends TestEntity {
             }
         }
 
-        if (getEntity().getLabTotalArmorPoints() < getEntity().getTotalOArmor()) {
+        if (!getEntity().hasPatchworkArmor()
+                && (getEntity().getLabTotalArmorPoints() < getEntity().getTotalOArmor())) {
             correct = false;
             buff.append("Too many armor points allocated");
         }


### PR DESCRIPTION
Mech validation tests for armor allocated in excess of the number of points provided from the allotted weight of armor. This was commented out seven years ago with no explanation in the code or the commit message. It was restored a few months ago to prevent starting a refit in MekHQ with too many armor points allocated, but the test for maximum armor points does not take patchwork into account. Since patchwork armor calculates the weight from the points allocated rather than vice-versa, the test is not relevant and should be skipped.

Fixes MegaMek/megameklab#768