### PR TITLE
Fix wreck decal path Linux UI rendering problem

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
@@ -116,8 +116,8 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         hexTileset = new HexTileset(boardview.game);
         tracker = new MediaTracker(boardview);
         try {
-            String wreckDecalPath = String.format("%s\\%s", DIR_NAME_WRECKS, DIR_NAME_BOTTOM_DECALS);
-            File wreckDir = new File(Configuration.unitImagesDir(), wreckDecalPath);
+            File wreckDir = new File(Configuration.unitImagesDir(), DIR_NAME_WRECKS);
+            File wreckDecalDir = new File(wreckDir, DIR_NAME_BOTTOM_DECALS);
             
             int bigWreckCount = 0;
             int tinyWreckCount = 0;
@@ -126,8 +126,8 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
             for(int decalIndex = 1; decalIndex < MAX_NUM_DECALS; decalIndex++) {
                 String heavyFileName = String.format("%s_%d_%s.png", FILENAME_PREFIX_WRECKS, decalIndex, FILENAME_SUFFIX_WRECKS_ASSAULTPLUS);
                 String lightFileName = String.format("%s_%d_%s.png", FILENAME_PREFIX_WRECKS, decalIndex, FILENAME_SUFFIX_WRECKS_ULTRALIGHT);
-                Image heavyImage = LoadSpecificImage(wreckDir, heavyFileName);
-                Image lightImage = LoadSpecificImage(wreckDir, lightFileName);
+                Image heavyImage = LoadSpecificImage(wreckDecalDir, heavyFileName);
+                Image lightImage = LoadSpecificImage(wreckDecalDir, lightFileName);
                 
                 if (heavyImage != null) {
                     bigWreckCount++;
@@ -218,12 +218,13 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         
         String suffix = EntityWreckHelper.getWeightSuffix(entity);
         String filename = String.format("crater_decal_%s.png", suffix);
-        String path = String.format("%s\\%s", DIR_NAME_WRECKS, DIR_NAME_BOTTOM_DECALS);
+        File wreckDir = new File(Configuration.unitImagesDir(), DIR_NAME_WRECKS);
+        File wreckDecalDir = new File(wreckDir, DIR_NAME_BOTTOM_DECALS);
         
         if(wreckageDecals.containsKey(filename)) {
             marker = wreckageDecals.get(filename);
         } else {
-            marker = TilesetManager.LoadSpecificImage(new File(Configuration.unitImagesDir(), path), filename);
+            marker = TilesetManager.LoadSpecificImage(wreckDecalDir, filename);
             wreckageDecals.put(filename, marker);
         }
         
@@ -245,12 +246,13 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         
         int wreckNum = (entity.getId() % this.wreckageDecalCount.get(suffix)) + 1;
         String filename = String.format("%s_%d_%s.png", FILENAME_PREFIX_WRECKS, wreckNum, suffix);
-        String path = String.format("%s\\%s", DIR_NAME_WRECKS, DIR_NAME_BOTTOM_DECALS);
+        File wreckDir = new File(Configuration.unitImagesDir(), DIR_NAME_WRECKS);
+        File wreckDecalDir = new File(wreckDir, DIR_NAME_BOTTOM_DECALS);
         
         if(wreckageDecals.containsKey(filename)) {
             marker = wreckageDecals.get(filename);
         } else {
-            marker = TilesetManager.LoadSpecificImage(new File(Configuration.unitImagesDir(), path), filename);
+            marker = TilesetManager.LoadSpecificImage(wreckDecalDir, filename);
             wreckageDecals.put(filename, marker);
         }
         
@@ -263,13 +265,15 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         
         String suffix = EntityWreckHelper.getWeightSuffix(entity);
         String filename = String.format("fuelleak_decal_%s.png", suffix);
-        String path = String.format("%s\\%s", DIR_NAME_WRECKS, DIR_NAME_BOTTOM_DECALS);
+        File wreckDir = new File(Configuration.unitImagesDir(), DIR_NAME_WRECKS);
+        File wreckDecalDir = new File(wreckDir, DIR_NAME_BOTTOM_DECALS);
         
         int rotationKey = entity.getId() % NUM_DECAL_ROTATIONS;
         String imageKey = String.format("%s%s", filename, rotationKey);
         
         if(!wreckageDecals.containsKey(imageKey)) {
-            Image baseImage = TilesetManager.LoadSpecificImage(new File(Configuration.unitImagesDir(), path), filename);
+            // Image baseImage = TilesetManager.LoadSpecificImage(new File(Configuration.unitImagesDir(), path), filename);
+            Image baseImage = TilesetManager.LoadSpecificImage(wreckDecalDir, filename);
             
             for(double x = 0; x < NUM_DECAL_ROTATIONS; x++) {
                 RotateFilter rf = new RotateFilter(x * 90);
@@ -295,13 +299,14 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         
         if(motivePrefix != null) {
             String filename = String.format("%s_decal_%s.png", motivePrefix, weightSuffix);
-            String path = String.format("%s\\%s", DIR_NAME_WRECKS, DIR_NAME_BOTTOM_DECALS);
+            File wreckDir = new File(Configuration.unitImagesDir(), DIR_NAME_WRECKS);
+            File wreckDecalDir = new File(wreckDir, DIR_NAME_BOTTOM_DECALS);
             
             int rotationKey = entity.getId() % NUM_DECAL_ROTATIONS;
             String imageKey = String.format("%s%s", filename, rotationKey);
             
             if(!wreckageDecals.containsKey(imageKey)) {
-                Image baseImage = TilesetManager.LoadSpecificImage(new File(Configuration.unitImagesDir(), path), filename);
+                Image baseImage = TilesetManager.LoadSpecificImage(wreckDecalDir, filename);
                 
                 for(double x = 0; x < NUM_DECAL_ROTATIONS; x++) {
                     RotateFilter rf = new RotateFilter(x * 90);

--- a/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
@@ -272,7 +272,6 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         String imageKey = String.format("%s%s", filename, rotationKey);
         
         if(!wreckageDecals.containsKey(imageKey)) {
-            // Image baseImage = TilesetManager.LoadSpecificImage(new File(Configuration.unitImagesDir(), path), filename);
             Image baseImage = TilesetManager.LoadSpecificImage(wreckDecalDir, filename);
             
             for(double x = 0; x < NUM_DECAL_ROTATIONS; x++) {


### PR DESCRIPTION
As I mentioned in Slack, I found 0.47.10 up to the latest dev unplayable as the UI would stop rendering any updates after awhile. Behavior started similar to #2191, but eventually the UI would not refresh at all.

Noticed the error below repeated in the logs. Note the mix of forward and back slashes in the file path on the first line, which causes a failure on Linux (possibly Mac OS as well),

```
Trying to load image for a non-existent file! Path: data/images/units/wrecks\bottomdecals/fuelleak_decal_assaultplus.png
18:56:10,456 ERROR [megamek.client.ui.swing.tileset.TilesetManager] {AWT-EventQueue-0} 
LoadSpecificImage() : Error opening image: fuelleak_decal_assaultplus.png

Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
        at megamek.client.ui.swing.tileset.TilesetManager.bottomLayerFuelLeakMarkerFor(TilesetManager.java:278)
        at megamek.client.ui.swing.boardview.IsometricSprite.drawImmobileElements(IsometricSprite.java:172)
        at megamek.client.ui.swing.boardview.IsometricSprite.drawOnto(IsometricSprite.java:159)
        at megamek.client.ui.swing.boardview.BoardView1.drawIsometricSpritesForHex(BoardView1.java:1921)
        at megamek.client.ui.swing.boardview.BoardView1.drawHexes(BoardView1.java:2517)
        at megamek.client.ui.swing.boardview.BoardView1.drawHexes(BoardView1.java:2461)
        at megamek.client.ui.swing.boardview.BoardView1.paintComponent(BoardView1.java:1292)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1074)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:907)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1083)
        at java.desktop/javax.swing.JViewport.paint(JViewport.java:737)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:907)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1083)
        at java.desktop/javax.swing.JComponent.paintToOffscreen(JComponent.java:5255)
        at java.desktop/javax.swing.BufferStrategyPaintManager.paint(BufferStrategyPaintManager.java:246)
        at java.desktop/javax.swing.RepaintManager.paint(RepaintManager.java:1323)
        at java.desktop/javax.swing.JComponent._paintImmediately(JComponent.java:5203)
        at java.desktop/javax.swing.JComponent.paintImmediately(JComponent.java:5013)
        at java.desktop/javax.swing.RepaintManager$4.run(RepaintManager.java:865)
        at java.desktop/javax.swing.RepaintManager$4.run(RepaintManager.java:848)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.desktop/javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:848)
        at java.desktop/javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:823)
        at java.desktop/javax.swing.RepaintManager.prePaintDirtyRegions(RepaintManager.java:772)
        at java.desktop/javax.swing.RepaintManager$ProcessingRunnable.run(RepaintManager.java:1890)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```