### PR TITLE
Loading transported units in MULs

### DIFF
--- a/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
@@ -395,6 +395,10 @@ public class DeploymentDisplay extends StatusBarPhaseDisplay {
     private void remove() {
         disableButtons();
         clientgui.getClient().sendDeleteEntity(cen);
+        // Also remove units that are carried by the present unit
+        for (Entity carried: clientgui.getClient().getGame().getEntity(cen).getLoadedUnits()) {
+            clientgui.getClient().sendDeleteEntity(carried.getId());
+        }
         cen = Entity.NONE;
     }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9365,12 +9365,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public void setDeployRound(int deployRound) {
         this.deployRound = deployRound;
-        // also set this for any transported units
-        for (Transporter transport : getTransports()) {
-            for (Entity e : transport.getLoadedUnits()) {
-                e.setDeployRound(deployRound);
-            }
-        }
 
         // Entity's that deploy after the start can set their own deploy zone
         // If the deployRound is being set back to 0, make sure we reset the

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -498,12 +498,9 @@ public abstract class Mech extends Entity {
         // if ba_grab_bars is on, then we need to add battlearmor handles,
         // otherwise clamp mounts
         // but first clear out whatever we have
-        Vector<Transporter> et = new Vector<Transporter>(getTransports());
-        for (Transporter t : et) {
-            if (t instanceof BattleArmorHandles) {
-                removeTransporter(t);
-            }
-        }
+        // Removed the removal of transporters so that loaded units don't get ditched
+        // This is an unofficial rule and it doesn't work well anyway as changing the option
+        // does not affect units that are in the game
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_BA_GRAB_BARS)) {
             addTransporter(new BattleArmorHandles());
         } else {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -29982,17 +29982,21 @@ public class Server implements Runnable {
         Set<Entity> transportCorrected = new HashSet<>();
         for (final Entity carrier: entities) {
             for (int carriedId: carrier.getBayLoadedUnitIds()) {
+                // First, see if a bay loaded unit can be found and unloaded,
+                // because it might be the wrong unit
                 Entity carried = game.getEntity(carriedId);
                 if (carried == null) {
                     continue;
                 }
                 int bay = carrier.getBay(carried).getBayNumber();
                 carrier.unload(carried);
+                // Now, load the correct unit if there is one
                 if (idMap.containsKey(carriedId)) {
                     Entity newCarried = game.getEntity(idMap.get(carriedId));
                     if (carrier.canLoad(newCarried, false)) {
                         carrier.load(newCarried, false, bay);
                         newCarried.setTransportId(carrier.getId());
+                        // Remember that the carried unit should not be treated again below
                         transportCorrected.add(newCarried);
                     }
                 }
@@ -30010,7 +30014,7 @@ public class Server implements Runnable {
             int origTrsp = entity.getTransportId();
             // Only act if the unit thinks it is transported
             if (origTrsp != Entity.NONE) {
-                // if the transporter is among the new units, 
+                // If the transporter is among the new units, go on with loading 
                 if (idMap.containsKey(origTrsp)) {
                     // The wrong transporter doesn't know of anything and does not need an update
                     Entity carrier = game.getEntity(idMap.get(origTrsp)); 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -29976,7 +29976,36 @@ public class Server implements Runnable {
         // Cycle through the entities again and update any carried units
         // and carrier units to use the correct server-given IDs.
         // Typically necessary when loading a MUL containing transported units.
+        
+        // First, deal with units loaded into bays. These are saved for the carrier
+        // in MULs and must be restored exactly to recreate the bay loading.
+        Set<Entity> transportCorrected = new HashSet<>();
+        for (final Entity carrier: entities) {
+            for (int carriedId: carrier.getBayLoadedUnitIds()) {
+                Entity carried = game.getEntity(carriedId);
+                if (carried == null) {
+                    continue;
+                }
+                int bay = carrier.getBay(carried).getBayNumber();
+                carrier.unload(carried);
+                if (idMap.containsKey(carriedId)) {
+                    Entity newCarried = game.getEntity(idMap.get(carriedId));
+                    if (carrier.canLoad(newCarried, false)) {
+                        carrier.load(newCarried, false, bay);
+                        newCarried.setTransportId(carrier.getId());
+                        transportCorrected.add(newCarried);
+                    }
+                }
+            }
+        }
+
+        // Now restore the transport settings from the entities' transporter IDs
+        // With anything other than bays, MULs only show the carrier, not the carried units 
         for (final Entity entity: entities) {
+            // Don't correct those that are already corrected
+            if (transportCorrected.contains(entity)) {
+                continue;
+            }
             // Get the original (client side) ID of the transporter
             int origTrsp = entity.getTransportId();
             // Only act if the unit thinks it is transported
@@ -29988,7 +30017,7 @@ public class Server implements Runnable {
                     if (carrier.canLoad(entity, false)) {
                         // The correct transporter must be told it's carrying something and
                         // the carried unit must be told where it is embarked
-                        game.getEntity(idMap.get(origTrsp)).load(entity);
+                        carrier.load(entity, false);
                         entity.setTransportId(idMap.get(origTrsp));
                     } else {
                         // This seems to be an invalid carrier; update the entity accordingly
@@ -30000,7 +30029,21 @@ public class Server implements Runnable {
                 }
             }
         }
-    
+        
+        // Set the "loaded keepers" which is apparently used for deployment unloading to
+        // differentiate between units loaded in the lobby and other carried units
+        // When entering a game from the lobby, this list is generated again, but not when 
+        // the added entities are loaded during a game. When getting loaded units from a MUL,
+        // act as if they were loaded in the lobby.
+        for (final Entity entity: entities) {
+            if (entity.getLoadedUnits().size() > 0) {
+                Vector<Integer> v = new Vector<>();
+                for (Entity en : entity.getLoadedUnits()) {
+                    v.add(en.getId());
+                }
+                entity.setLoadedKeepers(v);
+            }
+        }
 
         send(createAddEntityPacket(entityIds));
     }


### PR DESCRIPTION
Transported units in MULs didn't load correctly when their ID was changed by the server. Now the server reconstructs the correct unit transportation when multiple units are added at once, i.e. when loading a MUL.
Things to note:
- I tested this with Jumpship loading, BA clamp loading, infantry loading, from the lobby, late deployment and ingame reinforcement, unload during deployment and it all seemed to work. Im still sure there are quite a few things and situations I haven't tested and might not work. And looking at the changes this may well be better for post-stable (even though MUL loading with transports is quite broken now)
- Fighter squadrons don't get saved. This is done by an explicit check that makes the saver method skip squadrons. When this check is removed, the squadrons do save but simply don't appear when loaded. I have not looked into this further.
- The server doesn't do much checking when reconstructing the load status. I assume that MULs with transports are saved from the lobby, not hand-assembled. In any case, when something is totally off, things should still work, only the units will simply not be transported.
- When a transport is deleted during deployment, all carried units are deleted as well. This was not so yet (I wonder why) but if it isn't done, the carried units don't deploy but throw NPEs. Also, where would they go otherwise. It is possible to unload them before removing a carrier.
- I removed some code that concerns an unofficial rule (BA grab handles for all meks and tanks). Not the whole thing, only part. It would clear out all "transports" (the handles and clamps), removing carried units with them. The comments already marked this as bad and it is. I admit I have not much love for these unoff rules that simply override a limitation that is part of BT. I'll happily spend effort to remove this rule, when asked.
- I also removed a code part that would set the deployment round for carried units as it doesn't work when reinforcing with bay-loaded units. IMO setting a deployment round for carried units should not be necessary and their deployment round shouldn't matter and shouldn't be asked for. If we need to set it, something's wrong anyway. Better fail immediately.
- Sadly had to add further code to the Server but with IDs overwritten on the server side I couldn't think of a way to handle this gracefully and reliably on the client.
