### PR TITLE
Bug.#2413 fov darken tooltips

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2834,7 +2834,7 @@ ProtomechMapSet.Destroyed=Destroyed
 
 #Tactical Overlay - Unit field of view displays
 TacticalOverlaySettingsDialog.FovInsideEnabled=Highlight hexes inside Field of View of selected hex based on distance
-TacticalOverlaySettingsDialog.AlphaTooltip=Alpha values range from 0 (transparent) to 255 (opaque).
+TacticalOverlaySettingsDialog.AlphaTooltip=<HTML>Alpha values range from 0 (transparent) to 255 (opaque).<BR/> If sensors are on, half of this value is used to indicate hexes that are in sensor range but don't have LOS.</HTML>
 TacticalOverlaySettingsDialog.FovHighlightAlpha=Opaqueness Field of View overlay:
 TacticalOverlaySettingsDialog.FovHighlightRingsRadii=Sizes of disks that are to be highlighted: 
 TacticalOverlaySettingsDialog.FovHighlightRingsColors=Colors of disks that are to be highlighted (in Hue Saturation Brightness format):
@@ -2842,6 +2842,7 @@ TacticalOverlaySettingsDialog.FovOutsideEnabled=Darken hexes outside Field of Vi
 TacticalOverlaySettingsDialog.FovDarkenAlpha=Opaqueness for outside Field of View overlay:
 TacticalOverlaySettingsDialog.FovStripes=Number of Stripes
 TacticalOverlaySettingsDialog.FovGrayscale=Draw Grayscale
+TacticalOverlaySettingsDialog.FovStripesTooltip=<HTML>Determine nubmer of stripes to create a striped visual effect.  Select 0 for no stripes.<BR/> If sensors are on, hexes that are in sensor range but don't have LOS will be lightly darkened but will not have stripes.</HTML>
 
 #Tank Widget
 TankMapSet.FrontArmor=Front Armor

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -370,6 +370,8 @@ BoardView1.Tooltip.ArtilleryAttack1=Artillery: {0} in 1 turn<BR><FONT SIZE=-2>&n
 BoardView1.Tooltip.ArtilleryAttackN=Artillery: {0} in {2} turns<BR><FONT SIZE=-2>&nbsp;&nbsp;Ammo: {1}</FONT>
 BoardView1.Tooltip.SeenBy=Seen by: {0}
 BoardView1.Tooltip.Sensors=Sensor: {0}
+BoardView1.Tooltip.SensorsHexInRange=Hex is in sensor range
+BoardView1.Tooltip.SensorsHexNotInRange=Hex is <FONT COLOR=RED>not</FONT> in sensor range
 BoardView1.Tooltip.Spotting=Spotting {0}
 BoardView1.Tooltip.Swarmed=<FONT COLOR=#FF0000>Swarmed by {0}</FONT>
 BoardView1.Tooltip.Towing=Towing: {0}

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1570,6 +1570,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         fovDarkenAlpha.addChangeListener(this);
         fovDarkenAlpha.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.AlphaTooltip"));
         darkenAlphaLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovDarkenAlpha")); //$NON-NLS-1$
+        darkenAlphaLabel.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.AlphaTooltip"));
         row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(4,0)));
         row.add(Box.createRigidArea(DEPENDENT_INSET));
@@ -1598,8 +1599,10 @@ public class CommonSettingsDialog extends ClientDialog implements
         numStripesSlider.setPaintLabels(true);
         numStripesSlider.setMaximumSize(new Dimension(250, 100));
         numStripesSlider.addChangeListener(this);
+        numStripesSlider.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.FovStripesTooltip"));
         numStripesLabel = new JLabel(
                 Messages.getString("TacticalOverlaySettingsDialog.FovStripes")); //$NON-NLS-1$
+        numStripesLabel.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.FovStripesTooltip"));
         row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(4,0)));
         row.add(Box.createRigidArea(DEPENDENT_INSET));

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -5810,6 +5810,25 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                             new Object[] { distance }));
                 }
 
+                if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)) {
+                    LosEffects los = fovHighlightingAndDarkening.getCachedLosEffects(selectedEntity.getPosition(), mcoords);
+                    int bracket = Compute.getSensorRangeBracket(selectedEntity, null,
+                            fovHighlightingAndDarkening.cachedAllECMInfo);
+                    int range = Compute.getSensorRangeByBracket(game, selectedEntity, null, los);
+
+                    int maxSensorRange = bracket * range;
+                    int minSensorRange = Math.max((bracket - 1) * range, 0);
+                    if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_INCLUSIVE_SENSOR_RANGE)) {
+                        minSensorRange = 0;
+                    }
+                    txt.append("<BR>");
+                    if ((distance > minSensorRange) && (distance <= maxSensorRange)) {
+                        txt.append(Messages.getString("BoardView1.Tooltip.SensorsHexInRange"));
+                    } else {
+                        txt.append(Messages.getString("BoardView1.Tooltip.SensorsHexNotInRange"));
+                    }
+                }
+
                 if ((game.getPhase() == Phase.PHASE_MOVEMENT) &&
                         (movementTarget != null)) {
                     txt.append("<BR>");
@@ -5821,6 +5840,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                                 new Object[] { disPM }));
                     }
                 }
+
                 txt.append("</FONT></TD></TR></TABLE>"); //$NON-NLS-1$
             }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
@@ -255,7 +255,7 @@ class FovHighlightingAndDarkening {
      * If enviroment has changed between calls to this method the cache is
      * cleared.
      */
-    private LosEffects getCachedLosEffects(Coords src, Coords dest) {
+    public LosEffects getCachedLosEffects(Coords src, Coords dest) {
         ArrayList<StepSprite> pathSprites = boardView1.pathSprites;
         StepSprite lastStepSprite = pathSprites.size() > 0 ? pathSprites
                 .get(pathSprites.size() - 1) : null;

--- a/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
@@ -458,7 +458,7 @@ public class GeneralInfoMapSet implements DisplayMapSet {
             movementTypeR.setVisible(false);
         }
 
-        if ((en.getGame() != null) && en.getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)) {
+        if ((en.getGame() != null) && en.getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)) {
             curSensorsR.setVisible(true);
             visualRangeR.setVisible(true);
             curSensorsL.setVisible(true);


### PR DESCRIPTION
Fixes #2413 

Changes include:

1) Made it so the `UnitDisplay` general tab shows snesor information if the sensor option is on, before it was looking for the double blind option

2) Updated the boardview tooltip so that if sensors are on, the tooltip will indicate whether a hex is or is not in sensor range

3) Added a tooltip to the FOV darkening UI widgets in the client settings dialog that indicates that if sensors are on then in-sensor range hexes will be slightly less darkened.