### PR TITLE
Issue #2465: Ensure immobility takes into account the crew when applicable

### DIFF
--- a/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
@@ -692,8 +692,8 @@ public class UnitEditorDialog extends JDialog {
         panSystem.add(new JLabel("<html><b>" + Messages.getString("UnitEditorDialog.motiveDamage")
                 + "</b><br></html>"), gridBagConstraints);
         int motiveHits = 0;
-        // FIXME: motive hits arent working quite right
-        if (tank.isImmobile()) {
+        // Do not check the crew when determining if we're immobile here
+        if (tank.isImmobile(false)) {
             motiveHits = 4;
         } else if (tank.hasHeavyMovementDamage()) {
             motiveHits = 3;
@@ -1363,6 +1363,9 @@ public class UnitEditorDialog extends JDialog {
             if (null != motiveCrit) {
                 tank.resetMovementDamage();
                 tank.addMovementDamage(motiveCrit.getHits());
+
+                // Apply movement damage immediately in case we've decided to immobilize the tank
+                tank.applyMovementDamage();
             }
             if ((tank instanceof VTOL) && (null != flightStabilizerCrit)) {
                 if (flightStabilizerCrit.getHits() > 0) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1745,7 +1745,16 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     @Override
     public boolean isImmobile() {
-        return isShutDown() || ((crew != null) && crew.isUnconscious());
+        return isImmobile(true);
+    }
+
+    /**
+     * Is this entity shut down, or if applicable is the crew unconscious?
+     * @param checkCrew If true, consider the fitness of the crew when determining
+     *                  if the entity is immobile.
+     */
+    public boolean isImmobile(boolean checkCrew) {
+        return isShutDown() || (checkCrew && (crew != null) && crew.isUnconscious());
     }
 
     /**

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -505,17 +505,17 @@ public class Tank extends Entity {
     }
 
     @Override
-    public boolean isImmobile() {
+    public boolean isImmobile(boolean checkCrew) {
         if ((game != null)
                 && game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_NO_IMMOBILE_VEHICLES)) {
-            return super.isImmobile();
+            return super.isImmobile(checkCrew);
         }
         //Towed trailers need to reference the tractor, or they return Immobile due to 0 MP...
         //We do run into some double-blind entityList differences though, so include a null check
-        if (isTrailer() && getTractor() != Entity.NONE) {
-            return (game.getEntity(getTractor()) != null ? game.getEntity(getTractor()).isImmobile() : super.isImmobile() || m_bImmobile);
+        if (isTrailer() && (getTractor() != Entity.NONE)) {
+            return (game.getEntity(getTractor()) != null ? game.getEntity(getTractor()).isImmobile(checkCrew) : super.isImmobile(checkCrew) || m_bImmobile);
         }
-        return super.isImmobile() || m_bImmobile;
+        return m_bImmobile || super.isImmobile(checkCrew);
     }
     
     /**
@@ -715,14 +715,23 @@ public class Tank extends Entity {
 
     @Override
     public void applyDamage() {
+        applyMovementDamage();
+
+        super.applyDamage();
+    }
+
+    /**
+     * Applies movement damage to the Tank.
+     */
+    public void applyMovementDamage() {
         m_bImmobile |= m_bImmobileHit;
-        //Towed trailers need to use the values of the tractor, or they return Immobile due to 0 MP...
-        if (isTrailer() && getTractor() != Entity.NONE && game.getEntity(getTractor()).hasETypeFlag(Entity.ETYPE_TANK)) {
+
+        // Towed trailers need to use the values of the tractor, or they return Immobile due to 0 MP...
+        if (isTrailer() && (getTractor() != Entity.NONE) && game.getEntity(getTractor()).hasETypeFlag(Entity.ETYPE_TANK)) {
             Tank Tractor = (Tank) game.getEntity(getTractor());
             m_bImmobile = Tractor.m_bImmobile;
             m_bImmobileHit = Tractor.m_bImmobileHit;
         }
-        super.applyDamage();
     }
 
     @Override
@@ -3484,6 +3493,7 @@ public class Tank extends Entity {
         moderateMovementDamage = false;
         heavyMovementDamage = false;
         m_bImmobileHit = false;
+        m_bImmobile = false;
     }
 
     public void unlockTurret() {


### PR DESCRIPTION
This fixes un-fixable immobility on the MekHQ side for tanks and support tanks, fixing #2465.

Basically we had one~two~ problem~s~:
1. `m_bImmobile` was never cleared or reset when editing a Tank in the `UnitEditorDialog`. I have gone ahead and updated the respective routines to reset this value and apply immobility when instructed by the user.
~2. Even after fixing that issue, if the unit had no crew, `isPermanentlyImmobile` would still return `true` if you explicitly asked to ignore crew effects. This is the more in-depth part of the fix.~

~To fix the second problem, I went ahead and plumbed `ignoreCrew` all the way through your getWalkMP/getRunMP/etc set of methods. I then added `boolean isImmobile(boolean checkCrew)` to Entity, which for Tanks and SupportTanks uses that in its calculation of Walk MP.~

~These fixes together allow you to GM repair motive damage to tanks in MekHQ (or GM Restore Unit).~

A separate issue, not addressed by this PR, is that an uncrewed vehicle will still appear Crippled.