### PR TITLE
No ammo ammo weapon fix

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -942,7 +942,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // Ammo-specific Reasons
-        if (atype != null) {
+        if ((atype != null) || usesAmmo) {
+            // got ammo?
+            if (usesAmmo && ((ammo == null) || (ammo.getUsableShotsLeft() == 0))) {
+                return Messages.getString("WeaponAttackAction.OutOfAmmo");
+            }
+            
             // Are we dumping that ammo?
             if (usesAmmo && ammo != null && ammo.isDumping()) {
                 ae.loadWeaponWithSameAmmo(weapon);
@@ -967,11 +972,6 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     && (atype.getMunitionType() == AmmoType.M_FLARE)
                     && (target.getTargetType() != Targetable.TYPE_FLARE_DELIVER)) {
                 return Messages.getString("WeaponAttackAction.OnlyFlare");
-            }
-            
-            // got ammo?
-            if (usesAmmo && ((ammo == null) || (ammo.getUsableShotsLeft() == 0))) {
-                return Messages.getString("WeaponAttackAction.OutOfAmmo");
             }
 
             // Aeros must have enough ammo for the maximum rate of fire because

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -941,13 +941,13 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             return null;
         }
         
+        // got ammo?
+        if (usesAmmo && ((ammo == null) || (ammo.getUsableShotsLeft() == 0))) {
+            return Messages.getString("WeaponAttackAction.OutOfAmmo");
+        }
+        
         // Ammo-specific Reasons
-        if ((atype != null) || usesAmmo) {
-            // got ammo?
-            if (usesAmmo && ((ammo == null) || (ammo.getUsableShotsLeft() == 0))) {
-                return Messages.getString("WeaponAttackAction.OutOfAmmo");
-            }
-            
+        if (atype != null) {
             // Are we dumping that ammo?
             if (usesAmmo && ammo != null && ammo.isDumping()) {
                 ae.loadWeaponWithSameAmmo(weapon);


### PR DESCRIPTION
Fixes #2267 

WeaponAttackAction.toHitIsImpossible was skipping the "is ammo available" check for ammo weapons that don't have ammo attached, thus letting the user and/or bot fire said weapons. 

This is no longer the case, by moving the "is there ammo attached" check out on its own.