### PR TITLE
AbstractIcon: Implementing Null Protections

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
@@ -20,18 +20,10 @@ package megamek.client.ui.swing.tileset;
 
 import megamek.MegaMek;
 import megamek.common.util.fileUtils.ImageFileFactory;
-import megamek.client.ui.swing.util.PlayerColors;
 import megamek.common.util.fileUtils.ScaledImageFileFactory;
 import megamek.common.Configuration;
-import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
-import megamek.common.icons.AbstractIcon;
-import megamek.common.icons.Camouflage;
-import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.DirectoryItems;
-
-import java.awt.*;
-import java.awt.image.BufferedImage;
 
 public class MMStaticDirectoryManager {
     //region Variable Declarations
@@ -191,90 +183,4 @@ public class MMStaticDirectoryManager {
         return getMechTileset();
     }
     //endregion Refreshers
-
-    //region Camouflage
-    /**
-     * Returns an Image of the camo pattern given
-     * by its category (aka directory) and name (aka filename).
-     * Will try to return an image if the category indicates
-     * that a color was selected.
-     * When the camo image cannot be created, a placeholder
-     * "fail" image is returned.
-     *
-     * @see ImageUtil#failStandardImage()
-     */
-    @Deprecated
-    public static Image getCamoImage(String category, String name) {
-        // Return a fail image when parameters are null
-        if ((category == null) || (name == null)) {
-            return ImageUtil.failStandardImage();
-        }
-
-        // Make sure the camoDirectory has been initialized
-        // If the camoDirectory is still null, there's an error
-        // loading it which has been logged already
-        initializeCamouflage();
-        if (camouflageDirectory == null) {
-            return ImageUtil.failStandardImage();
-        }
-
-        // Try to get the camo image
-        try {
-            // A color was selected
-            if (Camouflage.NO_CAMOUFLAGE.equals(category)) {
-                return colorCamoImage(PlayerColors.getColor(name));
-            }
-
-            // Translate the root camo directory name.
-            // This could be improved by translating before saving it
-            if (AbstractIcon.ROOT_CATEGORY.equals(category)) {
-                category = "";
-            }
-
-            Image image = (Image) camouflageDirectory.getItem(category, name);
-            // When getItem() doesn't find the category+name, it returns null
-            if (image != null) {
-                return image;
-            }
-        } catch (Exception e) {
-            MegaMek.getLogger().error(e);
-        }
-
-        // An error must have occurred, fall back to the fail image
-        MegaMek.getLogger().error("Could not create camo image! Category: " + category + "; Name: " + name);
-        return ImageUtil.failStandardImage();
-    }
-
-    /**
-     * Returns an Image of the camo pattern or player color
-     * for the given entity.
-     * When the camo image cannot be created, a placeholder
-     * "fail" image is returned.
-     *
-     * @see ImageUtil#failStandardImage()
-     */
-    @Deprecated
-    public static Image getEntityCamoImage(Entity entity) {
-        return getCamoImage(entity.getCamoCategory(), entity.getCamoFileName());
-    }
-
-    /**
-     * Returns a standard size (84x72) image of a single color.
-     * When color is null, a "fail" standard image is returned.
-     *
-     * @see ImageUtil#failStandardImage()
-     */
-    @Deprecated
-    public static BufferedImage colorCamoImage(Color color) {
-        if (color == null) {
-            MegaMek.getLogger().error("A null color was passed.");
-            return ImageUtil.failStandardImage();
-        }
-        BufferedImage result = new BufferedImage(84, 72, BufferedImage.TYPE_INT_RGB);
-        Graphics2D graphics = result.createGraphics();
-        graphics.setColor(color);
-        graphics.fillRect(0, 0, 84, 72);
-        return result;
-    }
-    //endregion Camouflage
 }

--- a/megamek/src/megamek/common/icons/AbstractIcon.java
+++ b/megamek/src/megamek/common/icons/AbstractIcon.java
@@ -18,16 +18,12 @@
  */
 package megamek.common.icons;
 
-import megamek.MegaMek;
+import megamek.common.annotations.Nullable;
 import megamek.common.util.ImageUtil;
-import megamek.utils.MegaMekXmlUtil;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.PrintWriter;
 import java.io.Serializable;
 
 public abstract class AbstractIcon implements Serializable {
@@ -36,10 +32,9 @@ public abstract class AbstractIcon implements Serializable {
 
     public static final String ROOT_CATEGORY = "-- General --";
     public static final String DEFAULT_ICON_FILENAME = "None";
-    public static final int DEFAULT_IMAGE_SCALE = 75;
 
     private String category;
-    private String filename;
+    protected String filename;
     //endregion Variable Declarations
 
     //region Constructors
@@ -58,16 +53,16 @@ public abstract class AbstractIcon implements Serializable {
         return category;
     }
 
-    public void setCategory(String category) {
-        this.category = category;
+    public void setCategory(@Nullable String category) {
+        this.category = (category == null) ? ROOT_CATEGORY : category;
     }
 
     public String getFilename() {
         return filename;
     }
 
-    public void setFilename(String filename) {
-        this.filename = filename;
+    public void setFilename(@Nullable String filename) {
+        this.filename = (filename == null) ? DEFAULT_ICON_FILENAME : filename;
     }
     //endregion Getters/Setters
 
@@ -155,51 +150,10 @@ public abstract class AbstractIcon implements Serializable {
      */
     public abstract Image getBaseImage();
 
-    //region File IO
-    /**
-     * This writes the AbstractIcon to XML
-     * @param pw1 the PrintWriter to write to
-     * @param indent the indentation of the first line
-     */
-    public void writeToXML(PrintWriter pw1, int indent) {
-        MegaMekXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "AbstractIcon");
-        MegaMekXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "category", getCategory());
-        MegaMekXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "filename", getFilename());
-        MegaMekXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "AbstractIcon");
-    }
-
-    /**
-     * This is used to parse an AbstractIcon from a saved XML node
-     * @param retVal the AbstractIcon to parse into
-     * @param wn the node to parse from
-     * @return the parsed AbstractIcon
-     */
-    public static AbstractIcon parseFromXML(AbstractIcon retVal, Node wn) {
-        try {
-            NodeList nl = wn.getChildNodes();
-
-            for (int x = 0; x < nl.getLength(); x++) {
-                Node wn2 = nl.item(x);
-
-                if (wn2.getNodeName().equalsIgnoreCase("category")) {
-                    retVal.setCategory(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("filename")) {
-                    retVal.setFilename(wn2.getTextContent().trim());
-                }
-            }
-        } catch (Exception e) {
-            MegaMek.getLogger().error("Failed to parse icon from nodes", e);
-        }
-
-        return retVal;
-    }
-    //endregion File IO
-
     @Override
     public String toString() {
         return hasDefaultCategory() ? getFilename()
-                : (getCategory().endsWith("/") ? getCategory() + getFilename()
-                : getCategory() + "/" + getFilename());
+                : (getCategory().endsWith("/") ? getCategory() : getCategory() + "/") + getFilename();
     }
 
     @Override

--- a/megamek/src/megamek/common/icons/Camouflage.java
+++ b/megamek/src/megamek/common/icons/Camouflage.java
@@ -44,8 +44,7 @@ public class Camouflage extends AbstractIcon {
 
     @Override
     public Image getBaseImage() {
-        if ((MMStaticDirectoryManager.getCamouflage() == null) || (getCategory() == null)
-                || (getFilename() == null)) {
+        if (MMStaticDirectoryManager.getCamouflage() == null) {
             return null;
         } else if (Camouflage.NO_CAMOUFLAGE.equals(getCategory())) {
             return getColourCamouflageImage(PlayerColors.getColor(getFilename()));

--- a/megamek/src/megamek/common/icons/Portrait.java
+++ b/megamek/src/megamek/common/icons/Portrait.java
@@ -20,6 +20,7 @@ package megamek.common.icons;
 
 import megamek.MegaMek;
 import megamek.client.ui.swing.tileset.MMStaticDirectoryManager;
+import megamek.common.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
@@ -40,6 +41,13 @@ public class Portrait extends AbstractIcon {
     }
     //endregion Constructors
 
+    //region Getters/Setters
+    @Override
+    public void setFilename(@Nullable String filename) {
+        this.filename = (filename == null) ? DEFAULT_PORTRAIT_FILENAME : filename;
+    }
+    //endregion Getters/Setters
+
     //region Boolean Methods
     @Override
     public boolean hasDefaultFilename() {
@@ -59,21 +67,21 @@ public class Portrait extends AbstractIcon {
 
     @Override
     public Image getBaseImage() {
-        // If we can't create the portrait directory,
+        // If we can't create the portrait directory, return null
         if (MMStaticDirectoryManager.getPortraits() == null) {
             return null;
         }
 
-        String category = (hasDefaultCategory() || (getCategory() == null)) ? "" : getCategory();
-        String filename = (hasDefaultFilename() || (getFilename() == null))
-                ? DEFAULT_PORTRAIT_FILENAME : getFilename();
+        String category = hasDefaultCategory() ? "" : getCategory();
+        String filename = hasDefaultFilename() ? DEFAULT_PORTRAIT_FILENAME : getFilename();
 
         // Try to get the player's portrait file.
         Image portrait = null;
         try {
             portrait = (Image) MMStaticDirectoryManager.getPortraits().getItem(category, filename);
             if (portrait == null) {
-                portrait = (Image) MMStaticDirectoryManager.getPortraits().getItem("", DEFAULT_PORTRAIT_FILENAME);
+                portrait = (Image) MMStaticDirectoryManager.getPortraits().getItem("",
+                        DEFAULT_PORTRAIT_FILENAME);
             }
         } catch (Exception e) {
             MegaMek.getLogger().error(e);


### PR DESCRIPTION
I also removed some code in MMStaticDirectoryManager that was deprecated as part of the MHQ changes for AbstractIcon. This is required for the next MHQ AbstractIcon changes to prevent null values on load.