### PR TITLE
implement oversized quirk

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -7721,6 +7721,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if ((this instanceof Mech) && ((Mech) this).isSuperHeavy()) {
             roll.addModifier(4, "superheavy mech moving in building");
         }
+        
+        if (this.hasQuirk(OptionsConstants.QUIRK_NEG_OVERSIZED)) {
+            roll.addModifier(1, "oversized unit");
+        }
 
         int mod = 0;
         String desc;

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -99,6 +99,7 @@ public class LosEffects {
     boolean deadZone = false;
     boolean infProtected = false;
     boolean hasLoS = true;
+    boolean targetIsOversized = false;
     int plantedFields = 0;
     int heavyIndustrial = 0;
     int lightWoods = 0;
@@ -512,6 +513,9 @@ public class LosEffects {
         finalLoS.setMinimumWaterDepth(ai.minimumWaterDepth);
         
         finalLoS.targetLoc = target.getPosition();
+        
+        finalLoS.targetIsOversized = ai.targetEntity && ((Entity) target).hasQuirk(OptionsConstants.QUIRK_NEG_OVERSIZED);
+        
         return finalLoS;
     }
 
@@ -687,7 +691,8 @@ public class LosEffects {
             }
         }
 
-        if (targetCover != COVER_NONE) {
+        // partial cover modifiers apply unless the target is oversized
+        if ((targetCover != COVER_NONE) && !targetIsOversized) {
             if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_PARTIAL_COVER)) {
                 if ((targetCover == COVER_75LEFT) || (targetCover == COVER_75RIGHT)) {
                     modifiers.addModifier(1, "target has 75% cover");


### PR DESCRIPTION
Pretty straightforward. Per BMM page 88, oversized quirk (e.g. Mackie), prevents +1 from partial cover and makes it hard to move through buildings without hurting yourself.