### PR TITLE
destroyed head should still let torso cocpkit mechs fire weapons

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1116,9 +1116,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             if (sensorHits > 3) {
                 return Messages.getString("WeaponAttackAction.SensorsDestroyed");
             }
-        }
         // Industrialmechs and other unit types have destroyed sensors with 2 or more hits
-        if ((sensorHits > 1)
+        } else if ((sensorHits > 1)
                 || ((ae instanceof Mech) && (((Mech) ae).isIndustrial() && (sensorHits == 1)))) {
             return Messages.getString("WeaponAttackAction.SensorsDestroyed");
         }


### PR DESCRIPTION
Fixes #2300 

Mechs with torso mounted cockpits and destroyed heads have their own check for sensor damage and should be mutually exclusive with all other sensor checks.