### PR TITLE
prevent bot from auto-killing gun emplacements

### DIFF
--- a/megamek/src/megamek/client/bot/PhysicalCalculator.java
+++ b/megamek/src/megamek/client/bot/PhysicalCalculator.java
@@ -21,6 +21,7 @@ import megamek.common.BuildingTarget;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
+import megamek.common.GunEmplacement;
 import megamek.common.IGame;
 import megamek.common.IHex;
 import megamek.common.INarcPod;
@@ -312,7 +313,7 @@ public final class PhysicalCalculator {
         Targetable target = to;
         
         // if the object of our affections is in a building, we have to target the building instead
-        if(Compute.isInBuilding(game, to)) {
+        if(Compute.isInBuilding(game, to) || (to instanceof GunEmplacement)) {
             target = new BuildingTarget(to.getPosition(), game.getBoard(), false);
         }
         
@@ -599,7 +600,7 @@ public final class PhysicalCalculator {
         Targetable target = to;
         
         // if the object of our affections is in a building, we have to target the building instead
-        if(Compute.isInBuilding(game, to)) {
+        if(Compute.isInBuilding(game, to) || (to instanceof GunEmplacement)) {
             target = new BuildingTarget(to.getPosition(), game.getBoard(), false);
         }
         


### PR DESCRIPTION
Fixes #1954 - the bot would actually target gun emplacements directly with physical attacks, resulting in an insta-kill, because sometimes they didn't count as being inside the building. Now it is forced to target the building.