### PR TITLE
ignore gravity/heat when calculating damage levels

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
@@ -164,10 +164,11 @@ public class EntityImage {
         
         int calculatedDamageLevel = entity.getDamageLevel();
         
-        // crippled entities may be "crippled" due to harmless weapon jams or being out of ammo but 
-        // not having taken any actual damage
-        if(calculatedDamageLevel == Entity.DMG_CRIPPLED) {
-            if(entity.getArmorRemainingPercent() >= 1.0) {
+        // entities may be "damaged" or "crippled" due to harmless weapon jams, being out of ammo or otherwise but 
+        // not having taken any actual damage. In this case, it looks stupid for the entity to be all shot up, 
+        // so we pretend there's no damage.
+        if(calculatedDamageLevel > Entity.DMG_NONE) {
+            if((entity.getArmorRemainingPercent() >= 1.0) && (entity.getInternalRemainingPercent() >= 1.0)) {
                 calculatedDamageLevel = Entity.DMG_NONE;
             }
         }

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3484,6 +3484,7 @@ public class Tank extends Entity {
         minorMovementDamage = false;
         moderateMovementDamage = false;
         heavyMovementDamage = false;
+        m_bImmobileHit = false;
     }
 
     public void unlockTurret() {
@@ -4060,7 +4061,8 @@ public class Tank extends Entity {
 
     @Override
     public boolean isDmgHeavy() {
-        if (((double) getWalkMP(false, true) / getOriginalWalkMP()) <= 0.5) {
+        // when checking if MP has been reduced, we want to ignore damage and weather effects
+        if (((double) getMotiveDamage() / getOriginalWalkMP()) >= 0.5) {
             MegaMek.getLogger().debug(getDisplayName()
                     + " Lightly Damaged: Walk MP less than or equal to half the original Walk MP");
             return true;
@@ -4115,7 +4117,8 @@ public class Tank extends Entity {
 
     @Override
     public boolean isDmgLight() {
-        if (getWalkMP(false, true) < getOriginalWalkMP()) {
+        // when checking if MP has been reduced, we want to ignore gravity and various weather effects
+        if (getMotiveDamage() > 0) {
             MegaMek.getLogger().debug(getDisplayName()
                     + " Lightly Damaged: Walk MP less than the original Walk MP");
             return true;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -4061,7 +4061,7 @@ public class Tank extends Entity {
 
     @Override
     public boolean isDmgHeavy() {
-        // when checking if MP has been reduced, we want to ignore damage and weather effects
+        // when checking if MP has been reduced, we want to ignore non-damage effects such as weather/gravity
         if (((double) getMotiveDamage() / getOriginalWalkMP()) >= 0.5) {
             MegaMek.getLogger().debug(getDisplayName()
                     + " Lightly Damaged: Walk MP less than or equal to half the original Walk MP");
@@ -4117,7 +4117,7 @@ public class Tank extends Entity {
 
     @Override
     public boolean isDmgLight() {
-        // when checking if MP has been reduced, we want to ignore gravity and various weather effects
+        // when checking if MP has been reduced, we want to ignore non-damage effects such as weather/gravity
         if (getMotiveDamage() > 0) {
             MegaMek.getLogger().debug(getDisplayName()
                     + " Lightly Damaged: Walk MP less than the original Walk MP");

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -4060,7 +4060,7 @@ public class Tank extends Entity {
 
     @Override
     public boolean isDmgHeavy() {
-        if (((double) getWalkMP() / getOriginalWalkMP()) <= 0.5) {
+        if (((double) getWalkMP(false, true) / getOriginalWalkMP()) <= 0.5) {
             MegaMek.getLogger().debug(getDisplayName()
                     + " Lightly Damaged: Walk MP less than or equal to half the original Walk MP");
             return true;
@@ -4115,7 +4115,7 @@ public class Tank extends Entity {
 
     @Override
     public boolean isDmgLight() {
-        if (getWalkMP() < getOriginalWalkMP()) {
+        if (getWalkMP(false, true) < getOriginalWalkMP()) {
             MegaMek.getLogger().debug(getDisplayName()
                     + " Lightly Damaged: Walk MP less than the original Walk MP");
             return true;


### PR DESCRIPTION
Fixes #2309

Motive damage levels for tanks should (probably) be based only on damage received (or pre-configured) rather than gravity, weather and temporary heat effects.