### PR TITLE
Don't assume double-digit heat sink count

### DIFF
--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -297,11 +297,11 @@ public class MtfFile implements IMechLoader {
 
             mech.setOriginalJumpMP(Integer.parseInt(jumpMP.substring(8)));
 
-            boolean dblSinks = (heatSinks.substring(14).startsWith("Double"));
+            boolean dblSinks = heatSinks.endsWith("Double");
 
-            boolean laserSinks = heatSinks.substring(14).startsWith("Laser");
+            boolean laserSinks = heatSinks.endsWith("Laser");
 
-            boolean compactSinks = heatSinks.substring(14).startsWith("Compact");
+            boolean compactSinks = heatSinks.endsWith("Compact");
 
             int expectedSinks = Integer.parseInt(heatSinks.substring(11, 13).trim());
 


### PR DESCRIPTION
The mtf file parser looks for the heat sink type at a set index from the start of the line, which causes it not to match if there are fewer than ten heat sinks. Checking at the end of the line avoids the problem.

Fixes MegaMek/megameklab#793