### PR TITLE
Fix TRO exception

### DIFF
--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -416,12 +416,14 @@ public class TROView {
             if (skipMount(m, includeAmmo)) {
                 continue;
             }
-            if (!m.getType().isHittable()) {
+            // Skip armor and structure
+            if (!m.getType().isHittable() && (m.getLocation() >= 0)) {
                 if ((structure != EquipmentType.T_STRUCTURE_UNKNOWN)
                         && (EquipmentType.getStructureType(m.getType()) == structure)) {
                     continue;
                 }
-                if (entity.getArmorType(m.getLocation()) == EquipmentType.getArmorType(m.getType())) {
+                if ((m.getLocation() >= 0)
+                        && (entity.getArmorType(m.getLocation()) == EquipmentType.getArmorType(m.getType()))) {
                     continue;
                 }
             }


### PR DESCRIPTION
Adds a check for location before attempting to get the armor type for that location. That this point in the code, items in LOC_NONE have been skipped. The robotic control system and the DNI are exceptions.

Fixes MegaMek/megameklab#777