### PR TITLE
Issue #1803: Configure view changes Clan unit BV

### DIFF
--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -18,7 +18,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,7 +54,7 @@ import megamek.common.weapons.infantry.InfantryWeapon;
  * @author arlith
  * @since 2012-05-20
  */
-public class EquipChoicePanel extends JPanel implements Serializable {
+public class EquipChoicePanel extends JPanel {
     static final long serialVersionUID = 672299770230285567L;
 
     private final Entity entity;
@@ -643,8 +642,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
         for (Mounted m : entity.getAmmo()) {
             AmmoType at = (AmmoType) m.getType();
             ArrayList<AmmoType> vTypes = new ArrayList<AmmoType>();
-            Vector<AmmoType> vAllTypes = AmmoType.getMunitionsFor(at
-                    .getAmmoType());
+            Vector<AmmoType> vAllTypes = AmmoType.getMunitionsFor(at.getAmmoType());
             if (vAllTypes == null) {
                 continue;
             }
@@ -1060,7 +1058,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
 
             private List<AmmoType> m_vTypes;
 
-            private JComboBox<String> m_choice;
+            private JComboBox<AmmoType> m_choice;
             
             @SuppressWarnings("rawtypes")
             private JComboBox m_num_shots;
@@ -1086,12 +1084,12 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 m_mounted = m;
                 
                 AmmoType curType = (AmmoType) m.getType();
-                m_choice = new JComboBox<String>();
+                m_choice = new JComboBox<AmmoType>();
                 Iterator<AmmoType> e = m_vTypes.iterator();
                 for (int x = 0; e.hasNext(); x++) {
                     AmmoType at = e.next();
-                    m_choice.addItem(at.getName());
-                    if (at.getInternalName() == curType.getInternalName()) {
+                    m_choice.addItem(at);
+                    if (at.equals(curType)) {
                         m_choice.setSelectedIndex(x);
                     }
                 }
@@ -1349,7 +1347,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 } else {
                     for (Mounted ammoBin : weapon.getEntity().getAmmo()) {
                         if ((ammoBin.getLocation() != Entity.LOC_NONE)
-                            && ((WeaponType) weapon.getType()).getAmmoType() == ((AmmoType) ammoBin.getType()).getAmmoType()) {
+                            && AmmoType.canSwitchToAmmo(weapon, (AmmoType) ammoBin.getType())) {
                             matchingAmmoBins.add(ammoBin);
                         }
                     }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2666,6 +2666,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 // this ammo
                 for (int wid : mWeap.getBayWeapons()) {
                     Mounted bWeap = entity.getEquipment(wid);
+                    // FIXME: Consider new AmmoType::equals / BombType::equals
                     if (bWeap.getType().equals(sWeap.getType())) {
                         entity.loadWeapon(bWeap, mAmmo);
                         // Alert the server of the update.

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -1617,6 +1617,7 @@ public class Aero extends Entity implements IAero, IBomber {
 
         // subtract for explosive ammo
         double explosivePenalty = 0;
+        // FIXME: Consider new AmmoType::equals / BombType::equals
         Map<AmmoType, Boolean> ammos = new HashMap<AmmoType, Boolean>();
         for (Mounted mounted : getEquipment()) {
             int loc = mounted.getLocation();

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -17,8 +17,12 @@ package megamek.common;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Vector;
 
 import megamek.common.options.OptionsConstants;
@@ -143,6 +147,22 @@ public class AmmoType extends EquipmentType {
     public static final int T_BARRACUDA_T = 112;
     public static final int T_INFANTRY = 113;
     public static final int NUM_TYPES = 114;  //Should always be at the end with the highest number
+
+    /**
+     * Contains the {@code AmmoType}s that could share ammo (e.g. SRM 2 and SRM 6, both fire SRM rounds).
+     */
+    private static final Integer[] ALLOWED_BY_TYPE_ARRAY = { AmmoType.T_LRM, AmmoType.T_LRM_PRIMITIVE, AmmoType.T_LRM_STREAK, AmmoType.T_LRM_TORPEDO,
+        AmmoType.T_LRM_TORPEDO_COMBO, AmmoType.T_SRM, AmmoType.T_SRM_ADVANCED, AmmoType.T_SRM_PRIMITIVE, AmmoType.T_SRM_STREAK, AmmoType.T_SRM_TORPEDO,
+        AmmoType.T_MRM, AmmoType.T_MRM_STREAK, AmmoType.T_ROCKET_LAUNCHER, AmmoType.T_EXLRM, AmmoType.T_PXLRM, AmmoType.T_HSRM, AmmoType.T_MML,
+        AmmoType.T_NLRM };
+
+    /**
+     * Contains the set of {@code AmmoType}s which could share ammo (e.g. SRM 2 and SRM 6, both fire SRM rounds),
+     * and conceptually can share ammo.
+     * 
+     * NB: This is used in MekHQ.
+     */
+    public static final Set<Integer> ALLOWED_BY_TYPE = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALLOWED_BY_TYPE_ARRAY)));
 
     // ammo flags
     public static final BigInteger F_MG = BigInteger.valueOf(1).shiftLeft(0);
@@ -391,20 +411,6 @@ public class AmmoType extends EquipmentType {
     }
 
     /**
-     * When comparing <code>AmmoType</code>s, look at the ammoType and rackSize.
-     *
-     * @param other the <code>Object</code> to compare to this one.
-     * @return <code>true</code> if the other is an <code>AmmoType</code> object
-     *         of the same <code>ammoType</code> as this object. N.B. different
-     *         munition types are still equal.
-     */
-    @Override
-    public boolean equals(Object other) {
-        return equalsAmmoTypeOnly(other) && (getRackSize() == ((AmmoType) other)
-                .getRackSize());
-    }
-
-    /**
      * When comparing <code>AmmoType</code>s, look at the ammoType only.
      *
      * @param other the <code>Object</code> to compare to this one.
@@ -416,45 +422,111 @@ public class AmmoType extends EquipmentType {
         if (!(other instanceof AmmoType)) {
             return false;
         }
-        // there a couple of flags that need to be checked
-        if (getAmmoType() == T_MML) {
-            if (hasFlag(F_MML_LRM) != ((AmmoType) other).hasFlag(F_MML_LRM)) {
+
+        AmmoType otherAmmoType = (AmmoType) other;
+
+        // There a couple of flags that need to be checked before we check
+        // on getAmmoType() strictly.
+        if (is(T_MML)) {
+            if (hasFlag(F_MML_LRM) != otherAmmoType.hasFlag(F_MML_LRM)) {
                 return false;
             }
         }
-        if (getAmmoType() == T_AR10) {
-            if (hasFlag(F_AR10_BARRACUDA) != ((AmmoType) other)
-                    .hasFlag(F_AR10_BARRACUDA)) {
+
+        if (is(T_AR10)) {
+            if (hasFlag(F_AR10_BARRACUDA) != otherAmmoType.hasFlag(F_AR10_BARRACUDA)) {
                 return false;
             }
-            if (hasFlag(F_AR10_WHITE_SHARK) != ((AmmoType) other)
-                    .hasFlag(F_AR10_WHITE_SHARK)) {
+            if (hasFlag(F_AR10_WHITE_SHARK) != otherAmmoType.hasFlag(F_AR10_WHITE_SHARK)) {
                 return false;
             }
-            if (hasFlag(F_AR10_KILLER_WHALE) != ((AmmoType) other)
-                    .hasFlag(F_AR10_KILLER_WHALE)) {
+            if (hasFlag(F_AR10_KILLER_WHALE) != otherAmmoType.hasFlag(F_AR10_KILLER_WHALE)) {
                 return false;
             }
-            if (hasFlag(F_NUCLEAR) != ((AmmoType) other)
-                    .hasFlag(F_NUCLEAR)) {
+            if (hasFlag(F_NUCLEAR) != otherAmmoType.hasFlag(F_NUCLEAR)) {
                 return false;
             }
         }
-        return getAmmoType() == ((AmmoType) other).getAmmoType();
+
+        return is(otherAmmoType.getAmmoType());
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = ammoType;
-        result = prime * result
-                + ((flags == null) ? 0 : flags.hashCode());
-        result = prime * result + rackSize;
-        return result;
+    /**
+     * Gets a value indicating whether or not this {@code AmmoType}
+     * is compatible with another {@code AmmoType}.
+     * 
+     * NB: this roughly means the same ammo type and munition type, but not rack size.
+     * 
+     * @param other The other {@code AmmoType} to determine compatibility with.
+     */
+    public boolean isCompatibleWith(AmmoType other) {
+        if (other == null) {
+            return false;
+        }
+
+        // If it isn't an allowed type, then nope!
+        if (!ALLOWED_BY_TYPE.contains(getAmmoType()) 
+                || !ALLOWED_BY_TYPE.contains(other.getAmmoType())) {
+            return false;
+        }
+
+        // MML Launchers, ugh.
+        if ((is(T_MML) || other.is(T_MML)) && (getMunitionType() == other.getMunitionType())) {
+            // LRMs...
+            if (is(T_MML) && hasFlag(F_MML_LRM) && other.is(T_LRM)) {
+                return true;
+            } else if (other.is(T_MML) && other.hasFlag(AmmoType.F_MML_LRM) && is(T_LRM)) {
+                return true;
+            }
+
+            // SRMs
+            if (is(T_MML) && !hasFlag(AmmoType.F_MML_LRM) && is(T_SRM)) {
+                return true;
+            } else if (other.is(T_MML) && !other.hasFlag(AmmoType.F_MML_LRM) && is(T_SRM)) {
+                return true;
+            }
+        }
+
+        // AR-10 Launchers, ugh.
+        /*if (getAmmoType() == T_AR10 || a2.getAmmoType() == T_AR10) {
+            // Barracuda
+            if (getAmmoType() == T_AR10 && hasFlag(F_AR10_BARRACUDA) && a2.getAmmoType() == T_BARRACUDA) {
+                result = true;
+            } else if (a2.getAmmoType() == T_AR10 && a2.hasFlag(F_AR10_BARRACUDA) && getAmmoType() == T_BARRACUDA) {
+                result = true;
+            }
+            // Killer Whale
+            if (getAmmoType() == T_AR10 && hasFlag(F_AR10_KILLER_WHALE) && a2.getAmmoType() == T_KILLER_WHALE) {
+                result = true;
+            } else if (a2.getAmmoType() == T_AR10 && a2.hasFlag(F_AR10_KILLER_WHALE) && getAmmoType() == T_KILLER_WHALE) {
+                result = true;
+            }
+            // White Shark
+            if (getAmmoType() == T_AR10 && hasFlag(F_AR10_WHITE_SHARK) && a2.getAmmoType() == T_WHITE_SHARK) {
+                result = true;
+            } else if (a2.getAmmoType() == T_AR10 && a2.hasFlag(F_AR10_WHITE_SHARK) && getAmmoType() == T_WHITE_SHARK) {
+                result = true;
+            }
+        }*/
+
+        // General Launchers
+        if (is(other.getAmmoType()) && (getMunitionType() == other.getMunitionType())) {
+            return true;
+        }
+
+        return false;
     }
 
     public int getAmmoType() {
         return ammoType;
+    }
+
+    /**
+     * Gets a value indicating whether or not this is a certain ammo type.
+     * @param ammoType The ammo type to compare against.
+     */
+    public boolean is(int ammoType) {
+        return getAmmoType() == ammoType;
     }
 
     public long getMunitionType() {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3758,6 +3758,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public int getTotalAmmoOfType(EquipmentType et) {
         int totalShotsLeft = 0;
         for (Mounted amounted : getAmmo()) {
+            // FIXME: Consider new AmmoType::equals / BombType::equals
             if (amounted.getType().equals(et) && !amounted.isDumping()) {
                 totalShotsLeft += amounted.getUsableShotsLeft();
             }
@@ -4047,9 +4048,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         AmmoType atype = (AmmoType) mountedAmmo.getType();
         Mounted oldammo = mounted.getLinked();
 
-        if ((oldammo != null)
-            && (!((AmmoType) oldammo.getType()).equals(atype) || (((AmmoType) oldammo
-                .getType()).getMunitionType() != atype.getMunitionType()))) {
+        if ((oldammo != null) && (oldammo.getType() instanceof AmmoType)
+                && !((AmmoType) oldammo.getType()).equals(atype)) {
             return false;
         }
 
@@ -4124,6 +4124,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         EquipmentType altBomb = EquipmentType.get(IBomber.ALT_BOMB_ATTACK);
         EquipmentType diveBomb = EquipmentType.get(IBomber.DIVE_BOMB_ATTACK);
         for (Mounted eq : equipmentList) {
+            // FIXME: Consider new BombType::equals
             if (eq.getType().equals(spaceBomb) || eq.getType().equals(altBomb)
                     || eq.getType().equals(diveBomb)) {
                 bombAttacksToRemove.add(eq);

--- a/megamek/src/megamek/common/templates/AeroTROView.java
+++ b/megamek/src/megamek/common/templates/AeroTROView.java
@@ -175,6 +175,7 @@ public class AeroTROView extends TROView {
         int erv = 0;
         final int multiplier = ((WeaponType) bay.getType()).isCapital() ? 10 : 1;
         Mounted linker = null;
+        // FIXME: Consider new AmmoType::equals / BombType::equals
         final Map<AmmoType, Integer> shotsByAmmoType = bay.getBayAmmo().stream().map(aero::getEquipment)
                 .collect(Collectors.groupingBy(m -> (AmmoType) m.getType(),
                         Collectors.summingInt(Mounted::getBaseShotsLeft)));


### PR DESCRIPTION
When opening the Configure view for a Clan unit and clicking OK, the BV may change as in #1803. The root cause of this issue is the `JComboBox` supporting the ammo type selection uses strings, and in a number of cases (such as Ultra A/C ammo) there is no difference in the names between IS and Clan ammo. Because of this, no matter what selection logic you use under the hood the JComboBox will take the first matching string when changing the selection.

To fix this I simply switched the JComboBox to use AmmoTypes directly, instead of Strings. The names still appear identical (an issue for another PR), but the selection works. It works because I also removed `AmmoType::equals` and allowed it to fall back to `EquipmentType::equals`. Previously, AmmoType::equals used "loose" equality, ignoring munition types and bomb types. Now we use strict equality (and have an appropriate hash code too).

This fix is not one to take lightly, but one that appears to have no broad affect on MM. I've labeled the areas I wasn't sure of which used the old `AmmoType::equals` and `AmmoType::hashCode` so that I can get eyes on these other spots.

Fixes #1803.