### PR TITLE
expand boundary checking in background image drawing

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1259,7 +1259,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     if (x == 0) {
                         xRem = clipping.x % w;
                     }
-                    if (xRem >= 0 || yRem >= 0) {
+                    if (xRem > 0 || yRem > 0) {
                         try {
                             g.drawImage(
                                     bvBgImage.getSubimage(xRem, yRem, w - xRem,

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1259,7 +1259,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     if (x == 0) {
                         xRem = clipping.x % w;
                     }
-                    if (xRem > 0 || yRem > 0) {
+                    if ((xRem > 0) || (yRem > 0)) {
                         try {
                             g.drawImage(
                                     bvBgImage.getSubimage(xRem, yRem, w - xRem,

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1259,7 +1259,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     if (x == 0) {
                         xRem = clipping.x % w;
                     }
-                    if (xRem != 0 || yRem != 0) {
+                    if (xRem >= 0 || yRem >= 0) {
                         try {
                             g.drawImage(
                                     bvBgImage.getSubimage(xRem, yRem, w - xRem,


### PR DESCRIPTION
Explicit fix for #2215

Log entries after exception handling show the following error:

13:39:15,692 ERROR [megamek.client.ui.swing.boardview.BoardView1] {AWT-EventQueue-0} 
paintComponent() : Error drawing background image. Raster Bounds: 0.00, 0.00, width:447.00, height:447.00, Attempted Draw Coordinates: 0, -1, width:447, height:448

So the rendering code goes into the block starting at line 1262 because -1 is technically not equal to 0. But it getSubImage doesn't like being passed negative numbers for coordinates, so we'll avoid going there in more cases. Leaving the try/catch block in case some other geometry error crops up.