### PR TITLE
Fix armor BV calculation for SV BAR armor

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -1375,25 +1375,28 @@ public class Aero extends Entity implements IAero, IBomber {
             // total armor points
 
             switch (getArmorType(loc)) {
-            case EquipmentType.T_ARMOR_COMMERCIAL:
-                armorMultiplier = 0.5;
-                break;
-            case EquipmentType.T_ARMOR_HARDENED:
-                armorMultiplier = 2.0;
-                break;
-            case EquipmentType.T_ARMOR_REACTIVE:
-            case EquipmentType.T_ARMOR_REFLECTIVE:
-            case EquipmentType.T_ARMOR_BALLISTIC_REINFORCED:
-                armorMultiplier = 1.5;
-                break;
-            case EquipmentType.T_ARMOR_LC_LAMELLOR_FERRO_CARBIDE:
-            case EquipmentType.T_ARMOR_FERRO_LAMELLOR:
-            case EquipmentType.T_ARMOR_ANTI_PENETRATIVE_ABLATION:
-                armorMultiplier = 1.2;
-                break;
-            default:
-                armorMultiplier = 1.0;
-                break;
+                case EquipmentType.T_ARMOR_COMMERCIAL:
+                    armorMultiplier = 0.5;
+                    break;
+                case EquipmentType.T_ARMOR_HARDENED:
+                    armorMultiplier = 2.0;
+                    break;
+                case EquipmentType.T_ARMOR_REACTIVE:
+                case EquipmentType.T_ARMOR_REFLECTIVE:
+                case EquipmentType.T_ARMOR_BALLISTIC_REINFORCED:
+                    armorMultiplier = 1.5;
+                    break;
+                case EquipmentType.T_ARMOR_LC_LAMELLOR_FERRO_CARBIDE:
+                case EquipmentType.T_ARMOR_FERRO_LAMELLOR:
+                case EquipmentType.T_ARMOR_ANTI_PENETRATIVE_ABLATION:
+                    armorMultiplier = 1.2;
+                    break;
+                default:
+                    armorMultiplier = 1.0;
+                    break;
+            }
+            if (hasBARArmor(loc)) {
+                armorMultiplier *= getBARRating(loc) / 10.0;
             }
 
             if (blueShield) {

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -1304,7 +1304,7 @@ public class Tank extends Entity {
             bvText.append(startColumn);
             bvText.append(endColumn);
             bvText.append(startColumn);
-            double armorBV = (getArmor(loc) + modularArmor) * armorMultiplier * (getBARRating(loc) / 10);
+            double armorBV = (getArmor(loc) + modularArmor) * armorMultiplier * (getBARRating(loc) / 10.0);
             bvText.append(armorBV);
             dbv += armorBV;
             bvText.append(endColumn);


### PR DESCRIPTION
All support vehicles with BAR < 10 have incorrect BVs. The BV calculation for support vehicles is using integer division to compute the multiplier for BAR armor, which always makes it zero. Aero (which handles the BV calculations for ConvFighter and FixedWingSupport) does not apply the BAR multiplier at all.