### PR TITLE
Errata: aerospace unit crash with no velocity

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -6157,8 +6157,9 @@ public class Server implements Runnable {
                 }
             }
         }
+        // Units with velocity zero are treated like that had velocity two
         if (vel < 1) {
-            vel = 1;
+            vel = 2;
         }
 
         // deal crash damage only once


### PR DESCRIPTION
Per TW corrected 5th printing, p. 81, an aerospace unit with no velocity when it crashes is treated as if it had velocity 2. The rules do not say this is the minimum velocity, so presumably a unit with velocity 1 would still take 2d6 x 10 x 1 damage.

Fixes #2450