### PR TITLE
disable bot name field when editing existing bot

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
@@ -101,10 +101,11 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
     public BotConfigDialog(JFrame parent, BotClient existingBot) {
         this(parent, new HashSet<>());
         
+        nameField.setEnabled(false);
+        
         if (existingBot instanceof Princess) {
             this.princessBehavior = ((Princess) existingBot).getBehaviorSettings();
             nameField.setText(existingBot.getName());
-            nameField.setEnabled(false);
             setPrincessFields();
         }
     }

--- a/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
@@ -104,6 +104,7 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
         if (existingBot instanceof Princess) {
             this.princessBehavior = ((Princess) existingBot).getBehaviorSettings();
             nameField.setText(existingBot.getName());
+            nameField.setEnabled(false);
             setPrincessFields();
         }
     }


### PR DESCRIPTION
Fixes #2171 by disabling the option to edit the bot name if configuring an existing bot, as the "proper" fix is a lot more involved.