### PR TITLE
VGL smoke munitions

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -3041,7 +3041,6 @@ public class FireControl {
                 || AmmoType.M_PAINT_OBSCURANT == ammoType.getMunitionType()
                 || AmmoType.M_SMOKE == ammoType.getMunitionType()
                 || AmmoType.M_SMOKE_WARHEAD == ammoType.getMunitionType()
-                || AmmoType.M_SMOKEGRENADE == ammoType.getMunitionType()
                 || AmmoType.M_THUNDER == ammoType.getMunitionType()
                 || AmmoType.M_THUNDER_ACTIVE == ammoType.getMunitionType()
                 || AmmoType.M_THUNDER_AUGMENTED == ammoType.getMunitionType()

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -341,7 +341,7 @@ public class AmmoType extends EquipmentType {
     // vehicular grenade launcher
     public static final long M_CHAFF = 1l << 54;
     public static final long M_INCENDIARY = 1l << 55;
-    public static final long M_SMOKEGRENADE = 1l << 56;
+    // Number 56 was M_SMOKEGRENADE, but that has now been merged with M_SMOKE
 
     // Number 57 is used for iATMs IMP ammo in the ATM section above.
     // and 58 for IIW

--- a/megamek/src/megamek/common/weapons/VGLWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/VGLWeaponHandler.java
@@ -97,7 +97,7 @@ public class VGLWeaponHandler extends AmmoWeaponHandler {
         
         for (Coords c : affectedCoords) {
             Building bldg = game.getBoard().getBuildingAt(c);
-            if (atype.getMunitionType() == AmmoType.M_SMOKEGRENADE) {
+            if (atype.getMunitionType() == AmmoType.M_SMOKE) {
                 server.deliverSmokeGrenade(c, vPhaseReport);
             } else if (atype.getMunitionType() == AmmoType.M_CHAFF) {
                 server.deliverChaffGrenade(c, vPhaseReport);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -10317,7 +10317,7 @@ public class Server implements Runnable {
     }
 
     public void deliverSmokeGrenade(Coords coords, Vector<Report> vPhaseReport) {
-        Report r = new Report(5185, Report.PUBLIC);
+        Report r = new Report(5200, Report.PUBLIC);
         r.indent(2);
         r.add(coords.getBoardNum());
         vPhaseReport.add(r);


### PR DESCRIPTION
VGL smoke ammo is treated as fragmentation because the ammo has the M_SMOKE flag and the weapon handler checks for M_SMOKEGRENADE. I don't see any reason to have a separate constant for smoke grenades, since the difference between smoke artillery and smoke grenades is in the handler. Smoke grenades are also using the report for heavy smoke instead of light smoke, so I fixed that as well.

Fixes #2522