### PR TITLE
Bv weapon heat

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4500,7 +4500,8 @@ public abstract class Mech extends Entity {
             // half heat for streaks
             if ((wtype.getAmmoType() == AmmoType.T_SRM_STREAK)
                     || (wtype.getAmmoType() == AmmoType.T_MRM_STREAK)
-                    || (wtype.getAmmoType() == AmmoType.T_LRM_STREAK)) {
+                    || (wtype.getAmmoType() == AmmoType.T_LRM_STREAK)
+                    || (wtype.getAmmoType() == AmmoType.T_IATM)) {
                 weaponHeat *= 0.5;
             }
             // check to see if the weapon is a PPC and has a Capacitor attached

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -47,6 +47,7 @@ import megamek.common.weapons.lasers.ISRISCHyperLaser;
 import megamek.common.weapons.other.ISMekTaser;
 import megamek.common.weapons.other.TSEMPWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
+import megamek.common.weapons.prototypes.*;
 
 /**
  * You know what mechs are, silly.
@@ -4472,6 +4473,15 @@ public abstract class Mech extends Entity {
                 weaponHeat *= 6;
             }
 
+            // 1d6 extra heat; add half for heat calculations (1d3/+2 for small pulse)
+            if ((wtype instanceof ISERLaserLargePrototype)
+                    || (wtype instanceof ISPulseLaserLargePrototype)
+                    || (wtype instanceof ISPulseLaserMediumPrototype)
+                    || (wtype instanceof ISPulseLaserMediumRecovered)) {
+                weaponHeat += 3;
+            } else if (wtype instanceof ISPulseLaserSmallPrototype) {
+                weaponHeat += 2;
+            }
 
             String name = wtype.getName();
 


### PR DESCRIPTION
Two fixes for heat profile in BV calculation:
1. The iATM is a streak weapon, so only half the heat is counted.
2. Prototype ER and pulse lasers generated an additional random amount of heat each time they are fired, and have the average added to their heat when calculating heat efficiency (IO, 195).

Closes #2313 