### PR TITLE
apply flak attacks to all flying units

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -145,8 +145,10 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();
         Coords targetPos = target.getPosition();
         final int playerId = aaa.getPlayerId();
-        boolean isFlak = (target instanceof VTOL) || target.isAero();
-        boolean asfFlak = target.isAero();
+        boolean targetIsEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
+        boolean targetIsAirborneVTOL = targetIsEntity && ((Entity) target).isAirborneVTOLorWIGE();
+        boolean isFlak = targetIsAirborneVTOL || target.isAirborne();
+        boolean asfFlak = target.isAirborne();
         Entity bestSpotter = null;
         if (ae == null) {
             System.err.println("Artillery Entity is null!");


### PR DESCRIPTION
Artillery flak attacks, per TacOps page 185, should apply to any kind of airborne ground unit, e.g. WIGE, VTOL infantry, etc. 

Fixes #2043 

There's several related issues about vertical splash damage not being applied, but that's a lot more invasive to fix.