### PR TITLE
Fixed critical slot error in Right Arm of CPLT-C6

### DIFF
--- a/megamek/data/mechfiles/mechs/3050U/Catapult CPLT-C6.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Catapult CPLT-C6.mtf
@@ -54,7 +54,7 @@ Upper Arm Actuator
 ISPlasmaRifle
 ISPlasmaRifle
 ISPlasmaRifle
-ISPlasmaRifle Ammo
+ISPlasmaRifle
 ISPlasmaRifle Ammo
 ISPlasmaRifle Ammo
 ISPlasmaRifle Ammo

--- a/megamek/data/mechfiles/mechs/RS Unique/Hercules Julius.mtf
+++ b/megamek/data/mechfiles/mechs/RS Unique/Hercules Julius.mtf
@@ -12,7 +12,7 @@ Engine:350 XL Engine
 Structure:Standard
 Myomer:Standard
 
-Heat Sinks:10 Double
+Heat Sinks:12 Double
 Walk MP:5
 Jump MP:0
 


### PR DESCRIPTION
Minor change fixing an error in the MTF file for the CPLT-C6.