### PR TITLE
Allow HarJel II & III in cockpit location

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1595,8 +1595,7 @@ public class TestMech extends TestEntity {
                 }
                 return false;
             }
-            if ((eq.hasFlag(MiscType.F_HARJEL)|| eq.hasFlag(MiscType.F_HARJEL_II)
-                    || eq.hasFlag(MiscType.F_HARJEL_III)) && mech.hasSystem(Mech.SYSTEM_COCKPIT, location)) {
+            if (eq.hasFlag(MiscType.F_HARJEL) && mech.hasSystem(Mech.SYSTEM_COCKPIT, location)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" cannot be placed in the same location as the cockpit.\n");
                 }


### PR DESCRIPTION
Per rules clarification, the restriction against HarJel in the same location as the cockpit only applies to the original HarJel system from TacOps. HarJel II and III from IO are permitted in the cockpit location.
https://bg.battletech.com/forums/supplementary-rules/answered-io-harjel-all-types-and-head-locations/

Fixes #2161