### PR TITLE
Parse heat sink type correctly in older mtf files

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -6704,13 +6704,13 @@ public abstract class Mech extends Entity {
 
         sb.append(MtfFile.HEAT_SINKS).append(heatSinks()).append(" ");
         if (hasCompactHeatSinks()) {
-            sb.append("Compact");
+            sb.append(MtfFile.HS_COMPACT);
         } else if (hasLaserHeatSinks()) {
-            sb.append("Laser");
+            sb.append(MtfFile.HS_LASER);
         } else if (hasDoubleHeatSinks()) {
-            sb.append("Double");
+            sb.append(MtfFile.HS_DOUBLE);
         } else {
-            sb.append("Single");
+            sb.append(MtfFile.HS_SINGLE);
         }
         sb.append(newLine);
 

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -112,6 +112,10 @@ public class MtfFile implements IMechLoader {
     public static final String RULES_LEVEL = "rules level:";
     public static final String HEAT_SINKS = "heat sinks:";
     public static final String BASE_CHASSIS_HEAT_SINKS = "base chassis heat sinks:";
+    public static final String HS_SINGLE = "Single";
+    public static final String HS_DOUBLE = "Double";
+    public static final String HS_LASER = "Laser";
+    public static final String HS_COMPACT = "Compact";
     public static final String WALK_MP = "walk mp:";
     public static final String JUMP_MP = "jump mp:";
     public static final String ARMOR = "armor:";
@@ -297,11 +301,11 @@ public class MtfFile implements IMechLoader {
 
             mech.setOriginalJumpMP(Integer.parseInt(jumpMP.substring(8)));
 
-            boolean dblSinks = heatSinks.contains("Double");
+            boolean dblSinks = heatSinks.contains(HS_DOUBLE);
 
-            boolean laserSinks = heatSinks.contains("Laser");
+            boolean laserSinks = heatSinks.contains(HS_LASER);
 
-            boolean compactSinks = heatSinks.contains("Compact");
+            boolean compactSinks = heatSinks.contains(HS_COMPACT);
 
             int expectedSinks = Integer.parseInt(heatSinks.substring(11, 13).trim());
 

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -297,11 +297,11 @@ public class MtfFile implements IMechLoader {
 
             mech.setOriginalJumpMP(Integer.parseInt(jumpMP.substring(8)));
 
-            boolean dblSinks = heatSinks.endsWith("Double");
+            boolean dblSinks = heatSinks.contains("Double");
 
-            boolean laserSinks = heatSinks.endsWith("Laser");
+            boolean laserSinks = heatSinks.contains("Laser");
 
-            boolean compactSinks = heatSinks.endsWith("Compact");
+            boolean compactSinks = heatSinks.contains("Compact");
 
             int expectedSinks = Integer.parseInt(heatSinks.substring(11, 13).trim());
 


### PR DESCRIPTION
A while back I changed the code that parses the heat sink type from using `startsWith` on a substring starting at a particular index to `endsWith`, since the previous behavior required a two-digit heat sink count. Non-fusion engines can have fewer. This appeared correct given the way the line is written when generating the mtf, but there are some older mtf files around that include additional unneeded information. So we'll try `contains`.

Fixes #2426