### PR TITLE
Fix erroneous aero validation message in MML

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -1140,34 +1140,26 @@ public class TestAdvancedAerospace extends TestAero {
     
     @Override
     public String printLocations() {
-        StringBuffer buff = new StringBuffer();
+        StringBuilder buff = new StringBuilder();
         for (int i = 0; i < getEntity().locations(); i++) {
             String locationName = getEntity().getLocationName(i);
-            buff.append(locationName + ":");
-            buff.append("\n");
+            buff.append(locationName).append(":").append("\n");
             for (int j = 0; j < getEntity().getNumberOfCriticals(i); j++) {
                 CriticalSlot slot = getEntity().getCritical(i, j);
                 if (slot == null) {
                     j = getEntity().getNumberOfCriticals(i);                    
                 } else if (slot.getType() == CriticalSlot.TYPE_SYSTEM) {
-                        buff.append(Integer.toString(j)
-                                + ". UNKNOWN SYSTEM NAME");
+                        buff.append(j).append(". UNKNOWN SYSTEM NAME");
                         buff.append("\n");
                 } else if (slot.getType() == CriticalSlot.TYPE_EQUIPMENT) {
                     EquipmentType e = getEntity().getEquipmentType(slot);
-                    buff.append(Integer.toString(j) + ". "
-                            + e.getInternalName());
+                    buff.append(j).append(". ").append(e.getInternalName());
                     buff.append("\n");
                 }
             }
         }
-        return buff.toString();
-    }
-    
-    @Override
-    public boolean correctCriticals(StringBuffer buff) {
+
         double[] extra = extraSlotCost(vessel);
-        
         for (int i = 0; i < extra.length; i++) {
             if (extra[i] > 0) {
                 if (i < getEntity().locations()) {
@@ -1178,7 +1170,8 @@ public class TestAdvancedAerospace extends TestAero {
                 buff.append(" requires ").append(extra[i]).append(" tons of additional fire control.\n");
             }
         }
-        return super.correctCriticals(buff);
+
+        return buff.toString();
     }
     
     @Override

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -862,13 +862,8 @@ public class TestSmallCraft extends TestAero {
                 }
             }
         }
-        return buff.toString();
-    }
 
-    @Override
-    public boolean correctCriticals(StringBuffer buff) {
         double[] extra = extraSlotCost(getSmallCraft());
-        
         for (int i = 0; i < extra.length; i++) {
             if (extra[i] > 0) {
                 if (i < getEntity().locations()) {
@@ -879,9 +874,9 @@ public class TestSmallCraft extends TestAero {
                 buff.append(" requires ").append(extra[i]).append(" tons of additional fire control.\n");
             }
         }
-        return super.correctCriticals(buff);
+        return buff.toString();
     }
-    
+
     @Override
     public String getName() {
         if (smallCraft.hasETypeFlag(Entity.ETYPE_DROPSHIP)) {


### PR DESCRIPTION
I discovered while working on something else that when you load an aerospace unit in MML that exceeds the free weapon slot count allowance and requires extra weight for fire control, you get a popup validation window that shows the weight allotments, though it does not actually fail validation.

The problem is that I originally put the messages in correctCriticals, which gets called while producing the weight breakdown, but did not at that time get called during validation. At some point I included that method in the validation to fix a bug that wasn't catching unallocated equipment, and now the message pops up.

For the fix I moved it to a method that only gets called when creating the weight breakdown report.