### PR TITLE
Fix aero unit type modifiers.

### DIFF
--- a/megamek/src/megamek/common/ConvFighter.java
+++ b/megamek/src/megamek/common/ConvFighter.java
@@ -90,9 +90,6 @@ public class ConvFighter extends Aero {
     
     @Override
     public double getBVTypeModifier() {
-        if (hasStealth()) {
-            return 1.4;
-        }
         return 1.1;
     }
 

--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -500,6 +500,11 @@ public class FixedWingSupport extends ConvFighter {
         bvText.append("</BODY></HTML>");
     }
 
+    @Override
+    public double getBVTypeModifier() {
+        return 1.0;
+    }
+
     public long getEntityType(){
         return Entity.ETYPE_AERO | Entity.ETYPE_CONV_FIGHTER | Entity.ETYPE_FIXED_WING_SUPPORT;
     }


### PR DESCRIPTION
ConvFighter is accounting for stealth twice in BV calculations and the unit type modifier for fixed wing should be 1.0 instead of the 1.1 it inherits from ConvFighter.