### PR TITLE
Bridge elevation

### DIFF
--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -513,10 +513,7 @@ public class SharedUtility {
                     || (step.getType() == MoveStepType.LATERAL_LEFT_BACKWARDS)
                     || (step.getType() == MoveStepType.LATERAL_RIGHT_BACKWARDS))
                     && !(md.isJumping() && (entity.getJumpType() == Mech.JUMP_BOOSTER))
-                    && ((lastHex.getLevel() + entity.calcElevation(curHex,
-                            lastHex, step.getElevation(),
-                            md.getFinalClimbMode(), false)) != (curHex
-                            .getLevel() + entity.getElevation()))
+                    && (lastHex.getLevel() + lastElevation != (curHex.getLevel() + step.getElevation()))
                     && !(entity instanceof VTOL)
                     && !(md.getFinalClimbMode()
                             && curHex.containsTerrain(Terrains.BRIDGE) && ((curHex

--- a/megamek/src/megamek/common/actions/ChargeAttackAction.java
+++ b/megamek/src/megamek/common/actions/ChargeAttackAction.java
@@ -128,14 +128,30 @@ public class ChargeAttackAction extends DisplacementAttackAction {
             }
         }
 
+        IHex srcHex = game.getBoard().getHex(src);
         IHex targHex = game.getBoard().getHex(target.getPosition());
         // we should not be using the attacker's hex here since the attacker
         // will end up in
         // the target's hex
-        final int attackerElevation = elevation + targHex.getLevel();
+
+        // If the charge is coming across a bridge, we want the elevation above the bridge rather
+        // than the underlying terrain.
+        final int attackerElevation;
+        if (srcHex.containsTerrain(Terrains.BRIDGE)
+                && (elevation >= srcHex.getTerrain(Terrains.BRIDGE_ELEV).getLevel())) {
+            attackerElevation = elevation + targHex.getLevel() - srcHex.getTerrain(Terrains.BRIDGE_ELEV).getLevel();
+        } else {
+            attackerElevation = elevation + targHex.getLevel();
+        }
         final int attackerHeight = attackerElevation + ae.height();
-        final int targetElevation = target.getElevation()
-                                    + targHex.getLevel();
+        final int targetElevation;
+        if (targHex.containsTerrain(Terrains.BRIDGE)
+                && (target.getElevation() >= targHex.getTerrain(Terrains.BRIDGE_ELEV).getLevel())) {
+            targetElevation = target.getElevation() + targHex.getLevel()
+                    - targHex.getTerrain(Terrains.BRIDGE_ELEV).getLevel();
+        } else {
+            targetElevation = target.getElevation() + targHex.getLevel();
+        }
         final int targetHeight = targetElevation + target.getHeight();
         Building bldg = game.getBoard().getBuildingAt(getTargetPos());
         ToHitData toHit = null;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -8488,11 +8488,7 @@ public class Server implements Runnable {
                     || (step.getType() == MoveStepType.LATERAL_RIGHT_BACKWARDS))
                     && !(md.isJumping()
                             && (entity.getJumpType() == Mech.JUMP_BOOSTER))
-                    && ((lastHex.getLevel()
-                            + entity.calcElevation(curHex, lastHex,
-                                    step.getElevation(), curClimbMode,
-                                    false)) != (curHex.getLevel()
-                                            + entity.getElevation()))
+                    && (lastHex.getLevel() + lastElevation != curHex.getLevel() + step.getElevation())
                     && !(entity instanceof VTOL)
                     && !(curClimbMode
                             && curHex.containsTerrain(Terrains.BRIDGE)


### PR DESCRIPTION
Fixes two issues from incorrectly calculating a moving unit's elevation moving off a bridge.
1. When making a charge attack, against a unit not on the bridge, the attacking unit's elevation on the bridge is added to the level of the hex of the attacking unit, which may cause the charge to be considered illegal.
2. When moving backward off a bridge, the move from the bridge hex to non-bridge hex is treated as a change in elevation. In the fix for this I was able to simplify the code by reusing the calculations that were already performed when compiling the path.

Fixes #2447