### PR TITLE
Fix year thresholds for dropship engine and control multipliers.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -291,9 +291,9 @@ public class TestSmallCraft extends TestAero {
     public static double dropshipEngineMultiplier(int year) {
         if (year >= 2500) {
             return 0.065;
-        } else if (year >= 2400) {
-            return 0.0715;
         } else if (year >= 2351) {
+            return 0.0715;
+        } else if (year >= 2300) {
             return 0.0845;
         } else if (year >= 2251) {
             return 0.091;
@@ -309,9 +309,9 @@ public class TestSmallCraft extends TestAero {
     public static double dropshipControlMultiplier(int year) {
         if (year >= 2500) {
             return 0.0075;
-        } else if (year >= 2400) {
-            return 0.009;
         } else if (year >= 2351) {
+            return 0.009;
+        } else if (year >= 2300) {
             return 0.00975;
         } else if (year >= 2251) {
             return 0.0105;


### PR DESCRIPTION
The weight multipliers used in primitive dropship engine and control weight calculations and fuel factor improve at certain years. It looks like I copied the code from the small craft table and didn't notice that two of the years were different.

Fixes MegaMek/megameklab#823