### PR TITLE
Defensive BV for HarJel III should be -1.

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -8230,7 +8230,7 @@ public class MiscType extends EquipmentType {
         misc.cost = 360000;
         misc.flags = misc.flags.or(F_HARJEL_III).or(F_MECH_EQUIPMENT);
         misc.omniFixedOnly = true;
-        misc.bv = -2;
+        misc.bv = -1;
         misc.setInstantModeSwitch(true);
         String[] modes = { S_HARJEL_III_2F2R, S_HARJEL_III_4F0R, S_HARJEL_III_3F1R, S_HARJEL_III_1F3R,
                 S_HARJEL_III_0F4R };


### PR DESCRIPTION
Per IO, p. 191, HarJel II and III each apply -1 to the unit's defensive BV.