### PR TITLE
Primitive DS/SC armor calculation correction

### DIFF
--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -140,8 +140,8 @@ public class TestSmallCraft extends TestAero {
         AerospaceArmor a = AerospaceArmor.getArmor(sc.getArmorType(0),
                 TechConstants.isClan(sc.getArmorTechLevel(0)));
         if (null != a) {
-            return (int)Math.floor(a.pointsPerTon(sc) * maxArmorWeight(sc))
-                    + sc.get0SI() * 4;
+            return (int) Math.floor(a.pointsPerTon(sc) * maxArmorWeight(sc)
+                    + sc.get0SI() * (sc.isPrimitive() ? 2.64 : 4));
         } else {
             return 0;
         }


### PR DESCRIPTION
Dropships and small craft get free armor points equal to their SI per armor facing. For primitives this is included with the main armor in the 0.66 primitive armor multiplier. This is done in SmallCraft::getArmorWeight, but not in maxArmorPoints in TestSmallCraft. The parentheses needed some adjusting because the regular armor and free armor points are combined before applying the multiplier.

Partial fix for MegaMek/megameklab#752.