### PR TITLE
let units activating during movement phase move

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.TreeMap;
 import java.util.Vector;
 
+import megamek.common.IGame.Phase;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.logging.MMLogger;
@@ -3187,8 +3188,10 @@ public class MoveStep implements Serializable {
             return false;
         }
 
-        // Hidden units, and activating hidden units cannot move
-        if (entity.isHidden() || entity.isHiddenActivating()) {
+        // Hidden units, and activating hidden units cannot move 
+        // unless it is the movement phase and the plan is to activate then
+        // if we're in this method, we're implicitly in the movement phase
+        if (entity.isHidden() || (entity.isHiddenActivating() && (entity.hiddenActivationPhase != Phase.PHASE_MOVEMENT))) {
             return false;
         }
 


### PR DESCRIPTION
Fixes #2497

Pretty straight forward, per BMM and TM, you can declare that a unit will activate at the beginning of the movement phase and then move it as normal during the phase. This doesn't change existing behavior of you having to slightly pre-plan your unit activation, but it does let you actually move a unit that's been set to activate during the movement phase.