### PR TITLE
Ignore armor when checking for rotor equipment without a mast mount

### DIFF
--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -365,7 +365,10 @@ public class TestTank extends TestEntity {
         if (tank instanceof VTOL) {
             if (!tank.hasWorkingMisc(MiscType.F_MAST_MOUNT)) {
                 for (Mounted m : tank.getEquipment()) {
-                    if (m.getLocation() == VTOL.LOC_ROTOR) {
+                    // Units with patchwork armor place any armor slots in the same location
+                    // as the armor. This is for accounting convenience.
+                    if ((m.getLocation() == VTOL.LOC_ROTOR)
+                            && EquipmentType.getArmorType(m.getType()) == EquipmentType.T_ARMOR_UNKNOWN) {
                         buff.append("rotor equipment must be placed in mast mount");
                         correct = false;
                     }


### PR DESCRIPTION
When using bulky armor with patchwork, slots from bulky armor are placed in the same location. In vehicles the location for the armor slots doesn't make any difference since they have a per-unit slot limit, but it's convenient for accounting. These slots should be ignored when checking for illegal equipment in the rotor location.

Fixes MegaMek/megameklab#840