### PR TITLE
prevent grounded dropships from using mount button

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2773,6 +2773,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             setUnloadEnabled((ce.getUnitsUnloadableFromBays().size() > 0)
                              && !ce.isAirborne());
             setLoadEnabled(false);
+            setMountEnabled(false);
             return;
         }
 
@@ -5318,7 +5319,6 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         updateProneButtons();
         updateRACButton();
         updateSearchlightButton();
-        updateLoadButtons();
         updateElevationButtons();
         updateTakeOffButtons();
         updateLandButtons();


### PR DESCRIPTION
When selecting a grounded dropship after selecting a unit that can "mount", the mount button remains enabled, and throws an exception when clicked. 

This PR fixes that behavior by disabling the "mount" button for small craft (they can't mount anything anyway). 

Also removes a redundant call to updateLoadButtons().

Not really sure it's necessary for "stable", but can be merged relatively painlessly if we're making other changes anyway.