### PR TITLE
"Change Tileset Theme" menu entry disabled outside the Board Editor

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -965,6 +965,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             viewLOSSetting.setEnabled(false);
             viewUnitOverview.setEnabled(false);
             viewPlayerList.setEnabled(false);
+            viewChangeTheme.setEnabled(true);
         }
         // We're in-game.
         else if ((phase == IGame.Phase.PHASE_SET_ARTYAUTOHITHEXES)
@@ -981,6 +982,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             viewZoomOut.setEnabled(true);
             viewUnitOverview.setEnabled(true);
             viewPlayerList.setEnabled(true);
+            viewChangeTheme.setEnabled(false);
         }
         // We're in-game, but not in a phase with map functions.
         else {
@@ -990,6 +992,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             viewZoomOut.setEnabled(false);
             viewUnitOverview.setEnabled(false);
             viewPlayerList.setEnabled(false);
+            viewChangeTheme.setEnabled(false);
         }
 
         // We can only view the round report in certain phases.


### PR DESCRIPTION
I originally created this function when almost every map was a desert map and it really felt necessary. This is fortunately not the case anymore. At the time, I apparently didn't think about this being a server-hosted game. The tileset change happens only on the client side. When the server updates a hex, the new hex doesn't know of the client side theme change and looks bugged. I think it's just wrong to make client side changes that can be affected by server side changes like this and I see no way to redeem this (changing the theme for all players doesnt seem like a good solution either).

So, this function is okay for the board editor but not in-game.

Resolves #2246
(cheaply)