### PR TITLE
let MML launchers switch between MML ammo types

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15823,17 +15823,21 @@ public class AmmoType extends EquipmentType {
             return false;
         }
         
-        Mounted currentAmmoBin = weapon.getLinked();
+        AmmoType currentAmmoType = (AmmoType) weapon.getLinked().getType();
         
-        boolean ammoOfSameType = weapon.getLinked().getType().equals(otherAmmo);
+        boolean ammoOfSameType = currentAmmoType.equals(otherAmmo);
         
-        boolean caselessLoaded = ((AmmoType) currentAmmoBin.getType()).getMunitionType() == AmmoType.M_CASELESS;
+        // MMLs can swap between different specific ammo types, so we have a special case check here
+        boolean mmlAmmoMatch = currentAmmoType.getAmmoType() == AmmoType.T_MML &&
+                currentAmmoType.getRackSize() == otherAmmo.getRackSize();        
+        
+        boolean caselessLoaded = currentAmmoType.getMunitionType() == AmmoType.M_CASELESS;
         boolean otherBinCaseless = otherAmmo.getMunitionType() == AmmoType.M_CASELESS;
         boolean caselessMismatch = caselessLoaded != otherBinCaseless;
         
         boolean hasStaticFeed = weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_STATIC_FEED);
-        boolean staticFeedMismatch = hasStaticFeed && (((AmmoType) currentAmmoBin.getType()).getMunitionType() != otherAmmo.getMunitionType());
+        boolean staticFeedMismatch = hasStaticFeed && (currentAmmoType.getMunitionType() != otherAmmo.getMunitionType());
         
-        return ammoOfSameType && !caselessMismatch && !staticFeedMismatch;
+        return (ammoOfSameType || mmlAmmoMatch) && !caselessMismatch && !staticFeedMismatch;
     }
 }


### PR DESCRIPTION
Fix #2392. 

Not sure how long this bug has been around, but, different MML ammo isn't technically of the same type. Perform that specific comparison based on MML flag and rack size instead.