### PR TITLE
Return default heat sink name for 0 HS mechs

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1739,7 +1739,9 @@ public abstract class Mech extends Entity {
                 return m.getName();
             }
         }
-        return "";
+        
+        // if a mech has no heat sink equipment, we pretend like it has standard heat sinks.
+        return "Heat Sink";
     }
 
     public int getHeatCapacity(boolean includePartialWing,


### PR DESCRIPTION
Pretty straightforward. This method is only used in the TRO views to determine the text displayed in the 'Heat Sinks' line.

Fixes #2093 