### PR TITLE
fleeing not illegal in tornado

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -2878,7 +2878,7 @@ public class MoveStep implements Serializable {
 
         // only walking speed in Tornados
         if (game.getPlanetaryConditions().getWindStrength() == PlanetaryConditions.WI_TORNADO_F4) {
-            if (movementType != EntityMovementType.MOVE_WALK) {
+            if (getMpUsed() > tmpWalkMP) {
                 movementType = EntityMovementType.MOVE_ILLEGAL;
                 return;
             }

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -486,7 +486,7 @@ public class Report implements Serializable {
                 i++;
             }
             //add the sprite code at the beginning of the line
-            if (!imageCode.isEmpty()) {
+            if (imageCode != null && !imageCode.isEmpty()) {
                 if (text.toString().startsWith("\n")) {
                     text.insert(1, imageCode);
                 }


### PR DESCRIPTION
Fixes two issues:

- bulletproofs a scenario where having report unit sprites off while loading a save game with them on would cause a blank report to appear
- move step validation for tornadoes was checking for a "walk" movement type, whereas "flee" just sets it to "legal". Changed to check for actual mp used vs available.

fixes #2343