### PR TITLE
Add subcapital cannon ammo weights

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -11488,6 +11488,7 @@ public class AmmoType extends EquipmentType {
                 ammo.rackSize = 2;
                 ammo.ammoType = AmmoType.T_SCC;
                 ammo.shots = 1;
+                ammo.tonnage = 0.5;
                 ammo.bv = 47;
                 ammo.cost = 10000;
                 ammo.ammoRatio = 2;
@@ -11548,6 +11549,7 @@ public class AmmoType extends EquipmentType {
                 ammo.rackSize = 7;
                 ammo.ammoType = AmmoType.T_SCC;
                 ammo.shots = 1;
+                ammo.tonnage = 2;
                 ammo.bv = 124;
                 ammo.cost = 25000;
                 ammo.ammoRatio = 0.5;


### PR DESCRIPTION
Capital weapon ammo comes in sizes near 1 shot/ton, including some awkward sizes like 5 shots/4 tons. Consequently it is tracked by single shots rather than a set weight. Subcapital cannons do not have the tonnage field set, which causes each shot to use the default value of 1 ton.

Fixes MegaMek/megameklab#784.