### PR TITLE
Filter the unit selector for invalid units

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -142,6 +142,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
     protected boolean enableYearLimits = false;
     protected int allowedYear = ALLOWED_YEAR_ANY;
     protected boolean canonOnly = false;
+    protected boolean allowInvalid = true;
     protected int gameTechLevel = TechConstants.T_SIMPLE_INTRO;
     protected int techLevelDisplayType = TECH_LEVEL_DISPLAY_IS_CLAN;
     //endregion Variable Declarations
@@ -574,6 +575,8 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
                             (!enableYearLimits || (mech.getYear() <= allowedYear))
                             /* Canon */
                             && (!canonOnly || mech.isCanon())
+                            /* Invalid units */
+                            && (allowInvalid || !mech.getLevel().equals("F"))
                             /* Weight */
                             && ((nClass == EntityWeightClass.SIZE) || (nClass == mech.getWeightClass()))
                             /* Technology Level */

--- a/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
@@ -56,6 +56,7 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         enableYearLimits = gameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED);
         allowedYear = gameOptions.intOption(OptionsConstants.ALLOWED_YEAR);
         canonOnly = gameOptions.booleanOption(OptionsConstants.ALLOWED_CANON_ONLY);
+        allowInvalid = gameOptions.booleanOption(OptionsConstants.ALLOWED_ALLOW_ILLEGAL_UNITS);
         gameTechLevel = TechConstants.getSimpleLevel(gameOptions.stringOption("techlevel"));
     }
 


### PR DESCRIPTION
I thought the unit selector filtered out invalid units unless the game options allow them, but the only place the invalid units option is checked is when the server receives a new unit. I think it's reasonable to expect the unit selector to hide invalid units if they're not allowed by the game.

Closes #2436 