### PR TITLE
Prototype IJJ should only apply a -1 explosive equipment penalty to BV

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3750,7 +3750,8 @@ public abstract class Mech extends Entity {
             if ((etype instanceof MiscType)
                     && (etype.hasFlag(MiscType.F_PPC_CAPACITOR)
                             || etype.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)
-                            || etype.hasFlag(MiscType.F_EMERGENCY_COOLANT_SYSTEM))) {
+                            || etype.hasFlag(MiscType.F_EMERGENCY_COOLANT_SYSTEM)
+                            || etype.hasFlag(MiscType.F_JUMP_JET))) {
                 toSubtract = 1;
             }
 
@@ -3794,9 +3795,6 @@ public abstract class Mech extends Entity {
             // we subtract per critical slot
             toSubtract *= mounted.getCriticals();
             ammoPenalty += toSubtract;
-        }
-        if (getJumpType() == JUMP_PROTOTYPE_IMPROVED) {
-            ammoPenalty += this.getJumpMP(false, true);
         }
         // special case for blueshield, need to check each non-head location
         // seperately for CASE

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1990,6 +1990,7 @@ public class MiscType extends EquipmentType {
         misc.flags = misc.flags.or(F_JUMP_JET).or(F_MECH_EQUIPMENT);
         misc.subType |= S_PROTOTYPE | S_IMPROVED;
         misc.bv = 0;
+        misc.rulesRefs = "17,XTRO:SW1";
         // Not included in IO Progression data based on original source.
         misc.techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(3020, DATE_NONE, DATE_NONE, 3069)
                 .setISApproximate(true, false, false, false, false).setPrototypeFactions(F_FS)


### PR DESCRIPTION
Prototype improved jump jets explode when hit, so add an explosive equipment penalty to BV calculations. Ammo gets a -15 and most other explosive equipment gets -1/slot. Prototype IJJs are getting both the -15 and -1, for a total of -16/slot.