### PR TITLE
prevent weapons firing using right-click menu for hidden units

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -831,10 +831,12 @@ public class MapMenu extends JPopupMenu {
     private JMenu createWeaponsFireMenu() {
         JMenu menu = new JMenu("Weapons");
 
-        /*
-         * if ( myTarget == null || (myTarget instanceof Entity &&
-         * !myEntity.isEnemyOf((Entity)myTarget)) ){ return menu; }
-         */
+        // Hidden entities are not allowed to shoot without being revealed
+        // so let's not give them the option
+        if (myEntity.isHidden()) {
+            return menu;
+        }
+        
         menu.add(createFireJMenuItem());
         menu.add(createSkipJMenuItem());
         menu.add(createAlphaStrikeJMenuItem());


### PR DESCRIPTION
Fixes #2491 by preventing the generation of the weapons menu when the firing unit is hidden.