### PR TITLE
Use fastest movement mode to calculate infantry BV speed factor

### DIFF
--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1045,21 +1045,8 @@ public class Infantry extends Entity {
         // double weaponbv;
         double obr; //offensive battle rating
 
-        // adjust further for speed factor
-        // this is a bit weird, because the formula gives
-        // a different result than the table, because MASC/TSM
-        // is handled differently (page 315, TM, compare
-        // http://forums.classicbattletech.com/index.php/topic,20468.0.html
-        double speedFactor;
-        double speedFactorTableLookup = getRunMP(false, true, true)
-                + Math.round(Math.max(jumpMP, umuMP) / 2.0);
-        if (speedFactorTableLookup > 25) {
-            speedFactor = Math.pow(1 + ((((double) walkMP
-                + (Math.round(Math.max(jumpMP, umuMP) / 2.0))) - 5) / 10), 1.2);
-        } else {
-            speedFactor = Math
-                    .pow(1 + ((speedFactorTableLookup - 5) / 10), 1.2);
-        }
+        int speedFactorTableLookup = Math.max(getRunMP(false, true, true), Math.max(jumpMP, umuMP));
+        double speedFactor = Math.pow(1 + ((speedFactorTableLookup - 5) / 10.0), 1.2);
         speedFactor = Math.round(speedFactor * 100) / 100.0;
         double wbv = 0;
         if(null != primaryW) {


### PR DESCRIPTION
Unlike other units, which use ground + half jump/umu to calculate speed factor, conventional infantry use their fastest mode. In most cases this makes no difference, since those that have jump MP move at 1/1/3 and 1+3/2 rounds to 3. But SCUBA and mechanized VTOL are incorrect.