### PR TITLE
Don't reduce run MP below zero for hardened armor.

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1081,8 +1081,8 @@ public abstract class Mech extends Entity {
             return (getWalkMP(gravity, ignoreheat, ignoremodulararmor) * 2)
                     - (hasMPReducingHardenedArmor() ? 1 : 0);
         }
-        return super.getRunMP(gravity, ignoreheat, ignoremodulararmor)
-                - (hasMPReducingHardenedArmor() ? 1 : 0);
+        return Math.max(0, super.getRunMP(gravity, ignoreheat, ignoremodulararmor)
+                - (hasMPReducingHardenedArmor() ? 1 : 0));
     }
 
     /*


### PR DESCRIPTION
Modular armor reduces a unit's walk/cruise MP by one, and the run MP is recalculated from that. Hardened armor reduces a mech's run MP by one. In the unlikely event of a mech with a base walk MP of one and mounting both, the walk is reduced to zero, resulting in a run MP of zero. The hardened armor should not then drop it below zero. Rules for both are on TacOps p. 281.

Fixes #2371.