### PR TITLE
Fix rear/turret equipment loading

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -2953,11 +2953,13 @@ public abstract class Mech extends Entity {
     }
 
     public Mounted addEquipment(EquipmentType etype, EquipmentType etype2,
-            int loc,  boolean omniPod) throws LocationFullException {
+            int loc,  boolean omniPod, boolean armored) throws LocationFullException {
         Mounted mounted = new Mounted(this, etype);
         Mounted mounted2 = new Mounted(this, etype2);
         mounted.setOmniPodMounted(omniPod);
         mounted2.setOmniPodMounted(omniPod);
+        mounted.setArmored(armored);
+        mounted2.setArmored(armored);
         // check criticals for space
         if (getEmptyCriticals(loc) < 1) {
             throw new LocationFullException(mounted.getName() + " and "

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -117,10 +117,10 @@ public class MtfFile implements IMechLoader {
     public static final String BV = "bv:";
     public static final String WEAPONS = "weapons:";
     public static final String EMPTY = "-Empty-";
-    public static final String ARMORED = "(armored)";
-    public static final String OMNIPOD = "(omnipod)";
+    public static final String ARMORED = "(ARMORED)";
+    public static final String OMNIPOD = "(OMNIPOD)";
     public static final String NO_CRIT = "nocrit:";
-    public static final String SIZE = ":size:";
+    public static final String SIZE = ":SIZE:";
 
     /**
      * Creates new MtfFile
@@ -604,14 +604,14 @@ public class MtfFile implements IMechLoader {
         // check for removed arm actuators
         if (!(mech instanceof QuadMech)) {
             if ((loc == Mech.LOC_LARM) || (loc == Mech.LOC_RARM)) {
-                String toCheck = critData[loc][3].toLowerCase().trim();
+                String toCheck = critData[loc][3].toUpperCase().trim();
                 if (toCheck.endsWith(ARMORED)) {
                     toCheck = toCheck.substring(0, toCheck.length() - ARMORED.length()).trim();
                 }
                 if (!toCheck.equalsIgnoreCase("Hand Actuator")) {
                     mech.setCritical(loc, 3, null);
                 }
-                toCheck = critData[loc][2].toLowerCase().trim();
+                toCheck = critData[loc][2].toUpperCase().trim();
                 if (toCheck.endsWith(ARMORED)) {
                     toCheck = toCheck.substring(0, toCheck.length() - ARMORED.length()).trim();
                 }
@@ -628,7 +628,6 @@ public class MtfFile implements IMechLoader {
             String critName = critData[loc][i];
 
             critName = critName.trim();
-            String critNameLower = critName.toLowerCase();
             String critNameUpper = critName.toUpperCase();
             boolean rearMounted = false;
             boolean isArmored = false;
@@ -637,9 +636,10 @@ public class MtfFile implements IMechLoader {
             double size = 0.0;
 
             // Check for Armored Actuators
-            if (critNameLower.endsWith(ARMORED)) {
+            if (critNameUpper.endsWith(ARMORED)) {
                 critName = critName.substring(0, critName.length() - ARMORED.length()).trim();
                 isArmored = true;
+                critNameUpper = critName.toUpperCase();
             }
 
             if (critName.equalsIgnoreCase("Fusion Engine") || critName.equalsIgnoreCase("Engine")) {
@@ -672,44 +672,45 @@ public class MtfFile implements IMechLoader {
                 continue;
             }
 
-            int sizeIndex = critNameLower.indexOf(SIZE);
+            int sizeIndex = critNameUpper.indexOf(SIZE);
             if (sizeIndex > 0) {
                 size = Double.parseDouble(critName.substring(sizeIndex + SIZE.length()));
-                critName = critName.substring(0, sizeIndex);
+                critNameUpper = critNameUpper.substring(0, sizeIndex);
             }
-            if (critNameLower.endsWith(OMNIPOD)) {
-                critName = critName.substring(0, critName.length() - OMNIPOD.length()).trim();
+            if (critNameUpper.endsWith(OMNIPOD)) {
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - OMNIPOD.length()).trim();
                 isOmniPod = true;
             }
             if (critNameUpper.endsWith("(T)")) {
                 isTurreted = true;
-                critName = critName.substring(0, critName.length() - 3).trim();
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 3).trim();
             }
             if (critNameUpper.endsWith("(R)")) {
                 rearMounted = true;
-                critName = critName.substring(0, critName.length() - 3).trim();
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 3).trim();
             }
-            if (critNameLower.endsWith("(split)")) {
-                critName = critName.substring(0, critName.length() - 7).trim();
+            if (critNameUpper.endsWith("(split)")) {
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 7).trim();
             }
             // keep track of facing for vehicular grenade launchers
             int facing = -1;
             if (critNameUpper.endsWith("(FL)")) {
                 facing = 5;
-                critName = critName.substring(0, critName.length() - 4).trim();
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 4).trim();
             }
             if (critNameUpper.endsWith("(FR)")) {
                 facing = 1;
-                critName = critName.substring(0, critName.length() - 4).trim();
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 4).trim();
             }
             if (critNameUpper.endsWith("(RL)")) {
                 facing = 4;
-                critName = critName.substring(0, critName.length() - 4).trim();
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 4).trim();
             }
             if (critNameUpper.endsWith("(RR)")) {
                 facing = 2;
-                critName = critName.substring(0, critName.length() - 4).trim();
+                critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 4).trim();
             }
+            critName = critName.substring(0, critNameUpper.length());
             EquipmentType etype2 = null;
             if (critName.contains("|")) {
                 String critName2 = critName.substring(critName.indexOf("|") + 1);

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -689,7 +689,7 @@ public class MtfFile implements IMechLoader {
                 rearMounted = true;
                 critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 3).trim();
             }
-            if (critNameUpper.endsWith("(split)")) {
+            if (critNameUpper.endsWith("(SPLIT)")) {
                 critNameUpper = critNameUpper.substring(0, critNameUpper.length() - 7).trim();
             }
             // keep track of facing for vehicular grenade launchers
@@ -797,7 +797,7 @@ public class MtfFile implements IMechLoader {
                                     throw new EntityLoadingException("must combine ammo or heatsinks in one slot");
                                 }
                             }
-                            mount = mech.addEquipment(etype, etype2, loc, isOmniPod);
+                            mount = mech.addEquipment(etype, etype2, loc, isOmniPod, isArmored);
                         }
                         if (etype.isVariableSize()) {
                             if (size == 0.0) {

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -1,0 +1,58 @@
+/*
+ * MegaMek
+ * Copyright (C) 2020 The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package megamek.common.loaders;
+
+import megamek.common.*;
+import org.junit.Test;
+
+import java.io.*;
+
+import static org.junit.Assert.*;
+
+public class MtfFileTest {
+
+    private MtfFile toMtfFile(Mech mech) throws EntityLoadingException {
+        if (!mech.hasEngine() || mech.getEngine().getEngineType() == Engine.NONE) {
+            mech.setWeight(20.0);
+            mech.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+        }
+        String mtf = mech.getMtf();
+        byte[] bytes = mtf.getBytes();
+        InputStream istream = new ByteArrayInputStream(bytes);
+        return new MtfFile(istream);
+    }
+
+    @Test
+    public void testLoadEquipment() throws LocationFullException, EntityLoadingException {
+        Mech mech = new BipedMech();
+        EquipmentType laser = EquipmentType.get("Medium Laser");
+        Mounted mount = mech.addEquipment(laser, Mech.LOC_LT, true);
+        mount.setOmniPodMounted(true);
+        mount.setMechTurretMounted(true);
+        mount.setArmored(true);
+
+        MtfFile loader = toMtfFile(mech);
+        Mounted found = loader.getEntity().getCritical(Mech.LOC_LT, 0).getMount();
+
+        assertEquals(laser, found.getType());
+        assertTrue(found.isRearMounted());
+        assertTrue(found.isMechTurretMounted());
+    }
+}

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -42,17 +42,58 @@ public class MtfFileTest {
     @Test
     public void testLoadEquipment() throws LocationFullException, EntityLoadingException {
         Mech mech = new BipedMech();
-        EquipmentType laser = EquipmentType.get("Medium Laser");
-        Mounted mount = mech.addEquipment(laser, Mech.LOC_LT, true);
+        Mounted mount = new Mounted(mech, EquipmentType.get("Medium Laser"));
         mount.setOmniPodMounted(true);
         mount.setMechTurretMounted(true);
         mount.setArmored(true);
+        mech.addEquipment(mount, Mech.LOC_LT, true);
 
         MtfFile loader = toMtfFile(mech);
         Mounted found = loader.getEntity().getCritical(Mech.LOC_LT, 0).getMount();
 
-        assertEquals(laser, found.getType());
+        assertEquals(mount.getType(), found.getType());
         assertTrue(found.isRearMounted());
         assertTrue(found.isMechTurretMounted());
+        assertTrue(found.isArmored());
+    }
+
+    @Test
+    public void setVGLFacing() throws LocationFullException, EntityLoadingException {
+        Mech mech = new BipedMech();
+        EquipmentType vgl = EquipmentType.get("ISVehicularGrenadeLauncher");
+        mech.addEquipment(vgl, Mech.LOC_LT).setFacing(0);
+        mech.addEquipment(vgl, Mech.LOC_LT).setFacing(1);
+        mech.addEquipment(vgl, Mech.LOC_LT).setFacing(2);
+        mech.addEquipment(vgl, Mech.LOC_LT, true).setFacing(3);
+        mech.addEquipment(vgl, Mech.LOC_LT).setFacing(4);
+        mech.addEquipment(vgl, Mech.LOC_LT).setFacing(5);
+
+        MtfFile loader = toMtfFile(mech);
+        Entity loaded = loader.getEntity();
+
+        assertEquals(0, loaded.getCritical(Mech.LOC_LT, 0).getMount().getFacing());
+        assertEquals(1, loaded.getCritical(Mech.LOC_LT, 1).getMount().getFacing());
+        assertEquals(2, loaded.getCritical(Mech.LOC_LT, 2).getMount().getFacing());
+        assertEquals(3, loaded.getCritical(Mech.LOC_LT, 3).getMount().getFacing());
+        assertEquals(4, loaded.getCritical(Mech.LOC_LT, 4).getMount().getFacing());
+        assertEquals(5, loaded.getCritical(Mech.LOC_LT, 5).getMount().getFacing());
+    }
+
+    @Test
+    public void loadSuperheavyDoubleSlot() throws LocationFullException, EntityLoadingException {
+        Mech mech = new BipedMech();
+        mech.setWeight(120.0);
+        mech.setEngine(new Engine(360, Engine.NORMAL_ENGINE, 0));
+        EquipmentType hs = EquipmentType.get(EquipmentTypeLookup.SINGLE_HS);
+        mech.addEquipment(hs, hs, Mech.LOC_LT, true, true);
+
+        MtfFile loader = toMtfFile(mech);
+        CriticalSlot slot = loader.getEntity().getCritical(Mech.LOC_LT, 0);
+
+        assertEquals(hs, slot.getMount().getType());
+        assertEquals(hs, slot.getMount2().getType());
+        assertTrue(slot.getMount().isOmniPodMounted());
+        assertTrue(slot.getMount2().isOmniPodMounted());
+        assertTrue(slot.isArmored());
     }
 }


### PR DESCRIPTION
Modifies case sensitivity support in MtfLoader. Instead of going back and forth between upper case and lower case, all tags are converted to upper case (and will be exported that way in the future). Each tag is stripped from the version of the string that is used for comparison, then after checking all tags the original is truncated and used for the case-sensitive equipment lookup.

While adding tests for the altered code I discovered and fixed a bug that caused armored slots with two mounts (used for superheavies with doubled heat sinks or ammo, or LAM bomb bays) not to be set as armored.

Fixes #2544 