### PR TITLE
Housekeeping

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -816,7 +816,6 @@ CommonSettingsDialog.rightDragScroll=By right-clicking on the map and dragging.
 CommonSettingsDialog.scrollSensitivity=Scroll sensitivity:
 CommonSettingsDialog.showDamageLevel=Show damage to units on the unit label
 CommonSettingsDialog.showDamageDecal=Show damage to units on the unit icon
-CommonSettingsDialog.showMapHexPopup=Show Tooltip for hexes without units
 CommonSettingsDialog.showMapsheets=Show mapsheet borders.
 CommonSettingsDialog.showUnitId=Show each unit's unique Id next to its name.
 CommonSettingsDialog.showWrecks=Show wrecks.

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -794,8 +794,8 @@ CommonSettingsDialog.defaultWeaponSortOrder=Default Weapon Sort Order:
 CommonSettingsDialog.defaultWeaponSortOrderTooltip=<html>Sets the default weapon sort order for chassis/models without a specified default.  <br>Changing this setting won't effect games already in progress.</html>
 CommonSettingsDialog.entityOwnerColor=Add a border to the unit label
 CommonSettingsDialog.entityOwnerColorTip=Adds a colored border to unit labels. The border can be colored to distinguish between players or to distinguish between allied and enemy units. 
-CommonSettingsDialog.borderPlayerColor=Color the border to distinguish between the players
-CommonSettingsDialog.borderTeamColor=Color the border to show allied and enemy units 
+CommonSettingsDialog.teamColoring=Team Coloring 
+CommonSettingsDialog.teamColoringTip=Color unit label borders and minimap icons to show allied and enemy units
 CommonSettingsDialog.useAverageSkills=Use the current random skill settings when adding units in the lobby.
 CommonSettingsDialog.generateNames=Generate a random name for the pilots of new units.
 CommonSettingsDialog.getFocus=Get Focus when a new phase begins.
@@ -816,7 +816,7 @@ CommonSettingsDialog.rightDragScroll=By right-clicking on the map and dragging.
 CommonSettingsDialog.scrollSensitivity=Scroll sensitivity:
 CommonSettingsDialog.showDamageLevel=Show damage to units on the unit label
 CommonSettingsDialog.showDamageDecal=Show damage to units on the unit icon
-CommonSettingsDialog.showMapHexPopup=Show map hex popup.
+CommonSettingsDialog.showMapHexPopup=Show Tooltip for hexes without units
 CommonSettingsDialog.showMapsheets=Show mapsheet borders.
 CommonSettingsDialog.showUnitId=Show each unit's unique Id next to its name.
 CommonSettingsDialog.showWrecks=Show wrecks.
@@ -1334,10 +1334,13 @@ KeyBinds.cmdNames.toggleDrawLabels=Toggle Unit Labels
 KeyBinds.cmdDesc.toggleDrawLabels=Toggles between displaying and not displaying unit labels
 KeyBinds.cmdNames.toggleKeyBindDisplay=Toggle Shortcut Key Display
 KeyBinds.cmdDesc.toggleKeyBindDisplay=Toggles the map overlay showing various key shortcuts
+KeyBinds.cmdNames.toggleHexCoords=Toggle Hex Coords
+KeyBinds.cmdDesc.toggleHexCoords=Toggles the map showing the coords on each hex
 
 #Key Bindings Overlay
-KeyBindingsDisplay.fixedBinds=Toggle Unit Display and Minimap: Mouse Button 4\nZoom: Ctrl + Mouse Wheel\nTurn / Torso twist: Shift + Left-Click\nLine of Sight tool: Ctrl + Left-Click (two hexes)\nRuler tool: Alt + Left-Click (two hexes)
-KeyBindingsDisplay.heading=#FFFFFFKeyboard Shortcuts
+KeyBindingsDisplay.fixedBinds=Toggle Unit Display and Minimap: Mouse Button 4\nZoom: Mouse Wheel\nTurn / Torso twist: Shift + Left-Click\nLine of Sight tool: Ctrl + Left-Click (two hexes)\nRuler tool: Alt + Left-Click (two hexes)
+KeyBindingsDisplay.fixedBindsBoardEd=Zoom: Mouse Wheel\nLeft-Click: Draw Hex (replace previous terrain)\nShift + Left-Click: Draw Hex (add to previous terrain)\nCtrl + Left-Click: Draw Hex with hex elevation\nAlt + Left-Click: Eyedropper tool\nDrag-Right Mouse Button: Pan Map
+KeyBindingsDisplay.heading=#FFFFFFKeyboard Shortcuts - press {0} to toggle this overlay
 
 
 #LOS / Ruler tool

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -302,10 +302,17 @@
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
-   
+
     <KeyBind>
          <command>toggleKeyBindDisplay</command> <!-- Ctrl-K -->
         <keyCode>75</keyCode>
+        <modifier>2</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+         <command>toggleHexCoords</command> <!-- Ctrl-G -->
+        <keyCode>71</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -10,308 +10,308 @@
  -->
 <KeyBindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="keyBindingSchema.xsl">
     <KeyBind>
-         <command>scrollN</command> <!-- W -->
+        <command>scrollN</command> <!-- W -->
         <keyCode>87</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>scrollS</command> <!-- S -->
+        <command>scrollS</command> <!-- S -->
         <keyCode>83</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>scrollE</command> <!-- D -->
+        <command>scrollE</command> <!-- D -->
         <keyCode>68</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>scrollW</command> <!-- A -->
+        <command>scrollW</command> <!-- A -->
         <keyCode>65</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleIso</command> <!-- T -->
+        <command>toggleIso</command> <!-- T -->
         <keyCode>84</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleChat</command> <!-- Enter -->
+        <command>toggleChat</command> <!-- Enter -->
         <keyCode>10</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleChatCmd</command> <!-- Slash -->
+        <command>toggleChatCmd</command> <!-- Slash -->
         <keyCode>47</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>turnLeft</command> <!-- Shift-A -->
+        <command>turnLeft</command> <!-- Shift-A -->
         <keyCode>65</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>turnRight</command> <!-- Shift-D -->
+        <command>turnRight</command> <!-- Shift-D -->
         <keyCode>68</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>twistLeft</command> <!-- Shift-A -->
+        <command>twistLeft</command> <!-- Shift-A -->
         <keyCode>65</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>twistRight</command> <!-- Shift-D -->
+        <command>twistRight</command> <!-- Shift-D -->
         <keyCode>68</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>fire</command> <!-- F -->
+        <command>fire</command> <!-- F -->
         <keyCode>70</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextWeapon</command> <!-- E -->
+        <command>nextWeapon</command> <!-- E -->
         <keyCode>69</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevWeapon</command> <!-- Q -->
+        <command>prevWeapon</command> <!-- Q -->
         <keyCode>81</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextUnit</command> <!-- Ctrl-N -->
+        <command>nextUnit</command> <!-- Ctrl-N -->
         <keyCode>78</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevUnit</command> <!-- Shift-Q -->
+        <command>prevUnit</command> <!-- Shift-Q -->
         <keyCode>81</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTarget</command> <!-- C -->
+        <command>nextTarget</command> <!-- C -->
         <keyCode>67</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTarget</command> <!-- Z -->
+        <command>prevTarget</command> <!-- Z -->
         <keyCode>90</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTargetValid</command> <!-- Shift-C -->
+        <command>nextTargetValid</command> <!-- Shift-C -->
         <keyCode>67</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTargetValid</command> <!-- Shift-Z -->
+        <command>prevTargetValid</command> <!-- Shift-Z -->
         <keyCode>90</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTargetNoAllies</command> <!-- Ctrl-C -->
+        <command>nextTargetNoAllies</command> <!-- Ctrl-C -->
         <keyCode>67</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTargetNoAllies</command> <!-- Ctrl-Z -->
+        <command>prevTargetNoAllies</command> <!-- Ctrl-Z -->
         <keyCode>90</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTargetValidNoAllies</command> <!-- Ctrl+Shift-C -->
+        <command>nextTargetValidNoAllies</command> <!-- Ctrl+Shift-C -->
         <keyCode>67</keyCode>
         <modifier>3</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTargetValidNoAllies</command> <!-- Ctrl+Shift-Z -->
+        <command>prevTargetValidNoAllies</command> <!-- Ctrl+Shift-Z -->
         <keyCode>90</keyCode>
         <modifier>3</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>undo</command> <!-- Backspace -->
+        <command>undo</command> <!-- Backspace -->
         <keyCode>8</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>movementEnvelope</command> <!-- Ctrl-Q -->
+        <command>movementEnvelope</command> <!-- Ctrl-Q -->
         <keyCode>81</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>centerOnSelected</command> <!-- Space -->
+        <command>centerOnSelected</command> <!-- Space -->
         <keyCode>32</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>autoArtyDeployZone</command> <!-- Shift-Space -->
+        <command>autoArtyDeployZone</command> <!-- Shift-Space -->
         <keyCode>32</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>fieldOfFire</command> <!-- R -->
+        <command>fieldOfFire</command> <!-- R -->
         <keyCode>82</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>cancel</command> <!-- Escape -->
+        <command>cancel</command> <!-- Escape -->
         <keyCode>27</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>done</command> <!-- Ctrl-Enter -->
+        <command>done</command> <!-- Ctrl-Enter -->
         <keyCode>10</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udGeneral</command> <!-- F1 -->
+        <command>udGeneral</command> <!-- F1 -->
         <keyCode>112</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udPilot</command> <!-- F2 -->
+        <command>udPilot</command> <!-- F2 -->
         <keyCode>113</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udArmor</command> <!-- F3 -->
+        <command>udArmor</command> <!-- F3 -->
         <keyCode>114</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udSystems</command> <!-- F4 -->
+        <command>udSystems</command> <!-- F4 -->
         <keyCode>115</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udWeapons</command> <!-- F5 -->
+        <command>udWeapons</command> <!-- F5 -->
         <keyCode>116</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udExtras</command> <!-- F6 -->
+        <command>udExtras</command> <!-- F6 -->
         <keyCode>117</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleJump</command> <!-- J -->
+        <command>toggleJump</command> <!-- J -->
         <keyCode>74</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleConversion</command> <!-- M -->
+        <command>toggleConversion</command> <!-- M -->
         <keyCode>77</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevMode</command> <!-- Shift-Tab -->
+        <command>prevMode</command> <!-- Shift-Tab -->
         <keyCode>9</keyCode>
         <modifier>1</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextMode</command> <!-- Tab -->
+        <command>nextMode</command> <!-- Tab -->
         <keyCode>9</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleDrawLabels</command> <!-- Ctrl-Y -->
+        <command>toggleDrawLabels</command> <!-- Ctrl-Y -->
         <keyCode>89</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleKeyBindDisplay</command> <!-- Ctrl-K -->
+        <command>toggleKeyBindDisplay</command> <!-- Ctrl-K -->
         <keyCode>75</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleHexCoords</command> <!-- Ctrl-G -->
+        <command>toggleHexCoords</command> <!-- Ctrl-G -->
         <keyCode>71</keyCode>
         <modifier>2</modifier>
         <isRepeatable>false</isRepeatable>

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1422,12 +1422,8 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
      * Toggles the minimap window Also, toggles the minimap enabled setting
      */
     private void toggleMap() {
-        if (minimapW.isVisible()) {
-            GUIPreferences.getInstance().setMinimapEnabled(false);
-        } else {
-            GUIPreferences.getInstance().setMinimapEnabled(true);
-        }
         minimapW.setVisible(!minimapW.isVisible());
+        GUIPreferences.getInstance().setMinimapEnabled(minimapW.isVisible());
         if (minimapW.isVisible()) {
             frame.requestFocus();
         }

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -14,6 +14,7 @@ package megamek.client.ui.swing;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.Enumeration;
 import java.util.Vector;
@@ -460,6 +461,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
         menu.add(viewGameOptions);
         viewClientSettings = new JMenuItem(Messages.getString("CommonMenuBar.viewClientSettings")); //$NON-NLS-1$
         viewClientSettings.setActionCommand(ClientGUI.VIEW_CLIENT_SETTINGS);
+        viewClientSettings.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         viewClientSettings.addActionListener(this);
         menu.add(viewClientSettings);
         viewLOSSetting = new JMenuItem(Messages.getString("CommonMenuBar.viewLOSSetting")); //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -315,6 +315,7 @@ public class CommonSettingsDialog extends ClientDialog implements
     private boolean savedTeamColoring;
     private boolean savedUnitLabelBorder;
     private boolean savedShowDamageDecal;
+    private boolean savedShowDamageLabel;
     private String savedFovHighlightRingsRadii;
     private String savedFovHighlightRingsColors;
     private int savedFovHighlightAlpha;
@@ -359,7 +360,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         settingsPane.getVerticalScrollBar().setUnitIncrement(16);
         panTabs.add("Main", settingsPane);
         
-
         JScrollPane graphicsPane = new JScrollPane(getGraphicsPanel());
         graphicsPane.getVerticalScrollBar().setUnitIncrement(16);
         panTabs.add("Graphics", graphicsPane);
@@ -427,6 +427,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         // --------------        
 
         showDamageLevel = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageLevel")); //$NON-NLS-1$
+        showDamageLevel.addItemListener(this);
         row = new ArrayList<>();
         row.add(showDamageLevel);
         comps.add(row);
@@ -912,6 +913,7 @@ public class CommonSettingsDialog extends ClientDialog implements
             savedTeamColoring = gs.getTeamColoring();
             savedUnitLabelBorder = gs.getUnitLabelBorder();
             savedShowDamageDecal = gs.getShowDamageDecal();
+            savedShowDamageLabel = gs.getShowDamageLevel();
             savedFovHighlightRingsRadii = gs.getFovHighlightRingsRadii();
             savedFovHighlightRingsColors = gs.getFovHighlightRingsColorsHsb();
             savedFovHighlightAlpha = gs.getFovHighlightAlpha();
@@ -941,6 +943,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         guip.setTeamColoring(savedTeamColoring);
         guip.setUnitLabelBorder(savedUnitLabelBorder);
         guip.setShowDamageDecal(savedShowDamageDecal);
+        guip.setShowDamageLevel(savedShowDamageLabel);
         guip.setFovHighlightRingsRadii(savedFovHighlightRingsRadii);
         guip.setFovHighlightRingsColorsHsb(savedFovHighlightRingsColors);
         guip.setFovHighlightAlpha(savedFovHighlightAlpha);
@@ -1263,6 +1266,8 @@ public class CommonSettingsDialog extends ClientDialog implements
             
         } else if (source.equals(showDamageDecal)) {
             guip.setShowDamageDecal(showDamageDecal.isSelected());
+        } else if (source.equals(showDamageLevel)) {
+            guip.setShowDamageLevel(showDamageLevel.isSelected());
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -345,7 +345,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         setLayout(new BorderLayout());
         getContentPane().add(panTabs, BorderLayout.CENTER);
         getContentPane().add(getButtonsPanel(), BorderLayout.PAGE_END);
-        
         // Close this dialog when the window manager says to.
         addWindowListener(new WindowAdapter() {
             @Override
@@ -594,7 +593,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         row = new ArrayList<>();
         row.add(getFocus);
         comps.add(row);
-        
         mouseWheelZoom = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoom")); //$NON-NLS-1$
         row = new ArrayList<>();
         row.add(mouseWheelZoom);

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1795,7 +1795,7 @@ public class CommonSettingsDialog extends ClientDialog implements
 
     /** Constructs the button ordering panel for one phase. */ 
     private JScrollPane getButtonOrderPane(DefaultListModel<PhaseCommand> list, 
-            StatusBarPhaseDisplay.PhaseCommand commands[]) {
+            StatusBarPhaseDisplay.PhaseCommand[] commands) {
         JPanel panel = new JPanel();
         Arrays.sort(commands, cmdComp);        
         for (StatusBarPhaseDisplay.PhaseCommand cmd : commands) {

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -194,7 +194,6 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JCheckBox animateMove;
     private JCheckBox showWrecks;
     private JCheckBox soundMute;
-    private JCheckBox showMapHexPopup;
     private JCheckBox showWpsinTT;
     private JCheckBox showArmorMiniVisTT;
     private JCheckBox showPilotPortraitTT;
@@ -226,8 +225,6 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JCheckBox mmSymbol;
     private JCheckBox entityOwnerColor;
     private JCheckBox teamColoring;
-//    private JRadioButton borderTeamColor;
-//    private JRadioButton borderPlayerColor;
     private JCheckBox useSoftCenter;
     private JCheckBox levelhighlight;
     private JCheckBox shadowMap;
@@ -467,13 +464,6 @@ public class CommonSettingsDialog extends ClientDialog implements
 
         // Tooltip Stuff
         //
-        // Show Terrain in the TT
-        // NONSENSE, cant find out bridge CFs, building CFs etc. without 
-        showMapHexPopup = new JCheckBox(Messages.getString("CommonSettingsDialog.showMapHexPopup")); //$NON-NLS-1$
-//        row = new ArrayList<>();
-//        row.add(showMapHexPopup);
-//        comps.add(row);
-
         // Popup Delay and Dismiss Delay
         tooltipDelay = new JTextField(4);
         tooltipDelay.setMaximumSize(new Dimension(150,40));
@@ -735,7 +725,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         animateMove.setSelected(gs.getShowMoveStep());
         showWrecks.setSelected(gs.getShowWrecks());
         soundMute.setSelected(gs.getSoundMute());
-        showMapHexPopup.setSelected(gs.getShowMapHexPopup());
         tooltipDelay.setText(Integer.toString(gs.getTooltipDelay()));
         tooltipDismissDelay.setText(Integer.toString(gs.getTooltipDismissDelay()));
         tooltipDistSupression.setText(Integer.toString(gs.getTooltipDistSuppression()));
@@ -909,7 +898,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setShowMoveStep(animateMove.isSelected());
         gs.setShowWrecks(showWrecks.isSelected());
         gs.setSoundMute(soundMute.isSelected());
-        gs.setShowMapHexPopup(showMapHexPopup.isSelected());
         gs.setShowWpsinTT(showWpsinTT.isSelected());
         gs.setshowArmorMiniVisTT(showArmorMiniVisTT.isSelected());
         gs.setshowPilotPortraitTT(showPilotPortraitTT.isSelected());

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1865,7 +1865,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         p.add(advancedKeys);
 
         advancedValue = new JTextField(10);
-        advancedValue.setFont(new Font("LucidaSans", Font.PLAIN, 16));
+        advancedValue.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 16));
         advancedValue.addFocusListener(this);
         p.add(advancedValue);
 

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -44,7 +44,6 @@ import java.util.Map;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -54,7 +53,6 @@ import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
 import javax.swing.JSlider;
@@ -187,7 +185,6 @@ public class CommonSettingsDialog extends ClientDialog implements
 
     private JTabbedPane panTabs;
 
-    private JCheckBox minimapEnabled;
     private JCheckBox autoEndFiring;
     private JCheckBox autoDeclareSearchlight;
     private JCheckBox nagForMASC;
@@ -228,14 +225,13 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JCheckBox floatingIso;
     private JCheckBox mmSymbol;
     private JCheckBox entityOwnerColor;
-    private JRadioButton borderTeamColor;
-    private JRadioButton borderPlayerColor;
+    private JCheckBox teamColoring;
+//    private JRadioButton borderTeamColor;
+//    private JRadioButton borderPlayerColor;
     private JCheckBox useSoftCenter;
     private JCheckBox levelhighlight;
     private JCheckBox shadowMap;
     private JCheckBox hexInclines;
-    private JCheckBox mouseWheelZoom;
-    private JCheckBox mouseWheelZoomFlip;
 
     // Tactical Overlay Options
     private JCheckBox fovInsideEnabled;
@@ -416,11 +412,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         comps.add(row);
         // --------------        
 
-        minimapEnabled = new JCheckBox(Messages.getString("CommonSettingsDialog.minimapEnabled")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(minimapEnabled);
-        comps.add(row);
-        
         showDamageLevel = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageLevel")); //$NON-NLS-1$
         row = new ArrayList<>();
         row.add(showDamageLevel);
@@ -445,24 +436,13 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(entityOwnerColor);
         comps.add(row);
         
-        borderPlayerColor = new JRadioButton(Messages.getString("CommonSettingsDialog.borderPlayerColor"));
-        borderPlayerColor.addItemListener(this);
+        teamColoring = new JCheckBox(Messages.getString("CommonSettingsDialog.teamColoring"));
+        teamColoring.setToolTipText(Messages.getString("CommonSettingsDialog.teamColoringTip"));
+        teamColoring.addItemListener(this);
         row = new ArrayList<>();
-        row.add(Box.createRigidArea(DEPENDENT_INSET));
-        row.add(borderPlayerColor);
+        row.add(teamColoring);
         comps.add(row);
         
-        borderTeamColor = new JRadioButton(Messages.getString("CommonSettingsDialog.borderTeamColor"));
-        borderTeamColor.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(DEPENDENT_INSET));
-        row.add(borderTeamColor);
-        comps.add(row);
-        
-        ButtonGroup bg = new ButtonGroup();
-        bg.add(borderPlayerColor);
-        bg.add(borderTeamColor);
-
         useSoftCenter = new JCheckBox(Messages.getString("CommonSettingsDialog.useSoftCenter")); //$NON-NLS-1$
         useSoftCenter.setToolTipText(Messages.getString("CommonSettingsDialog.useSoftCenterTip"));
         useSoftCenter.addItemListener(this);
@@ -488,10 +468,11 @@ public class CommonSettingsDialog extends ClientDialog implements
         // Tooltip Stuff
         //
         // Show Terrain in the TT
+        // NONSENSE, cant find out bridge CFs, building CFs etc. without 
         showMapHexPopup = new JCheckBox(Messages.getString("CommonSettingsDialog.showMapHexPopup")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(showMapHexPopup);
-        comps.add(row);
+//        row = new ArrayList<>();
+//        row.add(showMapHexPopup);
+//        comps.add(row);
 
         // Popup Delay and Dismiss Delay
         tooltipDelay = new JTextField(4);
@@ -606,16 +587,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(getFocus);
         comps.add(row);
 
-        mouseWheelZoom = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoom")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(mouseWheelZoom);
-        comps.add(row);
-
-        mouseWheelZoomFlip = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoomFlip")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(mouseWheelZoomFlip);
-        comps.add(row);
-        
         autoEndFiring = new JCheckBox(Messages.getString("CommonSettingsDialog.autoEndFiring")); //$NON-NLS-1$
         row = new ArrayList<>();
         row.add(autoEndFiring);
@@ -755,7 +726,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         GUIPreferences gs = GUIPreferences.getInstance();
         IClientPreferences cs = PreferenceManager.getClientPreferences();
 
-        minimapEnabled.setSelected(gs.getMinimapEnabled());
         autoEndFiring.setSelected(gs.getAutoEndFiring());
         autoDeclareSearchlight.setSelected(gs.getAutoDeclareSearchlight());
         nagForMASC.setSelected(gs.getNagForMASC());
@@ -774,9 +744,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         showPilotPortraitTT.setSelected(gs.getshowPilotPortraitTT());
 
         defaultWeaponSortOrder.setSelectedIndex(gs.getDefaultWeaponSortOrder());
-
-        mouseWheelZoom.setSelected(gs.getMouseWheelZoom());
-        mouseWheelZoomFlip.setSelected(gs.getMouseWheelZoomFlip());
 
         // Select the correct char set (give a nice default to start).
         unitStartChar.setSelectedIndex(0);
@@ -825,11 +792,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         hexInclines.setSelected(gs.getHexInclines());
         useSoftCenter.setSelected(gs.getBoolean("SOFTCENTER"));
         entityOwnerColor.setSelected(gs.getUnitLabelBorder());
-        borderPlayerColor.setSelected(!gs.getUnitLabelBorderTeam());
-        borderTeamColor.setSelected(gs.getUnitLabelBorderTeam());
-        borderPlayerColor.setEnabled(entityOwnerColor.isSelected());
-        borderTeamColor.setEnabled(entityOwnerColor.isSelected());
-
+        teamColoring.setSelected(gs.getTeamColoring());
 
         File dir = Configuration.hexesDir();
         tileSets = new ArrayList<>(Arrays.asList(dir.listFiles(new FilenameFilter() {
@@ -935,8 +898,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setShowDamageLevel(showDamageLevel.isSelected());
         gs.setShowDamageDecal(showDamageDecal.isSelected());
         gs.setUnitLabelBorder(entityOwnerColor.isSelected());
-        gs.setUnitLabelBorderTeam(borderTeamColor.isSelected());
-        gs.setMinimapEnabled(minimapEnabled.isSelected());
+        gs.setTeamColoring(teamColoring.isSelected());
         gs.setAutoEndFiring(autoEndFiring.isSelected());
         gs.setAutoDeclareSearchlight(autoDeclareSearchlight.isSelected());
         gs.setDefaultWeaponSortOrder(defaultWeaponSortOrder.getSelectedIndex());
@@ -956,9 +918,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setTooltipDistSuppression(Integer.parseInt(tooltipDistSupression.getText()));
         cs.setUnitStartChar(((String) unitStartChar.getSelectedItem())
                 .charAt(0));
-
-        gs.setMouseWheelZoom(mouseWheelZoom.isSelected());
-        gs.setMouseWheelZoomFlip(mouseWheelZoomFlip.isSelected());
 
         cs.setMaxPathfinderTime(Integer.parseInt(maxPathfinderTime.getText()));
 
@@ -1261,13 +1220,15 @@ public class CommonSettingsDialog extends ClientDialog implements
                 clientgui.minimap.drawMap();
             }
 
-        } else if (source.equals(entityOwnerColor) 
-                || source.equals(borderPlayerColor)
-                || source.equals(borderTeamColor)) {
+        } else if (source.equals(teamColoring)) {
+            guip.setTeamColoring(teamColoring.isSelected());
+            if ((clientgui != null) && (clientgui.minimap != null)) {
+                clientgui.minimap.drawMap();
+            }
+
+        } else if (source.equals(entityOwnerColor)) {
             guip.setUnitLabelBorder(entityOwnerColor.isSelected());
-            guip.setUnitLabelBorderTeam(borderTeamColor.isSelected());
-            borderPlayerColor.setEnabled(entityOwnerColor.isSelected());
-            borderTeamColor.setEnabled(entityOwnerColor.isSelected());
+            
         } else if (source.equals(showDamageDecal)) {
             guip.setShowDamageDecal(showDamageDecal.isSelected());
         }

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -17,6 +17,8 @@ package megamek.client.ui.swing;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
@@ -72,6 +74,7 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.event.MouseInputAdapter;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.swing.StatusBarPhaseDisplay.PhaseCommand;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.common.Configuration;
@@ -183,8 +186,6 @@ public class CommonSettingsDialog extends ClientDialog implements
      */
     private static final long serialVersionUID = 1535370193846895473L;
 
-    private JTabbedPane panTabs;
-
     private JCheckBox autoEndFiring;
     private JCheckBox autoDeclareSearchlight;
     private JCheckBox nagForMASC;
@@ -229,6 +230,8 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JCheckBox levelhighlight;
     private JCheckBox shadowMap;
     private JCheckBox hexInclines;
+    private JCheckBox mouseWheelZoom;
+    private JCheckBox mouseWheelZoomFlip;
 
     // Tactical Overlay Options
     private JCheckBox fovInsideEnabled;
@@ -255,9 +258,9 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JComboBox<UITheme> uiThemes;
 
     // Avanced Settings
-    private JList<AdvancedOptionData> keys;
-    private int keysIndex = 0;
-    private JTextField value;
+    private JList<AdvancedOptionData> advancedKeys;
+    private int advancedKeyIndex = 0;
+    private JTextField advancedValue;
 
     // Button order
     private DefaultListModel<StatusBarPhaseDisplay.PhaseCommand> movePhaseCommands;
@@ -265,6 +268,8 @@ public class CommonSettingsDialog extends ClientDialog implements
     private DefaultListModel<StatusBarPhaseDisplay.PhaseCommand> firingPhaseCommands;
     private DefaultListModel<StatusBarPhaseDisplay.PhaseCommand> physicalPhaseCommands;
     private DefaultListModel<StatusBarPhaseDisplay.PhaseCommand> targetingPhaseCommands;
+    private StatusBarPhaseDisplay.CommandComparator cmdComp = new StatusBarPhaseDisplay.CommandComparator(); 
+    private PhaseCommandListMouseAdapter cmdMouseAdaptor = new PhaseCommandListMouseAdapter();
     
     private JComboBox<String> tileSetChoice;
     private List<File> tileSets;
@@ -296,6 +301,26 @@ public class CommonSettingsDialog extends ClientDialog implements
     
     private static final Dimension LABEL_SPACER = new Dimension(5,0);
     private static final Dimension DEPENDENT_INSET = new Dimension(25,0);
+    
+    // Save some values to restore them when the dialog is canceled
+    private boolean savedFovHighlight;
+    private boolean savedFovDarken;
+    private boolean savedFovGrayscale;
+    private boolean savedAOHexShadows;
+    private boolean savedShadowMap;
+    private boolean savedHexInclines;
+    private boolean savedLevelhighlight;
+    private boolean savedFloatingIso;
+    private boolean savedMmSymbol;
+    private boolean savedTeamColoring;
+    private boolean savedUnitLabelBorder;
+    private boolean savedShowDamageDecal;
+    private String savedFovHighlightRingsRadii;
+    private String savedFovHighlightRingsColors;
+    private int savedFovHighlightAlpha;
+    private int savedFovDarkenAlpha;
+    private int savedNumStripesSlider;
+    HashMap<String, String> savedAdvancedOpt = new HashMap<>();
 
     /**
      * Standard constructor. There is no default constructor for this class.
@@ -313,34 +338,13 @@ public class CommonSettingsDialog extends ClientDialog implements
      * @param owner - the <code>Frame</code> that owns this dialog.
      */
     public CommonSettingsDialog(JFrame owner) {
-        // Initialize our superclass with a title.
-        super(owner, Messages.getString("CommonSettingsDialog.title")); //$NON-NLS-1$
+        super(owner, Messages.getString("CommonSettingsDialog.title"), true);
 
-        panTabs = new JTabbedPane();
-
-        JPanel settingsPanel = getSettingsPanel();
-        JScrollPane settingsPane = new JScrollPane(settingsPanel);
-        panTabs.add("Main", settingsPane);
-
-        JPanel tacticalOverlaySettingsPanel = getTacticalOverlaySettingsPanel();
-        JScrollPane tacticalOverlaySettingsPane = new JScrollPane(tacticalOverlaySettingsPanel);
-        panTabs.add("Graphics", tacticalOverlaySettingsPane);
-
-        JPanel keyBindPanel = getKeyBindPanel();
-        JScrollPane keyBindScrollPane = new JScrollPane(keyBindPanel);
-        panTabs.add("Key Binds", keyBindScrollPane);
-
-        JPanel buttonOrderPanel = getButtonOrderPanel();
-        panTabs.add("Button Order", buttonOrderPanel);
-        
-        JPanel advancedSettingsPanel = getAdvancedSettingsPanel();
-        JScrollPane advancedSettingsPane = new JScrollPane(advancedSettingsPanel);
-        panTabs.add("Advanced", advancedSettingsPane);
-
+        JTabbedPane panTabs = new JTabbedPane();
         setLayout(new BorderLayout());
         getContentPane().add(panTabs, BorderLayout.CENTER);
         getContentPane().add(getButtonsPanel(), BorderLayout.PAGE_END);
-
+        
         // Close this dialog when the window manager says to.
         addWindowListener(new WindowAdapter() {
             @Override
@@ -349,15 +353,29 @@ public class CommonSettingsDialog extends ClientDialog implements
             }
         });
 
-        // Center this dialog.
-        pack();
+        // Add the tabs
+        JPanel settingsPanel = getSettingsPanel();
+        JScrollPane settingsPane = new JScrollPane(getSettingsPanel());
+        settingsPane.getVerticalScrollBar().setUnitIncrement(16);
+        panTabs.add("Main", settingsPane);
+        
 
-        // Make the thing wide enough so a horizontal scrollbar isn't
-        // necessary. I'm not sure why the extra hardcoded 10 pixels
-        // is needed, maybe it's a ms windows thing.
-        setLocationAndSize(settingsPanel.getPreferredSize().width
-                + settingsPane.getInsets().right + 20, settingsPanel
-                .getPreferredSize().height);
+        JScrollPane graphicsPane = new JScrollPane(getGraphicsPanel());
+        graphicsPane.getVerticalScrollBar().setUnitIncrement(16);
+        panTabs.add("Graphics", graphicsPane);
+
+        JScrollPane keyBindPane = new JScrollPane(getKeyBindPanel());
+        keyBindPane.getVerticalScrollBar().setUnitIncrement(16);
+        panTabs.add("Key Binds", keyBindPane);
+
+        panTabs.add("Button Order", getButtonOrderPanel());
+        
+        JScrollPane advancedSettingsPane = new JScrollPane(getAdvancedSettingsPanel());
+        advancedSettingsPane.getVerticalScrollBar().setUnitIncrement(16);
+        panTabs.add("Advanced", advancedSettingsPane);
+
+        pack();
+        setLocationAndSize(getPreferredSize().width, settingsPanel.getPreferredSize().height);
     }
 
     private JPanel getButtonsPanel() {
@@ -365,11 +383,11 @@ public class CommonSettingsDialog extends ClientDialog implements
         JPanel buttons = new JPanel();
         buttons.setLayout(new GridLayout(1, 0, 20, 5));
         JButton update = new JButton(Messages.getString("CommonSettingsDialog.Update")); //$NON-NLS-1$
-        update.setActionCommand(CommonSettingsDialog.UPDATE);
+        update.setActionCommand(UPDATE);
         update.addActionListener(this);
         buttons.add(update);
         JButton cancel = new JButton(Messages.getString("Cancel")); //$NON-NLS-1$
-        cancel.setActionCommand(CommonSettingsDialog.CANCEL);
+        cancel.setActionCommand(CANCEL);
         cancel.addActionListener(this);
         buttons.add(cancel);
 
@@ -383,7 +401,6 @@ public class CommonSettingsDialog extends ClientDialog implements
 
         // displayLocale settings
         JLabel displayLocaleLabel = new JLabel(Messages.getString("CommonSettingsDialog.locale")); //$NON-NLS-1$
-        // displayLocale = new JTextField(8);
         displayLocale = new JComboBox<String>();
         displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.English")); //$NON-NLS-1$
         displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Deutsch")); //$NON-NLS-1$
@@ -576,6 +593,16 @@ public class CommonSettingsDialog extends ClientDialog implements
         row = new ArrayList<>();
         row.add(getFocus);
         comps.add(row);
+        
+        mouseWheelZoom = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoom")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        row.add(mouseWheelZoom);
+        comps.add(row);
+
+        mouseWheelZoomFlip = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoomFlip")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        row.add(mouseWheelZoomFlip);
+        comps.add(row);
 
         autoEndFiring = new JCheckBox(Messages.getString("CommonSettingsDialog.autoEndFiring")); //$NON-NLS-1$
         row = new ArrayList<>();
@@ -713,167 +740,217 @@ public class CommonSettingsDialog extends ClientDialog implements
      */
     @Override
     public void setVisible(boolean visible) {
-        GUIPreferences gs = GUIPreferences.getInstance();
-        IClientPreferences cs = PreferenceManager.getClientPreferences();
+        // Initialize the dialog when it's being shown
+        if (visible) {
+            GUIPreferences gs = GUIPreferences.getInstance();
+            IClientPreferences cs = PreferenceManager.getClientPreferences();
 
-        autoEndFiring.setSelected(gs.getAutoEndFiring());
-        autoDeclareSearchlight.setSelected(gs.getAutoDeclareSearchlight());
-        nagForMASC.setSelected(gs.getNagForMASC());
-        nagForPSR.setSelected(gs.getNagForPSR());
-        nagForWiGELanding.setSelected(gs.getNagForWiGELanding());
-        nagForNoAction.setSelected(gs.getNagForNoAction());
-        animateMove.setSelected(gs.getShowMoveStep());
-        showWrecks.setSelected(gs.getShowWrecks());
-        soundMute.setSelected(gs.getSoundMute());
-        tooltipDelay.setText(Integer.toString(gs.getTooltipDelay()));
-        tooltipDismissDelay.setText(Integer.toString(gs.getTooltipDismissDelay()));
-        tooltipDistSupression.setText(Integer.toString(gs.getTooltipDistSuppression()));
-        showWpsinTT.setSelected(gs.getShowWpsinTT());
-        showArmorMiniVisTT.setSelected(gs.getshowArmorMiniVisTT());
-        showPilotPortraitTT.setSelected(gs.getshowPilotPortraitTT());
+            autoEndFiring.setSelected(gs.getAutoEndFiring());
+            autoDeclareSearchlight.setSelected(gs.getAutoDeclareSearchlight());
+            nagForMASC.setSelected(gs.getNagForMASC());
+            nagForPSR.setSelected(gs.getNagForPSR());
+            nagForWiGELanding.setSelected(gs.getNagForWiGELanding());
+            nagForNoAction.setSelected(gs.getNagForNoAction());
+            animateMove.setSelected(gs.getShowMoveStep());
+            showWrecks.setSelected(gs.getShowWrecks());
+            soundMute.setSelected(gs.getSoundMute());
+            tooltipDelay.setText(Integer.toString(gs.getTooltipDelay()));
+            tooltipDismissDelay.setText(Integer.toString(gs.getTooltipDismissDelay()));
+            tooltipDistSupression.setText(Integer.toString(gs.getTooltipDistSuppression()));
+            showWpsinTT.setSelected(gs.getShowWpsinTT());
+            showArmorMiniVisTT.setSelected(gs.getshowArmorMiniVisTT());
+            showPilotPortraitTT.setSelected(gs.getshowPilotPortraitTT());
 
-        defaultWeaponSortOrder.setSelectedIndex(gs.getDefaultWeaponSortOrder());
+            defaultWeaponSortOrder.setSelectedIndex(gs.getDefaultWeaponSortOrder());
+            
+            mouseWheelZoom.setSelected(gs.getMouseWheelZoom());
+            mouseWheelZoomFlip.setSelected(gs.getMouseWheelZoomFlip());
 
-        // Select the correct char set (give a nice default to start).
-        unitStartChar.setSelectedIndex(0);
-        for (int loop = 0; loop < unitStartChar.getItemCount(); loop++) {
-            if (unitStartChar.getItemAt(loop).charAt(0) == PreferenceManager
-                    .getClientPreferences().getUnitStartChar()) {
-                unitStartChar.setSelectedIndex(loop);
-                break;
+            // Select the correct char set (give a nice default to start).
+            unitStartChar.setSelectedIndex(0);
+            for (int loop = 0; loop < unitStartChar.getItemCount(); loop++) {
+                if (unitStartChar.getItemAt(loop).charAt(0) == PreferenceManager
+                        .getClientPreferences().getUnitStartChar()) {
+                    unitStartChar.setSelectedIndex(loop);
+                    break;
+                }
             }
-        }
 
-        maxPathfinderTime.setText(Integer.toString(cs.getMaxPathfinderTime()));
+            maxPathfinderTime.setText(Integer.toString(cs.getMaxPathfinderTime()));
 
-        keepGameLog.setSelected(cs.keepGameLog());
-        gameLogFilename.setEnabled(keepGameLog.isSelected());
-        gameLogFilename.setText(cs.getGameLogFilename());
-        // gameLogMaxSize.setEnabled(keepGameLog.isSelected());
-        // gameLogMaxSize.setText( Integer.toString(cs.getGameLogMaxSize()) );
-        stampFilenames.setSelected(cs.stampFilenames());
-        stampFormat.setEnabled(stampFilenames.isSelected());
-        stampFormat.setText(cs.getStampFormat());
+            keepGameLog.setSelected(cs.keepGameLog());
+            gameLogFilename.setEnabled(keepGameLog.isSelected());
+            gameLogFilename.setText(cs.getGameLogFilename());
+            // gameLogMaxSize.setEnabled(keepGameLog.isSelected());
+            // gameLogMaxSize.setText( Integer.toString(cs.getGameLogMaxSize()) );
+            stampFilenames.setSelected(cs.stampFilenames());
+            stampFormat.setEnabled(stampFilenames.isSelected());
+            stampFormat.setText(cs.getStampFormat());
 
-        defaultAutoejectDisabled.setSelected(cs.defaultAutoejectDisabled());
-        useAverageSkills.setSelected(cs.useAverageSkills());
-        generateNames.setSelected(cs.generateNames());
-        showUnitId.setSelected(cs.getShowUnitId());
+            defaultAutoejectDisabled.setSelected(cs.defaultAutoejectDisabled());
+            useAverageSkills.setSelected(cs.useAverageSkills());
+            generateNames.setSelected(cs.generateNames());
+            showUnitId.setSelected(cs.getShowUnitId());
 
-        int index = 0;
-        if (cs.getLocaleString().startsWith("de")) {
-            index = 1;
-        }
-        if (cs.getLocaleString().startsWith("ru")) {
-            index = 2;
-        }
-        displayLocale.setSelectedIndex(index);
-
-        showMapsheets.setSelected(gs.getShowMapsheets());
-        chkAntiAliasing.setSelected(gs.getAntiAliasing());
-        showDamageLevel.setSelected(gs.getShowDamageLevel());
-        showDamageDecal.setSelected(gs.getShowDamageDecal());
-        aOHexShadows.setSelected(gs.getAOHexShadows());
-        floatingIso.setSelected(gs.getFloatingIso());
-        mmSymbol.setSelected(gs.getMmSymbol());
-        levelhighlight.setSelected(gs.getLevelHighlight());
-        shadowMap.setSelected(gs.getShadowMap());
-        hexInclines.setSelected(gs.getHexInclines());
-        useSoftCenter.setSelected(gs.getBoolean("SOFTCENTER"));
-        entityOwnerColor.setSelected(gs.getUnitLabelBorder());
-        teamColoring.setSelected(gs.getTeamColoring());
-
-        File dir = Configuration.hexesDir();
-        tileSets = new ArrayList<>(Arrays.asList(dir.listFiles(new FilenameFilter() {
-            public boolean accept(File direc, String name) {
-                return name.endsWith(".tileset");
+            int index = 0;
+            if (cs.getLocaleString().startsWith("de")) {
+                index = 1;
             }
-        })));
-        dir = new File(Configuration.userdataDir(),
-                Configuration.hexesDir().toString());
-        File[] userDataTilesets = dir.listFiles(new FilenameFilter() {
-            public boolean accept(File direc, String name) {
-                return name.endsWith(".tileset");
+            if (cs.getLocaleString().startsWith("ru")) {
+                index = 2;
             }
-        });
-        if (userDataTilesets != null) {
-            tileSets.addAll(Arrays.asList(userDataTilesets));
-        }
-        tileSetChoice.removeAllItems();
-        for (int i = 0; (tileSets != null) && i < tileSets.size(); i++) {
-            String name = tileSets.get(i).getName();
-            tileSetChoice.addItem(name.substring(0, name.length() - 8));
-            if (name.equals(cs.getMapTileset())) {
-                tileSetChoice.setSelectedIndex(i);
+            displayLocale.setSelectedIndex(index);
+
+            showMapsheets.setSelected(gs.getShowMapsheets());
+            chkAntiAliasing.setSelected(gs.getAntiAliasing());
+            showDamageLevel.setSelected(gs.getShowDamageLevel());
+            showDamageDecal.setSelected(gs.getShowDamageDecal());
+            aOHexShadows.setSelected(gs.getAOHexShadows());
+            floatingIso.setSelected(gs.getFloatingIso());
+            mmSymbol.setSelected(gs.getMmSymbol());
+            levelhighlight.setSelected(gs.getLevelHighlight());
+            shadowMap.setSelected(gs.getShadowMap());
+            hexInclines.setSelected(gs.getHexInclines());
+            useSoftCenter.setSelected(gs.getBoolean("SOFTCENTER"));
+            entityOwnerColor.setSelected(gs.getUnitLabelBorder());
+            teamColoring.setSelected(gs.getTeamColoring());
+
+            File dir = Configuration.hexesDir();
+            tileSets = new ArrayList<>(Arrays.asList(dir.listFiles(new FilenameFilter() {
+                public boolean accept(File direc, String name) {
+                    return name.endsWith(".tileset");
+                }
+            })));
+            dir = new File(Configuration.userdataDir(),
+                    Configuration.hexesDir().toString());
+            File[] userDataTilesets = dir.listFiles(new FilenameFilter() {
+                public boolean accept(File direc, String name) {
+                    return name.endsWith(".tileset");
+                }
+            });
+            if (userDataTilesets != null) {
+                tileSets.addAll(Arrays.asList(userDataTilesets));
             }
-        }
-
-        skinFiles.removeAllItems();
-        List<String> xmlFiles = new ArrayList<>(Arrays
-                .asList(Configuration.skinsDir().list(new FilenameFilter() {
-                    public boolean accept(File directory, String fileName) {
-                        return fileName.endsWith(".xml");
-                    }
-                })));
-        String[] files = new File(Configuration.userdataDir(), Configuration.skinsDir().toString())
-                .list(new FilenameFilter() {
-                    public boolean accept(File directory, String fileName) {
-                        return fileName.endsWith(".xml");
-                    }
-                });
-        if (files != null) {
-            xmlFiles.addAll(Arrays.asList(files));
-        }
-        Collections.sort(xmlFiles);
-        for (String file : xmlFiles) {
-            if (SkinXMLHandler.validSkinSpecFile(file)) {
-                skinFiles.addItem(file);
+            tileSetChoice.removeAllItems();
+            for (int i = 0; (tileSets != null) && i < tileSets.size(); i++) {
+                String name = tileSets.get(i).getName();
+                tileSetChoice.addItem(name.substring(0, name.length() - 8));
+                if (name.equals(cs.getMapTileset())) {
+                    tileSetChoice.setSelectedIndex(i);
+                }
             }
-        }
-        // Select the default file first
-        skinFiles.setSelectedItem(SkinXMLHandler.defaultSkinXML);
-        // If this select fials, the default skin will be selected
-        skinFiles.setSelectedItem(GUIPreferences.getInstance().getSkinFile());
 
-        uiThemes.removeAllItems();
-        for (LookAndFeelInfo lafInfo : UIManager.getInstalledLookAndFeels()) {
-            uiThemes.addItem(new UITheme(lafInfo.getClassName(), lafInfo.getName()));
-        }
-        uiThemes.setSelectedItem(new UITheme(GUIPreferences.getInstance().getUITheme()));
-        
-        fovInsideEnabled.setSelected(gs.getFovHighlight());
-        fovHighlightAlpha.setValue((int) ((100./255.) * gs.getFovHighlightAlpha()));
-        fovHighlightRingsRadii.setText( gs.getFovHighlightRingsRadii());
-        fovHighlightRingsColors.setText( gs.getFovHighlightRingsColorsHsb() );
-        fovOutsideEnabled.setSelected(gs.getFovDarken());
-        fovDarkenAlpha.setValue((int) ((100./255.) * gs.getFovDarkenAlpha()));
-        numStripesSlider.setValue(gs.getFovStripes());
-        fovGrayscaleEnabled.setSelected(gs.getFovGrayscale());
-        
-        fovHighlightAlpha.setEnabled(fovInsideEnabled.isSelected());
-        fovHighlightRingsRadii.setEnabled(fovInsideEnabled.isSelected());
-        fovHighlightRingsColors.setEnabled(fovInsideEnabled.isSelected());
-        fovDarkenAlpha.setEnabled(fovOutsideEnabled.isSelected());
-        numStripesSlider.setEnabled(fovOutsideEnabled.isSelected());
-        fovGrayscaleEnabled.setEnabled(fovOutsideEnabled.isSelected());
-        
-        darkenAlphaLabel.setEnabled(fovOutsideEnabled.isSelected());
-        numStripesLabel.setEnabled(fovOutsideEnabled.isSelected());
-        fovHighlightRingsColorsLabel.setEnabled(fovInsideEnabled.isSelected());
-        fovHighlightRingsRadiiLabel.setEnabled(fovInsideEnabled.isSelected());
-        highlightAlphaLabel.setEnabled(fovInsideEnabled.isSelected());
-        
-        stampFormatLabel.setEnabled(stampFilenames.isSelected());
-        gameLogFilenameLabel.setEnabled(keepGameLog.isSelected());
+            skinFiles.removeAllItems();
+            List<String> xmlFiles = new ArrayList<>(Arrays
+                    .asList(Configuration.skinsDir().list(new FilenameFilter() {
+                        public boolean accept(File directory, String fileName) {
+                            return fileName.endsWith(".xml");
+                        }
+                    })));
+            String[] files = new File(Configuration.userdataDir(), Configuration.skinsDir().toString())
+                    .list(new FilenameFilter() {
+                        public boolean accept(File directory, String fileName) {
+                            return fileName.endsWith(".xml");
+                        }
+                    });
+            if (files != null) {
+                xmlFiles.addAll(Arrays.asList(files));
+            }
+            Collections.sort(xmlFiles);
+            for (String file : xmlFiles) {
+                if (SkinXMLHandler.validSkinSpecFile(file)) {
+                    skinFiles.addItem(file);
+                }
+            }
+            // Select the default file first
+            skinFiles.setSelectedItem(SkinXMLHandler.defaultSkinXML);
+            // If this select fials, the default skin will be selected
+            skinFiles.setSelectedItem(GUIPreferences.getInstance().getSkinFile());
 
-        getFocus.setSelected(gs.getFocus());
+            uiThemes.removeAllItems();
+            for (LookAndFeelInfo lafInfo : UIManager.getInstalledLookAndFeels()) {
+                uiThemes.addItem(new UITheme(lafInfo.getClassName(), lafInfo.getName()));
+            }
+            uiThemes.setSelectedItem(new UITheme(GUIPreferences.getInstance().getUITheme()));
+
+            fovInsideEnabled.setSelected(gs.getFovHighlight());
+            fovHighlightAlpha.setValue((int) ((100./255.) * gs.getFovHighlightAlpha()));
+            fovHighlightRingsRadii.setText( gs.getFovHighlightRingsRadii());
+            fovHighlightRingsColors.setText( gs.getFovHighlightRingsColorsHsb() );
+            fovOutsideEnabled.setSelected(gs.getFovDarken());
+            fovDarkenAlpha.setValue((int) ((100./255.) * gs.getFovDarkenAlpha()));
+            numStripesSlider.setValue(gs.getFovStripes());
+            fovGrayscaleEnabled.setSelected(gs.getFovGrayscale());
+
+            fovHighlightAlpha.setEnabled(fovInsideEnabled.isSelected());
+            fovHighlightRingsRadii.setEnabled(fovInsideEnabled.isSelected());
+            fovHighlightRingsColors.setEnabled(fovInsideEnabled.isSelected());
+            fovDarkenAlpha.setEnabled(fovOutsideEnabled.isSelected());
+            numStripesSlider.setEnabled(fovOutsideEnabled.isSelected());
+            fovGrayscaleEnabled.setEnabled(fovOutsideEnabled.isSelected());
+
+            darkenAlphaLabel.setEnabled(fovOutsideEnabled.isSelected());
+            numStripesLabel.setEnabled(fovOutsideEnabled.isSelected());
+            fovHighlightRingsColorsLabel.setEnabled(fovInsideEnabled.isSelected());
+            fovHighlightRingsRadiiLabel.setEnabled(fovInsideEnabled.isSelected());
+            highlightAlphaLabel.setEnabled(fovInsideEnabled.isSelected());
+
+            stampFormatLabel.setEnabled(stampFilenames.isSelected());
+            gameLogFilenameLabel.setEnabled(keepGameLog.isSelected());
+
+            getFocus.setSelected(gs.getFocus());
+            
+            savedFovHighlight = gs.getFovHighlight();
+            savedFovDarken = gs.getFovDarken();
+            savedFovGrayscale = gs.getFovGrayscale();
+            savedAOHexShadows = gs.getAOHexShadows();
+            savedShadowMap = gs.getShadowMap();
+            savedHexInclines = gs.getHexInclines();
+            savedLevelhighlight = gs.getLevelHighlight();
+            savedFloatingIso = gs.getFloatingIso();
+            savedMmSymbol = gs.getMmSymbol();
+            savedTeamColoring = gs.getTeamColoring();
+            savedUnitLabelBorder = gs.getUnitLabelBorder();
+            savedShowDamageDecal = gs.getShowDamageDecal();
+            savedFovHighlightRingsRadii = gs.getFovHighlightRingsRadii();
+            savedFovHighlightRingsColors = gs.getFovHighlightRingsColorsHsb();
+            savedFovHighlightAlpha = gs.getFovHighlightAlpha();
+            savedFovDarkenAlpha = gs.getFovDarkenAlpha();
+            savedNumStripesSlider = gs.getFovStripes();
+            savedAdvancedOpt.clear();
+            
+            advancedKeys.clearSelection();
+            
+        }   
         super.setVisible(visible);
-    }
-
-    /**
-     * Cancel any updates made in this dialog, and closes it.
-     */
+    }       
+            
+    /** Cancel any updates made in this dialog and close it.  */     
     void cancel() {
+        // Restore values that are immediately updated by player clicks
+        GUIPreferences guip = GUIPreferences.getInstance();
+        guip.setFovHighlight(savedFovHighlight);
+        guip.setFovDarken(savedFovDarken);
+        guip.setFovGrayscale(savedFovGrayscale);
+        guip.setAOHexShadows(savedAOHexShadows);
+        guip.setShadowMap(savedShadowMap);
+        guip.setHexInclines(savedHexInclines);
+        guip.setLevelHighlight(savedLevelhighlight);
+        guip.setFloatingIso(savedFloatingIso);
+        guip.setMmSymbol(savedMmSymbol);
+        guip.setTeamColoring(savedTeamColoring);
+        guip.setUnitLabelBorder(savedUnitLabelBorder);
+        guip.setShowDamageDecal(savedShowDamageDecal);
+        guip.setFovHighlightRingsRadii(savedFovHighlightRingsRadii);
+        guip.setFovHighlightRingsColorsHsb(savedFovHighlightRingsColors);
+        guip.setFovHighlightAlpha(savedFovHighlightAlpha);
+        guip.setFovDarkenAlpha(savedFovDarkenAlpha);
+        guip.setFovStripes(savedNumStripesSlider);
+         
+        for (String option: savedAdvancedOpt.keySet()) {
+            GUIPreferences.getInstance().setValue(option, savedAdvancedOpt.get(option));
+        }
+
         setVisible(false);
     }
 
@@ -906,6 +983,9 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setTooltipDistSuppression(Integer.parseInt(tooltipDistSupression.getText()));
         cs.setUnitStartChar(((String) unitStartChar.getSelectedItem())
                 .charAt(0));
+        
+        gs.setMouseWheelZoom(mouseWheelZoom.isSelected());
+        gs.setMouseWheelZoomFlip(mouseWheelZoomFlip.isSelected());
 
         cs.setMaxPathfinderTime(Integer.parseInt(maxPathfinderTime.getText()));
 
@@ -977,12 +1057,9 @@ public class CommonSettingsDialog extends ClientDialog implements
             cs.setMapTileset(tileSetFileName);
         }
 
-        ToolTipManager.sharedInstance().setInitialDelay(
-                GUIPreferences.getInstance().getTooltipDelay());
-        if (GUIPreferences.getInstance().getTooltipDismissDelay() > 0)
-        {
-            ToolTipManager.sharedInstance().setDismissDelay(
-                    GUIPreferences.getInstance().getTooltipDismissDelay());
+        ToolTipManager.sharedInstance().setInitialDelay(gs.getTooltipDelay());
+        if (gs.getTooltipDismissDelay() > 0) {
+            ToolTipManager.sharedInstance().setDismissDelay(gs.getTooltipDismissDelay());
         }
 
         // Lets iterate through all of the KeyCommandBinds and see if they've
@@ -1123,19 +1200,14 @@ public class CommonSettingsDialog extends ClientDialog implements
      */
     public void actionPerformed(ActionEvent event) {
         String command = event.getActionCommand();
-        if (CommonSettingsDialog.UPDATE.equalsIgnoreCase(command)) {
+        if (command.equals(UPDATE)) {
             update();
-        } else if (CommonSettingsDialog.CANCEL.equalsIgnoreCase(command)) {
+        } else if (command.equals(CANCEL)) {
             cancel();
         }
     }
 
-    /**
-     * Handle the player clicking checkboxes. <p/> Implements the
-     * <code>ItemListener</code> interface.
-     *
-     * @param event - the <code>ItemEvent</code> that initiated this call.
-     */
+    /** Handle some setting changes that directly update e.g. the board. */
     public void itemStateChanged(ItemEvent event) {
         Object source = event.getItemSelectable();
         GUIPreferences guip = GUIPreferences.getInstance();
@@ -1149,10 +1221,6 @@ public class CommonSettingsDialog extends ClientDialog implements
             stampFormatLabel.setEnabled(stampFilenames.isSelected());
         } else if (source.equals(fovInsideEnabled)) {
             guip.setFovHighlight(fovInsideEnabled.isSelected());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
             fovHighlightAlpha.setEnabled(fovInsideEnabled.isSelected());
             fovHighlightRingsRadii.setEnabled(fovInsideEnabled.isSelected());
             fovHighlightRingsColors.setEnabled(fovInsideEnabled.isSelected());
@@ -1161,10 +1229,6 @@ public class CommonSettingsDialog extends ClientDialog implements
             highlightAlphaLabel.setEnabled(fovInsideEnabled.isSelected());
         } else if (source.equals(fovOutsideEnabled)) {
             guip.setFovDarken(fovOutsideEnabled.isSelected());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
             fovDarkenAlpha.setEnabled(fovOutsideEnabled.isSelected());
             numStripesSlider.setEnabled(fovOutsideEnabled.isSelected());
             darkenAlphaLabel.setEnabled(fovOutsideEnabled.isSelected());
@@ -1172,36 +1236,16 @@ public class CommonSettingsDialog extends ClientDialog implements
             fovGrayscaleEnabled.setEnabled(fovOutsideEnabled.isSelected());
         } else if (source.equals(fovGrayscaleEnabled)) {
             guip.setFovGrayscale(fovGrayscaleEnabled.isSelected());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         } else if (source.equals(aOHexShadows)) {
             guip.setAOHexShadows(aOHexShadows.isSelected());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         } else if (source.equals(shadowMap)) {
             guip.setShadowMap(shadowMap.isSelected());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         } else if (source.equals(hexInclines)) {
             guip.setHexInclines(hexInclines.isSelected());
         } else if (source.equals(levelhighlight)) {
             guip.setLevelHighlight(levelhighlight.isSelected());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         } else if (source.equals(floatingIso)) {
             guip.setFloatingIso(floatingIso.isSelected());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         } else if (source.equals(mmSymbol)) {
             guip.setMmSymbol(mmSymbol.isSelected());
             if ((clientgui != null) && (clientgui.minimap != null)) {
@@ -1222,41 +1266,28 @@ public class CommonSettingsDialog extends ClientDialog implements
         }
     }
 
-    public void focusGained(FocusEvent e) {
-    }
+    public void focusGained(FocusEvent e) { }
 
     public void focusLost(FocusEvent e) {
         Object src = e.getSource();
         GUIPreferences guip = GUIPreferences.getInstance();          
         if (src.equals(fovHighlightRingsRadii)) {
             guip.setFovHighlightRingsRadii(fovHighlightRingsRadii.getText());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
             return;
         } else if (src.equals(fovHighlightRingsColors)) {
             guip.setFovHighlightRingsColorsHsb(fovHighlightRingsColors.getText());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
             return;
         } 
         // For Advanced options
-        String option = "Advanced" + keys.getModel().getElementAt(keysIndex).option;
-        GUIPreferences.getInstance().setValue(option, value.getText());
-        if (option.equals(GUIPreferences.ADVANCED_SHOW_COORDS)
-                && (clientgui != null) && (clientgui.bv != null)) {
-            clientgui.bv.clearHexImageCache();
-            clientgui.bv.repaint();
-        }
+        String option = "Advanced" + advancedKeys.getModel().getElementAt(advancedKeyIndex).option;
+        savedAdvancedOpt.put(option, guip.getString(option));        
+        guip.setValue(option, advancedValue.getText());
     }
 
     /** 
      * The Graphics Tab
      */
-    private JPanel getTacticalOverlaySettingsPanel() {
+    private JPanel getGraphicsPanel() {
 
         ArrayList<ArrayList<Component>> comps = new ArrayList<ArrayList<Component>>();
         ArrayList<Component> row;
@@ -1567,20 +1598,24 @@ public class CommonSettingsDialog extends ClientDialog implements
         
         return createSettingsPanel(comps);
     }
-
+    
     /**
      * Creates a panel with a box for all of the commands that can be bound to
      * keys.
      *
      * @return
      */
-    private JPanel getKeyBindPanel(){
+    private JPanel getKeyBindPanel() {
         // Create the panel to hold all the components
         // We will have an N x 43 grid, the first column is for labels, the
         //  second column will hold text fields for modifiers, the third
         //  column holds text fields for keys, and the fourth has a checkbox for
         //  isRepeatable.
+        JPanel outer = new JPanel();
+        outer.setLayout(new FlowLayout(FlowLayout.LEFT));
+        
         JPanel keyBinds = new JPanel(new GridBagLayout());
+        outer.add(keyBinds);
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = gbc.gridy = 0;
         gbc.insets = new Insets(0,10,5,10);
@@ -1710,7 +1745,7 @@ public class CommonSettingsDialog extends ClientDialog implements
             key.setFocusTraversalKeysEnabled(false);
             repeatable.setFocusTraversalKeysEnabled(false);
         }
-        return keyBinds;
+        return outer;
     }
     
     /**
@@ -1725,98 +1760,50 @@ public class CommonSettingsDialog extends ClientDialog implements
         JTabbedPane phasePane = new JTabbedPane();
         buttonOrderPanel.add(phasePane);
         
-        StatusBarPhaseDisplay.PhaseCommand commands[];
-        StatusBarPhaseDisplay.CommandComparator cmdComp = 
-                new StatusBarPhaseDisplay.CommandComparator(); 
-        PhaseCommandListMouseAdapter cmdMouseAdaptor = 
-                new PhaseCommandListMouseAdapter();
-
         // MovementPhaseDisplay        
-        JPanel movementPanel = new JPanel();
-        movePhaseCommands = 
-                new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
-        commands = MovementDisplay.MoveCommand.values();
-        Arrays.sort(commands, cmdComp);        
-        for (StatusBarPhaseDisplay.PhaseCommand cmd : commands) {
-            movePhaseCommands.addElement(cmd);
-        }
-        JList<StatusBarPhaseDisplay.PhaseCommand> moveList = new JList<>(movePhaseCommands);
-        moveList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        moveList.addMouseListener(cmdMouseAdaptor);
-        moveList.addMouseMotionListener(cmdMouseAdaptor);
-        movementPanel.add(moveList);
-        JScrollPane movementScrollPane = new JScrollPane(movementPanel);
-        phasePane.add("Movement", movementScrollPane);
+        movePhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        phasePane.add("Movement", getButtonOrderPane(movePhaseCommands,
+                MovementDisplay.MoveCommand.values()));
         
         // DeploymentPhaseDisplay
-        JPanel deployPanel = new JPanel();
-        deployPhaseCommands = 
-                new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
-        commands = DeploymentDisplay.DeployCommand.values();
-        Arrays.sort(commands, cmdComp);        
-        for (StatusBarPhaseDisplay.PhaseCommand cmd : commands) {
-            deployPhaseCommands.addElement(cmd);
-        }
-        JList<StatusBarPhaseDisplay.PhaseCommand> deployList = new JList<>(deployPhaseCommands);
-        deployList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        deployList.addMouseListener(cmdMouseAdaptor);
-        deployList.addMouseMotionListener(cmdMouseAdaptor);
-        deployPanel.add(deployList);
-        JScrollPane deployScrollPane = new JScrollPane(deployPanel);
-        phasePane.add("Deployment", deployScrollPane);
+        deployPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        phasePane.add("Deployment", getButtonOrderPane(deployPhaseCommands,
+                DeploymentDisplay.DeployCommand.values()));
         
         // FiringPhaseDisplay
-        JPanel firingPanel = new JPanel();
-        firingPhaseCommands = 
-                new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
-        commands = FiringDisplay.FiringCommand.values();
-        Arrays.sort(commands, cmdComp);        
-        for (StatusBarPhaseDisplay.PhaseCommand cmd : commands) {
-            firingPhaseCommands.addElement(cmd);
-        }
-        JList<StatusBarPhaseDisplay.PhaseCommand> firingList = new JList<>(firingPhaseCommands);
-        firingList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        firingList.addMouseListener(cmdMouseAdaptor);
-        firingList.addMouseMotionListener(cmdMouseAdaptor);
-        firingPanel.add(firingList);
-        JScrollPane firingScrollPane = new JScrollPane(firingPanel);
-        phasePane.add("Firing", firingScrollPane);
+        firingPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        phasePane.add("Firing", getButtonOrderPane(firingPhaseCommands,
+                FiringDisplay.FiringCommand.values()));
         
         // PhysicalPhaseDisplay
-        JPanel physicalPanel = new JPanel();
-        physicalPhaseCommands = 
-                new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
-        commands = PhysicalDisplay.PhysicalCommand.values();
-        Arrays.sort(commands, cmdComp);        
-        for (StatusBarPhaseDisplay.PhaseCommand cmd : commands) {
-            physicalPhaseCommands.addElement(cmd);
-        }
-        JList<StatusBarPhaseDisplay.PhaseCommand> physicalList = new JList<>(physicalPhaseCommands);
-        physicalList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        physicalList.addMouseListener(cmdMouseAdaptor);
-        physicalList.addMouseMotionListener(cmdMouseAdaptor);
-        physicalPanel.add(physicalList);
-        JScrollPane physicalScrollPane = new JScrollPane(physicalPanel);
-        phasePane.add("Physical", physicalScrollPane);          
+        physicalPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        phasePane.add("Physical", getButtonOrderPane(physicalPhaseCommands,
+                PhysicalDisplay.PhysicalCommand.values()));          
         
         // TargetingPhaseDisplay
-        JPanel targetingPanel = new JPanel();
-        targetingPhaseCommands = 
-                new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
-        commands = TargetingPhaseDisplay.TargetingCommand.values();
-        Arrays.sort(commands, cmdComp);        
-        for (StatusBarPhaseDisplay.PhaseCommand cmd : commands) {
-            targetingPhaseCommands.addElement(cmd);
-        }
-        JList<StatusBarPhaseDisplay.PhaseCommand> targetingList = new JList<>(targetingPhaseCommands);
-        targetingList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        targetingList.addMouseListener(cmdMouseAdaptor);
-        targetingList.addMouseMotionListener(cmdMouseAdaptor);
-        targetingPanel.add(targetingList);
-        JScrollPane targetingScrollPane = new JScrollPane(targetingPanel);
-        phasePane.add("Targeting", targetingScrollPane);            
+        targetingPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        phasePane.add("Targeting", getButtonOrderPane(targetingPhaseCommands,
+                TargetingPhaseDisplay.TargetingCommand.values()));
         
         return buttonOrderPanel;
+    }
+
+    /** Constructs the button ordering panel for one phase. */ 
+    private JScrollPane getButtonOrderPane(DefaultListModel<PhaseCommand> list, 
+            StatusBarPhaseDisplay.PhaseCommand commands[]) {
+        JPanel panel = new JPanel();
+        Arrays.sort(commands, cmdComp);        
+        for (StatusBarPhaseDisplay.PhaseCommand cmd : commands) {
+            list.addElement(cmd);
+        }
+        JList<StatusBarPhaseDisplay.PhaseCommand> jlist = new JList<>(list);
+        jlist.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        jlist.addMouseListener(cmdMouseAdaptor);
+        jlist.addMouseMotionListener(cmdMouseAdaptor);
+        panel.add(jlist);
+        JScrollPane scrollPane = new JScrollPane(panel);
+        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+        return scrollPane;
     }
 
     private JPanel createSettingsPanel(ArrayList<ArrayList<Component>> comps) {
@@ -1853,40 +1840,42 @@ public class CommonSettingsDialog extends ClientDialog implements
             opts[i] = new AdvancedOptionData(s[i]);
         }
         Arrays.sort(opts);
-        keys = new JList<>(opts);
-        keys.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        keys.addListSelectionListener(this);
-        keys.addMouseMotionListener(new MouseMotionAdapter() {
+        advancedKeys = new JList<>(opts);
+        advancedKeys.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        advancedKeys.addListSelectionListener(this);
+        advancedKeys.addMouseMotionListener(new MouseMotionAdapter() {
             @Override
             public void mouseMoved(MouseEvent e) {
-                int index = keys.locationToIndex(e.getPoint());
+                int index = advancedKeys.locationToIndex(e.getPoint());
                 if (index > -1) {
-                    AdvancedOptionData dat = keys.getModel().getElementAt(index);
+                    AdvancedOptionData dat = advancedKeys.getModel().getElementAt(index);
                     if (dat.hasTooltipText()) {
-                        keys.setToolTipText(dat.getTooltipText());
+                        advancedKeys.setToolTipText(dat.getTooltipText());
                     } else {
-                        keys.setToolTipText(null);
+                        advancedKeys.setToolTipText(null);
                     }
                 }
             }
         });
-        p.add(keys);
+        p.add(advancedKeys);
 
-        value = new JTextField(10);
-        value.addFocusListener(this);
-        p.add(value);
+        advancedValue = new JTextField(10);
+        advancedValue.setFont(new Font("LucidaSans", Font.PLAIN, 16));
+        advancedValue.addFocusListener(this);
+        p.add(advancedValue);
 
         return p;
     }
 
+    /** Used to note which advanced setting is currently clicked. */  
     public void valueChanged(ListSelectionEvent event) {
         if (event.getValueIsAdjusting()) {
             return;
         }
-        if (event.getSource().equals(keys)) {
-            value.setText(GUIPreferences.getInstance().getString(
-                    "Advanced" + keys.getSelectedValue().option));
-            keysIndex = keys.getSelectedIndex();
+        if (event.getSource().equals(advancedKeys)) {
+            advancedValue.setText(GUIPreferences.getInstance().getString(
+                    "Advanced" + advancedKeys.getSelectedValue().option));
+            advancedKeyIndex = advancedKeys.getSelectedIndex();
         }
     }
 
@@ -1896,23 +1885,11 @@ public class CommonSettingsDialog extends ClientDialog implements
         if (evt.getSource().equals(fovHighlightAlpha)) {
             // Need to convert from 0-100 to 0-255
             guip.setFovHighlightAlpha((int) (fovHighlightAlpha.getValue() * 2.55));
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         } else if (evt.getSource().equals(fovDarkenAlpha)) {
             // Need to convert from 0-100 to 0-255
             guip.setFovDarkenAlpha((int) (fovDarkenAlpha.getValue() * 2.55));
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         } else if (evt.getSource().equals(numStripesSlider)) {
             guip.setFovStripes(numStripesSlider.getValue());
-            if ((clientgui != null) && (clientgui.bv != null)) {
-                clientgui.bv.clearHexImageCache();
-                clientgui.bv.repaint();
-            }
         }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -116,7 +116,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String DISPLAY_SIZE_HEIGHT = "DisplaySizeHeight";
     public static final String DISPLAY_SIZE_WIDTH = "DisplaySizeWidth";
     public static final String UNIT_LABEL_BORDER = "EntityOwnerLabelColor";
-    public static final String UNIT_LABEL_BORDER_TEAM = "EntityTeamLabelColor";
+    public static final String TEAM_COLORING = "EntityTeamLabelColor";
     public static final String FOCUS = "Focus";
     public static final String GAME_OPTIONS_SIZE_HEIGHT = "GameOptionsSizeHeight";
     public static final String GAME_OPTIONS_SIZE_WIDTH = "GameOptionsSizeWidth";
@@ -293,7 +293,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
 
         store.setDefault(ADVANCED_MOVE_STEP_DELAY, 50);
-        store.setDefault(ADVANCED_DARKEN_MAP_AT_NIGHT, true);
+        store.setDefault(ADVANCED_DARKEN_MAP_AT_NIGHT, false);
         setDefault(ADVANCED_MAPSHEET_COLOR, "blue");
         store.setDefault(ADVANCED_TRANSLUCENT_HIDDEN_UNITS, true);
         store.setDefault(ADVANCED_ATTACK_ARROW_TRANSPARENCY, 0x80);
@@ -312,14 +312,20 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
         store.setDefault(FOV_HIGHLIGHT_RINGS_COLORS_HSB, "0.3 1.0 1.0 ; 0.45 1.0 1.0 ; 0.6 1.0 1.0 ; 0.75 1.0 1.0 ; 0.9 1.0 1.0 ; 1.05 1.0 1.0 ");
-
+        store.setDefault(FOV_HIGHLIGHT,false);
+        store.setDefault(FOV_HIGHLIGHT_ALPHA, 40);
+        store.setDefault(FOV_DARKEN,true);
+        store.setDefault(FOV_DARKEN_ALPHA, 100);
+        store.setDefault(FOV_STRIPES, 35);
+        store.setDefault(FOV_GRAYSCALE, "false");
 
         store.setDefault(ANTIALIASING, true);
         store.setDefault(AOHEXSHADOWS, false);
-        store.setDefault(SHADOWMAP, false);
+        store.setDefault(SHADOWMAP, true);
         store.setDefault(INCLINES, true);
         store.setDefault(FLOATINGISO, false);
         store.setDefault(LEVELHIGHLIGHT, false);
+
         store.setDefault(AUTO_END_FIRING, true);
         store.setDefault(AUTO_DECLARE_SEARCHLIGHT, true);
         store.setDefault(CHAT_LOUNGE_TABS, true);
@@ -331,17 +337,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(GAME_OPTIONS_SIZE_HEIGHT,400);
         store.setDefault(GAME_OPTIONS_SIZE_WIDTH,400);
         store.setDefault(FIRING_SOLUTIONS,true);
-        store.setDefault(FOV_HIGHLIGHT,false);
-        store.setDefault(FOV_HIGHLIGHT_ALPHA, 40);
-        store.setDefault(FOV_DARKEN,true);
-        store.setDefault(FOV_DARKEN_ALPHA, 100);
-        store.setDefault(FOV_STRIPES, 35);
-        store.setDefault(FOV_GRAYSCALE, "false");
+
         store.setDefault(IMAGE_CHOOSER_POS_X, 200);
         store.setDefault(IMAGE_CHOOSER_POS_Y, 150);
         store.setDefault(IMAGE_CHOOSER_SIZE_WIDTH, 500);
         store.setDefault(IMAGE_CHOOSER_SIZE_HEIGHT, 400);
         store.setDefault(IMAGE_CHOOSER_SPLIT_POS, 50);
+        
         setDefault(MAP_TEXT_COLOR, Color.black);
         store.setDefault(MAP_ZOOM_INDEX, 7);
         store.setDefault(MECH_SELECTOR_INCLUDE_MODEL, true);
@@ -359,16 +361,20 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(MECH_SELECTOR_SHOW_ADVANCED, false);
         store.setDefault(MECH_SELECTOR_SIZE_HEIGHT,600);
         store.setDefault(MECH_SELECTOR_SIZE_WIDTH,800);
+        
         store.setDefault(MINIMAP_COLOURS, "defaultminimap.txt");
         store.setDefault(MINIMAP_ENABLED, true);
         store.setDefault(MINIMUM_SIZE_HEIGHT, 200);
         store.setDefault(MINIMUM_SIZE_WIDTH, 120);
+        
         store.setDefault(MINI_REPORT_POS_X, 200);
         store.setDefault(MINI_REPORT_POS_Y, 150);
         store.setDefault(MINI_REPORT_SIZE_HEIGHT, 300);
         store.setDefault(MINI_REPORT_SIZE_WIDTH, 400);
-        store.setDefault(MOUSE_WHEEL_ZOOM, false);
-        store.setDefault(MOUSE_WHEEL_ZOOM_FLIP, false);
+        
+        store.setDefault(MOUSE_WHEEL_ZOOM, true);
+        store.setDefault(MOUSE_WHEEL_ZOOM_FLIP, true);
+        
         store.setDefault(NAG_FOR_BOT_README, true);
         store.setDefault(NAG_FOR_CRUSHING_BUILDINGS, true);
         store.setDefault(NAG_FOR_MAP_ED_README, true);
@@ -382,34 +388,45 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(NAG_FOR_MECHANICAL_FALL_DAMAGE,true);
         store.setDefault(NAG_FOR_DOOMED, true);
         store.setDefault(NAG_FOR_WIGE_LANDING, true);
+        
         setDefault(RULER_COLOR_1, Color.cyan);
         setDefault(RULER_COLOR_2, Color.magenta);
         store.setDefault(RULER_POS_X, 0);
         store.setDefault(RULER_POS_Y, 0);
         store.setDefault(RULER_SIZE_HEIGHT, 300);
         store.setDefault(RULER_SIZE_WIDTH, 500);
+        
         store.setDefault(SCROLL_SENSITIVITY, 3);
         store.setDefault(SHOW_FIELD_OF_FIRE, true);
         store.setDefault(SHOW_MAPHEX_POPUP, true);
         store.setDefault(SHOW_MOVE_STEP, true);
         store.setDefault(SHOW_WRECKS, true);
         store.setDefault(SOUND_BING_FILENAME, "data/sounds/call.wav");
+        
         store.setDefault(TOOLTIP_DELAY, 1000);
         store.setDefault(TOOLTIP_DISMISS_DELAY, -1);
         store.setDefault(TOOLTIP_DIST_SUPRESSION, BoardView1.HEX_DIAG);
+        store.setDefault(SHOW_WPS_IN_TT, true);
+        store.setDefault(SHOW_ARMOR_MINIVIS_TT, true);
+        store.setDefault(SHOW_PILOT_PORTRAIT_TT, true);
+        
+        store.setDefault(USE_ISOMETRIC, false);
+        
         store.setDefault(WINDOW_SIZE_HEIGHT, 600);
         store.setDefault(WINDOW_SIZE_WIDTH, 800);
+        
         store.setDefault(RND_MAP_SIZE_HEIGHT, 500);
         store.setDefault(RND_MAP_SIZE_WIDTH, 500);
         store.setDefault(RND_MAP_POS_X, 400);
         store.setDefault(RND_MAP_POS_Y, 400);
         store.setDefault(RND_MAP_ADVANCED, false);
+        store.setDefault(BOARDEDIT_LOAD_SIZE_WIDTH, 400);
+        store.setDefault(BOARDEDIT_LOAD_SIZE_HEIGHT, 300);
+        
         store.setDefault(SHOW_MAPSHEETS, false);
-        store.setDefault(SHOW_WPS_IN_TT, false);
-        store.setDefault(SHOW_ARMOR_MINIVIS_TT, false);
-        store.setDefault(SHOW_PILOT_PORTRAIT_TT, false);
-        store.setDefault(USE_ISOMETRIC, false);
+        
         store.setDefault(SHOW_UNIT_OVERVIEW, true);
+        store.setDefault(DEFAULT_WEAP_SORT_ORDER, Entity.WeaponSortOrder.DEFAULT.ordinal());
         store.setDefault(SHOW_DAMAGE_LEVEL, false);
         store.setDefault(SHOW_DAMAGE_DECAL, true);
         store.setDefault(SKIN_FILE, "BW - Default.xml");
@@ -428,16 +445,11 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(RAT_PAD_BV, false);
         store.setDefault(RAT_SELECTED_RAT, "");
         
-        store.setDefault(BOARDEDIT_LOAD_SIZE_WIDTH, 400);
-        store.setDefault(BOARDEDIT_LOAD_SIZE_HEIGHT, 300);
+        setDefault(ALLY_UNIT_COLOR, new Color(60, 140, 240));  // greenish blue
+        setDefault(ENEMY_UNIT_COLOR, new Color(200, 40, 40)); // red
+        setDefault(MY_UNIT_COLOR, new Color(40, 210, 40));  // light green
+        setDefault(TEAM_COLORING, true);
         
-        store.setDefault(DEFAULT_WEAP_SORT_ORDER,
-                Entity.WeaponSortOrder.DEFAULT.ordinal());
-        
-        setDefault(ALLY_UNIT_COLOR, new Color(80, 250, 250));
-        setDefault(ENEMY_UNIT_COLOR, new Color(220, 20, 20));
-        setDefault(MY_UNIT_COLOR, new Color(20, 220, 20));
-        setDefault(UNIT_LABEL_BORDER_TEAM, true);
         setDefault(SHOW_KEYBINDS_OVERLAY, true);
         
     }
@@ -482,8 +494,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return store.getBoolean(AUTO_END_FIRING);
     }
     
-    public boolean getUnitLabelBorderTeam() {
-        return store.getBoolean(UNIT_LABEL_BORDER_TEAM);
+    public boolean getTeamColoring() {
+        return store.getBoolean(TEAM_COLORING);
     }
 
     public boolean getAutoDeclareSearchlight() {
@@ -1151,8 +1163,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setValue(BOARDEDIT_LOAD_SIZE_WIDTH, i);
     }
     
-    public void setUnitLabelBorderTeam(boolean bt) {
-        store.setValue(UNIT_LABEL_BORDER_TEAM, bt);
+    public void setTeamColoring(boolean bt) {
+        store.setValue(TEAM_COLORING, bt);
     }
 
     public void setMiniReportSizeHeight(int i) {

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -312,12 +312,12 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
         store.setDefault(FOV_HIGHLIGHT_RINGS_COLORS_HSB, "0.3 1.0 1.0 ; 0.45 1.0 1.0 ; 0.6 1.0 1.0 ; 0.75 1.0 1.0 ; 0.9 1.0 1.0 ; 1.05 1.0 1.0 ");
-        store.setDefault(FOV_HIGHLIGHT,false);
+        store.setDefault(FOV_HIGHLIGHT, false);
         store.setDefault(FOV_HIGHLIGHT_ALPHA, 40);
-        store.setDefault(FOV_DARKEN,true);
+        store.setDefault(FOV_DARKEN, true);
         store.setDefault(FOV_DARKEN_ALPHA, 100);
         store.setDefault(FOV_STRIPES, 35);
-        store.setDefault(FOV_GRAYSCALE, "false");
+        store.setDefault(FOV_GRAYSCALE, false);
 
         store.setDefault(ANTIALIASING, true);
         store.setDefault(AOHEXSHADOWS, false);
@@ -336,7 +336,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(UNIT_LABEL_BORDER, true);
         store.setDefault(GAME_OPTIONS_SIZE_HEIGHT,400);
         store.setDefault(GAME_OPTIONS_SIZE_WIDTH,400);
-        store.setDefault(FIRING_SOLUTIONS,true);
+        store.setDefault(FIRING_SOLUTIONS, true);
 
         store.setDefault(IMAGE_CHOOSER_POS_X, 200);
         store.setDefault(IMAGE_CHOOSER_POS_Y, 150);
@@ -353,14 +353,14 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(MECH_SELECTOR_INCLUDE_YEAR, true);
         store.setDefault(MECH_SELECTOR_INCLUDE_LEVEL, true);
         store.setDefault(MECH_SELECTOR_INCLUDE_COST, true);
-        store.setDefault(MECH_SELECTOR_UNIT_TYPE,0);
-        store.setDefault(MECH_SELECTOR_WEIGHT_CLASS,15);
-        store.setDefault(MECH_SELECTOR_RULES_LEVELS,"[0]");
+        store.setDefault(MECH_SELECTOR_UNIT_TYPE, 0);
+        store.setDefault(MECH_SELECTOR_WEIGHT_CLASS, 15);
+        store.setDefault(MECH_SELECTOR_RULES_LEVELS, "[0]");
         store.setDefault(MECH_SELECTOR_SORT_COLUMN, 0);
         store.setDefault(MECH_SELECTOR_SORT_ORDER, "ASCENDING");
         store.setDefault(MECH_SELECTOR_SHOW_ADVANCED, false);
-        store.setDefault(MECH_SELECTOR_SIZE_HEIGHT,600);
-        store.setDefault(MECH_SELECTOR_SIZE_WIDTH,800);
+        store.setDefault(MECH_SELECTOR_SIZE_HEIGHT, 600);
+        store.setDefault(MECH_SELECTOR_SIZE_WIDTH, 800);
         
         store.setDefault(MINIMAP_COLOURS, "defaultminimap.txt");
         store.setDefault(MINIMAP_ENABLED, true);

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -708,8 +708,6 @@ public class MiniMap extends JPanel {
         }
         
         Color oldColor = g.getColor();
-        // g.setColor(BACKGROUND);
-        // g.fillRect(0, 0, getSize().width, getSize().height);
         g.setColor(oldColor);
         if (!minimized) {
             roadHexIndexes.removeAllElements();
@@ -955,19 +953,19 @@ public class MiniMap extends JPanel {
                 String label;
                 switch (heightDisplayMode) {
                     case SHOW_NO_HEIGHT:
-                        label = Messages.getString("MiniMap.NoHeightLabel"); //$NON-NLS-1$
+                        label = Messages.getString("MiniMap.NoHeightLabel"); 
                         break;
                     case SHOW_GROUND_HEIGHT:
-                        label = Messages.getString("MiniMap.GroundHeightLabel"); //$NON-NLS-1$
+                        label = Messages.getString("MiniMap.GroundHeightLabel");
                         break;
                     case SHOW_BUILDING_HEIGHT:
-                        label = Messages.getString("MiniMap.BuildingHeightLabel"); //$NON-NLS-1$
+                        label = Messages.getString("MiniMap.BuildingHeightLabel"); 
                         break;
                     case SHOW_TOTAL_HEIGHT:
-                        label = Messages.getString("MiniMap.TotalHeightLabel"); //$NON-NLS-1$
+                        label = Messages.getString("MiniMap.TotalHeightLabel"); 
                         break;
                     default:
-                        label = ""; //$NON-NLS-1$
+                        label = "";
                 }
                 g.drawString(label, 17, (getSize().height - 14) + 12);
             }
@@ -1253,6 +1251,20 @@ public class MiniMap extends JPanel {
 
         Graphics2D g2 = (Graphics2D)g;
         Stroke svStroke = g2.getStroke();
+        
+        // Choose player or team color depending on preferences
+        Color iconColor = PlayerColors.getColor(entity.getOwner().getColorIndex(), false);
+        if (GUIPreferences.getInstance().getTeamColoring() && (m_client != null)) {
+            boolean isLocalTeam = entity.getOwner().getTeam() == m_client.getLocalPlayer().getTeam();
+            boolean isLocalPlayer = entity.getOwner().equals(m_client.getLocalPlayer());
+            if (isLocalPlayer) {
+                iconColor = GUIPreferences.getInstance().getMyUnitColor();
+            } else if (isLocalTeam) {
+                iconColor = GUIPreferences.getInstance().getAllyUnitColor();
+            } else {
+                iconColor = GUIPreferences.getInstance().getEnemyUnitColor();
+            }
+        }
 
         if (GUIPreferences.getInstance().getBoolean(GUIPreferences.MMSYMBOL)) {
             AffineTransform svTransform = g2.getTransform();
@@ -1313,9 +1325,8 @@ public class MiniMap extends JPanel {
                 form = STRAT_INFANTRY;
             }
 
-            // Fill the form in player color
-            g2.setColor(new Color(PlayerColors.getColorRGB(
-                    entity.getOwner().getColorIndex())));
+            // Fill the form in player color / team color
+            g.setColor(iconColor);
             g2.fill(form);
 
             // Add the weight class or other lettering for certain units
@@ -1356,10 +1367,8 @@ public class MiniMap extends JPanel {
                 g.setColor(new Color(100,100,100,200));
                 g.drawOval(baseX - radius, baseY - radius, dia, dia);
 
-                // Fill the icon according to player color
-                Color pColor = new Color(
-                        PlayerColors.getColorRGB(entity.getOwner().getColorIndex()));
-                g.setColor(pColor);
+                // Fill the form in player color / team color
+                g.setColor(iconColor);
                 g.fillOval(baseX - radius, baseY - radius, dia, dia);
 
                 // Draw a white border to better show the player color
@@ -1372,10 +1381,8 @@ public class MiniMap extends JPanel {
                 g.setColor(new Color(100,100,100,200));
                 g.drawPolygon(xPoints, yPoints, xPoints.length);
 
-                // Fill the icon according to the player color
-                Color pColor = new Color(
-                        PlayerColors.getColorRGB(entity.getOwner().getColorIndex()));
-                g.setColor(pColor);
+                // Fill the form in player color / team color
+                g.setColor(iconColor);
                 g.fillPolygon(xPoints, yPoints, xPoints.length);
 
                 // Draw a white border to better show the player color

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -1704,19 +1704,25 @@ public class MiniMap extends JPanel {
                 initializeMap();
             } else {
                 if (x < 14) {
-                    zoomIn();
+                    if (GUIPreferences.getInstance().getMouseWheelZoomFlip()) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
                 } else if ((x < 28) && (zoom > 2)) {
-                    heightDisplayMode = ((++heightDisplayMode) > NBR_MODES) ? 0
-                            : heightDisplayMode;
+                    heightDisplayMode = ((++heightDisplayMode) > NBR_MODES) ? 0 : heightDisplayMode;
                     initializeMap();
                 } else if (x > (getSize().width - 14)) {
-                    zoomOut();
+                    if (GUIPreferences.getInstance().getMouseWheelZoomFlip()) {
+                        zoomOut();
+                    } else {
+                        zoomIn();
+                    }
                 } else {
                     // Minimize button
                     heightBufer = getSize().height;
                     setSize(getSize().width, 14);
                     m_mapImage = createImage(Math.max(1, getSize().width), 14);
-
                     minimized = true;
                     initializeMap();
                 }  
@@ -1728,8 +1734,7 @@ public class MiniMap extends JPanel {
                 return;
             }
             if ((me.getModifiers() & InputEvent.CTRL_MASK) != 0) {
-                m_bview
-                        .checkLOS(translateCoords(x - leftMargin, y - topMargin));
+                m_bview.checkLOS(translateCoords(x - leftMargin, y - topMargin));
             } else {
                 m_bview.centerOnPointRel(
                         ((double)(x - leftMargin))/(double)((hexSideBySin30[zoom] + hexSide[zoom])*m_board.getWidth()),

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1141,7 +1141,16 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         if (e.getName().equals(GUIPreferences.AOHEXSHADOWS)
                 || e.getName().equals(GUIPreferences.FLOATINGISO)
                 || e.getName().equals(GUIPreferences.LEVELHIGHLIGHT)
-                || e.getName().equals(GUIPreferences.ADVANCED_SHOW_COORDS)) {
+                || e.getName().equals(GUIPreferences.ADVANCED_SHOW_COORDS)
+                || e.getName().equals(GUIPreferences.FOV_DARKEN)
+                || e.getName().equals(GUIPreferences.FOV_DARKEN_ALPHA)
+                || e.getName().equals(GUIPreferences.FOV_GRAYSCALE)
+                || e.getName().equals(GUIPreferences.FOV_HIGHLIGHT)
+                || e.getName().equals(GUIPreferences.FOV_HIGHLIGHT_ALPHA)
+                || e.getName().equals(GUIPreferences.FOV_STRIPES)
+                || e.getName().equals(GUIPreferences.FOV_HIGHLIGHT_RINGS_COLORS_HSB)
+                || e.getName().equals(GUIPreferences.FOV_HIGHLIGHT_RINGS_RADII)
+                || e.getName().equals(GUIPreferences.SHADOWMAP)) {
             clearHexImageCache();
             repaint();
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -757,11 +757,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -778,11 +774,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -806,11 +798,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -857,11 +845,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -889,11 +873,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -921,11 +901,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -953,11 +929,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -985,11 +957,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -1007,11 +975,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -1038,11 +1002,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override
@@ -1057,11 +1017,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
                     @Override
                     public boolean shouldPerformAction() {
-                        if (shouldIgnoreKeyCommands()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
+                        return !shouldIgnoreKeyCommands();
                     }
 
                     @Override

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1050,6 +1050,28 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         toggleKeybindsOverlay();
                     }
                 });
+        
+        // Register the action for TOGGLE_HEX_COORDS
+        controller.registerCommandAction(KeyCommandBind.TOGGLE_HEX_COORDS.cmd,
+                new CommandAction() {
+
+                    @Override
+                    public boolean shouldPerformAction() {
+                        if (shouldIgnoreKeyCommands()) {
+                            return false;
+                        } else {
+                            return true;
+                        }
+                    }
+
+                    @Override
+                    public void performAction() {
+                        boolean coordsShown = GUIPreferences.getInstance().getBoolean(GUIPreferences.ADVANCED_SHOW_COORDS);
+                        GUIPreferences.getInstance().setValue(GUIPreferences.ADVANCED_SHOW_COORDS, !coordsShown);
+                    }
+
+                });
+
     }
 
     private boolean shouldIgnoreKeyCommands() {
@@ -1106,7 +1128,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
         if (e.getName().equals(GUIPreferences.ADVANCED_DRAW_ENTITY_LABEL)
                 || e.getName().equals(GUIPreferences.UNIT_LABEL_BORDER)
-                || e.getName().equals(GUIPreferences.UNIT_LABEL_BORDER_TEAM)
+                || e.getName().equals(GUIPreferences.TEAM_COLORING)
                 || e.getName().equals(GUIPreferences.SHOW_DAMAGE_DECAL)) {
             updateEntityLabels();
             for (Sprite s: wreckSprites) {
@@ -1118,7 +1140,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
         if (e.getName().equals(GUIPreferences.AOHEXSHADOWS)
                 || e.getName().equals(GUIPreferences.FLOATINGISO)
-                || e.getName().equals(GUIPreferences.LEVELHIGHLIGHT)) {
+                || e.getName().equals(GUIPreferences.LEVELHIGHLIGHT)
+                || e.getName().equals(GUIPreferences.ADVANCED_SHOW_COORDS)) {
             clearHexImageCache();
             repaint();
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1129,7 +1129,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         if (e.getName().equals(GUIPreferences.ADVANCED_DRAW_ENTITY_LABEL)
                 || e.getName().equals(GUIPreferences.UNIT_LABEL_BORDER)
                 || e.getName().equals(GUIPreferences.TEAM_COLORING)
-                || e.getName().equals(GUIPreferences.SHOW_DAMAGE_DECAL)) {
+                || e.getName().equals(GUIPreferences.SHOW_DAMAGE_DECAL)
+                || e.getName().equals(GUIPreferences.SHOW_DAMAGE_LEVEL)) {
             updateEntityLabels();
             for (Sprite s: wreckSprites) {
                 s.prepare();

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -535,7 +535,7 @@ class EntitySprite extends Sprite {
 
                 // Draw a label border with player colors or team coloring
                 if (guip.getUnitLabelBorder()) {
-                    if (guip.getUnitLabelBorderTeam()) {
+                    if (guip.getTeamColoring()) {
                         boolean isLocalTeam = entity.getOwner().getTeam() == bv.clientgui.getClient().getLocalPlayer().getTeam();
                         boolean isLocalPlayer = entity.getOwner().equals(bv.clientgui.getClient().getLocalPlayer());
                         if (isLocalPlayer) {

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -80,7 +80,8 @@ public enum KeyCommandBind {
     PREV_MODE("prevMode", false, KeyEvent.VK_TAB, InputEvent.CTRL_MASK), // Default: Tab
     NEXT_MODE("nextMode", false, KeyEvent.VK_TAB, 0), // Default: Tab
     TOGGLE_DRAW_LABELS("toggleDrawLabels", false, KeyEvent.VK_Y, 0), // Default: Y
-    TOGGLE_KEYBIND_DISPLAY("toggleKeyBindDisplay", false, KeyEvent.VK_K, InputEvent.CTRL_MASK); // Default: Ctrl-K
+    TOGGLE_KEYBIND_DISPLAY("toggleKeyBindDisplay", false, KeyEvent.VK_K, InputEvent.CTRL_MASK), // Default: Ctrl-K
+    TOGGLE_HEX_COORDS("toggleHexCoords", false, KeyEvent.VK_G, InputEvent.CTRL_MASK); // Default: Ctrl-G
 
 
     /**


### PR DESCRIPTION
Even youtubers sometimes don't seem to configure anything in MM which makes me think that the MM default config should be improved already. This and other things:

- Replaced the unit label border teamcolor sub-option with a general team coloring option that also applies to the minimap. Also changed the ally color to more of a blue. While player coloring may have applications, I believe teamcoloring has no downside as a default option and is therefore on by default. Resolves #2259 
- Removed the option from the Client Settings to not show a hex tooltip in hexes without units (i.e., never show the terrain). This prevents a player from seeing a bridge's or building CF, armor or any other complicated terrain with (I think) no remedy but to set this precise option in the Client Settings. Not useful on any but the simplest maps.
- Set the tooltip to show weapons, armor and the portrait by default. These are all very useful (or nice in the case of portraits) and players shouldn't have to first turn them on.
- Added the keybind to toggle the Keybinds Board Overlay directly into the header text to clarify that this can be easily toggled and made it more opaque to improve readability.
- The Keybinds Board Overlay will now show some relevant keybinds in the Board Editor
- Set the "Darken Map at night" option to default off. I noticed with a youtuber that this doesn't read well ("Oh this is a blue map set") and it's probably more annoying than helpful after a while (i.e., 10 seconds).
- Set the terrain shadows to default on. People don't see to have many issues with them and I do think they improve the overall look.
- Removed the option "Minimap can be shown" from the Client Settings. Instead the minimap will be shown and re-shown when it was on before and not be opened by MM again if it was closed by the player.
- Set "Mouse Wheel Zoom" to default true, as zooming with the wheel instead of scrolling is standard game behavior.
- Set "Flip mouse wheel" to default true as zooming in with wheel up is also standard game behavior.
- The minimap now respects the "Flip mouse wheel" setting.
- Added a keybind for toggling hex coords, Ctrl-G. Some games such as Civ use this shortcut to show a grid; we dont have a grid, but coords are the next best thing.
- Added a menu shortcut for the Client Settings, Alt-C. Should have done this a million clicks before.
- In the Client Settings, set the font of the advanced settings value (the text field) to the SANS_SERIF logical font which will make the unicode characters appear there correctly (at least on my system). 
- Made the Client Settings and Boardview use PreferenceChangeEvents to show changes directly instead of unnecessary boardview calls.
- Made the Client Settings actually revert changes when it's cancelled.

![image](https://user-images.githubusercontent.com/17069663/95476319-6bdfdc00-0987-11eb-94ff-61ea9c774369.png) ![image](https://user-images.githubusercontent.com/17069663/95476461-8fa32200-0987-11eb-8126-fe1ac36b28d8.png)

