### PR TITLE
Fix primitive dropship/small craft armor weight calculation

### DIFF
--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -712,13 +712,15 @@ public class SmallCraft extends Aero {
 
     @Override
     public double getArmorWeight() {
-        // first I need to subtract SI bonus from total armor
-        int armorPoints = getTotalOArmor();
+        // first I need to subtract SI bonus from total armor. We need to retain the fractional part
+        //  for primitive craft because the primitive multiplier is applied to both before rounding.
+        double armorPoints = getTotalOArmor();
         int freeSI = getSI() * (locations() - 1); // no armor in hull location
         if (isPrimitive()) {
-            freeSI = (int) (freeSI * 0.66);
+            armorPoints -= freeSI * 0.66;
+        } else {
+            armorPoints -= freeSI;
         }
-        armorPoints -= freeSI;
         double armorPerTon = SmallCraft.armorPointsPerTon(getWeight(), isSpheroid(),
                 getArmorType(0), TechConstants.isClan(getArmorTechLevel(0)));
 


### PR DESCRIPTION
The number of armor points that a small craft or dropship has is the armor tonnage x point per ton + SI x armor facings. For primitive craft this number is multiplied by 0.66. MM is calculating the maximum armor correctly. But when the armor weight is calculated when the unit is loaded, the two armor sources are treated as if they are rounded separately, which can result in the total armor weight being rounded up an extra half ton.

Fixes MegaMek/megameklab#821