### PR TITLE
don't apply vibra bomb damage to moving unit not in hex

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11582,7 +11582,7 @@ public class Server implements Runnable {
                 // if the moving entity is not actually moving into the vibrabomb
                 // hex, it won't get damaged
                 Integer excludeEntityID = null;
-                if(!coords.equals(mf.getCoords())) {
+                if (!coords.equals(mf.getCoords())) {
                     excludeEntityID = entity.getId();
                 }
                     
@@ -11757,7 +11757,7 @@ public class Server implements Runnable {
             if (entity.isAirborne()) {
                 continue;
             }
-            
+
             // check for the OptionsConstants.ADVGRNDMOV_NO_PREMOVE_VIBRA option
             // If it's set, and the target has not yet moved,
             // it doesn't get damaged.
@@ -11771,7 +11771,7 @@ public class Server implements Runnable {
             }
             
             // the "currently moving entity" may not be in the same hex, so it needs to be excluded
-            if((entityToExclude != null) && (entity.getId() == entityToExclude)) {
+            if ((entityToExclude != null) && (entity.getId() == entityToExclude)) {
                 // report not hitting vibrabomb
                 r = new Report(2157);
                 r.subject = entity.getId();

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11578,7 +11578,15 @@ public class Server implements Runnable {
                 r.add(entity.getShortName(), true);
                 r.add(mf.getCoords().getBoardNum(), true);
                 vMineReport.add(r);
-                explodeVibrabomb(mf, vMineReport, false);
+                
+                // if the moving entity is not actually moving into the vibrabomb
+                // hex, it won't get damaged
+                Integer excludeEntityID = null;
+                if(!coords.equals(mf.getCoords())) {
+                    excludeEntityID = entity.getId();
+                }
+                    
+                explodeVibrabomb(mf, vMineReport, false, excludeEntityID);
             }
 
             // Hack; when moving, the Mech isn't in the hex during
@@ -11738,7 +11746,7 @@ public class Server implements Runnable {
      *
      * @param mf The <code>Minefield</code> to explode
      */
-    private void explodeVibrabomb(Minefield mf, Vector<Report> vBoomReport, boolean reduce) {
+    private void explodeVibrabomb(Minefield mf, Vector<Report> vBoomReport, boolean reduce, Integer entityToExclude) {
         Iterator<Entity> targets = game.getEntities(mf.getCoords());
         Report r;
 
@@ -11749,7 +11757,7 @@ public class Server implements Runnable {
             if (entity.isAirborne()) {
                 continue;
             }
-
+            
             // check for the OptionsConstants.ADVGRNDMOV_NO_PREMOVE_VIBRA option
             // If it's set, and the target has not yet moved,
             // it doesn't get damaged.
@@ -11761,12 +11769,23 @@ public class Server implements Runnable {
                 vBoomReport.add(r);
                 continue;
             }
-            // report hitting vibrabomb
-            r = new Report(2160);
-            r.subject = entity.getId();
-            r.add(entity.getShortName(), true);
-            vBoomReport.add(r);
-
+            
+            // the "currently moving entity" may not be in the same hex, so it needs to be excluded
+            if((entityToExclude != null) && (entity.getId() == entityToExclude)) {
+                // report not hitting vibrabomb
+                r = new Report(2157);
+                r.subject = entity.getId();
+                r.add(entity.getShortName(), true);
+                vBoomReport.add(r);
+                continue;
+            } else {
+                // report hitting vibrabomb
+                r = new Report(2160);
+                r.subject = entity.getId();
+                r.add(entity.getShortName(), true);
+                vBoomReport.add(r);
+            }
+            
             int damage = mf.getDensity();
             while (damage > 0) {
                 int cur_damage = Math.min(5, damage);


### PR DESCRIPTION
Basically, a unit moving out of a vibrabomb hex *can* still detonate the vibrabomb field if it's heavier than the field's tonnage setting by at least 10 tons, but it shouldn't take any damage.

Fixes #1978 