### PR TITLE
Fix explosive equipment penalty for mech BV

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3710,7 +3710,6 @@ public abstract class Mech extends Entity {
                 continue;
             }
 
-            // CASE II means no subtraction
             if (!hasExplosiveEquipmentPenalty(loc)) {
                 continue;
             }
@@ -3781,7 +3780,24 @@ public abstract class Mech extends Entity {
             }
 
             // we subtract per critical slot
-            toSubtract *= mounted.getCriticals();
+            int criticals;
+            if (mounted.isSplit()) {
+                criticals = 0;
+                for (int l = 0; l < locations(); l++) {
+                    if (((l == mounted.getLocation()) || (l == mounted.getSecondLocation()))
+                            && hasExplosiveEquipmentPenalty(l)) {
+                        for (int i = 0; i < getNumberOfCriticals(l); i++) {
+                            CriticalSlot slot = getCritical(l, i);
+                            if ((slot != null) && mounted.equals(slot.getMount())) {
+                                criticals++;
+                            }
+                        }
+                    }
+                }
+            } else {
+                criticals = mounted.getCriticals();
+            }
+            toSubtract *= criticals;
             ammoPenalty += toSubtract;
         }
         // special case for blueshield, need to check each non-head location

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3373,7 +3373,7 @@ public abstract class Mech extends Entity {
      * @return    Whether explosive equipment in the location should decrease BV
      */
     private boolean hasExplosiveEquipmentPenalty(int loc) {
-        if (hasCASEII(loc)) {
+        if ((loc == Entity.LOC_NONE) || hasCASEII(loc)) {
             return false;
         }
         if (!entityIsQuad() && ((loc == Mech.LOC_RARM) || (loc == Mech.LOC_LARM))) {
@@ -3710,7 +3710,7 @@ public abstract class Mech extends Entity {
                 continue;
             }
 
-            if (!hasExplosiveEquipmentPenalty(loc)) {
+            if (!hasExplosiveEquipmentPenalty(loc) && !hasExplosiveEquipmentPenalty(mounted.getSecondLocation())) {
                 continue;
             }
 


### PR DESCRIPTION
This fixes two issues with calculating the explosive equipment penalty for mechs:
1. Equipment in legs is being treated like equipment in arms.
2. Weapons split between two adjacent locations is treated like it's all in the primary location. For instance, a heavy gauss rifle with two CT crits and the rest side torso are being treated like all crits are in the CT.

Rules summary:
For each crit of explosive equipment in a vulnerable location, subtract 15 for ammo or 1 for other explosive equipment such as gauss rifle.
Any location with CASE II is not vulnerable. Otherwise, a vulnerable location is any head, CT, or leg, or side torso that has >= 3 engine slots, or any location without CASE that has a vulnerable location next on the transfer diagram. This is transitive, so an arm without CASE is vulnerable if the side torso also doesn't have CASE.

See #2313