### PR TITLE
VTOL pathfinding and movement corrections

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2242,6 +2242,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             case VTOL:
                 maxAlt = hex.surface() + 50;
                 // When under a bridge, restrict upward movement
+                // "- 1" to correct that height() reports one less than the rules (TW p.99) say
                 if (hex.containsTerrain(Terrains.BRIDGE_ELEV)
                         && assumedElevation < hex.terrainLevel(Terrains.BRIDGE_ELEV)) {
                     maxAlt = hex.terrainLevel(Terrains.BRIDGE_ELEV) - height() - 1;   

--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -637,6 +637,10 @@ public class Terrain implements ITerrain, Serializable {
             rv = false;
         } else if (type == Terrains.FOLIAGE_ELEV && (level < 1 || level > 3)) {
             rv = false;
+        } else if (type == Terrains.BLDG_ELEV && level < 1) {
+            rv = false;
+        } else if (type == Terrains.BRIDGE_ELEV && level < 0) {
+            rv = false;
         }
 
         if (!rv && (errBuff != null)) {

--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -637,9 +637,9 @@ public class Terrain implements ITerrain, Serializable {
             rv = false;
         } else if (type == Terrains.FOLIAGE_ELEV && (level < 1 || level > 3)) {
             rv = false;
-        } else if (type == Terrains.BLDG_ELEV && level < 1) {
+        } else if ((type == Terrains.BLDG_ELEV) && (level < 1)) {
             rv = false;
-        } else if (type == Terrains.BRIDGE_ELEV && level < 0) {
+        } else if ((type == Terrains.BRIDGE_ELEV) && (level < 0)) {
             rv = false;
         }
 

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -167,7 +167,7 @@ public class PathDecorator {
      */
     public static void AdjustElevationForForwardMovement(MovePath source) {
         // Do this only for VTOLs
-        if (!(source.getEntity().getMovementMode() == EntityMovementMode.VTOL)) {
+        if (source.getEntity().getMovementMode() != EntityMovementMode.VTOL) {
             return;
         }
         

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -22,8 +22,10 @@ import java.util.Set;
 
 import megamek.common.BulldozerMovePath;
 import megamek.common.Coords;
+import megamek.common.EntityMovementMode;
 import megamek.common.IHex;
 import megamek.common.MovePath;
+import megamek.common.Terrains;
 import megamek.common.MovePath.MoveStepType;
 
 /**
@@ -160,37 +162,58 @@ public class PathDecorator {
     }
     
     /**
-     * Given a path, adds "UP" steps to it so that a forward movement can pass over intervening terrain
+     * For units using VTOL movement, add "UP" steps to the end of the MovePath source 
+     * so that a forward movement can pass over intervening terrain
      */
     public static void AdjustElevationForForwardMovement(MovePath source) {
+        // Do this only for VTOLs
+        if (!(source.getEntity().getMovementMode() == EntityMovementMode.VTOL)) {
+            return;
+        }
+        
         // get the hex that is in the direction we're facing
         Coords destinationCoords = source.getFinalCoords().translated(source.getFinalFacing());
         IHex destHex = source.getGame().getBoard().getHex(destinationCoords);
-        
-        if(destHex == null) {
+        if (destHex == null) {
             return;
         }
         
-        // determine if the destination hex allows the unit in question to go up
-        // if not, we're done here
+        // If the unit cannot go up in it's current hex, nothing can be done
         int entityElevation = source.getFinalElevation();
         boolean canGoUp = source.getEntity().canGoUp(entityElevation, source.getFinalCoords());
-        if(!canGoUp) {
+        if (!canGoUp) {
             return;
         }
         
-        // add as many UP steps as MP will allow, until we are above whatever terrain feature is in the way. 
-        int desiredElevation = destHex.maxTerrainFeatureElevation(false);
+        IHex srcHex = source.getGame().getBoard().getHex(source.getFinalCoords());
+        int absHeight = srcHex.getLevel() + entityElevation;  
+        int destElevation = absHeight - destHex.getLevel();
+        int safeElevation = destHex.maxTerrainFeatureElevation(false);
         
-        while(entityElevation <= desiredElevation) {
+        // Add as many UP steps as MP will allow, until able to move forward 
+        while (destElevation <= safeElevation) {
+            // Do not go up if the unit can go forward before rising above the 
+            // maximum terrain elevation, e.g. under a bridge
+            // VTOLs shouldn't land in this way, however.
+            boolean noLanding = (destElevation >= 1);
+            if (destHex.containsTerrain(Terrains.BLDG_ELEV)) {
+                noLanding &= destElevation > (destHex.terrainLevel(Terrains.BLDG_ELEV) - destHex.depth());
+            }
+            if (destHex.containsTerrain(Terrains.BRIDGE_ELEV)) {
+                noLanding &= destElevation != destHex.terrainLevel(Terrains.BRIDGE_ELEV);
+            }
+            if (source.getEntity().isElevationValid(destElevation, destHex) && noLanding) {
+                return;
+            }   
+
             source.addStep(MoveStepType.UP);
-            
+
             if(!source.isMoveLegal()) {
                 source.removeLastStep();
                 return;
             }
             
-            entityElevation++;
+            destElevation++;
         }
     }
 }


### PR DESCRIPTION
Some love for VTOL movement:
- Makes the Go Up and Go Down buttons behave when over and under bridges
- Allows going under bridges without acrobatics
- Decouples the terrain checks for woods, buildings, bridges and so on so that they can be used in the same hex without error. Having buildings or woods in water should also work better than before. Bridges under water are not allowed tho.
- The pathfinder will now provide paths that scale hills, terrain and buildings when necessary (and able). Limited this function to VTOL movement tho. It doesn't seem to have much use for infantry in buildings. I tested it for submarines but this will make them surface when the player might not really want them to. I think the depth of a sub should be directly controlled by the player even if thats a little more effort.

![image](https://user-images.githubusercontent.com/17069663/95022057-0df48100-0675-11eb-80a5-e2f07c622d48.png)
![image](https://user-images.githubusercontent.com/17069663/95022111-704d8180-0675-11eb-8219-7945e6daf0c9.png)

Resolves #2280 