### PR TITLE
Fix cost calculation for tank and conventional fighter heat sinks and power amplifiers

### DIFF
--- a/megamek/src/megamek/common/ConvFighter.java
+++ b/megamek/src/megamek/common/ConvFighter.java
@@ -19,6 +19,7 @@ package megamek.common;
 import java.util.Map;
 
 import megamek.common.options.OptionsConstants;
+import megamek.common.verifier.TestEntity;
 
 /**
  * @author Jay Lawson
@@ -136,7 +137,7 @@ public class ConvFighter extends Aero {
         // heat sinks
         int sinkCost = 2000 + (4000 * getHeatType());// == HEAT_DOUBLE ? 6000:
         // 2000;
-        cost += sinkCost * getHeatSinks();
+        cost += sinkCost * TestEntity.calcHeatNeutralHSRequirement(this);
 
         // weapons
         cost += getWeaponsAndEquipmentCost(ignoreAmmo);

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -13790,7 +13790,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     public double getPowerAmplifierWeight() {
         // If we're fusion- or fission-powered, we need no amplifiers to begin
         // with.
-        if(hasEngine() && (getEngine().isFusion() || (getEngine().getEngineType() == Engine.FISSION))) {
+        if (hasEngine() && (getEngine().isFusion() || (getEngine().getEngineType() == Engine.FISSION))) {
             return 0.0;
         }
         // Otherwise we need to iterate over our weapons, find out which of them
@@ -13799,16 +13799,26 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         for (Mounted m : getWeaponList()) {
             WeaponType wt = (WeaponType) m.getType();
             if ((wt.hasFlag(WeaponType.F_LASER) && (wt.getAmmoType() == AmmoType.T_NA))
-                || wt.hasFlag(WeaponType.F_PPC)
-                || wt.hasFlag(WeaponType.F_PLASMA)
-                || wt.hasFlag(WeaponType.F_PLASMA_MFUK)
-                || (wt.hasFlag(WeaponType.F_FLAMER) && (wt.getAmmoType() == AmmoType.T_NA))) {
+                    || wt.hasFlag(WeaponType.F_PPC)
+                    || wt.hasFlag(WeaponType.F_PLASMA)
+                    || wt.hasFlag(WeaponType.F_PLASMA_MFUK)
+                    || (wt.hasFlag(WeaponType.F_FLAMER) && (wt.getAmmoType() == AmmoType.T_NA))) {
+                total += m.getTonnage();
+            }
+            if ((m.getLinkedBy() != null) && (m.getLinkedBy().getType() instanceof
+                    MiscType) && m.getLinkedBy().getType().
+                    hasFlag(MiscType.F_PPC_CAPACITOR)) {
+                total += m.getLinkedBy().getTonnage();
+            }
+        }
+        for (Mounted m : getMisc()) {
+            if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)) {
                 total += m.getTonnage();
             }
         }
         // Finally use that total to compute and return the actual power
         // amplifier weight.
-        return Math.ceil(total / 5) / 2;
+        return RoundWeight.nextHalfTon(total);
     }
 
     public Vector<Integer> getLoadedKeepers() {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -13793,6 +13793,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         if (hasEngine() && (getEngine().isFusion() || (getEngine().getEngineType() == Engine.FISSION))) {
             return 0.0;
         }
+        // Small support vehicles do not need power amplifiers.
+        if (getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+            return 0.0;
+        }
         // Otherwise we need to iterate over our weapons, find out which of them
         // require amplification, and keep a running weight total of those.
         double total = 0.0;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2704,11 +2704,12 @@ public class Tank extends Entity {
         double turretWeight = 0;
         double paWeight = getPowerAmplifierWeight();
         for (Mounted m : getWeaponList()) {
-            if (!hasNoTurret() && (m.getLocation() == getLocTurret())) {
+            if ((m.getLocation() == getLocTurret()) || (m.getLocation() == getLocTurret2())) {
                 turretWeight += m.getTonnage() / 10.0;
-            }
-            if (!hasNoDualTurret() && (m.getLocation() == getLocTurret2())) {
-                turretWeight += m.getTonnage() / 10.0;
+                if ((m.getLinkedBy() != null) && (m.getLinkedBy().getType() instanceof MiscType)
+                        && m.getLinkedBy().getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
+                    turretWeight += m.getLinkedBy().getTonnage() / 10.0;
+                }
             }
         }
         turretWeight = RoundWeight.standard(turretWeight, this);

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -27,6 +27,7 @@ import java.util.Vector;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.verifier.SupportVeeStructure;
+import megamek.common.verifier.TestEntity;
 import megamek.common.weapons.flamers.VehicleFlamerWeapon;
 import megamek.common.weapons.lasers.CLChemicalLaserWeapon;
 
@@ -2699,15 +2700,10 @@ public class Tank extends Entity {
         }
 
         double freeHeatSinks = (hasEngine() ? getEngine().getWeightFreeEngineHeatSinks() : 0);
-        int sinks = 0;
+        int sinks = TestEntity.calcHeatNeutralHSRequirement(this);
         double turretWeight = 0;
-        double paWeight = 0;
+        double paWeight = getPowerAmplifierWeight();
         for (Mounted m : getWeaponList()) {
-            WeaponType wt = (WeaponType) m.getType();
-            if (wt.hasFlag(WeaponType.F_LASER) || wt.hasFlag(WeaponType.F_PPC)) {
-                sinks += wt.getHeat();
-                paWeight += m.getTonnage() / 10.0;
-            }
             if (!hasNoTurret() && (m.getLocation() == getLocTurret())) {
                 turretWeight += m.getTonnage() / 10.0;
             }
@@ -2715,12 +2711,7 @@ public class Tank extends Entity {
                 turretWeight += m.getTonnage() / 10.0;
             }
         }
-        paWeight = Math.ceil(paWeight * 2) / 2;
-        if ((hasEngine() && (getEngine().isFusion() || getEngine().getEngineType() == Engine.FISSION))
-                || getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
-            paWeight = 0;
-        }
-        turretWeight = Math.ceil(turretWeight * 2) / 2;
+        turretWeight = RoundWeight.standard(turretWeight, this);
         costs[i++] = 20000 * paWeight;
         costs[i++] = 2000 * Math.max(0, sinks - freeHeatSinks);
         costs[i++] = turretWeight * 5000;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -870,7 +870,7 @@ public abstract class TestEntity implements TestEntityOption {
             // Spot welders are treated as energy weapons on units that don't have a fusion or fission engine
             if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)
                 && entity.hasEngine() && (entity.getEngine().isFusion()
-                                                || entity.getEngine().getEngineType() == Engine.FISSION)) {
+                                                || (entity.getEngine().getEngineType() == Engine.FISSION))) {
                 continue;
             }
             heat += m.getType().getHeat();

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -829,8 +829,19 @@ public abstract class TestEntity implements TestEntityOption {
      * @return The number of heat sinks required in construction
      */
     protected int heatNeutralHSRequirement() {
+        return calcHeatNeutralHSRequirement(getEntity());
+    }
+
+    /**
+     * Computes heat sink requirement for heat-neutral units (vehicles, conventional fighters,
+     * protomechs). This is a total of energy weapons that don't use ammo and some other miscellaneous
+     * equipment.
+     *
+     * @return The number of heat sinks required in construction
+     */
+    public static int calcHeatNeutralHSRequirement(Entity entity) {
         int heat = 0;
-        for (Mounted m : getEntity().getWeaponList()) {
+        for (Mounted m : entity.getWeaponList()) {
             WeaponType wt = (WeaponType) m.getType();
             if ((wt.hasFlag(WeaponType.F_LASER) && (wt.getAmmoType() == AmmoType.T_NA))
                     || wt.hasFlag(WeaponType.F_PPC)
@@ -855,16 +866,16 @@ public abstract class TestEntity implements TestEntityOption {
                 heat += 5;
             }
         }
-        for (Mounted m : getEntity().getMisc()) {
+        for (Mounted m : entity.getMisc()) {
             // Spot welders are treated as energy weapons on units that don't have a fusion or fission engine
             if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)
-                && getEntity().hasEngine() && (getEntity().getEngine().isFusion()
-                                                || getEntity().getEngine().getEngineType() == Engine.FISSION)) {
+                && entity.hasEngine() && (entity.getEngine().isFusion()
+                                                || entity.getEngine().getEngineType() == Engine.FISSION)) {
                 continue;
             }
             heat += m.getType().getHeat();
         }
-        if (getEntity().hasStealth()) {
+        if (entity.hasStealth()) {
             heat += 10;
         }
         return heat;


### PR DESCRIPTION
The cost calculation for Tank does not include all equipment that can affect the cost of power amplifiers and heat sinks. Since there are methods elsewhere that perform these calculations I used them instead. For heat sink calculations I added a static method to TestEntity to avoid having to create an instance that involves the additional overhead of parsing the options file.

Since the turret weight is calculated in the same loop, I added some fixes to that as well. A PPC capacitor is included in the weight of a turret mounted PPC, and small support vehicle turrets should be rounded to the kg and not the half ton.

Fixes MegaMek/megameklab#762