### PR TITLE
Fix check for legal move when resolving domino effect

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -2053,8 +2053,8 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
                     MovePath stepBackward = new MovePath(client.getGame(), e);
                     stepForward.addStep(MoveStepType.FORWARDS);
                     stepBackward.addStep(MoveStepType.BACKWARDS);
-                    stepForward.compile(client.getGame(), e);
-                    stepBackward.compile(client.getGame(), e);
+                    stepForward.compile(client.getGame(), e, false);
+                    stepBackward.compile(client.getGame(), e, false);
                     
                     String title = Messages.getString("CFRDomino.Title");
                     String msg = Messages.getString("CFRDomino.Message",

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -12845,6 +12845,8 @@ public class Server implements Runnable {
                                 throw new IllegalStateException();
                             }
                             MovePath mp = (MovePath) rp.packet.getData()[1];
+                            mp.setGame(getGame());
+                            mp.setEntity(violation);
                             // Move based on the feedback
                             if (mp != null) {
                                 // Report

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -12845,10 +12845,10 @@ public class Server implements Runnable {
                                 throw new IllegalStateException();
                             }
                             MovePath mp = (MovePath) rp.packet.getData()[1];
-                            mp.setGame(getGame());
-                            mp.setEntity(violation);
                             // Move based on the feedback
                             if (mp != null) {
+                                mp.setGame(getGame());
+                                mp.setEntity(violation);
                                 // Report
                                 r = new Report(2352);
                                 r.indent(3);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -12798,6 +12798,8 @@ public class Server implements Runnable {
             MovePath stepBackwards = new MovePath(game, violation);
             stepForward.addStep(MoveStepType.FORWARDS);
             stepBackwards.addStep(MoveStepType.BACKWARDS);
+            stepForward.compile(getGame(), violation, false);
+            stepBackwards.compile(getGame(), violation, false);
             if ((direction != violation.getFacing())
                     && (direction != ((violation.getFacing() + 3) % 6))
                     && !entity.getIsJumpingNow()


### PR DESCRIPTION
Rules for domino effect are found on TW, 152-3.

In the scenario that generated the NPE, the target of a DFA attack was pushed into a hex containing another mech. The other mech was given the choice to move forward or backward to avoid the domino effect, though there was another mech in the forward hex, so that move should have been illegal. When the two MovePaths are compiled on the client side, clipping is left on, so the illegal step is removed from the forward MovePath. isMoveLegal() returns true, since the illegal move is not there. If selected, the empty path is sent to the server, which expects either a null (no action) or a MovePath with a single move in it.

Not clipping the path when compiling it leaves the step in place and correctly returns false to isMoveLegal(). On the server side, the moves are not compiled before checking whether either is legal. This will correctly validate the end position, but will not evaluate such things as changing elevation by 3+ levels.

Fixes #2430 