### PR TITLE
Allow java.util.TreeMap to be deserialized

### DIFF
--- a/megamek/resources/megamek/serialkiller.xml
+++ b/megamek/resources/megamek/serialkiller.xml
@@ -35,6 +35,7 @@
         <regexp>java\.util\.Hashtable$</regexp>
         <regexp>java\.util\.LinkedHashSet$</regexp>
         <regexp>java\.util\.LinkedList$</regexp>
+        <regexp>java\.util\.TreeMap$</regexp>
         <regexp>java\.util\.TreeSet$</regexp>
         <regexp>java\.util\.Vector$</regexp>
         <regexp>\[Ljava\.lang\.Object;$</regexp>


### PR DESCRIPTION
A user reported on Slack that attempting to drop multiple units from an airborn dropship caused an error when attempting to deserialize a java.util.TreeMap. This PR whitelists the TreeMap class in the serialkiller config to fix this issue.