### PR TITLE
Fix primitive small craft fuel weight calculation.

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -869,7 +869,7 @@ public class Aero extends Entity implements IAero, IBomber {
 
     public double getFuelPointsPerTon() {
         if (isPrimitive()) {
-            return 80 * primitiveFuelFactor();
+            return 80 / primitiveFuelFactor();
         }
         return 80;
     }


### PR DESCRIPTION
The primitive fuel factor is the extra weight per point of fuel. Since we use it to compute points per ton, we should be dividing by the factor instead of multiplying. The various large craft all override Aero::getFuelPointsPerTon to calculate based on weight, and they all correctly divide.

Fixes MegaMek/megameklab#830