### PR TITLE
Two talon bugs

### DIFF
--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -593,42 +593,18 @@ public class MechFileParser {
             }
 
             if (m.getType().hasFlag(MiscType.F_TALON)) {
-                if (ent instanceof BipedMech) {
-                    if ((m.getLocation() != Mech.LOC_LLEG)
-                            && (m.getLocation() != Mech.LOC_RLEG)) {
-                        throw new EntityLoadingException(
-                                "Talons are only legal in the Legs for "+ent.getShortName());
+                if (ent instanceof Mech) {
+                    if (!ent.locationIsLeg(m.getLocation())) {
+                        throw new EntityLoadingException("Talons are only legal in the Legs for " + ent.getShortName());
                     }
-
-                    if (!ent.hasWorkingMisc(MiscType.F_TALON, -1, Mech.LOC_RLEG)
-                            || !ent.hasWorkingMisc(MiscType.F_TALON, -1,
-                                    Mech.LOC_LLEG)) {
-                        throw new EntityLoadingException(
-                                "Talons must be in all legs for "+ent.getShortName());
+                    for (int loc = 0; loc < ent.locations(); loc++) {
+                        if (ent.locationIsLeg(loc) && !ent.hasWorkingMisc(MiscType.F_TALON, -1, loc)) {
+                            throw new EntityLoadingException("Talons must be in all legs for " + ent.getShortName());
+                        }
                     }
-                } else if (ent instanceof QuadMech) {
-                    if ((m.getLocation() != Mech.LOC_LLEG)
-                            && (m.getLocation() != Mech.LOC_RLEG)
-                            && (m.getLocation() != Mech.LOC_LARM)
-                            && (m.getLocation() != Mech.LOC_RARM)) {
-                        throw new EntityLoadingException(
-                                "Talons are only legal in the Legs for "+ent.getShortName());
-                    }
-
-                    if (!ent.hasWorkingMisc(MiscType.F_TALON, -1, Mech.LOC_RLEG)
-                            || !ent.hasWorkingMisc(MiscType.F_TALON, -1,
-                                    Mech.LOC_LLEG)
-                            || !ent.hasWorkingMisc(MiscType.F_TALON, -1,
-                                    Mech.LOC_LARM)
-                            || !ent.hasWorkingMisc(MiscType.F_TALON, -1,
-                                    Mech.LOC_LARM)) {
-                        throw new EntityLoadingException(
-                                "Talons must be in all legs for "+ent.getShortName());
-                    }
-
                 } else {
-                    throw new EntityLoadingException(
-                            "Unable to load talons in non-Mek entity for "+ent.getShortName());
+                    throw new EntityLoadingException("Unable to load talons in non-Mek entity for "
+                            + ent.getShortName());
                 }
             }
 

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1001,11 +1001,11 @@ public class TestMech extends TestEntity {
             }
             
             if (m.getType().hasFlag(MiscType.F_TALON)) {
+                int slots = getMech().isSuperHeavy() ? 1 : 2;
                 for (int loc = 0; loc < mech.locations(); loc++) {
-                    if (mech.locationIsLeg(loc)
-                            && countCriticalSlotsFromEquipInLocation(mech, m, loc) != 2) {
+                    if (mech.locationIsLeg(loc) && countCriticalSlotsFromEquipInLocation(mech, m, loc) != slots) {
                         illegal = true;
-                        buff.append("Talons require two critical slots in each leg.\n");
+                        buff.append("Talons require").append(slots).append(" critical slots in each leg.\n");
                         break;
                     }
                 }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1005,7 +1005,7 @@ public class TestMech extends TestEntity {
                 for (int loc = 0; loc < mech.locations(); loc++) {
                     if (mech.locationIsLeg(loc) && countCriticalSlotsFromEquipInLocation(mech, m, loc) != slots) {
                         illegal = true;
-                        buff.append("Talons require").append(slots).append(" critical slots in each leg.\n");
+                        buff.append("Talons require ").append(slots).append(" critical slots in each leg.\n");
                         break;
                     }
                 }


### PR DESCRIPTION
This fixes two bugs with loading and validating mechs with talons:
1. Superheavies only require one slot in each leg for talons.
2. During post-load init, anything that is not a biped or quad is treated as a non-mech, which results in tripod mechs with talons throwing an EntityLoadingException.

Fixes MegaMek/megameklab#844