### PR TITLE
don't use potential crit roll to determine actual crit check

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3966,8 +3966,7 @@ public class Aero extends Entity implements IAero, IBomber {
         } else if (getEngineHits() > 0) {
             MegaMek.getLogger().debug(getDisplayName() + " CRIPPLED: " + engineHits + " Engine Hits.");
             return true;
-        }
-        if (fuelTankHit()) {
+        } else if (fuelTankHit()) {
             MegaMek.getLogger().debug(getDisplayName() + " CRIPPLED: Fuel Tank Hit");
             return true;
         } else if (checkCrew && (getCrew() != null) && (getCrew().getHits() >= 4)) {

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -118,6 +118,7 @@ public class Aero extends Entity implements IAero, IBomber {
     private int engineHits = 0;
     private int avionicsHits = 0;
     private int cicHits = 0;
+    private boolean fuelTankHit = false;
     private boolean gearHit = false;
     private int structIntegrity;
     private int orig_structIntegrity;
@@ -676,6 +677,14 @@ public class Aero extends Entity implements IAero, IBomber {
             hits = 3;
         }
         fcsHits = hits;
+    }
+    
+    public boolean fuelTankHit() {
+        return fuelTankHit;
+    }
+    
+    public void setFuelTankHit(boolean value) {
+        fuelTankHit = value;
     }
 
     public void setCICHits(int hits) {
@@ -3960,7 +3969,7 @@ public class Aero extends Entity implements IAero, IBomber {
             System.out.println(msg + engineHits + " Engine Hits.");
             return true;
         }
-        if (getPotCrit() == CRIT_FUEL_TANK) {
+        if (fuelTankHit()) {
             System.out.println(msg + " Fuel Tank Hit.");
             return true;
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -25328,6 +25328,8 @@ public class Server implements Runnable {
                     r.choose(false);
                     reports.add(r);
                 }
+                
+                aero.setFuelTankHit(true);
                 break;
             case Aero.CRIT_CREW:
                 // pilot hit


### PR DESCRIPTION
Adds an explicit flag to indicate that an aerospace unit's fuel tank was hit. This fixes an observed behavior where, sometimes, for no apparent reason, an aerospace unit would display as crippled.

The actual cause is that there's this "get/setPotCrit" method which stores the potential crit roll result when rolling a critical hit on an aero. That's fine, but the 'isCrippled()' method uses that to check whether the fuel tank has been hit. Sometimes, the potential crit hit result would be the fuel tank, but no actual crit hits would get rolled, and then the unit would show as crippled.