### PR TITLE
don't set ammo count for one-shot weapons on update

### DIFF
--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1204,7 +1204,12 @@ public class EquipChoicePanel extends JPanel {
                 }
                 AmmoType at = m_vTypes.get(n);
                 m_mounted.changeAmmoType(at);
-                m_mounted.setShotsLeft((Integer)m_num_shots.getSelectedItem());
+                
+                // set # shots only for non-one shot weapons
+                if (m_mounted.getLocation() != Entity.LOC_NONE) {
+                    m_mounted.setShotsLeft((Integer)m_num_shots.getSelectedItem());
+                }
+                
                 if (chDump.isSelected()) {
                     m_mounted.setShotsLeft(0);
                 }


### PR DESCRIPTION
Fix #2424 

When editing munitions, swapping ammo type would silently set # of shots for one-shot weapons to the default (max ammo bin size). Don't do that any more.