### PR TITLE
update turret crit bark; implement equipment hit

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -470,7 +470,8 @@
 3820=<font color='C00000'>Turret locked.</font>
 3825=<font color='C00000'>Turret jammed.</font>
 3830=<font color='C00000'>Ammunition explosion! <data> takes <data> damage, reducing its CF to <data>.</font>
-3835=<font color='C00000'>Equipment hit.</font>
+3831=<font color='C00000'>Ammunition explosion</font> - no effect.
+3835=<font color='C00000'>Equipment hit</font> - no effect.
 3840=<font color='C00000'><data> is hit!</font>
 3841=<font color='C00000'>Weapon hit, but no functional weapons remaining.</font>
 3845=<font color='C00000'><data> jams!</font>

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -32704,7 +32704,7 @@ public class Server implements Runnable {
         r.indent(0);
         vDesc.add(r);
 
-        int critRoll = 12;//Compute.d6(2);
+        int critRoll = Compute.d6(2);
         if (critRoll < 6) {
             r = new Report(3805);
             r.type = Report.PUBLIC;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -32704,7 +32704,7 @@ public class Server implements Runnable {
         r.indent(0);
         vDesc.add(r);
 
-        int critRoll = Compute.d6(2);
+        int critRoll = 12;//Compute.d6(2);
         if (critRoll < 6) {
             r = new Report(3805);
             r.type = Report.PUBLIC;
@@ -32820,6 +32820,15 @@ public class Server implements Runnable {
                 }
             }
             boom = (int) Math.floor(bldg.getDamageToScale() * boom);
+            
+            if (boom == 0) {
+                Report rNoAmmo = new Report(3831);
+                rNoAmmo.type = Report.PUBLIC;
+                rNoAmmo.indent(1);
+                vDesc.add(rNoAmmo);
+                return vDesc;
+            }
+            
             r.add(boom);
             int curCF = bldg.getCurrentCF(coords);
             curCF -= Math.min(curCF, boom);
@@ -32866,15 +32875,32 @@ public class Server implements Runnable {
                 vDesc.add(r);
             }
         } else if (critRoll == 12) {
-            // other
-            r = new Report(3835);
-            r.type = Report.PUBLIC;
-            r.indent(1);
+            // non-weapon equipment is hit
+            Vector<Mounted> equipmentList = new Vector<>();
+            for (GunEmplacement gun : guns) {
+                for (Mounted equipment : gun.getMisc()) {
+                    if (!equipment.isHit()) {
+                        equipmentList.add(equipment);
+                    }
+                }
+            }
+            
+            if (equipmentList.size() > 0) {
+                Mounted equipment = equipmentList.elementAt(Compute.randomInt(equipmentList.size()));
+                equipment.setHit(true);
+                r = new Report(3840);
+                r.type = Report.PUBLIC;
+                r.indent(1);
+                r.add(equipment.getDesc());
+            } else {
+                r = new Report(3835);
+                r.type = Report.PUBLIC;
+                r.indent(1);
+            }
             vDesc.add(r);
         }
 
         return vDesc;
-
     }
 
     public void sendChangedBuildings(Vector<Building> buildings) {


### PR DESCRIPTION
Two changes:

If an ammo explosion hit on a turret results in no damage for whatever reason, give an explicit message.

Also, implement non-weapon and non-ammo crits on turrets (e.g. ECM suites, etc) instead of an "equipment hit" message that does nothing.

Fixes #2510 and #907