### PR TITLE
correct VTOL stacking check

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -1134,7 +1134,7 @@ public class MoveStep implements Serializable {
 
         // Check for a stacking violation.
         final Entity violation = Compute.stackingViolation(game,
-                entity.getId(), getPosition());
+                entity, getElevation(), getPosition(), null);
         if ((violation != null) && (getType() != MoveStepType.CHARGE)
                 && (getType() != MoveStepType.DFA)) {
             setStackingViolation(true);


### PR DESCRIPTION
MoveStep was always assuming the elevation in the hex being stepped into is the same as the entity's current elevation, which isn't correct for non-aerospace airborne units (VTOLs, WIGEs, LAMs in airmech mode etc). Use the step's actual elevation for stacking violation check instead.

The null is because that overload of "stackingViolation" requires a transport, and we wouldn't be in this code if we were loaded in a transport.

Fixes #1233