### PR TITLE
Remove nag for airborne unit entering rubble hex

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -515,7 +515,7 @@ public class Compute {
         // check for rubble
         if ((movementType != EntityMovementType.MOVE_JUMP)
             && (destHex.terrainLevel(Terrains.RUBBLE) > 0)
-            && (entity.getMovementMode() != EntityMovementMode.VTOL)
+            && (destElevation == 0)
             && !isPavementStep
             && entity.canFall()) {
             return true;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -7504,7 +7504,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if (!lastPos.equals(curPos)
                 && ((moveType != EntityMovementType.MOVE_JUMP) || isLastStep)
                 && (curHex.terrainLevel(Terrains.RUBBLE) > 0) && !isPavementStep
-                && canFall()) {
+                && (step.getElevation() == 0) && canFall()) {
             adjustDifficultTerrainPSRModifier(roll);
             if (hasAbility(OptionsConstants.PILOT_TM_MOUNTAINEER)) {
                 roll.addModifier(-1, "Mountaineer");


### PR DESCRIPTION
A unit that flies over a rubble hex gets a PSR nag and a danger indicator (*) on the step sprite if it starts its turn on the ground. This is because the logic in canFall() is based on the unit's current state. Adding a check for the step's elevation correctly determines that the PSR is not needed.

Note that the PSR is not actually performed by the server, since the unit's elevation is changed before the step is question is processed.

Fixes #2530 