### PR TITLE
fix bot counterbattery NPE

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -299,6 +299,7 @@
 3165=<font color='C00000'>THE PROTOTYPE JAMS</font>; 
 3170=<font color='C00000'>THE RAC JAMS</font>;
 3172=<font color='C00000'>THE INSULATOR OVERHEATS THE LASER</font>;
+3173=<font color='C00000'>Ammo feed problem, possible jam, rolls <data>: </font>
 3175=Fired PPC without field inhibitor, checking for damage:
 3178=<newline>PPC overloads and burns out.
 3180=Needs <data> to avoid damage, rolls <data>: <msg:3181,3182>

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -588,7 +588,14 @@ public abstract class BotClient extends Client {
             
             return true;
         } catch (Throwable t) {
-            MegaMek.getLogger().error(t.toString());
+            StringBuilder sb = new StringBuilder();
+            sb.append(t.toString()).append("\r\n");
+           
+            for (StackTraceElement traceElement : t.getStackTrace()) {
+                sb.append(traceElement.toString());
+                
+            }
+            MegaMek.getLogger().error(sb.toString());
             
             return false;
         }

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -588,15 +588,7 @@ public abstract class BotClient extends Client {
             
             return true;
         } catch (Throwable t) {
-            StringBuilder sb = new StringBuilder();
-            sb.append(t.toString()).append("\r\n");
-           
-            for (StackTraceElement traceElement : t.getStackTrace()) {
-                sb.append(traceElement.toString());
-                
-            }
-            MegaMek.getLogger().error(sb.toString());
-            
+            MegaMek.getLogger().error(t);            
             return false;
         }
     }

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -194,8 +194,8 @@ public class ArtilleryTargetingControl {
         for(Iterator<Entity> enemies = game.getAllEnemyEntities(shooter); enemies.hasNext();) {
             Entity e = enemies.next();
             
-            // skip airborne entities
-            if(!e.isAirborne() && !e.isAirborneVTOLorWIGE()) {
+            // skip airborne entities, and those off board - we'll handle them later
+            if(!e.isAirborne() && !e.isAirborneVTOLorWIGE() && !e.isOffBoard()) {
                 targetSet.add(new HexTarget(e.getPosition(), Targetable.TYPE_HEX_ARTILLERY));
                 
                 // while we're here, consider shooting at hexes within "MAX_BLAST_RADIUS"
@@ -233,7 +233,7 @@ public class ArtilleryTargetingControl {
             for(Coords donutHex : BotGeometry.getHexDonut(coords, radius)) {
                 // don't bother adding off-board donuts.
                 if(game.getBoard().contains(donutHex)) {
-                    targetList.add(new HexTarget(donutHex, game.getBoard(), Targetable.TYPE_HEX_ARTILLERY));
+                    targetList.add(new HexTarget(donutHex, Targetable.TYPE_HEX_ARTILLERY));
                 }
             }
         }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1118,11 +1118,11 @@ public class Compute {
             && (targHex != null) && targHex.containsTerrain(Terrains.WATER) 
             && (targBottom < 0)) {
             
-            if (targTop >= 0) {
-                targetInPartialWater = true;
-            } else {
-                targetUnderwater = true;
-            }
+                if (targTop >= 0) {
+                    targetInPartialWater = true;
+                } else {
+                    targetUnderwater = true;
+                }
         }
 
         // allow naval units on surface to be attacked from above or below

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4374,6 +4374,9 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         //Target's hex
         IHex targHex = game.getBoard().getHex(target.getPosition());
         
+        boolean targetHexContainsWater = targHex != null && targHex.containsTerrain(Terrains.WATER);
+        boolean targetHexContainsFortified = targHex != null && targHex.containsTerrain(Terrains.FORTIFIED);
+        
         Entity te = null;
         if (ttype == Targetable.TYPE_ENTITY) {
             //Some of these weapons only target valid entities
@@ -4413,7 +4416,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         
         // Fortified/Dug-In Infantry
         if ((target instanceof Infantry) && wtype != null && !wtype.hasFlag(WeaponType.F_FLAMER)) {
-            if (targHex.containsTerrain(Terrains.FORTIFIED)
+            if (targetHexContainsFortified
                     || (((Infantry) target).getDugIn() == Infantry.DUG_IN_COMPLETE)) {
                 toHit.addModifier(2, Messages.getString("WeaponAttackAction.DugInInf"));
             }
@@ -4424,7 +4427,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         if (te != null && (te instanceof Mech) && ((Mech) te).isSuperHeavy()) {
             partialWaterLevel = 2;
         }
-        if ((te != null) && targHex.containsTerrain(Terrains.WATER)
+        if ((te != null) && targetHexContainsWater
                 // target in partial water
                 && (targHex.terrainLevel(Terrains.WATER) == partialWaterLevel) && (targEl == 0) && (te.height() > 0)) { 
             los.setTargetCover(los.getTargetCover() | LosEffects.COVER_HORIZONTAL);
@@ -4434,7 +4437,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // Change hit table for partial cover, accomodate for partial
         // underwater(legs)
         if (los.getTargetCover() != LosEffects.COVER_NONE) {
-            if (underWater && (targHex.containsTerrain(Terrains.WATER) && (targEl == 0) 
+            if (underWater && (targetHexContainsWater && (targEl == 0) 
                     && (te != null && te.height() > 0))) {
                 // weapon underwater, target in partial water
                 toHit.setHitTable(ToHitData.HIT_PARTIAL_COVER);
@@ -4531,7 +4534,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // Change hit table for surface naval vessels hit by underwater attacks
-        if (underWater && targHex.containsTerrain(Terrains.WATER) && (null != te) && te.isSurfaceNaval()) {
+        if (underWater && targetHexContainsWater && (null != te) && te.isSurfaceNaval()) {
             toHit.setHitTable(ToHitData.HIT_UNDERWATER);
         }
         


### PR DESCRIPTION
Fixes an observed NPE when the bot was targeting off-board units for counterbattery fire with on-board artillery. We do this by introducing a number of null checks, and short-circuiting some computations.

Also improves exception logging, as it was only logging the exception and not even the line number.