### PR TITLE
Fix nag for running in low G when using sprinting rules

### DIFF
--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -376,14 +376,18 @@ public class SharedUtility {
 
             // Check if used more MPs than Mech/Vehicle would have w/o gravity
             if (!i.hasMoreElements() && !firstStep) {
-                if ((entity instanceof Mech) || (entity instanceof VTOL)) {
+                if ((entity instanceof Mech) || (entity instanceof Tank)) {
                     if ((moveType == EntityMovementType.MOVE_WALK)
                             || (moveType == EntityMovementType.MOVE_VTOL_WALK)
                             || (moveType == EntityMovementType.MOVE_RUN)
-                            || (moveType == EntityMovementType  .MOVE_VTOL_RUN)
+                            || (moveType == EntityMovementType.MOVE_VTOL_RUN)
                             || (moveType == EntityMovementType.MOVE_SPRINT)
                             || (moveType == EntityMovementType.MOVE_VTOL_SPRINT)) {
-                        if (step.getMpUsed() > entity.getRunningGravityLimit()) {
+                        int limit = entity.getRunningGravityLimit();
+                        if (step.isOnlyPavement() && entity.isEligibleForPavementBonus()) {
+                            limit++;
+                        }
+                        if (step.getMpUsed() > limit) {
                             rollTarget = entity.checkMovedTooFast(step, overallMoveType);
                             checkNag(rollTarget, nagReport, psrList);
                         }
@@ -411,25 +415,6 @@ public class SharedUtility {
                         }
                         if (step.getMpUsed() > entity.getSprintMP(false, false, false)) {
                             rollTarget = entity.checkMovedTooFast(step, overallMoveType);
-                            checkNag(rollTarget, nagReport, psrList);
-                        }
-                    }
-                } else if (entity instanceof Tank) {
-                    if ((moveType == EntityMovementType.MOVE_WALK)
-                            || (moveType == EntityMovementType.MOVE_RUN)
-                            || (moveType == EntityMovementType.MOVE_SPRINT)) {
-                        // For Tanks, we need to check if the tank had more MPs
-                        // because it was moving along a road
-                        if ((step.getMpUsed() > entity.getRunningGravityLimit()) && !step.isOnlyPavement()) {
-                            rollTarget = entity.checkMovedTooFast(step, overallMoveType);
-                            checkNag(rollTarget, nagReport, psrList);
-                        }
-                        // If the tank was moving on a road, he got a +1 bonus.
-                        // N.B. The Ask Precentor Martial forum said that a 4/6
-                        // tank on a road can move 5/7, **not** 5/8.
-                        else if (step.getMpUsed() > entity.getRunningGravityLimit() + 1) {
-                            rollTarget = entity.checkMovedTooFast(step,
-                                    overallMoveType);
                             checkNag(rollTarget, nagReport, psrList);
                         }
                     }

--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -380,9 +380,10 @@ public class SharedUtility {
                     if ((moveType == EntityMovementType.MOVE_WALK)
                             || (moveType == EntityMovementType.MOVE_VTOL_WALK)
                             || (moveType == EntityMovementType.MOVE_RUN)
-                            || (moveType == EntityMovementType  .MOVE_VTOL_RUN)) {
-                        //TODO: need to adjust for sprinting, but game options are not passed
-                        if (step.getMpUsed() > entity.getRunMP(false, false, false)) {
+                            || (moveType == EntityMovementType  .MOVE_VTOL_RUN)
+                            || (moveType == EntityMovementType.MOVE_SPRINT)
+                            || (moveType == EntityMovementType.MOVE_VTOL_SPRINT)) {
+                        if (step.getMpUsed() > entity.getRunningGravityLimit()) {
                             rollTarget = entity.checkMovedTooFast(step, overallMoveType);
                             checkNag(rollTarget, nagReport, psrList);
                         }
@@ -408,8 +409,6 @@ public class SharedUtility {
                             SharedUtility.checkNag(rollTarget, nagReport,
                                     psrList);
                         }
-                    } else if (moveType == EntityMovementType.MOVE_SPRINT
-                            || moveType == EntityMovementType.MOVE_VTOL_SPRINT) {
                         if (step.getMpUsed() > entity.getSprintMP(false, false, false)) {
                             rollTarget = entity.checkMovedTooFast(step, overallMoveType);
                             checkNag(rollTarget, nagReport, psrList);
@@ -417,22 +416,18 @@ public class SharedUtility {
                     }
                 } else if (entity instanceof Tank) {
                     if ((moveType == EntityMovementType.MOVE_WALK)
-                            || (moveType == EntityMovementType.MOVE_VTOL_WALK)
                             || (moveType == EntityMovementType.MOVE_RUN)
-                            || (moveType == EntityMovementType.MOVE_VTOL_RUN)) {
-
+                            || (moveType == EntityMovementType.MOVE_SPRINT)) {
                         // For Tanks, we need to check if the tank had more MPs
                         // because it was moving along a road
-                        if ((step.getMpUsed() > entity.getRunMP(false, false,
-                                false)) && !step.isOnlyPavement()) {
+                        if ((step.getMpUsed() > entity.getRunningGravityLimit()) && !step.isOnlyPavement()) {
                             rollTarget = entity.checkMovedTooFast(step, overallMoveType);
                             checkNag(rollTarget, nagReport, psrList);
                         }
                         // If the tank was moving on a road, he got a +1 bonus.
                         // N.B. The Ask Precentor Martial forum said that a 4/6
                         // tank on a road can move 5/7, **not** 5/8.
-                        else if (step.getMpUsed() > (entity.getRunMP(false,
-                                false, false) + 1)) {
+                        else if (step.getMpUsed() > entity.getRunningGravityLimit() + 1) {
                             rollTarget = entity.checkMovedTooFast(step,
                                     overallMoveType);
                             checkNag(rollTarget, nagReport, psrList);

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2296,6 +2296,14 @@ public class Tank extends Entity {
     }
 
     @Override
+    public int getRunningGravityLimit() {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_VEHICLE_ADVANCED_MANEUVERS)) {
+            return getSprintMP(false, false, false);
+        }
+        return getRunMP(false, false, false);
+    }
+
+    @Override
     public int getHeatCapacity(boolean radicalHeatSinks) {
         return DOES_NOT_TRACK_HEAT;
     }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -33264,14 +33264,18 @@ public class Server implements Runnable {
                                              int cachedMaxMPExpenditure) {
         PilotingRollData rollTarget;
         if (game.getPlanetaryConditions().getGravity() != 1) {
-            if (entity instanceof Mech) {
+            if ((entity instanceof Mech) || (entity instanceof Tank)) {
                 if ((moveType == EntityMovementType.MOVE_WALK)
                         || (moveType == EntityMovementType.MOVE_VTOL_WALK)
                         || (moveType == EntityMovementType.MOVE_RUN)
                         || (moveType == EntityMovementType.MOVE_SPRINT)
                         || (moveType == EntityMovementType.MOVE_VTOL_RUN)
                         || (moveType == EntityMovementType.MOVE_VTOL_SPRINT)) {
-                    if (step.getMpUsed() > cachedMaxMPExpenditure) {
+                    int limit = cachedMaxMPExpenditure;
+                    if (step.isOnlyPavement() && entity.isEligibleForPavementBonus()) {
+                        limit++;
+                    }
+                    if (step.getMpUsed() > limit) {
                         // We moved too fast, let's make PSR to see if we get
                         // damage
                         game.addExtremeGravityPSR(entity.checkMovedTooFast(
@@ -33304,27 +33308,6 @@ public class Server implements Runnable {
                                 0, "jumped in high gravity"));
                         game.addExtremeGravityPSR(rollTarget);
                     }
-                }
-            } else if (entity instanceof Tank) {
-                if ((moveType == EntityMovementType.MOVE_WALK)
-                        || (moveType == EntityMovementType.MOVE_VTOL_WALK)
-                        || (moveType == EntityMovementType.MOVE_RUN)
-                        || (moveType == EntityMovementType.MOVE_VTOL_RUN)
-                        || (moveType == EntityMovementType.MOVE_SPRINT)
-                        || (moveType == EntityMovementType.MOVE_VTOL_SPRINT)) {
-                    // For Tanks, we need to check if the tank had
-                    // more MPs because it was moving along a road.
-                    if ((step.getMpUsed() > cachedMaxMPExpenditure)
-                        && !step.isOnlyPavement()) {
-                        game.addExtremeGravityPSR(entity.checkMovedTooFast(
-                                step, moveType));
-                    } else if (step.getMpUsed() > (cachedMaxMPExpenditure + 1)) {
-                        // If the tank was moving on a road, he got a +1 bonus.
-                        // N.B. The Ask Precentor Martial forum said that a 4/6
-                        // tank on a road can move 5/7, **not** 5/8.
-                        game.addExtremeGravityPSR(entity.checkMovedTooFast(
-                                step, moveType));
-                    } // End tank-has-road-bonus
                 }
             }
         }


### PR DESCRIPTION
When using the sprinting rules in low G, the player gets a nag screen for running faster than the maximum run/flank MP at 1G or for sprinting faster than the maximum sprint MP at 1G. The server only considers the maximum 1G movement with whatever movement rules are in place. I confirmed with TPTB that the server's behavior is correct and changed the client side check to be consistent with it. I also consolidated some code and fixed some omissions in the process. Vehicles using overdrive movement (advanced maneuvers optional rule) are treated like sprinting mechs, jump-capable vehicles require the PSR when jumping > 1G jump MP, and quadvees in vehicle moving on pavement have the +1 pavement bonus taken into account.

Fixes #2431 