### PR TITLE
Combo box to select player names when loading saved game

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -550,6 +550,9 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
             newGame = (IGame) xstream.fromXML(gzi);
         } catch (Exception e) {
             MegaMek.getLogger().error("Unable to load file: " + fc.getSelectedFile(), e);
+            JOptionPane.showMessageDialog(frame, Messages.getString("MegaMek.LoadGameAlert.message"),
+            Messages.getString("MegaMek.LoadGameAlert.title"), JOptionPane.ERROR_MESSAGE);
+            return;
         }
 
         Vector<String> playerNames = null;

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -40,13 +40,17 @@ import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.awt.Window;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
+import java.util.Vector;
+import java.util.zip.GZIPInputStream;
 
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
@@ -59,6 +63,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
+
+import com.thoughtworks.xstream.XStream;
 
 import megamek.MegaMek;
 import megamek.client.Client;
@@ -93,6 +99,7 @@ import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.ImageUtil;
+import megamek.common.util.SerializationHelper;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.server.ScenarioLoader;
 import megamek.server.Server;
@@ -536,7 +543,24 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
             // I want a file, y'know!
             return;
         }
-        HostDialog hd = new HostDialog(frame);
+
+        IGame newGame = null;
+        try (InputStream is = new FileInputStream(fc.getSelectedFile()); InputStream gzi = new GZIPInputStream(is)) {
+            XStream xstream = SerializationHelper.getXStream();
+            newGame = (IGame) xstream.fromXML(gzi);
+        } catch (Exception e) {
+            MegaMek.getLogger().error("Unable to load file: " + fc.getSelectedFile(), e);
+        }
+
+        Vector<String> playerNames = null;
+        if (newGame != null) {
+            playerNames = new Vector<>();
+            for (IPlayer player : newGame.getPlayersVector()) {
+                playerNames.add(player.getName());
+            }
+        }
+
+        HostDialog hd = new HostDialog(frame, playerNames);
         hd.setVisible(true);
 
         if (!hd.dataValidation("MegaMek.LoadGameAlert.title")) {
@@ -678,7 +702,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         if (!("".equals(sd.localName))) {
             hasSlot = true;
         }
-        hd.getPlayerNameField().setText(sd.localName);
+        hd.setPlayerName(sd.localName);
         hd.setVisible(true);
 
         if (!hd.dataValidation("MegaMek.HostScenarioAlert.title")) {

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
@@ -141,6 +141,9 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
         } else {
             if (playerNameCombo == null) {
                 playerNameCombo = new JComboBox<String>(playerNames);
+                Dimension preferredSize = playerNameCombo.getPreferredSize();
+                preferredSize.setSize(180, preferredSize.getHeight());
+                playerNameCombo.setPreferredSize(preferredSize);
                 playerNameCombo.setEditable(true);
             }
             playerNameCombo.setSelectedItem(playerName);

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
@@ -32,10 +32,40 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.List;
+import java.awt.event.KeyEvent;
 import java.util.Vector;
 
 public abstract class AbstractGameConnectionDialog extends ClientDialog implements ActionListener {
+
+    /**
+     * We need a way to access the action map for a JComboBox editor, so that we can
+     * have it fire an action when wenter is pressed. This simple class allows this.
+     */
+    public class SimpleComboBoxEditor extends JTextField implements ComboBoxEditor {
+
+        private static final long serialVersionUID = 4496820410417436582L;
+
+        @Override
+        public Component getEditorComponent() {
+            return this;
+        }
+
+        @Override
+        public void setItem(Object anObject) {
+            if (anObject != null) {
+                setText(anObject.toString());
+            } else {
+                setText(null);
+            }
+        }
+
+        @Override
+        public Object getItem() {
+            return getText();
+        }
+
+    }
+
     private static final long serialVersionUID = -5114410402284987181L;
     private String playerName;
     private int port;
@@ -153,7 +183,24 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
         if (playerNames == null) {
             playerNameField.addActionListener(listener);
         } else {
-            playerNameCombo.addActionListener(listener);
+            // Make it so an action is fired when enter is pressed
+            // This is necessary because the default JComboBox ActionEven
+            // can't distinguish between typing and hitting enter
+            // Note, this won't work with multiple action listeners
+            //  but that shouldn't be a problem for these dialogs
+            SimpleComboBoxEditor cbe = new SimpleComboBoxEditor();
+            InputMap im = cbe.getInputMap();
+            ActionMap am = cbe.getActionMap();
+            im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "enter");
+            am.put("enter", new AbstractAction() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    listener.actionPerformed(e);
+                }
+            });
+            playerNameCombo.setEditor(cbe);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/ConnectDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/ConnectDialog.java
@@ -52,8 +52,8 @@ public class ConnectDialog extends AbstractGameConnectionDialog {
         JLabel yourNameL = new JLabel(Messages.getString("MegaMek.yourNameL"), SwingConstants.RIGHT);
         JLabel serverAddrL = new JLabel(Messages.getString("MegaMek.serverAddrL"), SwingConstants.RIGHT);
         JLabel portL = new JLabel(Messages.getString("MegaMek.portL"), SwingConstants.RIGHT);
-        setPlayerNameField(new JTextField(getClientPreferences().getLastPlayerName(), 16));
-        getPlayerNameField().addActionListener(this);
+        setPlayerName(getClientPreferences().getLastPlayerName());
+        addPlayerNameActionListener(this);
         serverAddressField = new JTextField(getClientPreferences().getLastConnectAddr(), 16);
         serverAddressField.addActionListener(this);
         setPortField(new JTextField(getClientPreferences().getLastConnectPort() + "", 4));

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
@@ -22,6 +22,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
+import java.util.Vector;
 
 import javax.swing.JCheckBox;
 import javax.swing.JFrame;
@@ -49,11 +50,11 @@ public class HostDialog extends AbstractGameConnectionDialog {
 
     /** Constructs a host game dialog for hosting or loading a game. */
     public HostDialog(JFrame frame) {
-        this(frame, "");
+        super(frame, Messages.getString("MegaMek.HostDialog.title"), true, "");
     }
 
-    public HostDialog(JFrame frame, String playerName) {
-        super(frame, Messages.getString("MegaMek.HostDialog.title"), true, playerName);
+    public HostDialog(JFrame frame, Vector<String> playerNames) {
+        super(frame, Messages.getString("MegaMek.HostDialog.title"), true, "", playerNames);
     }
 
     //region Initialization
@@ -64,9 +65,9 @@ public class HostDialog extends AbstractGameConnectionDialog {
         JLabel portLabel = new JLabel(Messages.getString("MegaMek.portL"), SwingConstants.RIGHT);
         JLabel metaserverLabel = new JLabel(Messages.getString("MegaMek.metaserverL"), SwingConstants.RIGHT);
 
-        setPlayerNameField(new JTextField(getClientPreferences().getLastPlayerName(), 16));
+        setPlayerName(getClientPreferences().getLastPlayerName());
         playerNameLabel.setLabelFor(getPlayerNameField());
-        getPlayerNameField().addActionListener(this);
+        addPlayerNameActionListener(this);
 
         serverPassField = new JTextField(getClientPreferences().getLastServerPass(), 16);
         serverPassLabel.setLabelFor(serverPassField);
@@ -151,6 +152,11 @@ public class HostDialog extends AbstractGameConnectionDialog {
     public void actionPerformed(ActionEvent e) {
         // reached from the Okay button or pressing Enter in the text fields
         super.actionPerformed(e);
+
+        // We should ignore combo box changed actions
+        if (e.getActionCommand().equals("comboBoxChanged")) {
+            return;
+        }
         setServerPass(serverPassField.getText());
         setRegister(chkRegister.isSelected());
         setMetaserver(metaserverField.getText());

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
@@ -50,11 +50,19 @@ public class HostDialog extends AbstractGameConnectionDialog {
 
     /** Constructs a host game dialog for hosting or loading a game. */
     public HostDialog(JFrame frame) {
-        super(frame, Messages.getString("MegaMek.HostDialog.title"), true, "");
+        this(frame, "", null);
+    }
+
+    public HostDialog(JFrame frame, String playerName) {
+        this(frame, playerName, null);
     }
 
     public HostDialog(JFrame frame, Vector<String> playerNames) {
-        super(frame, Messages.getString("MegaMek.HostDialog.title"), true, "", playerNames);
+        this(frame, "", playerNames);
+    }
+
+    public HostDialog(JFrame frame, String playerName, Vector<String> playerNames) {
+        super(frame, Messages.getString("MegaMek.HostDialog.title"), true, playerName, playerNames);
     }
 
     //region Initialization

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
@@ -153,10 +153,6 @@ public class HostDialog extends AbstractGameConnectionDialog {
         // reached from the Okay button or pressing Enter in the text fields
         super.actionPerformed(e);
 
-        // We should ignore combo box changed actions
-        if (e.getActionCommand().equals("comboBoxChanged")) {
-            return;
-        }
         setServerPass(serverPassField.getText());
         setRegister(chkRegister.isSelected());
         setMetaserver(metaserverField.getText());


### PR DESCRIPTION
For debugging, we get saved games submitted by players.  Generally, we don't know the names of the players in these saved games so it usually creates an annoying workflow of loading the game, finding the player names, then exiting and reloading.  It would be convenient to have the host dialog populate a list of players in the game to select from, but still function the same as the old load dialog.  This pull request adds this functionality.

I read in the serialized game to scrape the list of players and then `AbstractConnectionDialog` was updated such that it can take a list of player names.  If no player name list is passed (aka, null), then everything functions as before, but if the player name list is supplied then a `JComboBox` is used instead of a `JTextField` and the combo box is populated with the list of player names.  It's still editable, so users can use whatever username they want.

It turns out the action events for `JTextField` and `JComboBox` behave differently.  For the `JTextField` it seems that an edit event is only fired when the user hits enter, and the old behavior was based around this (so when you hit enter in the text box, the dialog closes).  With a `JComboBox` anytime you stop typing it fires a `comboBoxEdited` event, but this event can't distinguish between normal typing and enter being pressed.  I created a work around for this, so the behavior is as expected, but the code is a kludgy.   It could definitely be improved.