### PR TITLE
Fix protomech myomer booster BV calculation

### DIFF
--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -1482,10 +1482,15 @@ public class Protomech extends Entity {
         bvText.append(endRow);
 
         // adjust further for speed factor
-        double speedFactor = Math
-                .pow(1 + ((((double) getRunMP(false, true, true) + (Math
-                        .round(Math.max(jumpMP, umuMP) / 2.0))) - 5) / 10), 1.2);
-        speedFactor = Math.round(speedFactor * 100) / 100.0;
+        int mp = getRunMPwithoutMyomerBooster(false, true, true)
+                + (int) Math.round(Math.max(jumpMP, umuMP) / 2.0);
+        // Unlike MASC and superchargers, which use walk x 2 for speed factor, myomer booster adds
+        // one to run + 1/2 jump MP
+        if (hasMyomerBooster()) {
+            mp++;
+        }
+        double speedFactor = Math.round(Math.pow(1 + ((mp - 5) / 10.0), 1.2) * 100.0) / 100.0;
+        calculations[5] = speedFactor;
 
         obv = weaponBV * speedFactor;
         

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -1490,7 +1490,6 @@ public class Protomech extends Entity {
             mp++;
         }
         double speedFactor = Math.round(Math.pow(1 + ((mp - 5) / 10.0), 1.2) * 100.0) / 100.0;
-        calculations[5] = speedFactor;
 
         obv = weaponBV * speedFactor;
         


### PR DESCRIPTION
While most units use full running speed (2xwalk) for MASC or supercharger to calculate BV speed factor, protomechs with myomer booster use normal running + 1, along with half jump/umu as with other units.