### PR TITLE
Unit Tooltip Work

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -364,8 +364,8 @@ BoardView1.Tooltip.Arrow=<FONT COLOR=#{0}>&#10145; </FONT>
 BoardView1.Tooltip.MovementF=<FONT COLOR=#A030A0><I>{0} {1} (Mod: {2})</I></FONT>
 BoardView1.Tooltip.Weapon=&nbsp;{1}{2}
 BoardView1.Tooltip.WeaponN=&nbsp;<B>{0} x</B>  {1}{2}
-BoardView1.Tooltip.TurretLocked=<I><FONT COLOR=RED>Turret locked!</FONT><I>
-BoardView1.Tooltip.Immobile=<I><FONT COLOR=RED>Immobile</FONT><I>
+BoardView1.Tooltip.TurretLocked=<I><FONT COLOR=RED>Turret locked!</FONT></I>
+BoardView1.Tooltip.Immobile=<I><FONT COLOR=RED>Immobile</FONT></I>
 BoardView1.Tooltip.ArtilleryAttack1=Artillery: {0} in 1 turn<BR><FONT SIZE=-2>&nbsp;&nbsp;Ammo: {1}</FONT>
 BoardView1.Tooltip.ArtilleryAttackN=Artillery: {0} in {2} turns<BR><FONT SIZE=-2>&nbsp;&nbsp;Ammo: {1}</FONT>
 BoardView1.Tooltip.SeenBy=Seen by: {0}

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -276,12 +276,12 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_FIRE_SOLN_CANSEE_COLOR, "cyan");
         setDefault(ADVANCED_FIRE_SOLN_NOSEE_COLOR, "red");
         setDefault(ADVANCED_ARMORMINI_UNITS_PER_BLOCK, 10);
-        setDefault(ADVANCED_ARMORMINI_ARMOR_CHAR, "\u2588");     // █
-        setDefault(ADVANCED_ARMORMINI_IS_CHAR, "\u2593");       //  ▓
-        setDefault(ADVANCED_ARMORMINI_DESTROYED_CHAR, "\u2327");
-        setDefault(ADVANCED_ARMORMINI_COLOR_INTACT, new Color(0, 0, 0)); // HTML hex #008000
-        setDefault(ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG, new Color(221, 96, 0));  // HTML hex #DD6000
-        setDefault(ADVANCED_ARMORMINI_COLOR_DAMAGED, new Color(255, 204, 204));  // HTML hex #FFCCCC
+        setDefault(ADVANCED_ARMORMINI_ARMOR_CHAR, "\u2B1B"); // Centered Filled Square    
+        setDefault(ADVANCED_ARMORMINI_IS_CHAR, "\u25A3"); // Centered Square with Dot     
+        setDefault(ADVANCED_ARMORMINI_DESTROYED_CHAR, "\u2715"); // Centered x 
+        setDefault(ADVANCED_ARMORMINI_COLOR_INTACT, new Color(100, 180, 100)); // medium green 
+        setDefault(ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG, new Color(180, 180, 100));  // medium yellow
+        setDefault(ADVANCED_ARMORMINI_COLOR_DAMAGED, new Color(150, 80, 80));  // medium dark red  
         setDefault(ADVANCED_ARMORMINI_FONT_SIZE_MOD, -2);
         setDefault(WARNING_COLOR, Color.RED);
         setDefault(ADVANCED_LOW_FOLIAGE_COLOR, new Color(80, 230, 80));

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -736,7 +736,7 @@ class EntitySprite extends Sprite {
                 // This is a really awkward way of making sure
                 addToTT("ArmorMiniPanelPartNoRear", BR, entity.getLocationAbbr(loc), fontSize);
                 for (int a = 0; a <= entity.getOInternal(loc)/visUnit; a++) {
-                    addToTT("BlockColored", NOBR, destroyedChar, fontSize, colorIntact);
+                    addToTT("BlockColored", NOBR, destroyedChar, fontSize, colorDamaged);
                 }
 
             } else {
@@ -758,6 +758,7 @@ class EntitySprite extends Sprite {
                             addToTT("BlockColored", NOBR, armorChar, fontSize, colorDamaged);
                         }
                     }
+                    tooltipString.append("&nbsp;&nbsp;");
                     addToTT("ArmorMiniPanelPart", BR, entity.getLocationAbbr(loc), fontSize);
                 } else {
                     addToTT("ArmorMiniPanelPartNoRear", BR, entity.getLocationAbbr(loc), fontSize);
@@ -1111,12 +1112,10 @@ class EntitySprite extends Sprite {
                 } else {
                     ranges = wtype.getRanges(curWp);
                 }
-                String rangeString = "(";
+                String rangeString = " \u22EF ";
                 if ((ranges[RangeType.RANGE_MINIMUM] != WeaponType.WEAPON_NA) 
                         && (ranges[RangeType.RANGE_MINIMUM] != 0)) {
-                    rangeString += ranges[RangeType.RANGE_MINIMUM] + "/";
-                } else {
-                    rangeString += "-/";
+                    rangeString += "(" + ranges[RangeType.RANGE_MINIMUM] + ") ";
                 }
                 int maxRange = RangeType.RANGE_LONG;
                 if (bv.game.getOptions().booleanOption(
@@ -1126,11 +1125,10 @@ class EntitySprite extends Sprite {
                 for (int i = RangeType.RANGE_SHORT; i <= maxRange; i++) {
                     rangeString += ranges[i];
                     if (i != maxRange) {
-                        rangeString += "/";
+                        rangeString += "\u2B1D";
                     }
                 }
-                
-                weapDesc += rangeString + ")";
+                weapDesc += rangeString;
                 if (wpNames.containsKey(weapDesc)) {
                     int number = wpNames.get(weapDesc);
                     if (number > 0) 


### PR DESCRIPTION
This PR...
Applies some formatting to the tooltip weapon display
Applies default characters based on gsparks3's suggestions to the TT armor display that work with all UI lookandfeels and hopefully on all OS (worked on Win10) 
Applies tolerable default colors to the TT armor display that work for both light and dark UI lookandfeels 

Resolves #2240 

![image](https://user-images.githubusercontent.com/17069663/94986086-0d1bfc00-055c-11eb-87a1-96845c98ae65.png)
![image](https://user-images.githubusercontent.com/17069663/94986091-16a56400-055c-11eb-99bb-3302661d3308.png)
![image](https://user-images.githubusercontent.com/17069663/94986095-1a38eb00-055c-11eb-82d8-af73fe7bafb1.png)

