### PR TITLE
Address instability in BV calcs for Aeros #2273

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -1357,8 +1357,8 @@ public class Aero extends Entity implements IAero, IBomber {
 
         boolean blueShield = hasWorkingMisc(MiscType.F_BLUE_SHIELD);
 
-        for (int loc = 0; loc < (this instanceof SmallCraft ? locations() : (locations() - 1)); loc++) {
-
+        // For Aeros other than SmallCraft ignore their Wings and Fuselage for armor in BV calcs
+        for (int loc = 0; loc < (this instanceof SmallCraft ? locations() : (locations() - 2)); loc++) {
             int modularArmor = 0;
             for (Mounted mounted : getEquipment()) {
                 if ((mounted.getType() instanceof MiscType) && mounted.getType().hasFlag(MiscType.F_MODULAR_ARMOR)

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -182,6 +182,7 @@ public class EntityListFile {
      */
     public static String getLocString(Entity entity, int indentLvl) {
         boolean isMech = entity instanceof Mech;
+        boolean isNonSmallCraftAero = (entity instanceof Aero) && !(entity instanceof SmallCraft);
         boolean haveSlot = false;
         StringBuffer output = new StringBuffer();
         StringBuffer thisLoc = new StringBuffer();
@@ -190,6 +191,10 @@ public class EntityListFile {
         // Walk through the locations for the entity,
         // and only record damage and ammo.
         for (int loc = 0; loc < entity.locations(); loc++) {
+            // Aero.LOC_WINGS and Aero.LOC_FUSELAGE are not "real"
+            // locations for the purpose of being destroyed or blown off,
+            // but they may contain equipment which should be used below.
+            boolean isPseudoLocation = isNonSmallCraftAero && (loc >= Aero.LOC_WINGS);
 
             // if the location is blown off, remove it so we can get the real
             // values
@@ -209,9 +214,14 @@ public class EntityListFile {
                 isDestroyed = false;
             }
 
+            if (isPseudoLocation) {
+                isDestroyed = false;
+                blownOff = false;
+            }
+
             // Record damage to armor and internal structure.
             // Destroyed locations have lost all their armor and IS.
-            if (!isDestroyed) {
+            if (!isDestroyed && !isPseudoLocation) {
                 int currentArmor;
                 if (entity instanceof BattleArmor){
                     currentArmor = entity.getArmor(loc);


### PR DESCRIPTION
This attempts to address the instability in BV calcs for Aeros seen in #2273. I'm definitely new to this area of the code base, but it looks like the BV calcs were not updated when LOC_WINGS or LOC_FUSELAGE was added (not sure which). It also appears that the location string details were not updated either. I updated both to detect these as "pseudo" locations not appropriate for armor, but otherwise appropriate for equipment. This may not be the best means of resolving this issue.