### PR TITLE
Ejection damage

### DIFF
--- a/megamek/data/mechfiles/mechs/3039u/Hatchetman HCT-3F.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Hatchetman HCT-3F.mtf
@@ -1,39 +1,40 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-3F
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3023
-Source:TRO 3039 - Succession Wars
-Rules Level:1
+techbase:Inner Sphere
+era:3023
+source:TRO 3039 - Succession Wars
+rules level:3
 
-Mass:45
-Engine:180 Fusion Engine
-Structure:Standard
-Myomer:Standard
+mass:45
+engine:180 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:11 Single
-Walk MP:4
-Jump MP:4
+heat sinks:11 Single
+walk mp:4
+jump mp:4
 
-Armor:Standard(Inner Sphere)
-LA Armor:11
-RA Armor:11
-LT Armor:14
-RT Armor:14
-CT Armor:14
-HD Armor:6
-LL Armor:11
-RL Armor:11
-RTL Armor:4
-RTR Armor:4
-RTC Armor:4
+armor:Standard(Inner Sphere)
+LA armor:11
+RA armor:11
+LT armor:14
+RT armor:14
+CT armor:14
+HD armor:6
+LL armor:11
+RL armor:11
+RTL armor:4
+RTR armor:4
+RTC armor:4
 
 Weapons:3
-Medium Laser, Right Arm
 Medium Laser, Left Arm
-Autocannon/10, Right Torso
+Medium Laser, Right Arm
+AC/10, Right Torso
 
 Left Arm:
 Shoulder

--- a/megamek/data/mechfiles/mechs/3039u/Wolfhound WLF-1.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Wolfhound WLF-1.mtf
@@ -1,41 +1,42 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-1
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3028
-Source:TRO 3039 - Succession Wars
-Rules Level:1
+techbase:Inner Sphere
+era:3028
+source:TRO 3039 - Succession Wars
+rules level:3
 
-Mass:35
-Engine:210 Fusion Engine
-Structure:Standard
-Myomer:Standard
+mass:35
+engine:210 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Single
-Walk MP:6
-Jump MP:0
+heat sinks:10 Single
+walk mp:6
+jump mp:0
 
-Armor:Standard(Inner Sphere)
-LA Armor:12
-RA Armor:12
-LT Armor:11
-RT Armor:11
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:11
+RT armor:11
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
 Weapons:5
 Large Laser, Right Arm
-Medium Laser, Center Torso
-Medium Laser, Center Torso
-Medium Laser, Right Torso
 Medium Laser, Left Torso
+Medium Laser, Right Torso
+Medium Laser, Center Torso
+Medium Laser, Center Torso
 
 Left Arm:
 Shoulder

--- a/megamek/data/mechfiles/mechs/3039u/Wolfhound WLF-1A.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Wolfhound WLF-1A.mtf
@@ -1,40 +1,41 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-1A
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3028
-Source:TRO 3039 - Succession Wars
-Rules Level:1
+techbase:Inner Sphere
+era:3028
+source:TRO 3039 - Succession Wars
+rules level:3
 
-Mass:35
-Engine:210 Fusion Engine
-Structure:Standard
-Myomer:Standard
+mass:35
+engine:210 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:11 Single
-Walk MP:6
-Jump MP:0
+heat sinks:11 Single
+walk mp:6
+jump mp:0
 
-Armor:Standard(Inner Sphere)
-LA Armor:12
-RA Armor:12
-LT Armor:11
-RT Armor:11
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:11
+RT armor:11
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
 Weapons:4
 Large Laser, Right Arm
-Medium Laser, Center Torso
 Medium Laser, Left Torso
 Medium Laser, Right Torso
+Medium Laser, Center Torso
 
 Left Arm:
 Shoulder

--- a/megamek/data/mechfiles/mechs/3039u/Wolfhound WLF-1B.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Wolfhound WLF-1B.mtf
@@ -1,34 +1,35 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-1B
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3028
-Source:TRO 3039 - Succession Wars
-Rules Level:1
+techbase:Inner Sphere
+era:3028
+source:TRO 3039 - Succession Wars
+rules level:3
 
-Mass:35
-Engine:210 Fusion Engine
-Structure:Standard
-Myomer:Standard
+mass:35
+engine:210 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Single
-Walk MP:6
-Jump MP:0
+heat sinks:10 Single
+walk mp:6
+jump mp:0
 
-Armor:Standard(Inner Sphere)
-LA Armor:12
-RA Armor:12
-LT Armor:11
-RT Armor:11
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:11
+RT armor:11
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
 Weapons:5
 Large Laser, Right Arm

--- a/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5D.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5D.mtf
@@ -1,38 +1,39 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-5D
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3062
-Source:TRO 3050 - Civil War
-Rules Level:2
+techbase:Inner Sphere
+era:3062
+source:TRO 3050 - Civil War
+rules level:3
 
-Mass:45
-Engine:180 XL Engine(IS)
-Structure:IS Standard
-Myomer:Standard
+mass:45
+engine:180 XL Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:4
-Jump MP:4
+heat sinks:10 Double
+walk mp:4
+jump mp:4
 
-Armor:Standard(Inner Sphere)
-LA Armor:10
-RA Armor:10
-LT Armor:12
-RT Armor:12
-CT Armor:15
-HD Armor:8
-LL Armor:16
-RL Armor:16
-RTL Armor:4
-RTR Armor:4
-RTC Armor:5
+armor:Standard(Inner Sphere)
+LA armor:10
+RA armor:10
+LT armor:12
+RT armor:12
+CT armor:15
+HD armor:8
+LL armor:16
+RL armor:16
+RTL armor:4
+RTR armor:4
+RTC armor:5
 
 Weapons:2
-Ultra AC/10, Right Torso
 ER Medium Laser, Left Torso
+Ultra AC/10, Right Torso
 
 Left Arm:
 Shoulder
@@ -145,3 +146,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
+

--- a/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5DD.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5DD.mtf
@@ -1,38 +1,39 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-5DD
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3065
-Source:TRO 3050 - Civil War
-Rules Level:2
+techbase:Inner Sphere
+era:3065
+source:TRO 3050 - Civil War
+rules level:3
 
-Mass:45
-Engine:225 XL Engine(IS)
-Structure:IS Standard
-Myomer:Standard
+mass:45
+engine:225 XL Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:5
-Jump MP:5
+heat sinks:10 Double
+walk mp:5
+jump mp:5
 
-Armor:Standard(Inner Sphere)
-LA Armor:14
-RA Armor:14
-LT Armor:16
-RT Armor:16
-CT Armor:21
-HD Armor:9
-LL Armor:22
-RL Armor:22
-RTL Armor:6
-RTR Armor:6
-RTC Armor:7
+armor:Standard(Inner Sphere)
+LA armor:14
+RA armor:14
+LT armor:16
+RT armor:16
+CT armor:21
+HD armor:9
+LL armor:22
+RL armor:22
+RTL armor:6
+RTR armor:6
+RTC armor:7
 
 Weapons:2
-Rotary AC/2, Right Torso
 ER Medium Laser, Left Torso
+Rotary AC/2, Right Torso
 
 Left Arm:
 Shoulder
@@ -145,3 +146,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
+

--- a/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5K.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5K.mtf
@@ -1,50 +1,50 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-5K
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3075
-Source:TRO 3050 - Jihad
-Rules Level:2
+techbase:Inner Sphere
+era:3075
+source:TRO 3050 - Jihad
+rules level:3
 
-Mass:45
-Engine:180 XL Engine
-Structure:Standard
-Myomer:Standard
+mass:45
+engine:180 XL Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:4
-Jump MP:4
+heat sinks:10 Double
+walk mp:4
+jump mp:4
 
-Armor:Standard
-LA Armor:13
-RA Armor:13
-LT Armor:16
-RT Armor:16
-CT Armor:19
-HD Armor:9
-LL Armor:21
-RL Armor:21
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:13
+RA armor:13
+LT armor:16
+RT armor:16
+CT armor:19
+HD armor:9
+LL armor:21
+RL armor:21
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
-Weapons:5
-1 ISMediumPulseLaser, Right Arm
-1 ISMediumPulseLaser, Left Arm
-1 ISMRM30, Right Torso, Ammo:16
-1 ISERMediumLaser, Left Torso
-1 ISC3SlaveUnit, Head
+Weapons:4
+Medium Pulse Laser, Left Arm
+Medium Pulse Laser, Right Arm
+ER Medium Laser, Left Torso
+MRM 30, Right Torso
 
 Left Arm:
 Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
 ISMediumPulseLaser
 -Empty-
 -Empty-
@@ -69,12 +69,12 @@ Left Torso:
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
 ISERMediumLaser
 -Empty-
 -Empty-
@@ -83,13 +83,13 @@ Right Torso:
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISMRM30
-ISMRM30
-ISMRM30
-ISMRM30
-ISMRM30
-ISMRM30 Ammo
-ISMRM30 Ammo
+MRM 30
+MRM 30
+MRM 30
+MRM 30
+MRM 30
+IS MRM 30 Ammo
+IS MRM 30 Ammo
 ISCASE
 -Empty-
 
@@ -148,3 +148,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
+

--- a/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5S.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-5S.mtf
@@ -1,40 +1,41 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-5S
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3049
-Source:TRO 3050 - Clan Invasion
-Rules Level:2
+techbase:Inner Sphere
+era:3049
+source:TRO 3050 - Clan Invasion
+rules level:3
 
-Mass:45
-Engine:180 XL Engine
-Structure:Standard
-Myomer:Standard
+mass:45
+engine:180 XL Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Single
-Walk MP:4
-Jump MP:4
+heat sinks:10 Single
+walk mp:4
+jump mp:4
 
-Armor:Ferro-Fibrous
-LA Armor:14
-RA Armor:14
-LT Armor:16
-RT Armor:16
-CT Armor:21
-HD Armor:9
-LL Armor:22
-RL Armor:22
-RTL Armor:6
-RTR Armor:6
-RTC Armor:6
+armor:Ferro-Fibrous(Inner Sphere)
+LA armor:14
+RA armor:14
+LT armor:16
+RT armor:16
+CT armor:21
+HD armor:9
+LL armor:22
+RL armor:22
+RTL armor:6
+RTR armor:6
+RTC armor:6
 
 Weapons:4
-1 ISLBXAC10, Right Torso, Ammo:10
-1 ISMediumPulseLaser, Left Torso
-1 ISMediumPulseLaser, Left Arm
-1 ISMediumPulseLaser, Right Arm
+Medium Pulse Laser, Left Arm
+Medium Pulse Laser, Right Arm
+Medium Pulse Laser, Left Torso
+LB 10-X AC, Right Torso
 
 Left Arm:
 Shoulder
@@ -42,9 +43,9 @@ Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
 ISMediumPulseLaser
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 -Empty-
 -Empty-
 -Empty-
@@ -59,9 +60,9 @@ ISMediumPulseLaser
 Hatchet
 Hatchet
 Hatchet
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 -Empty-
 
 Left Torso:
@@ -70,13 +71,13 @@ Fusion Engine
 Fusion Engine
 Heat Sink
 ISMediumPulseLaser
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Right Torso:
 Fusion Engine
@@ -89,7 +90,7 @@ ISLBXAC10
 ISLBXAC10
 ISLBXAC10
 ISLBXAC10
-ISLBXAC10 CL Ammo
+IS LB 10-X Cluster Ammo
 ISCASE
 
 Center Torso:
@@ -103,7 +104,7 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-Ferro-Fibrous
+IS Ferro-Fibrous
 -Empty-
 
 Head:
@@ -147,4 +148,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
 

--- a/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-6D.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-6D.mtf
@@ -1,41 +1,41 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-6D
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3062
-Source:TRO 3050 - Civil War
-Rules Level:2
+techbase:Inner Sphere
+era:3062
+source:TRO 3050 - Civil War
+rules level:3
 
-Mass:45
-Engine:225 XL Engine
-Structure:Endo Steel
-Myomer:Standard
+mass:45
+engine:225 XL Engine(IS)
+structure:IS Endo Steel
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:5
-Jump MP:5
+heat sinks:10 Double
+walk mp:5
+jump mp:5
 
-Armor:Standard Armor
-LA Armor:14
-RA Armor:14
-LT Armor:16
-RT Armor:16
-CT Armor:21
-HD Armor:9
-LL Armor:22
-RL Armor:22
-RTL Armor:6
-RTR Armor:6
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:14
+RA armor:14
+LT armor:16
+RT armor:16
+CT armor:21
+HD armor:9
+LL armor:22
+RL armor:22
+RTL armor:6
+RTR armor:6
+RTC armor:6
 
-Weapons:5
-1 ISERMediumLaser, Left Arm
-1 ISRotaryAC5, Right Torso, Ammo:40
-1 ISERMediumLaser, Left Torso
-1 ISGuardianECM, Left Torso
-1 ISERMediumLaser, Head
+Weapons:4
+ER Medium Laser, Left Arm
+ER Medium Laser, Left Torso
+Rotary AC/5, Right Torso
+ER Medium Laser, Head
 
 Left Arm:
 Shoulder
@@ -43,12 +43,12 @@ Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
 ISERMediumLaser
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 -Empty-
 
 Right Arm:
@@ -59,25 +59,25 @@ Hand Actuator
 Hatchet
 Hatchet
 Hatchet
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 -Empty-
 
 Left Torso:
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
 ISERMediumLaser
-ISGuardianECM
-ISGuardianECM
-Endo-Steel
-Endo-Steel
-Endo-Steel
+ISGuardianECMSuite
+ISGuardianECMSuite
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 
 Right Torso:
 Fusion Engine
@@ -105,7 +105,7 @@ Fusion Engine
 Fusion Engine
 Fusion Engine
 Jump Jet
-Endo-Steel
+IS Endo Steel
 
 Head:
 Life Support
@@ -148,4 +148,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
 

--- a/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-6S.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Hatchetman HCT-6S.mtf
@@ -1,54 +1,55 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-6S
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3064
-Source:TRO 3050 - Civil War
-Rules Level:2
+techbase:Inner Sphere
+era:3064
+source:TRO 3050 - Civil War
+rules level:3
 
-Mass:45
-Engine:180 Light Engine
-Structure:Standard
-Myomer:Standard
+mass:45
+engine:180 Light Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:4
-Jump MP:4
+heat sinks:10 Double
+walk mp:4
+jump mp:4
 
-Armor:Ferro-Fibrous
-LA Armor:14
-RA Armor:14
-LT Armor:16
-RT Armor:16
-CT Armor:21
-HD Armor:9
-LL Armor:22
-RL Armor:22
-RTL Armor:6
-RTR Armor:6
-RTC Armor:6
+armor:Ferro-Fibrous(Inner Sphere)
+LA armor:14
+RA armor:14
+LT armor:16
+RT armor:16
+CT armor:21
+HD armor:9
+LL armor:22
+RL armor:22
+RTL armor:6
+RTR armor:6
+RTC armor:6
 
 Weapons:4
-1 ISERMediumLaser, Right Arm
-1 ISERMediumLaser, Left Arm
-1 ISLBXAC10, Right Torso, Ammo:20
-1 ISERMediumLaser, Left Torso
+ER Medium Laser, Left Arm
+ER Medium Laser, Right Arm
+ER Medium Laser, Left Torso
+LB 10-X AC, Right Torso
 
 Left Arm:
 Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
 ISERMediumLaser
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Right Arm:
 Shoulder
@@ -59,24 +60,24 @@ Hatchet
 Hatchet
 Hatchet
 ISERMediumLaser
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Left Torso:
 Fusion Engine
 Fusion Engine
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
 ISERMediumLaser
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Right Torso:
 Fusion Engine
@@ -87,10 +88,10 @@ ISLBXAC10
 ISLBXAC10
 ISLBXAC10
 ISLBXAC10
-ISLBXAC10 Ammo
-ISLBXAC10 Ammo
+IS LB 10-X AC Ammo
+IS LB 10-X AC Ammo
 ISCASE
-Ferro-Fibrous
+IS Ferro-Fibrous
 
 Center Torso:
 Fusion Engine
@@ -103,8 +104,8 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Head:
 Life Support
@@ -147,3 +148,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
+

--- a/megamek/data/mechfiles/mechs/3050U/Wolfhound WLF-2.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Wolfhound WLF-2.mtf
@@ -1,41 +1,42 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-2
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3052
-Source:TRO 3050 - Clan Invasion
-Rules Level:2
+techbase:Inner Sphere
+era:3052
+source:TRO 3050 - Clan Invasion
+rules level:3
 
-Mass:35
-Engine:210 Fusion Engine
-Structure:Standard
-Myomer:Standard
+mass:35
+engine:210 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:6
-Jump MP:0
+heat sinks:10 Double
+walk mp:6
+jump mp:0
 
-Armor:Standard Armor
-LA Armor:12
-RA Armor:12
-LT Armor:11
-RT Armor:11
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:11
+RT armor:11
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
 Weapons:5
-1 ISERLargeLaser, Right Arm
-1 ISMediumLaser, Right Torso
-1 ISMediumLaser, Left Torso
-1 ISMediumLaser, Center Torso (R)
-1 ISMediumLaser, Center Torso
+ER Large Laser, Right Arm
+Medium Laser, Left Torso
+Medium Laser, Right Torso
+Medium Laser, Center Torso
+Medium Laser, Center Torso
 
 Left Arm:
 Shoulder
@@ -66,10 +67,10 @@ ISERLargeLaser
 -Empty-
 
 Left Torso:
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISMediumLaser
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+Medium Laser
 -Empty-
 -Empty-
 -Empty-
@@ -80,10 +81,10 @@ ISMediumLaser
 -Empty-
 
 Right Torso:
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISMediumLaser
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+Medium Laser
 -Empty-
 -Empty-
 -Empty-
@@ -104,8 +105,8 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISMediumLaser (R)
-ISMediumLaser
+Medium Laser (R)
+Medium Laser
 
 Head:
 Life Support
@@ -148,4 +149,5 @@ Foot Actuator
 -Empty-
 -Empty-
 -Empty-
+
 

--- a/megamek/data/mechfiles/mechs/3050U/Wolfhound WLF-3S.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Wolfhound WLF-3S.mtf
@@ -1,52 +1,53 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-3S
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3064
-Source:TRO 3050 - Civil War
-Rules Level:2
+techbase:Inner Sphere
+era:3064
+source:TRO 3050 - Civil War
+rules level:3
 
-Mass:35
-Engine:210 Light Engine
-Structure:Endo Steel
-Myomer:Standard
+mass:35
+engine:210 Light Engine(IS)
+structure:IS Endo Steel
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:12 Double
-Walk MP:6
-Jump MP:0
+heat sinks:12 Double
+walk mp:6
+jump mp:0
 
-Armor:Standard Armor
-LA Armor:12
-RA Armor:12
-LT Armor:11
-RT Armor:11
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:11
+RT armor:11
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
 Weapons:5
-1 ISERPPC, Right Arm
-1 ISERMediumLaser, Right Torso
-1 ISERMediumLaser, Left Torso
-1 ISERMediumLaser, Center Torso
-1 ISERSmallLaser, Center Torso (R)
+ER PPC, Right Arm
+ER Medium Laser, Left Torso
+ER Medium Laser, Right Torso
+ER Medium Laser, Center Torso
+ER Small Laser, Center Torso
 
 Left Arm:
 Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 -Empty-
 -Empty-
 -Empty-
@@ -58,39 +59,39 @@ Lower Arm Actuator
 ISERPPC
 ISERPPC
 ISERPPC
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
-Endo-Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 -Empty-
 
 Left Torso:
 Fusion Engine
 Fusion Engine
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
 ISERMediumLaser
-Endo-Steel
-Endo-Steel
+IS Endo Steel
+IS Endo Steel
 -Empty-
 
 Right Torso:
 Fusion Engine
 Fusion Engine
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
 ISERMediumLaser
-Endo-Steel
-Endo-Steel
+IS Endo Steel
+IS Endo Steel
 -Empty-
 
 Center Torso:
@@ -148,4 +149,5 @@ Foot Actuator
 -Empty-
 -Empty-
 -Empty-
+
 

--- a/megamek/data/mechfiles/mechs/3050U/Wolfhound WLF-4W.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Wolfhound WLF-4W.mtf
@@ -1,41 +1,42 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-4W
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3069
-Source:TRO 3050 - Jihad
-Rules Level:2
+techbase:Inner Sphere
+era:3069
+source:TRO 3050 - Jihad
+rules level:3
 
-Mass:35
-Engine:210 Fusion Engine
-Structure:Endo Steel
-Myomer:Standard
+mass:35
+engine:210 Fusion Engine(IS)
+structure:IS Endo Steel
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:6
-Jump MP:0
+heat sinks:10 Double
+walk mp:6
+jump mp:0
 
-Armor:Standard
-LA Armor:12
-RA Armor:12
-LT Armor:11
-RT Armor:11
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:11
+RT armor:11
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
 Weapons:5
-1 ISERMediumLaser, Right Arm
-1 ISERSmallLaser, Right Arm
-1 ISLightPPC, Right Torso
-1 ISLightPPC, Left Torso
-1 ISLightPPC, Center Torso
+ER Medium Laser, Right Arm
+ER Small Laser, Right Arm
+Light PPC, Left Torso
+Light PPC, Right Torso
+Light PPC, Center Torso
 
 Left Arm:
 Shoulder
@@ -66,32 +67,32 @@ ISERSmallLaser
 -Empty-
 
 Left Torso:
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISLightPPC
-ISLightPPC
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+Light PPC
+Light PPC
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 
 Right Torso:
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISLightPPC
-ISLightPPC
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+Light PPC
+Light PPC
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 
 Center Torso:
 Fusion Engine
@@ -104,8 +105,8 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISLightPPC
-ISLightPPC
+Light PPC
+Light PPC
 
 Head:
 Life Support
@@ -148,3 +149,5 @@ Foot Actuator
 -Empty-
 -Empty-
 -Empty-
+
+

--- a/megamek/data/mechfiles/mechs/ProtoTypes/Wolfhound WLF-2H.mtf
+++ b/megamek/data/mechfiles/mechs/ProtoTypes/Wolfhound WLF-2H.mtf
@@ -1,33 +1,34 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-2H
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3082
-Rules Level:4
+techbase:Inner Sphere
+era:3082
+rules level:4
 
-Mass:35
-Engine:210 XL Engine(IS)
-Structure:Endo Steel
-Myomer:Standard
+mass:35
+engine:210 XL Engine(IS)
+structure:IS Endo Steel
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:11 Double
-Walk MP:6
-Jump MP:0
+heat sinks:11 Double
+walk mp:6
+jump mp:0
 
-Armor:Standard(Inner Sphere)
-LA Armor:12
-RA Armor:12
-LT Armor:12
-RT Armor:12
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:4
-RTR Armor:4
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:12
+RT armor:12
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:4
+RTR armor:4
+RTC armor:6
 
 Weapons:4
 Heavy PPC, Right Arm
@@ -40,14 +41,14 @@ Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 
 Right Arm:
 Shoulder
@@ -58,10 +59,10 @@ Heavy PPC
 Heavy PPC
 Heavy PPC
 PPC Capacitor
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 
 Left Torso:
 Fusion Engine
@@ -138,8 +139,8 @@ Hip
 Upper Leg Actuator
 Lower Leg Actuator
 Foot Actuator
-Endo Steel
-Endo Steel
+IS Endo Steel
+IS Endo Steel
 -Empty-
 -Empty-
 -Empty-

--- a/megamek/data/mechfiles/mechs/Starterbook Sword and Dragon/Hatchetman HCT-3F Austin.mtf
+++ b/megamek/data/mechfiles/mechs/Starterbook Sword and Dragon/Hatchetman HCT-3F Austin.mtf
@@ -1,47 +1,50 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-3F (Austin)
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3039
-Source:Starterbook: Sword and Dragon - Succession Wars
-Rules Level:4
+techbase:Inner Sphere
+era:3039
+source:Starterbook: Sword and Dragon - Succession Wars
+rules level:4
 
-Mass:45
-Engine:180 Fusion Engine
-Structure:Standard
-Myomer:Standard
+mass:45
+engine:180 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:11 Single
-Walk MP:4
-Jump MP:4
+heat sinks:11 Single
+walk mp:4
+jump mp:4
 
-Armor:Standard Armor
-LA Armor:11
-RA Armor:11
-LT Armor:14
-RT Armor:14
-CT Armor:14
-HD Armor:6
-LL Armor:11
-RL Armor:11
-RTL Armor:4
-RTR Armor:4
-RTC Armor:4
+armor:Standard(Inner Sphere)
+LA armor:11
+RA armor:11
+LT armor:14
+RT armor:14
+CT armor:14
+HD armor:6
+LL armor:11
+RL armor:11
+RTL armor:4
+RTR armor:4
+RTC armor:4
 
-Weapons:2
-1 ISLBXAC10Prototype, Right Torso, Ammo:20
-3 ISMediumLaser, Left Arm
+Weapons:4
+Medium Laser, Left Arm
+Medium Laser, Left Arm
+Medium Laser, Left Arm
+Prototype LB 10-X Autocannon, Right Torso
 
 Left Arm:
 Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
-ISMediumLaser
-ISMediumLaser
-ISMediumLaser
+Medium Laser
+Medium Laser
+Medium Laser
 -Empty-
 -Empty-
 -Empty-
@@ -101,8 +104,8 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISLBXAC10 CL Ammo
-ISLBXAC10 Ammo
+IS LB 10-X Cluster Ammo
+IS LB 10-X AC Ammo
 
 Head:
 Life Support
@@ -145,4 +148,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
 

--- a/megamek/data/mechfiles/mechs/Starterpack Sword and Dragon/Hatchetman HCT-5S Austin.mtf
+++ b/megamek/data/mechfiles/mechs/Starterpack Sword and Dragon/Hatchetman HCT-5S Austin.mtf
@@ -1,34 +1,35 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-5S (Austin)
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3059
-Source:Starterbook: Sword and Dragon - Clan Invasion
-Rules Level:4
+techbase:Inner Sphere
+era:3059
+source:Starterbook: Sword and Dragon - Clan Invasion
+rules level:4
 
-Mass:45
-Engine:180 Light Engine
-Structure:Standard
-Myomer:Standard
+mass:45
+engine:180 Light Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:4
-Jump MP:4
+heat sinks:10 Double
+walk mp:4
+jump mp:4
 
-Armor:Ferro-Fibrous
-LA Armor:14
-RA Armor:14
-LT Armor:16
-RT Armor:16
-CT Armor:21
-HD Armor:9
-LL Armor:22
-RL Armor:22
-RTL Armor:6
-RTR Armor:6
-RTC Armor:6
+armor:Ferro-Fibrous(Inner Sphere)
+LA armor:14
+RA armor:14
+LT armor:16
+RT armor:16
+CT armor:21
+HD armor:9
+LL armor:22
+RL armor:22
+RTL armor:6
+RTR armor:6
+RTC armor:6
 
 Weapons:4
 ER Medium Laser, Left Arm
@@ -44,11 +45,11 @@ Hand Actuator
 ISERMediumLaser
 ISERMediumLaser
 ISERMediumLaser
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Right Arm:
 Shoulder
@@ -61,8 +62,8 @@ ISDoubleHeatSink
 Hatchet
 Hatchet
 Hatchet
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Left Torso:
 Fusion Engine
@@ -73,10 +74,10 @@ ISDoubleHeatSink
 ISDoubleHeatSink
 ISDoubleHeatSink
 ISDoubleHeatSink
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Right Torso:
 Fusion Engine
@@ -90,7 +91,7 @@ ISLBXAC10
 IS LB 10-X Cluster Ammo
 IS LB 10-X AC Ammo
 ISCASE
-Ferro-Fibrous
+IS Ferro-Fibrous
 
 Center Torso:
 Fusion Engine
@@ -103,8 +104,8 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-Ferro-Fibrous
-Ferro-Fibrous
+IS Ferro-Fibrous
+IS Ferro-Fibrous
 
 Head:
 Life Support
@@ -147,4 +148,5 @@ Jump Jet
 -Empty-
 -Empty-
 -Empty-
+
 

--- a/megamek/data/mechfiles/mechs/Wolf and Blake/Wolfhound WLF-4WA.mtf
+++ b/megamek/data/mechfiles/mechs/Wolf and Blake/Wolfhound WLF-4WA.mtf
@@ -1,40 +1,40 @@
-Version:1.0
+Version:1.2
 Wolfhound
 WLF-4WA
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3071
-Source:Starterbook: Wolf & Blake - Jihad
-Rules Level:2
+techbase:Inner Sphere
+era:3071
+source:Starterbook: Wolf & Blake - Jihad
+rules level:3
 
-Mass:35
-Engine:210 Fusion Engine
-Structure:Endo Steel
-Myomer:Standard
+mass:35
+engine:210 Fusion Engine(IS)
+structure:IS Endo Steel
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:10 Double
-Walk MP:6
-Jump MP:0
+heat sinks:10 Double
+walk mp:6
+jump mp:0
 
-Armor:Standard
-LA Armor:12
-RA Armor:12
-LT Armor:11
-RT Armor:11
-CT Armor:16
-HD Armor:9
-LL Armor:16
-RL Armor:16
-RTL Armor:5
-RTR Armor:5
-RTC Armor:6
+armor:Standard(Inner Sphere)
+LA armor:12
+RA armor:12
+LT armor:11
+RT armor:11
+CT armor:16
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:5
+RTR armor:5
+RTC armor:6
 
-Weapons:4
-1 ISGuardianECM, Right Arm
-1 ISLightPPC, Right Torso
-1 ISLightPPC, Left Torso
-1 ISLightPPC, Center Torso
+Weapons:3
+Light PPC, Left Torso
+Light PPC, Right Torso
+Light PPC, Center Torso
 
 Left Arm:
 Shoulder
@@ -54,8 +54,8 @@ Right Arm:
 Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
-ISGuardianECM
-ISGuardianECM
+ISGuardianECMSuite
+ISGuardianECMSuite
 -Empty-
 -Empty-
 -Empty-
@@ -65,32 +65,32 @@ ISGuardianECM
 -Empty-
 
 Left Torso:
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISLightPPC
-ISLightPPC
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+Light PPC
+Light PPC
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 
 Right Torso:
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISDouble Heat Sink
-ISLightPPC
-ISLightPPC
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
-Endo Steel
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+Light PPC
+Light PPC
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
 
 Center Torso:
 Fusion Engine
@@ -103,8 +103,8 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISLightPPC
-ISLightPPC
+Light PPC
+Light PPC
 
 Head:
 Life Support
@@ -147,3 +147,5 @@ Foot Actuator
 -Empty-
 -Empty-
 -Empty-
+
+

--- a/megamek/data/mechfiles/mechs/XTRs/Republic I/Hatchetman HCT-7R.mtf
+++ b/megamek/data/mechfiles/mechs/XTRs/Republic I/Hatchetman HCT-7R.mtf
@@ -1,34 +1,35 @@
-Version:1.0
+Version:1.2
 Hatchetman
 HCT-7R
 
 Config:Biped
-TechBase:Inner Sphere
-Era:3114
-Source:XTRO Republic I - Late Republic
-Rules Level:4
+techbase:Inner Sphere
+era:3114
+source:XTRO Republic I - Late Republic
+rules level:4
 
-Mass:45
-Engine:225 Light Engine(IS)
-Structure:IS Standard
-Myomer:Standard
+mass:45
+engine:225 Light Engine(IS)
+structure:IS Standard
+myomer:Standard
+ejection:Full Head Ejection System
 
-Heat Sinks:12 Double
-Walk MP:5
-Jump MP:5
+heat sinks:12 Double
+walk mp:5
+jump mp:5
 
-Armor:Ferro-Fibrous(Inner Sphere)
-LA Armor:14
-RA Armor:14
-LT Armor:16
-RT Armor:16
-CT Armor:21
-HD Armor:9
-LL Armor:22
-RL Armor:22
-RTL Armor:6
-RTR Armor:6
-RTC Armor:6
+armor:Ferro-Fibrous(Inner Sphere)
+LA armor:14
+RA armor:14
+LT armor:16
+RT armor:16
+CT armor:21
+HD armor:9
+LL armor:22
+RL armor:22
+RTL armor:6
+RTR armor:6
+RTC armor:6
 
 Weapons:7
 Medium X-Pulse Laser, Right Arm

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -7247,6 +7247,38 @@ public abstract class Mech extends Entity {
         }
         return success;
     }
+    
+    /**
+     * Convenience function that returns the critical slot containing the cockpit
+     * @return
+     */
+    public List<CriticalSlot> getCockpit() {
+        List<CriticalSlot> retVal = new ArrayList<>();
+        
+        switch (cockpitType) {
+        // these always occupy slots 2 and 3 in the head
+        case Mech.COCKPIT_COMMAND_CONSOLE:
+        case Mech.COCKPIT_DUAL:
+        case Mech.COCKPIT_SMALL_COMMAND_CONSOLE:
+        case Mech.COCKPIT_INTERFACE:
+        case Mech.COCKPIT_QUADVEE:
+        case Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+            retVal.add(getCritical(Mech.LOC_HEAD, 2));
+            retVal.add(getCritical(Mech.LOC_HEAD, 3));
+            break;
+        case Mech.COCKPIT_TORSO_MOUNTED:
+            for (int critIndex = 0; critIndex < getNumberOfCriticals(Mech.LOC_CT); critIndex++) {
+                CriticalSlot slot = getCritical(Mech.LOC_CT, critIndex);
+                if (slot.getIndex() == SYSTEM_COCKPIT) {
+                    retVal.add(slot);
+                }
+            }
+        default:
+            retVal.add(getCritical(Mech.LOC_HEAD, 2));
+        }
+        
+        return retVal;
+    }
 
     /**
      * Determines which crew slot is associated with a particular cockpit critical.

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -33528,6 +33528,19 @@ public class Server implements Runnable {
                 }
             } // Crew safely ejects.
 
+            // ejection damages the cockpit
+            // kind of irrelevant in stand-alone games, but important for MekHQ
+            if (entity instanceof Mech) {
+                Mech mech = (Mech) entity;
+                // in case of mechs with 'full head ejection', the head is treated as blown off
+                if (mech.hasFullHeadEject()) {
+                    entity.destroyLocation(Mech.LOC_HEAD, true);
+                } else {
+                    for (CriticalSlot slot : (mech.getCockpit())) {
+                        slot.setDestroyed(true);
+                    }
+                }
+            }            
         } // End entity-is-Mek or fighter
         else if (game.getBoard().contains(entity.getPosition())
                  && (entity instanceof Tank)) {


### PR DESCRIPTION
Implements the ruling here: https://bg.battletech.com/forums/strategic-operations/answered-repairing-an-ejected-cockpit/

Basically, when ejecting from a mech, the cockpit is treated as having been hit (maybe repairable in MekHQ, maybe not). For mechs with full-head ejection systems, the head is treated as being blown off.

Also adds full-head ejection to the various Wolfhounds and Hatchetmen that were missing it. As a consequence, they're all now 'advanced rules'. Review with whitespace off. 

Mech edits were made with MML.