### PR TITLE
Issue #2517: Ensure AmmoType::canSwitchToAmmo ignores munition types

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15897,16 +15897,19 @@ public class AmmoType extends EquipmentType {
         
         AmmoType currentAmmoType = (AmmoType) weapon.getLinked().getType();
         
+        // Ammo of the same type and rack size should be allowed
         boolean ammoOfSameType = currentAmmoType.equalsAmmoTypeOnly(otherAmmo)
                 && (currentAmmoType.getRackSize() == otherAmmo.getRackSize());
         
         // MMLs can swap between different specific ammo types, so we have a special case check here
         boolean mmlAmmoMatch = (currentAmmoType.getAmmoType() == AmmoType.T_MML)
-                && (otherAmmo.getAmmoType() == AmmoType.T_MML);
+                && (otherAmmo.getAmmoType() == AmmoType.T_MML)
+                && (currentAmmoType.getRackSize() == otherAmmo.getRackSize());
         
         // LBXs can swap between cluster and slug ammo types
         boolean lbxAmmoMatch = (currentAmmoType.getAmmoType() == AmmoType.T_AC_LBX)
-                && (otherAmmo.getAmmoType() == AmmoType.T_AC_LBX);
+                && (otherAmmo.getAmmoType() == AmmoType.T_AC_LBX)
+                && (currentAmmoType.getRackSize() == otherAmmo.getRackSize());
         
         boolean caselessLoaded = currentAmmoType.getMunitionType() == AmmoType.M_CASELESS;
         boolean otherBinCaseless = otherAmmo.getMunitionType() == AmmoType.M_CASELESS;

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15897,17 +15897,16 @@ public class AmmoType extends EquipmentType {
         
         AmmoType currentAmmoType = (AmmoType) weapon.getLinked().getType();
         
-        boolean ammoOfSameType = currentAmmoType.equals(otherAmmo);
+        boolean ammoOfSameType = currentAmmoType.equalsAmmoTypeOnly(otherAmmo)
+                && currentAmmoType.getRackSize() == otherAmmo.getRackSize();
         
         // MMLs can swap between different specific ammo types, so we have a special case check here
         boolean mmlAmmoMatch = currentAmmoType.getAmmoType() == AmmoType.T_MML &&
-                otherAmmo.getAmmoType() == AmmoType.T_MML &&
-                currentAmmoType.getRackSize() == otherAmmo.getRackSize();
+                otherAmmo.getAmmoType() == AmmoType.T_MML;
         
         // LBXs can swap between cluster and slug ammo types
         boolean lbxAmmoMatch = currentAmmoType.getAmmoType() == AmmoType.T_AC_LBX &&
-                otherAmmo.getAmmoType() == AmmoType.T_AC_LBX &&
-                currentAmmoType.getRackSize() == otherAmmo.getRackSize();
+                otherAmmo.getAmmoType() == AmmoType.T_AC_LBX;
         
         boolean caselessLoaded = currentAmmoType.getMunitionType() == AmmoType.M_CASELESS;
         boolean otherBinCaseless = otherAmmo.getMunitionType() == AmmoType.M_CASELESS;

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15898,15 +15898,15 @@ public class AmmoType extends EquipmentType {
         AmmoType currentAmmoType = (AmmoType) weapon.getLinked().getType();
         
         boolean ammoOfSameType = currentAmmoType.equalsAmmoTypeOnly(otherAmmo)
-                && currentAmmoType.getRackSize() == otherAmmo.getRackSize();
+                && (currentAmmoType.getRackSize() == otherAmmo.getRackSize());
         
         // MMLs can swap between different specific ammo types, so we have a special case check here
-        boolean mmlAmmoMatch = currentAmmoType.getAmmoType() == AmmoType.T_MML &&
-                otherAmmo.getAmmoType() == AmmoType.T_MML;
+        boolean mmlAmmoMatch = (currentAmmoType.getAmmoType() == AmmoType.T_MML)
+                && (otherAmmo.getAmmoType() == AmmoType.T_MML);
         
         // LBXs can swap between cluster and slug ammo types
-        boolean lbxAmmoMatch = currentAmmoType.getAmmoType() == AmmoType.T_AC_LBX &&
-                otherAmmo.getAmmoType() == AmmoType.T_AC_LBX;
+        boolean lbxAmmoMatch = (currentAmmoType.getAmmoType() == AmmoType.T_AC_LBX)
+                && (otherAmmo.getAmmoType() == AmmoType.T_AC_LBX);
         
         boolean caselessLoaded = currentAmmoType.getMunitionType() == AmmoType.M_CASELESS;
         boolean otherBinCaseless = otherAmmo.getMunitionType() == AmmoType.M_CASELESS;

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -277,6 +277,23 @@ public class FireControlTest {
         Mockito.when(mockAmmoAc5Flechette.getType()).thenReturn(mockAmmoTypeAc5Flechette);
         Mockito.when(mockAmmoAc5Flechette.isAmmoUsable()).thenReturn(true);
 
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Std).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Std));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Std).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Flak));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Std).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Incendiary));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Std).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAc5Flechette));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Flak).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Std));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Flak).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Flak));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Flak).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Incendiary));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Flak).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAc5Flechette));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Incendiary).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Std));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Incendiary).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Flak));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Incendiary).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Incendiary));
+        Mockito.doReturn(true).when(mockAmmoTypeAC5Incendiary).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAc5Flechette));
+        Mockito.doReturn(true).when(mockAmmoTypeAc5Flechette).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Std));
+        Mockito.doReturn(true).when(mockAmmoTypeAc5Flechette).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Flak));
+        Mockito.doReturn(true).when(mockAmmoTypeAc5Flechette).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAC5Incendiary));
+        Mockito.doReturn(true).when(mockAmmoTypeAc5Flechette).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAc5Flechette));
+
         // LB10X
         mockLB10X = Mockito.mock(WeaponType.class);
         mockAmmoTypeLB10XSlug = Mockito.mock(AmmoType.class);
@@ -294,6 +311,11 @@ public class FireControlTest {
         Mockito.when(mockAmmoTypeLB10XCluster.getMunitionType()).thenReturn(AmmoType.M_CLUSTER);
         Mockito.when(mockAmmoLB10XCluster.getType()).thenReturn(mockAmmoTypeLB10XCluster);
         Mockito.when(mockAmmoLB10XCluster.isAmmoUsable()).thenReturn(true);
+
+        Mockito.doReturn(true).when(mockAmmoTypeLB10XSlug).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLB10XSlug));
+        Mockito.doReturn(true).when(mockAmmoTypeLB10XSlug).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLB10XCluster));
+        Mockito.doReturn(true).when(mockAmmoTypeLB10XCluster).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLB10XSlug));
+        Mockito.doReturn(true).when(mockAmmoTypeLB10XCluster).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLB10XCluster));
 
         // MML
         mockMML5 = Mockito.mock(MMLWeapon.class);
@@ -327,6 +349,23 @@ public class FireControlTest {
         Mockito.when(mockAmmoTypeLrm5Frag.getAmmoType()).thenReturn(AmmoType.T_MML);
         Mockito.when(mockAmmoLrm5Frag.getType()).thenReturn(mockAmmoTypeLrm5Frag);
         Mockito.when(mockAmmoLrm5Frag.isAmmoUsable()).thenReturn(true);
+
+        Mockito.doReturn(true).when(mockAmmoTypeSRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeSRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeSRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeSRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeInferno5));
+        Mockito.doReturn(true).when(mockAmmoTypeSRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLrm5Frag));
+        Mockito.doReturn(true).when(mockAmmoTypeLRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeSRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeLRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeLRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeInferno5));
+        Mockito.doReturn(true).when(mockAmmoTypeLRM5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLrm5Frag));
+        Mockito.doReturn(true).when(mockAmmoTypeInferno5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeSRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeInferno5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeInferno5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeInferno5));
+        Mockito.doReturn(true).when(mockAmmoTypeInferno5).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLrm5Frag));
+        Mockito.doReturn(true).when(mockAmmoTypeLrm5Frag).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeSRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeLrm5Frag).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLRM5));
+        Mockito.doReturn(true).when(mockAmmoTypeLrm5Frag).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeInferno5));
+        Mockito.doReturn(true).when(mockAmmoTypeLrm5Frag).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeLrm5Frag));
 
         // ATM
         mockAtm5Weapon = Mockito.mock(Mounted.class);
@@ -362,6 +401,23 @@ public class FireControlTest {
         Mockito.when(mockAmmoTypeAtm5Inferno.getRackSize()).thenReturn(5);
         Mockito.when(mockAmmoAtm5Inferno.getType()).thenReturn(mockAmmoTypeAtm5Inferno);
         Mockito.when(mockAmmoAtm5Inferno.isAmmoUsable()).thenReturn(true);
+
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5He).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5He));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5He).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5St));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5He).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Er));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5He).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Inferno));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5St).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5He));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5St).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5St));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5St).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Er));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5St).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Inferno));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Er).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5He));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Er).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5St));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Er).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Er));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Er).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Inferno));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Inferno).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5He));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Inferno).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5St));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Inferno).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Er));
+        Mockito.doReturn(true).when(mockAmmoTypeAtm5Inferno).equalsAmmoTypeOnly(Mockito.eq(mockAmmoTypeAtm5Inferno));
 
         shooterWeapons = new ArrayList<>(3);
         Mockito.when(mockShooter.getWeaponList()).thenReturn(shooterWeapons);

--- a/megamek/unittests/megamek/common/AmmoTypeTest.java
+++ b/megamek/unittests/megamek/common/AmmoTypeTest.java
@@ -64,8 +64,10 @@ public class AmmoTypeTest {
         Mockito.when(mockAC5AmmoType.getRackSize()).thenReturn(5);
         Mockito.when(mockSRM4AmmoType.getAmmoType()).thenReturn(AmmoType.T_SRM);
         Mockito.when(mockSRM4AmmoType.getRackSize()).thenReturn(4);
+        Mockito.when(mockSRM4AmmoType.getMunitionType()).thenReturn(AmmoType.M_STANDARD);
         Mockito.when(mockInferno4AmmoType.getAmmoType()).thenReturn(AmmoType.T_SRM);
         Mockito.when(mockInferno4AmmoType.getRackSize()).thenReturn(4);
+        Mockito.when(mockInferno4AmmoType.getMunitionType()).thenReturn(AmmoType.M_INFERNO);
         Mockito.when(mockAC10AmmoType.getAmmoType()).thenReturn(AmmoType.T_AC);
         Mockito.when(mockAC10AmmoType.getRackSize()).thenReturn(10);
         Mockito.when(mockSRM6AmmoType.getAmmoType()).thenReturn(AmmoType.T_SRM);
@@ -85,6 +87,11 @@ public class AmmoTypeTest {
         Mockito.when(mockAmmoAC5Empty.isAmmoUsable()).thenReturn(false);
 
         Mockito.when(mockNotAmmo.getType()).thenReturn(notAmmoType);
+
+        Mockito.doReturn(true).when(mockSRM4AmmoType).equalsAmmoTypeOnly(Mockito.eq(mockSRM4AmmoType));
+        Mockito.doReturn(true).when(mockSRM4AmmoType).equalsAmmoTypeOnly(Mockito.eq(mockInferno4AmmoType));
+        Mockito.doReturn(true).when(mockInferno4AmmoType).equalsAmmoTypeOnly(Mockito.eq(mockInferno4AmmoType));
+        Mockito.doReturn(true).when(mockInferno4AmmoType).equalsAmmoTypeOnly(Mockito.eq(mockSRM4AmmoType));
     }
 
     @Test
@@ -111,5 +118,15 @@ public class AmmoTypeTest {
 
         // Test something that's not ammo.
         Assert.assertFalse(AmmoType.isAmmoValid(mockNotAmmo, mockAC5));
+    }
+
+    @Test
+    public void testCanSwitchToAmmo() {
+        Mounted mockWeapon = Mockito.mock(Mounted.class);
+        Mockito.when(mockWeapon.getLinked()).thenReturn(mockAmmoSrm4);
+
+        Assert.assertTrue(AmmoType.canSwitchToAmmo(mockWeapon, mockInferno4AmmoType));
+
+        Assert.assertFalse(AmmoType.canSwitchToAmmo(mockWeapon, mockSRM6AmmoType));
     }
 }


### PR DESCRIPTION
This makes sure that `AmmoType::canSwitchToAmmo` ignores munition types, fixing #2517.