### PR TITLE
Remove obsolete and incorrect isTrailer() override.

### DIFF
--- a/megamek/src/megamek/common/SuperHeavyTank.java
+++ b/megamek/src/megamek/common/SuperHeavyTank.java
@@ -521,9 +521,4 @@ public class SuperHeavyTank extends Tank {
         }
         return "?";
     }
-
-    @Override
-    public boolean isTrailer() {
-        return hasWorkingMisc(MiscType.F_TRAILER_MODIFICATION);
-    }
 }


### PR DESCRIPTION
Combat vehicles identify trailers using the boolean `trailer` field. Support vehicles override isTrailer to check for the trailer chassis mod, but SuperHeavyVehicle should be using the implementation in the parent class.

Fixes MegaMek/megameklab#812.