### PR TITLE
Don't leave an empty slot between SH compact engine and gyro

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -7344,6 +7344,30 @@ public abstract class Mech extends Entity {
     }
 
     /**
+     * Add the critical slots necessary for a standard gyro. Also set the gyro
+     * type variable. Note: This is part of the mek creation public API, and
+     * might not be referenced by any MegaMek code.
+     *
+     * @return false if insufficient critical space
+     */
+    public boolean addSuperheavyGyro() {
+        if (getEmptyCriticals(LOC_CT) < 2) {
+            return false;
+        }
+        addCritical(LOC_CT, 3, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_GYRO));
+        if (getEngine().getEngineType() == Engine.COMPACT_ENGINE) {
+            addCritical(LOC_CT, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                    SYSTEM_GYRO));
+        } else {
+            addCritical(LOC_CT, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                    SYSTEM_GYRO));
+        }
+        setGyroType(GYRO_SUPERHEAVY);
+        return true;
+    }
+
+    /**
      * Add the critical slots necessary for a compact gyro. Also set the gyro
      * type variable. Note: This is part of the mek creation public API, and
      * might not be referenced by any MegaMek code.


### PR DESCRIPTION
When setting the gyro criticals, the first slot is always at index 3. This is not correct for superheavy mechs with a compact engine, which only takes two superheavy slots. This adds a separate method for adding a superheavy gyro that checks engine type for use by MML.

See MegaMek/megameklab#845