### PR TITLE
Include explosive equipment penalty for B-pod and M-pod

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3735,7 +3735,9 @@ public abstract class Mech extends Entity {
                     || (etype instanceof CLImprovedHeavyLaserSmall)
                     || (etype instanceof ISRISCHyperLaser)
                     || (etype instanceof TSEMPWeapon)
-                    || (etype instanceof ISMekTaser)) {
+                    || (etype instanceof ISMekTaser)
+                    || (etype.hasFlag(WeaponType.F_B_POD)
+                    || (etype.hasFlag(WeaponType.F_M_POD)))) {
                 toSubtract = 1;
             }
 
@@ -3783,13 +3785,6 @@ public abstract class Mech extends Entity {
             if ((etype instanceof AmmoType)
                     && (mounted.getUsableShotsLeft() == 0)) {
                 continue;
-            }
-
-            // B- and M-Pods shouldn't subtract
-            if ((etype instanceof WeaponType)
-                    && (etype.hasFlag(WeaponType.F_B_POD) || etype
-                            .hasFlag(WeaponType.F_M_POD))) {
-                toSubtract = 0;
             }
 
             // we subtract per critical slot


### PR DESCRIPTION
B-pods and M-pods should be treated as explosive equipment (TW, 304 and TOAUE, 195). The M-Pod reference explicitly states that it should be treated as a gauss weapon when calculating defensive battle rating. The code assigning zero to the explosive penalty is ten years old and last touched eight years ago, but whatever the reason it was added in the first place the current rules state otherwise.

Cf. #2313  