### PR TITLE
cache expensive bot computations; forego certain game events

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1351,31 +1351,31 @@ public class FireControl {
         return 0;
     }
 
-    private boolean isCommander(final Entity entity) {
+    protected boolean isCommander(final Entity entity) {
         if (owner.getFireControlState().commanderCached(entity)) {
             return owner.getFireControlState().isCommander(entity);
-        } else {
-            owner.getFireControlState().setCommander(entity, 
-                    entity.isCommander() || entity.hasC3M() || entity.hasC3i() || entity.hasC3MM() ||
-                    (owner.getHighestEnemyInitiativeId() == entity.getId()));
+        } 
+
+        owner.getFireControlState().setCommander(entity, 
+                entity.isCommander() || entity.hasC3M() || entity.hasC3i() || entity.hasC3MM() ||
+                (owner.getHighestEnemyInitiativeId() == entity.getId()));
             
-            return owner.getFireControlState().isCommander(entity);
-        }
+        return owner.getFireControlState().isCommander(entity);
     }
 
-    private boolean isSubCommander(final Entity entity) {
+    protected boolean isSubCommander(final Entity entity) {
         if (owner.getFireControlState().subCommanderCached(entity)) {
             return owner.getFireControlState().isSubCommander(entity);
-        } else {
-            final int initBonus = entity.getHQIniBonus() + entity.getQuirkIniBonus();  //removed in IO + entity.getMDIniBonus()
-            owner.getFireControlState().setSubCommander(entity, 
-                    entity.hasC3() || entity.hasTAG() || entity.hasBoostedC3() || entity.hasNovaCEWS() ||
-                   entity.isUsingSpotlight() || entity.hasBAP() || entity.hasActiveECM() || entity.hasActiveECCM() ||
-                   entity.hasQuirk(OptionsConstants.QUIRK_POS_IMPROVED_SENSORS) || entity.hasEiCockpit() ||
-                   (0 < initBonus));
-            
-            return owner.getFireControlState().isSubCommander(entity);
         }
+
+        final int initBonus = entity.getHQIniBonus() + entity.getQuirkIniBonus();
+        owner.getFireControlState().setSubCommander(entity, 
+                entity.hasC3() || entity.hasTAG() || entity.hasBoostedC3() || entity.hasNovaCEWS() ||
+               entity.isUsingSpotlight() || entity.hasBAP() || entity.hasActiveECM() || entity.hasActiveECCM() ||
+               entity.hasQuirk(OptionsConstants.QUIRK_POS_IMPROVED_SENSORS) || entity.hasEiCockpit() ||
+               (0 < initBonus));
+            
+        return owner.getFireControlState().isSubCommander(entity);
     }
 
     /**

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1352,16 +1352,30 @@ public class FireControl {
     }
 
     private boolean isCommander(final Entity entity) {
-        return entity.isCommander() || entity.hasC3M() || entity.hasC3i() || entity.hasC3MM() ||
-               (owner.getHighestEnemyInitiativeId() == entity.getId());
+        if (owner.getFireControlState().commanderCached(entity)) {
+            return owner.getFireControlState().isCommander(entity);
+        } else {
+            owner.getFireControlState().setCommander(entity, 
+                    entity.isCommander() || entity.hasC3M() || entity.hasC3i() || entity.hasC3MM() ||
+                    (owner.getHighestEnemyInitiativeId() == entity.getId()));
+            
+            return owner.getFireControlState().isCommander(entity);
+        }
     }
 
     private boolean isSubCommander(final Entity entity) {
-        final int initBonus = entity.getHQIniBonus() + entity.getQuirkIniBonus();  //removed in IO + entity.getMDIniBonus()
-        return entity.hasC3() || entity.hasTAG() || entity.hasBoostedC3() || entity.hasNovaCEWS() ||
-               entity.isUsingSpotlight() || entity.hasBAP() || entity.hasActiveECM() || entity.hasActiveECCM() ||
-               entity.hasQuirk(OptionsConstants.QUIRK_POS_IMPROVED_SENSORS) || entity.hasEiCockpit() ||
-               (0 < initBonus);
+        if (owner.getFireControlState().subCommanderCached(entity)) {
+            return owner.getFireControlState().isSubCommander(entity);
+        } else {
+            final int initBonus = entity.getHQIniBonus() + entity.getQuirkIniBonus();  //removed in IO + entity.getMDIniBonus()
+            owner.getFireControlState().setSubCommander(entity, 
+                    entity.hasC3() || entity.hasTAG() || entity.hasBoostedC3() || entity.hasNovaCEWS() ||
+                   entity.isUsingSpotlight() || entity.hasBAP() || entity.hasActiveECM() || entity.hasActiveECCM() ||
+                   entity.hasQuirk(OptionsConstants.QUIRK_POS_IMPROVED_SENSORS) || entity.hasEiCockpit() ||
+                   (0 < initBonus));
+            
+            return owner.getFireControlState().isSubCommander(entity);
+        }
     }
 
     /**
@@ -2062,14 +2076,14 @@ public class FireControl {
                                                     ammoConservation, game);
         
         if(shooter.canFlipArms()) {
-            shooter.setArmsFlipped(true);
+            shooter.setArmsFlipped(true, false);
             FiringPlan betaStrike = getFullFiringPlan(shooter, target, ammoConservation, game);
             betaStrike.setFlipArms(true);
             if(betaStrike.getUtility() > alphaStrike.getUtility()) {
                 alphaStrike = betaStrike;
             }
             
-            shooter.setArmsFlipped(false);
+            shooter.setArmsFlipped(false, false);
         }
         
         // Although they don't track heat, infantry/BA do need to make tradeoffs
@@ -2125,7 +2139,7 @@ public class FireControl {
                                                        target, targetState, game);
         
         if(shooter.canFlipArms()) {
-            shooter.setArmsFlipped(true);
+            shooter.setArmsFlipped(true, false);
             FiringPlan betaStrike = guessFullFiringPlan(shooter, shooterState,
                                                         target, targetState, game);
             betaStrike.setFlipArms(true);
@@ -2133,7 +2147,7 @@ public class FireControl {
                 alphaStrike = betaStrike;
             }
             
-            shooter.setArmsFlipped(false);
+            shooter.setArmsFlipped(false, false);
         }
         
         // Infantry and BA may have alternative options, so we need to consider

--- a/megamek/src/megamek/client/bot/princess/FireControlState.java
+++ b/megamek/src/megamek/client/bot/princess/FireControlState.java
@@ -19,6 +19,8 @@ public class FireControlState {
     private LinkedList<Entity> orderedFiringEntities;
     private Map<Integer, Integer> weaponRanges;
     private Map<Integer, Integer> airborneTargetWeaponRanges;
+    private Map<Integer, Boolean> isCommander;
+    private Map<Integer, Boolean> isSubCommander;
     
     public FireControlState() {
         additionalTargets = new ArrayList<>();
@@ -26,6 +28,8 @@ public class FireControlState {
         orderedFiringEntities = new LinkedList<>();
         weaponRanges = new HashMap<>();
         airborneTargetWeaponRanges = new HashMap<>();
+        isCommander = new HashMap<>();
+        isSubCommander = new HashMap<>();
     }
     
     /**
@@ -69,6 +73,30 @@ public class FireControlState {
         return airborneTarget ? airborneTargetWeaponRanges : weaponRanges;
     }
     
+    public boolean subCommanderCached(Entity entity) {
+        return isSubCommander.containsKey(entity.getId());
+    }
+    
+    public boolean commanderCached(Entity entity) {
+        return isCommander.containsKey(entity.getId());
+    }
+    
+    public boolean isSubCommander(Entity entity) {
+        return isSubCommander.get(entity.getId());
+    }
+    
+    public boolean isCommander(Entity entity) {
+        return isCommander.get(entity.getId());
+    }
+    
+    public void setSubCommander(Entity entity, boolean value) {
+        isSubCommander.put(entity.getId(), value);                
+    }
+    
+    public void setCommander(Entity entity, boolean value) {
+        isCommander.put(entity.getId(), value);                
+    }
+    
     /**
      * Clears data that shouldn't persist phase-to-phase
      */
@@ -77,5 +105,7 @@ public class FireControlState {
     	clearOrderedFiringEntities();
     	weaponRanges.clear();
     	airborneTargetWeaponRanges.clear();
+    	isCommander.clear();
+    	isSubCommander.clear();
     }
 }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1844,8 +1844,20 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Set whether or not the mech's arms are flipped to the rear
      */
     public void setArmsFlipped(boolean armsFlipped) {
+        setArmsFlipped(armsFlipped, true);
+    }
+    
+    /**
+     * Set whether or not the mech's arms are flipped to the rear.
+     * Does not fire the game event, useful for when it's called repeatedly
+     * such as during bot turn calculations
+     */
+    public void setArmsFlipped(boolean armsFlipped, boolean fireEvent) {
         this.armsFlipped = armsFlipped;
-        game.processGameEvent(new GameEntityChangeEvent(this, this));
+        
+        if (fireEvent) {
+            game.processGameEvent(new GameEntityChangeEvent(this, this));
+        }
     }
 
     /**

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -246,6 +246,9 @@ public class FireControlTest {
                .when(testFireControl)
                .getTargetMovementModifier(Mockito.anyInt(), Mockito.anyBoolean(), Mockito.anyBoolean(),
                                           Mockito.any(IGame.class));
+        
+        Mockito.doReturn(false).when(testFireControl).isCommander(Mockito.any(Entity.class));
+        Mockito.doReturn(false).when(testFireControl).isSubCommander(Mockito.any(Entity.class));
 
         // AC5
         mockWeaponTypeAC5 = Mockito.mock(WeaponType.class);
@@ -2142,29 +2145,29 @@ public class FireControlTest {
         Assert.assertEquals(baseUtility, testFiringPlan.getUtility(), TOLERANCE);
 
         // Make the target a commander.
-        Mockito.when(mockTarget.isCommander()).thenReturn(true);
         testFiringPlan = Mockito.spy(new FiringPlan(mockTarget));
         Mockito.doReturn(15.0).when(testFiringPlan).getExpectedDamage();
         Mockito.doReturn(0.46129).when(testFiringPlan).getExpectedCriticals();
         Mockito.doReturn(0.02005).when(testFiringPlan).getKillProbability();
         Mockito.doReturn(0).when(testFiringPlan).getHeat();
         Mockito.doReturn(0.0).when(testFireControl).calcDamageAllocationUtility(Mockito.any(Targetable.class), Mockito.anyDouble());
+        Mockito.doReturn(true).when(testFireControl).isCommander(Mockito.any(Entity.class));
         testFireControl.calculateUtility(testFiringPlan, overheatTolerance, false);
         Assert.assertEquals(baseUtility * (1 + FireControl.COMMANDER_UTILITY), testFiringPlan.getUtility(), TOLERANCE);
-        Mockito.when(mockTarget.isCommander()).thenReturn(false);
+        Mockito.doReturn(false).when(testFireControl).isCommander(Mockito.any(Entity.class));
 
         // Make the target a sub-commander.
-        Mockito.when(mockTarget.hasC3()).thenReturn(true);
         testFiringPlan = Mockito.spy(new FiringPlan(mockTarget));
         Mockito.doReturn(15.0).when(testFiringPlan).getExpectedDamage();
         Mockito.doReturn(0.46129).when(testFiringPlan).getExpectedCriticals();
         Mockito.doReturn(0.02005).when(testFiringPlan).getKillProbability();
         Mockito.doReturn(0).when(testFiringPlan).getHeat();
         Mockito.doReturn(0.0).when(testFireControl).calcDamageAllocationUtility(Mockito.any(Targetable.class), Mockito.anyDouble());
+        Mockito.doReturn(true).when(testFireControl).isSubCommander(Mockito.any(Entity.class));
         testFireControl.calculateUtility(testFiringPlan, overheatTolerance, false);
         Assert.assertEquals(baseUtility * (1 + FireControl.SUB_COMMANDER_UTILITY), testFiringPlan.getUtility(),
                             TOLERANCE);
-        Mockito.when(mockTarget.hasC3()).thenReturn(false);
+        Mockito.doReturn(false).when(testFireControl).isSubCommander(Mockito.any(Entity.class));
 
         // Make the target a Strategic Building Target.
         final BuildingTarget mockBuilding = Mockito.mock(BuildingTarget.class);


### PR DESCRIPTION
This addresses #2565.

Two performance improvements:
- cache the results of the isCommander() and isSubCommander() computations which contain multiple method calls, each of which loops through all of an entity's equipment multiple times. These are invariant while the bot is calculating a single unit's move.

- don't fire game events when flipping mech arms during a move calculation

The save game provided in the report went from taking about 30 seconds to evaluate each of the Ostscout's paths to taking about 30 seconds to evaluate the Ostscout's entire path set.