### PR TITLE
Check Small Pilot ability to AirMech/Aero Pilot Skill Roll.

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -2685,7 +2685,8 @@ public class Aero extends Entity implements IAero, IBomber {
 
         // Small/torso-mounted cockpit penalty?
         if ((getCockpitType() == Aero.COCKPIT_SMALL)
-                && !hasAbility(OptionsConstants.MD_BVDNI)) {
+                && (!hasAbility(OptionsConstants.MD_BVDNI)
+                && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             prd.addModifier(1, "Small Cockpit");
         }
 

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -2685,8 +2685,8 @@ public class Aero extends Entity implements IAero, IBomber {
 
         // Small/torso-mounted cockpit penalty?
         if ((getCockpitType() == Aero.COCKPIT_SMALL)
-                && (!hasAbility(OptionsConstants.MD_BVDNI)
-                        && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
+                && !hasAbility(OptionsConstants.MD_BVDNI)
+                && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT)) {
             prd.addModifier(1, "Small Cockpit");
         }
 

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -2686,7 +2686,7 @@ public class Aero extends Entity implements IAero, IBomber {
         // Small/torso-mounted cockpit penalty?
         if ((getCockpitType() == Aero.COCKPIT_SMALL)
                 && (!hasAbility(OptionsConstants.MD_BVDNI)
-                && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
+                        && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             prd.addModifier(1, "Small Cockpit");
         }
 

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -718,7 +718,7 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
         // Small/torso-mounted cockpit penalty?
         if ((getCockpitType() == Mech.COCKPIT_SMALL)
                 && (!hasAbility(OptionsConstants.MD_BVDNI)
-                && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
+                        && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             roll.addModifier(1, "Small Cockpit");
         }
 

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -717,8 +717,8 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
 
         // Small/torso-mounted cockpit penalty?
         if ((getCockpitType() == Mech.COCKPIT_SMALL)
-                && (!hasAbility(OptionsConstants.MD_BVDNI)
-                        && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
+                && !hasAbility(OptionsConstants.MD_BVDNI)
+                && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT)) {
             roll.addModifier(1, "Small Cockpit");
         }
 

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -717,7 +717,8 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
 
         // Small/torso-mounted cockpit penalty?
         if ((getCockpitType() == Mech.COCKPIT_SMALL)
-                && !hasAbility(OptionsConstants.MD_BVDNI)) {
+                && (!hasAbility(OptionsConstants.MD_BVDNI)
+                && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             roll.addModifier(1, "Small Cockpit");
         }
 


### PR DESCRIPTION
It may fix #2512. While battlemechs are checks Small Pilot for determine the penalty of Small Cockpit, Land-Air Mech and Aero units lacks the same check so the penalty is applied whatever the pilot has Small Pilot or not. Currently, these two units only check Small Pilot for the penalty of cramped cockpit check.