### PR TITLE
Fix mp calculation for quadvee with track/wheel damage.

### DIFF
--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -157,7 +157,7 @@ public class QuadVee extends QuadMech {
         if (badTracks == 4) {
             return 0;
         } else if (badTracks > 1) {
-            wmp = wmp / 1 << badTracks;
+            wmp = wmp / (1 << badTracks);
         }
 
         //Now apply modifiers


### PR DESCRIPTION
QuadVees that take damage to the wheel/track critical (or lose the location) should have their mp reduced, not increased. Parentheses are important.

Fixes #2253 