### PR TITLE
Apply ammo explosion feedback to pilot before entity damage

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -28146,12 +28146,6 @@ public class Server implements Runnable {
         }
 
         mounted.setShotsLeft(0);
-        Vector<Report> newReports = damageEntity(en, hit, damage, true);
-        for (Report rep : newReports) {
-            rep.indent(2);
-        }
-        vDesc.addAll(newReports);
-        Report.addNewline(vDesc);
 
         int pilotDamage = 2;
         if (en instanceof Aero) {
@@ -28178,6 +28172,13 @@ public class Server implements Runnable {
         } else {
             Report.addNewline(vDesc);
         }
+
+        Vector<Report> newReports = damageEntity(en, hit, damage, true);
+        for (Report rep : newReports) {
+            rep.indent(2);
+        }
+        vDesc.addAll(newReports);
+        Report.addNewline(vDesc);
 
         return vDesc;
     }


### PR DESCRIPTION
When handling the effects of an equipment explosion the damage is applied to the entity before giving the feedback damage to the pilot. With autoeject enabled, the crew is ejected before the pilot damage is handled, so it never happens. The rules state that the feedback damage still applies when autoeject is enabled (TO:AR, p. 165).

Fixes #2523 