### PR TITLE
Fix machine gun array linking and bv

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -1841,14 +1841,14 @@ public class Aero extends Entity implements IAero, IBomber {
             }
             // calc MG Array here:
             if (wtype.hasFlag(WeaponType.F_MGA)) {
-                double mgaBV = 0;
-                for (Mounted possibleMG : getTotalWeaponList()) {
-                    if (possibleMG.getType().hasFlag(WeaponType.F_MG)
-                            && (possibleMG.getLocation() == weapon.getLocation())) {
-                        mgaBV += possibleMG.getType().getBV(this);
+                double mgBV = 0;
+                for (int eqNum : weapon.getBayWeapons()) {
+                    Mounted mg = getEquipment(eqNum);
+                    if ((mg != null) && (!mg.isDestroyed())) {
+                        mgBV += mg.getType().getBV(this);
                     }
                 }
-                dBV = mgaBV * 0.67;
+                dBV = mgBV * 0.67;
             }
             bvText.append(startRow);
             bvText.append(startColumn);
@@ -1994,14 +1994,14 @@ public class Aero extends Entity implements IAero, IBomber {
             }
             // calc MG Array here:
             if (wtype.hasFlag(WeaponType.F_MGA)) {
-                double mgaBV = 0;
-                for (Mounted possibleMG : getTotalWeaponList()) {
-                    if (possibleMG.getType().hasFlag(WeaponType.F_MG)
-                            && (possibleMG.getLocation() == mounted.getLocation())) {
-                        mgaBV += possibleMG.getType().getBV(this);
+                double mgBV = 0;
+                for (int eqNum : mounted.getBayWeapons()) {
+                    Mounted mg = getEquipment(eqNum);
+                    if ((mg != null) && (!mg.isDestroyed())) {
+                        mgBV += mg.getType().getBV(this);
                     }
                 }
-                dBV = mgaBV * 0.67;
+                dBV = mgBV * 0.67;
             }
             // artemis bumps up the value
             // PPC caps do, too

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -957,14 +957,14 @@ public class Dropship extends SmallCraft {
                 }
                 // calc MG Array here:
                 if (wtype.hasFlag(WeaponType.F_MGA)) {
-                    double mgaBV = 0;
-                    for (Mounted possibleMG : getTotalWeaponList()) {
-                        if (possibleMG.getType().hasFlag(WeaponType.F_MG)
-                                && (possibleMG.getLocation() == mounted.getLocation())) {
-                            mgaBV += possibleMG.getType().getBV(this);
+                    double mgBV = 0;
+                    for (int eqNum : mounted.getBayWeapons()) {
+                        Mounted mg = getEquipment(eqNum);
+                        if ((mg != null) && (!mg.isDestroyed())) {
+                            mgBV += mg.getType().getBV(this);
                         }
                     }
-                    dBV = mgaBV * 0.67;
+                    dBV = mgBV * 0.67;
                 }
                 // and we'll add the tcomp here too
                 if (wtype.hasFlag(WeaponType.F_DIRECT_FIRE)) {

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4225,15 +4225,14 @@ public abstract class Mech extends Entity {
             }
             // calc MG Array here:
             if (wtype.hasFlag(WeaponType.F_MGA)) {
-                double mgaBV = 0;
-                for (Mounted possibleMG : getWeaponList()) {
-                    if (possibleMG.getType().hasFlag(WeaponType.F_MG)
-                            && (possibleMG.getLocation() == weapon
-                                    .getLocation())) {
-                        mgaBV += possibleMG.getType().getBV(this);
+                double mgBV = 0;
+                for (int eqNum : weapon.getBayWeapons()) {
+                    Mounted mg = getEquipment(eqNum);
+                    if ((mg != null) && (!mg.isDestroyed())) {
+                        mgBV += mg.getType().getBV(this);
                     }
                 }
-                dBV = mgaBV * 0.67;
+                dBV = mgBV * 0.67;
             }
             String name = wtype.getName();
             // artemis bumps up the value
@@ -4537,15 +4536,14 @@ public abstract class Mech extends Entity {
             }
             // calc MG Array here:
             if (wtype.hasFlag(WeaponType.F_MGA)) {
-                double mgaBV = 0;
-                for (Mounted possibleMG : getWeaponList()) {
-                    if (possibleMG.getType().hasFlag(WeaponType.F_MG)
-                            && (possibleMG.getLocation() == mounted
-                                    .getLocation())) {
-                        mgaBV += possibleMG.getType().getBV(this);
+                double mgBV = 0;
+                for (int eqNum : mounted.getBayWeapons()) {
+                    Mounted mg = getEquipment(eqNum);
+                    if ((mg != null) && (!mg.isDestroyed())) {
+                        mgBV += mg.getType().getBV(this);
                     }
                 }
-                dBV = mgaBV * 0.67;
+                dBV = mgBV * 0.67;
             }
 
             // artemis bumps up the value

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -1614,15 +1614,14 @@ public class Tank extends Entity {
 
             // calc MG Array here:
             if (wtype.hasFlag(WeaponType.F_MGA)) {
-                double mgaBV = 0;
-                for (Mounted possibleMG : getWeaponList()) {
-                    if (possibleMG.getType().hasFlag(WeaponType.F_MG)
-                            && (possibleMG.getLocation() == mounted
-                                    .getLocation())) {
-                        mgaBV += possibleMG.getType().getBV(this);
+                double mgBV = 0;
+                for (int eqNum : mounted.getBayWeapons()) {
+                    Mounted mg = getEquipment(eqNum);
+                    if ((mg != null) && (!mg.isDestroyed())) {
+                        mgBV += mg.getType().getBV(this);
                     }
                 }
-                dBV = mgaBV * 0.67;
+                dBV = mgBV * 0.67;
             }
 
             bvText.append(weaponName);

--- a/megamek/unittests/megamek/common/MechFileParserTest.java
+++ b/megamek/unittests/megamek/common/MechFileParserTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 - The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+package megamek.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MechFileParserTest {
+
+    @Test
+    public void splitMGsBetweenMGAs() throws LocationFullException {
+        Mech mech = new BipedMech();
+        Mounted mga1 = mech.addEquipment(EquipmentType.get("ISMGA"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISMG"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISMG"), Mech.LOC_LT);
+        Mounted mga2 = mech.addEquipment(EquipmentType.get("ISMGA"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISMG"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISMG"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISMG"), Mech.LOC_LT);
+
+        MechFileParser.linkMGAs(mech);
+
+        assertEquals(2, mga1.getBayWeapons().size());
+        assertEquals(3, mga2.getBayWeapons().size());
+    }
+
+    @Test
+    public void loadMGAsFromContiguousBlocks() throws LocationFullException {
+        Mech mech = new BipedMech();
+        Mounted mga1 = mech.addEquipment(EquipmentType.get("ISLMGA"), Mech.LOC_LT);
+        Mounted mga2 = mech.addEquipment(EquipmentType.get("ISMGA"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISMG"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISLightMG"), Mech.LOC_LT);
+        mech.addEquipment(EquipmentType.get("ISLightMG"), Mech.LOC_LT);
+        Mounted lastMG = mech.addEquipment(EquipmentType.get("ISMG"), Mech.LOC_LT);
+
+        MechFileParser.linkMGAs(mech);
+
+        // The first MGA should load the second and third, and the second MGA only the first
+        assertEquals(2, mga1.getBayWeapons().size());
+        assertEquals(1, mga2.getBayWeapons().size());
+        assertFalse(mech.hasLinkedMGA(lastMG));
+    }
+}


### PR DESCRIPTION
This fixes some related issues with machine gun arrays. Each array can link up to four machine guns of the same type in the same location. MM uses the bay weapon list in `Mounted` to track which guns are linked. The linking happens in `MechFileParser#postLoadInit`, which is called when the unit is loaded and also called by MML when changes may affect weapon linkings.

Problems:
1. The loop that checks for machine guns to link will link all machine guns of the correct size in the location that have not already been linked until it is full or runs out of guns. This does not allow the unit to split guns between separate arrays. For example, the Linebacker I has two MGAs in each arm, which should each have three MGs. But it always assigns four to the first one and the other two to the remaining one. It is also not possible to have additional unlinked machine guns in the location if the MGA is not full.
2. The BV of a machine gun array is the sum of the linked guns x 0.67. The BV code currently ignores any linking restrictions and includes the BV of all machine guns in the location. So in the case of the Linebacker I, each arm MGA is assigned twice the correct BV.

Fixes:
1. I changed the linking code to look for a contiguous block of qualifying machine guns in the location. Once the first eligible gun is found, any successive slot occupied by anything other than an eligible MG stops the process. So an MGA followed by the linked guns or a block of linked guns followed by the MGA will both work. Placing the MGA in the middle of a block of machine guns will cause the guns preceding the MGA to be linked and those following to be independent. I believe that this fits intuitive behavior.
2. I factored the linking code out of the `postLoadInit` method, which is ~700 lines, which also makes it a distinct unit available for testing.
3. The BV calculations only count the linked guns. This involves functionally identical code in six different places, but I left it to keep the changes minimal since I'm working on a complete rewrite of the BV code. This will fix the bug in the meantime.

Fixes #2195
