### PR TITLE
Upgrade XStream to 1.4.14

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -28,7 +28,7 @@ configurations {
 }
 
 dependencies {
-    implementation 'com.thoughtworks.xstream:xstream:1.4.11'
+    implementation 'com.thoughtworks.xstream:xstream:1.4.14'
     implementation 'org.freemarker:freemarker:2.3.28'
     implementation 'log4j:log4j:1.2.17'
     implementation 'org.apache.commons:commons-text:1.8'


### PR DESCRIPTION
XStream 1.4.13 includes a fix for the illegal reflective operation warning when using Java 9+. The latest version includes a fix for a security vulnerability. See https://x-stream.github.io/changes.html