### PR TITLE
Add F_INF_SUPPORT flag to infantry TAG.

### DIFF
--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportTAGWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportTAGWeapon.java
@@ -37,8 +37,7 @@ public class InfantrySupportTAGWeapon extends InfantryWeapon {
 
 	public InfantrySupportTAGWeapon() {
 		super();
-		flags = flags.andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_TANK_WEAPON)
-		        .andNot(F_BA_WEAPON).andNot(F_PROTO_WEAPON).or(F_TAG).or(F_NO_FIRES).or(F_INF_ENCUMBER);
+		flags = flags.andNot(F_MECH_WEAPON).or(F_INF_SUPPORT).or(F_TAG).or(F_NO_FIRES).or(F_INF_ENCUMBER);
 
 		name = "TAG (Light, Man-Portable)";
 		setInternalName(EquipmentTypeLookup.INFANTRY_TAG);


### PR DESCRIPTION
Per infantry specialization rules (TO, p. 153), infantry TAG is a support weapon. Adding the flag causes it to show up in the correct list in MML, and prevents it from being put in a BA anti-personnel mount.

Fixes MegaMek/megameklab#807.