### PR TITLE
fix minefield clearance eligibility; bulletproof attack handling

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1159,8 +1159,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // Only weapons allowed to clear minefields can target a hex for minefield clearance
-        if ((target instanceof MinefieldTarget) && 
-                ((atype == null) || ((atype != null) && !AmmoType.canClearMinefield(atype)))) {
+        if ((target.getTargetType() == Targetable.TYPE_MINEFIELD_CLEAR) && 
+                ((atype == null) || !AmmoType.canClearMinefield(atype))) {
             return Messages.getString("WeaponAttackAction.CantClearMines");
         }
         

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1159,7 +1159,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // Only weapons allowed to clear minefields can target a hex for minefield clearance
-        if ((target instanceof MinefieldTarget) && atype != null && !AmmoType.canClearMinefield(atype)) {
+        if ((target instanceof MinefieldTarget) && 
+                ((atype == null) || ((atype != null) && !AmmoType.canClearMinefield(atype)))) {
             return Messages.getString("WeaponAttackAction.CantClearMines");
         }
         

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1173,33 +1173,34 @@ public class WeaponHandler implements AttackHandler, Serializable {
                         r.subject = subjectId;
                         vPhaseReport.addElement(r);
                         hits = 0;
-                    }
-                    // targeting a hex for igniting
-                    if ((target.getTargetType() == Targetable.TYPE_HEX_IGNITE)
+                    // targeting a hex for igniting    
+                    } else if ((target.getTargetType() == Targetable.TYPE_HEX_IGNITE)
                             || (target.getTargetType() == Targetable.TYPE_BLDG_IGNITE)) {
                         handleIgnitionDamage(vPhaseReport, bldg, hits);
                         hits = 0;
-                    }
                     // targeting a hex for clearing
-                    if (target.getTargetType() == Targetable.TYPE_HEX_CLEAR) {
+                    } else if (target.getTargetType() == Targetable.TYPE_HEX_CLEAR) {
                         nDamage = nDamPerHit * hits;
                         handleClearDamage(vPhaseReport, bldg, nDamage);
                         hits = 0;
-                    }
                     // Targeting a building.
-                    if (target.getTargetType() == Targetable.TYPE_BUILDING) {
+                    } else if (target.getTargetType() == Targetable.TYPE_BUILDING) {
                         // The building takes the full brunt of the attack.
                         nDamage = nDamPerHit * hits;
                         handleBuildingDamage(vPhaseReport, bldg, nDamage,
                                 target.getPosition());
                         hits = 0;
-                    }
-                    if (entityTarget != null) {
+                    } else if (entityTarget != null) {
                         handleEntityDamage(entityTarget, vPhaseReport, bldg,
                                 hits, nCluster, bldgAbsorbs);
                         server.creditKill(entityTarget, ae);
                         hits -= nCluster;
                         firstHit = false;
+                    } else {
+                        // we shouldn't be here, but if we get here, let's set hits to 0
+                        // to avoid infinite loops
+                        hits = 0;
+                        getLogger().error(getClass(), "Unexpected target type: " + target.getTargetType());
                     }
                 } // Handle the next cluster.
             } else { // We missed, but need to handle special miss cases


### PR DESCRIPTION
Fixes #1813 

"can clear minefield" was checking ammo types, but lasers don't have ammo, so they were reporting as being able to clear minefields.

Doing that was causing the WeaponAttackHandler to go into an endless loop as the number of hits would never get reduced. Added a fallback case to reduce the number of hits anyway and log it, to at least avoid going into an endless loop.