### PR TITLE
Open up Compute and MMRandom to allow mocking in tests

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Vector;
 
@@ -215,6 +216,15 @@ public class Compute {
      */
     public static void setRNG(int type) {
         random = MMRandom.generate(type);
+    }
+
+    /**
+     * Sets the RNG to the specific instance.
+     * @param random A non-null instance of {@see MMRandom} to use
+     *               for all random number generation.
+     */
+    public static void setRNG(MMRandom random) {
+        Compute.random = Objects.requireNonNull(random);
     }
 
     /**

--- a/megamek/src/megamek/common/MMRandom.java
+++ b/megamek/src/megamek/common/MMRandom.java
@@ -72,7 +72,7 @@ public abstract class MMRandom {
      * @throws IllegalArgumentException will be thrown if the
      *             input is <= 0.
      */
-    Roll d6(int nDice) {
+    public Roll d6(int nDice) {
         if (0 >= nDice) {
             throw new IllegalArgumentException(
                     "Must ask for a positive number of rolls, not " + nDice);
@@ -86,7 +86,7 @@ public abstract class MMRandom {
         return roll;
     }
 
-    Roll d6(int nDice, int keep) {
+    public Roll d6(int nDice, int keep) {
         if (0 >= nDice) {
             throw new IllegalArgumentException(
                     "Must ask for a positive number of rolls, not " + nDice);
@@ -106,7 +106,7 @@ public abstract class MMRandom {
     /**
      * A single die
      */
-    Roll d6() {
+    public Roll d6() {
         return d6(1);
     }
 
@@ -118,13 +118,13 @@ public abstract class MMRandom {
      *            any random number returned by this method.
      * @return a random <code>int</code> from the value set [0, maxValue).
      */
-    abstract int randomInt(int maxValue);
+    public abstract int randomInt(int maxValue);
 
     /**
      * Returns a random <code>float</code> in the range of 0 to 1
      * @return a random <code>float</code> from the value set [0,1]
      */
-    abstract float randomFloat();
+    public abstract float randomFloat();
 
     /**
      * Uses com.sun.java.util.collections.Random


### PR DESCRIPTION
This makes `MMRandom` mockable to enable testing of classes that currently have non-deterministic behavior due to their use of Compute. To make use of it, tests would call `Compute.setRNG(...)` with their mocked random number generator, and call `Compute.setRNG(MMRandom.R_DEFAULT)` to reset it to the default type.