### PR TITLE
Don't add cockpit TA for non-fighter subclasses of Aero.

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -295,7 +295,7 @@ public class Aero extends Entity implements IAero, IBomber {
     @Override
     protected void addSystemTechAdvancement(CompositeTechLevel ctl) {
         super.addSystemTechAdvancement(ctl);
-        if (getCockpitTechAdvancement() != null) {
+        if (isFighter() && getCockpitTechAdvancement() != null) {
             ctl.addComponent(getCockpitTechAdvancement());
         }
     }

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -295,7 +295,7 @@ public class Aero extends Entity implements IAero, IBomber {
     @Override
     protected void addSystemTechAdvancement(CompositeTechLevel ctl) {
         super.addSystemTechAdvancement(ctl);
-        if (isFighter() && getCockpitTechAdvancement() != null) {
+        if (isFighter() && (getCockpitTechAdvancement() != null)) {
             ctl.addComponent(getCockpitTechAdvancement());
         }
     }


### PR DESCRIPTION
Fixes early primitive tech advancement calculation for non-fighter aerospace units that call the parent method.

Partial fix for MegaMek/megamek#765