### PR TITLE
Fix TargetRoll description if negative modifier is first

### DIFF
--- a/megamek/src/megamek/common/TargetRoll.java
+++ b/megamek/src/megamek/common/TargetRoll.java
@@ -47,7 +47,7 @@ public class TargetRoll implements Serializable {
      */
     public static final int CHECK_FALSE = Integer.MIN_VALUE + 1;
 
-    private ArrayList<TargetRollModifier> modifiers = new ArrayList<TargetRollModifier>();
+    private List<TargetRollModifier> modifiers = new ArrayList<>();
 
     private int total;
 
@@ -103,7 +103,7 @@ public class TargetRoll implements Serializable {
     }
 
     public List<TargetRollModifier> getModifiers() {
-        return new ArrayList<TargetRollModifier>(modifiers);
+        return new ArrayList<>(modifiers);
     }
 
     /**
@@ -111,7 +111,7 @@ public class TargetRoll implements Serializable {
      */
     public String getDesc() {
         boolean first = true;
-        StringBuffer allDesc = new StringBuffer();
+        StringBuilder allDesc = new StringBuilder();
 
         for (TargetRollModifier modifier : modifiers) {
 
@@ -126,13 +126,12 @@ public class TargetRoll implements Serializable {
             // add desc
             if (first) {
                 first = false;
+                allDesc.append(modifier.getValue());
             } else {
-                allDesc.append((modifier.getValue() < 0 ? " - " : " + "));
+                allDesc.append((modifier.getValue() < 0 ? " - " : " + "))
+                        .append(Math.abs(modifier.getValue()));
             }
-            allDesc.append(Math.abs(modifier.getValue()));
-            allDesc.append(" (");
-            allDesc.append(modifier.getDesc());
-            allDesc.append(")");
+            allDesc.append(" (").append(modifier.getDesc()).append(")");
         }
 
         return allDesc.toString();
@@ -231,7 +230,7 @@ public class TargetRoll implements Serializable {
      */
 
     public void removeAutos(boolean removeImpossibles) {
-        ArrayList<TargetRollModifier> toKeep = new ArrayList<TargetRollModifier>();
+        List<TargetRollModifier> toKeep = new ArrayList<>();
         for (TargetRollModifier modifier : modifiers) {
             if (!removeImpossibles) {
                 if ((modifier.getValue() != AUTOMATIC_FAIL)
@@ -270,5 +269,4 @@ public class TargetRoll implements Serializable {
             total += modifier.getValue();
         }
     }
-
 }

--- a/megamek/unittests/megamek/common/TargetRollTest.java
+++ b/megamek/unittests/megamek/common/TargetRollTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 - The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+
+package megamek.common;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TargetRollTest {
+    @Test
+    public void impossibleTest() {
+        TargetRoll roll = new TargetRoll(TargetRoll.IMPOSSIBLE, "inconceivable");
+        assertEquals(TargetRoll.IMPOSSIBLE, roll.getValue());
+        assertEquals("Impossible", roll.getValueAsString());
+        assertEquals("inconceivable", roll.getDesc());
+
+        roll.addModifier(-2, "ignored bonus");
+
+        assertEquals(TargetRoll.IMPOSSIBLE, roll.getValue());
+        assertEquals("Impossible", roll.getValueAsString());
+        assertEquals("inconceivable", roll.getDesc());
+    }
+
+    @Test
+    public void automaticFailureTest() {
+        TargetRoll roll = new TargetRoll(TargetRoll.AUTOMATIC_FAIL, "inconceivable");
+        assertEquals(TargetRoll.AUTOMATIC_FAIL, roll.getValue());
+        assertEquals("Automatic Failure", roll.getValueAsString());
+        assertEquals("inconceivable", roll.getDesc());
+
+        roll.addModifier(-2, "ignored bonus");
+
+        assertEquals(TargetRoll.AUTOMATIC_FAIL, roll.getValue());
+        assertEquals("Automatic Failure", roll.getValueAsString());
+        assertEquals("inconceivable", roll.getDesc());
+    }
+
+    @Test
+    public void automaticSuccessTest() {
+        TargetRoll roll = new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "great success");
+        assertEquals(TargetRoll.AUTOMATIC_SUCCESS, roll.getValue());
+        assertEquals("Automatic Success", roll.getValueAsString());
+        assertEquals("great success", roll.getDesc());
+
+        roll.addModifier(+2, "ignored malus");
+
+        assertEquals(TargetRoll.AUTOMATIC_SUCCESS, roll.getValue());
+        assertEquals("Automatic Success", roll.getValueAsString());
+        assertEquals("great success", roll.getDesc());
+    }
+    
+    @Test
+    public void checkFalseTest() {
+        TargetRoll roll = new TargetRoll(TargetRoll.CHECK_FALSE, "check one, check one two");
+        assertEquals(TargetRoll.CHECK_FALSE, roll.getValue());
+        assertEquals("Did not need to roll", roll.getValueAsString());
+        assertEquals("check one, check one two", roll.getDesc());
+
+        roll.addModifier(+2, "ignored malus");
+
+        assertEquals(TargetRoll.CHECK_FALSE, roll.getValue());
+        assertEquals("Did not need to roll", roll.getValueAsString());
+        assertEquals("check one, check one two", roll.getDesc());
+    }
+
+    @Test
+    public void getDescNegativeFirstMod() {
+        TargetRoll roll = new TargetRoll();
+
+        roll.addModifier(-1, "first");
+        roll.addModifier(2, "second");
+        roll.addModifier(-3, "third");
+        roll.addModifier(0, "fourth");
+
+        assertEquals("-1 (first) + 2 (second) - 3 (third) + 0 (fourth)", roll.getDesc());
+        assertEquals(-2, roll.getValue());
+        assertEquals("-2", roll.getValueAsString());
+    }
+
+    @Test
+    public void getDescPositiveFirstMod() {
+        TargetRoll roll = new TargetRoll();
+
+        roll.addModifier(1, "first");
+        roll.addModifier(-2, "second");
+        roll.addModifier(3, "third");
+        roll.addModifier(0, "fourth");
+
+        assertEquals("1 (first) - 2 (second) + 3 (third) + 0 (fourth)", roll.getDesc());
+        assertEquals(2, roll.getValue());
+        assertEquals("2", roll.getValueAsString());
+    }
+}


### PR DESCRIPTION
Fixes bug in `TargetRoll::getDesc` if the first modifier is negative, seen testing `MekLocation::getAllMods`. Adds basic tests for `TargetRoll` as well.

Before:
```
location.getAllMods(tech).getDesc()  // "1 (difficulty) + 1 (site mod) + 0 (D)"
location.getAllMods(tech).getValue() // 0
```

After:
```
location.getAllMods(tech).getDesc()  // "-1 (difficulty) + 1 (site mod) + 0 (D)"
location.getAllMods(tech).getValue() // 0
```

This seems to be safe enough for 0.48.