### PR TITLE
Don't reset position following a failed maneuver

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -7704,7 +7704,7 @@ public class Server implements Runnable {
                             continueTurnFromFishtail = true;
                         }
                         curFacing = entity.getFacing();
-                        entity.setPosition(curPos);
+                        curPos = entity.getPosition();
                         entity.setSecondaryFacing(curFacing);
                         break;
                     }


### PR DESCRIPTION
I'm not sure why this line is there. It's possibly a vestige from a copy/paste. But I can't think of any reason it would be correct to reset the Entity's position after processing a failed vehicle maneuver to what it was before.

Fixes #2398 