### PR TITLE
Remove F_TANK_WEAPON flag from aero external missile weapons

### DIFF
--- a/megamek/src/megamek/common/weapons/bombs/BombISRL10.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombISRL10.java
@@ -45,7 +45,7 @@ public class BombISRL10 extends MissileWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 0;
-        this.flags = flags.or(F_MISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);
+        this.flags = flags.or(F_MISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 6;
         this.medAV = 6;
         this.maxRange = RANGE_MED;

--- a/megamek/src/megamek/common/weapons/bombs/CLAAAMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/CLAAAMissileWeapon.java
@@ -46,7 +46,7 @@ public class CLAAAMissileWeapon extends ThunderBoltWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 9000;
-        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 20;
         this.medAV = 20;
         this.maxRange = RANGE_MED;

--- a/megamek/src/megamek/common/weapons/bombs/CLASEWMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/CLASEWMissileWeapon.java
@@ -51,7 +51,7 @@ public class CLASEWMissileWeapon extends ThunderBoltWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 20000;
-        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 0;
         this.medAV = 0;
         this.longAV = 0;

--- a/megamek/src/megamek/common/weapons/bombs/CLASMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/CLASMissileWeapon.java
@@ -48,7 +48,7 @@ public class CLASMissileWeapon extends ThunderBoltWeapon {
         shortAV = 30;
         medAV = 30;
         longAV = 30;
-        flags = flags.or(F_ANTI_SHIP).or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        flags = flags.or(F_ANTI_SHIP).or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         maxRange = RANGE_LONG;
         ammoType = AmmoType.T_AS_MISSILE;
         capital = false;

--- a/megamek/src/megamek/common/weapons/bombs/CLBombTAG.java
+++ b/megamek/src/megamek/common/weapons/bombs/CLBombTAG.java
@@ -47,7 +47,7 @@ public class CLBombTAG extends TAGWeapon {
         this.extremeRange = 20;
         this.bv = 0;
         this.cost = 50000;
-        flags = flags.or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);
+        flags = flags.or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         rulesRefs = "238,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
     	.setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/bombs/CLLAAMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/CLLAAMissileWeapon.java
@@ -45,7 +45,7 @@ public class CLLAAMissileWeapon extends ThunderBoltWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 6000;
-        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 6;
         this.medAV = 6;
         this.maxRange = RANGE_MED;

--- a/megamek/src/megamek/common/weapons/bombs/ISAAAMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/ISAAAMissileWeapon.java
@@ -45,7 +45,7 @@ public class ISAAAMissileWeapon extends ThunderBoltWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 9000;
-        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 20;
         this.medAV = 20;
         this.maxRange = RANGE_MED;

--- a/megamek/src/megamek/common/weapons/bombs/ISASEWMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/ISASEWMissileWeapon.java
@@ -51,7 +51,7 @@ public class ISASEWMissileWeapon extends ThunderBoltWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 20000;
-        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 0;
         this.medAV = 0;
         this.longAV = 0;

--- a/megamek/src/megamek/common/weapons/bombs/ISASMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/ISASMissileWeapon.java
@@ -48,7 +48,7 @@ public class ISASMissileWeapon extends ThunderBoltWeapon {
         shortAV = 30;
         medAV = 30;
         longAV = 30;
-        flags = flags.or(F_ANTI_SHIP).or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        flags = flags.or(F_ANTI_SHIP).or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         maxRange = RANGE_LONG;
         ammoType = AmmoType.T_AS_MISSILE;
         capital = false;

--- a/megamek/src/megamek/common/weapons/bombs/ISBombTAG.java
+++ b/megamek/src/megamek/common/weapons/bombs/ISBombTAG.java
@@ -47,7 +47,7 @@ public class ISBombTAG extends TAGWeapon {
         this.extremeRange = 20;
         this.bv = 0;
         this.cost = 50000;
-        flags = flags.or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);
+        flags = flags.or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         rulesRefs = "238,TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
     	.setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/bombs/ISLAAMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/ISLAAMissileWeapon.java
@@ -45,7 +45,7 @@ public class ISLAAMissileWeapon extends ThunderBoltWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 6000;
-        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON);;
+        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE).or(F_BOMB_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 6;
         this.medAV = 6;
         this.maxRange = RANGE_MED;


### PR DESCRIPTION
Weapons used to fire missiles mounted as external stores inherit the F_TANK_WEAPON flag from MIssileWeapon, which causes them to show up in equipment available for vehicles in MML.

Fixes MegaMek/megamek#860.