### PR TITLE
Moving to fully use isConventionalInfantry

### DIFF
--- a/megamek/src/megamek/client/bot/CEntity.java
+++ b/megamek/src/megamek/client/bot/CEntity.java
@@ -373,7 +373,7 @@ public class CEntity {
         }
 
         // Most units, including BA, are equipped with conventional weapons
-        if (!(entity instanceof Infantry) || (entity instanceof BattleArmor)) {
+        if (!entity.isConventionalInfantry()) {
 
             if (entity instanceof BattleArmor) {
                 number_of_shooters = ((BattleArmor) entity)
@@ -668,7 +668,7 @@ public class CEntity {
         }
 
         if (entity instanceof Infantry) {
-            if (!(entity instanceof BattleArmor)) {
+            if (entity.isConventionalInfantry()) {
                 armor = INFANTRY_ARMOR;
             } else {
                 if (entity.isClan()) {
@@ -981,7 +981,7 @@ public class CEntity {
         // troopers
         // TODO: This will probably need some revamping when Total Warfare is
         // released.
-        if ((entity instanceof Infantry) & !(entity instanceof BattleArmor)) {
+        if (entity.isConventionalInfantry()) {
             result = ((Infantry) entity).getShootingStrength();
         }
 

--- a/megamek/src/megamek/client/bot/PhysicalCalculator.java
+++ b/megamek/src/megamek/client/bot/PhysicalCalculator.java
@@ -333,7 +333,7 @@ public final class PhysicalCalculator {
             return null;
         }
 
-        if ((to instanceof Infantry) && !(to instanceof BattleArmor)) {
+        if (to.isConventionalInfantry()) {
             targetConvInfantry = true;
         }
 
@@ -559,7 +559,7 @@ public final class PhysicalCalculator {
         }
 
         // Conventional infantry in the open suffer double damage.
-        if ((to instanceof Infantry) && !(to instanceof BattleArmor)) {
+        if (to.isConventionalInfantry()) {
             IHex e_hex = game.getBoard().getHex(to.getPosition());
             if (!e_hex.containsTerrain(Terrains.WOODS)
                     && !e_hex.containsTerrain(Terrains.BUILDING)) {
@@ -609,7 +609,7 @@ public final class PhysicalCalculator {
             return 0.0;
         }
 
-        if ((to instanceof Infantry) && !(to instanceof BattleArmor)) {
+        if (to.isConventionalInfantry()) {
             targetConvInfantry = true;
         }
 
@@ -799,7 +799,7 @@ public final class PhysicalCalculator {
             }
         }
         // If the target is conventional infantry
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             // Create a single element vector with total number of troopers
             max_index = 0;
             armor_values[0] = ((Infantry) target).getShootingStrength();

--- a/megamek/src/megamek/client/bot/TestBot.java
+++ b/megamek/src/megamek/client/bot/TestBot.java
@@ -524,13 +524,8 @@ public class TestBot extends BotClient {
                                     toHit = DfaAttackAction.toHit(game, option
                                             .getEntity().getId(), target
                                                                           .getEntity(), option);
-                                    damage = 2 * DfaAttackAction
-                                            .getDamageFor(
-                                                    option.getEntity(),
-                                                    (target.getEntity() instanceof Infantry)
-                                                    && !(target
-                                                            .getEntity() instanceof BattleArmor)
-                                                         );
+                                    damage = 2 * DfaAttackAction.getDamageFor(option.getEntity(),
+                                            target.getEntity().isConventionalInfantry());
                                     self_threat = (option
                                                            .getCEntity()
                                                            .getThreatUtility(
@@ -1184,7 +1179,7 @@ public class TestBot extends BotClient {
                 }
 
                 // For good measure, infantry cannot attack multiple targets
-                if ((en instanceof Infantry) && !(en instanceof BattleArmor)) {
+                if (en.isConventionalInfantry()) {
                     starg_mod = 13;
                 }
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1415,8 +1415,7 @@ public class FireControl {
         } else if (0.5 > damageFraction
                    || Targetable.TYPE_BUILDING == target.getTargetType()
                    || Targetable.TYPE_HEX_CLEAR == target.getTargetType()
-                   || owner.getGame().getEntity(target.getTargetId()) instanceof Infantry
-                   || owner.getGame().getEntity(target.getTargetId()) instanceof BattleArmor) {
+                   || owner.getGame().getEntity(target.getTargetId()) instanceof Infantry) {
             return 0;
         }
         //In the remaining case(0.5<=damage), return the fraction of target HP dealt as the penalty scaling factor(multiplied by the weight value to produce a penalty).

--- a/megamek/src/megamek/client/generator/RandomSkillsGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomSkillsGenerator.java
@@ -185,8 +185,7 @@ public class RandomSkillsGenerator implements Serializable {
             //Now we need to make all kinds of adjustments based on the table on pg. 40 of TW
 
            //infantry anti-mech skill should be one higher unless foot
-            if(((e instanceof Infantry) && !(e instanceof BattleArmor))
-                    & (e.getMovementMode() != EntityMovementMode.INF_LEG)) {
+            if (e.isConventionalInfantry() && (e.getMovementMode() != EntityMovementMode.INF_LEG)) {
                 skills[1]++;
             }
 
@@ -208,8 +207,7 @@ public class RandomSkillsGenerator implements Serializable {
                     skills[1]++;
                 }
                 //gunnery is worse for infantry, conv fighters and small craft
-                if(((e instanceof Infantry) && !(e instanceof BattleArmor))
-                        || (e instanceof ConvFighter) || (e instanceof SmallCraft)) {
+                if (e.isConventionalInfantry() || (e instanceof ConvFighter) || (e instanceof SmallCraft)) {
                     skills[0]++;
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -674,20 +674,19 @@ public class CustomMechDialog extends ClientDialog implements ActionListener,
                     continue;
                 }
 
-                // a bunch of stuf should get disabled for conv infantry
-                if ((((entity instanceof Infantry) && !(entity instanceof BattleArmor)))
-                        && (option.getName().equals(OptionsConstants.MD_VDNI) || option.getName()
-                                .equals(OptionsConstants.MD_BVDNI))) {
+                // a bunch of stuff should get disabled for conv infantry
+                if (entity.isConventionalInfantry()
+                        && (option.getName().equals(OptionsConstants.MD_VDNI)
+                        || option.getName().equals(OptionsConstants.MD_BVDNI))) {
                     continue;
                 }
 
-                // a bunch of stuff should get disabled for all but conventional
-                // infantry
-                if (!((entity instanceof Infantry) && !(entity instanceof BattleArmor))
+                // a bunch of stuff should get disabled for all but conventional infantry
+                if (!entity.isConventionalInfantry()
                         && (option.getName().equals(OptionsConstants.MD_PL_ENHANCED)
-                                || option.getName().equals(OptionsConstants.MD_PL_MASC)
-                                || option.getName().equals(OptionsConstants.MD_CYBER_IMP_AUDIO) || option
-                                .getName().equals(OptionsConstants.MD_CYBER_IMP_VISUAL))) {
+                        || option.getName().equals(OptionsConstants.MD_PL_MASC)
+                        || option.getName().equals(OptionsConstants.MD_CYBER_IMP_AUDIO)
+                        || option.getName().equals(OptionsConstants.MD_CYBER_IMP_VISUAL))) {
                     continue;
                 }
 

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1,17 +1,16 @@
 /*
  * MegaMek - Copyright (C) 2003, 2004 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
-
 package megamek.client.ui.swing;
 
 import java.awt.GridBagConstraints;
@@ -55,7 +54,7 @@ import megamek.common.weapons.infantry.InfantryWeapon;
  * @since 2012-05-20
  */
 public class EquipChoicePanel extends JPanel {
-    static final long serialVersionUID = 672299770230285567L;
+    private static final long serialVersionUID = 672299770230285567L;
 
     private final Entity entity;
 
@@ -296,10 +295,9 @@ public class EquipChoicePanel extends JPanel {
         }
 
         // set up infantry armor
-        if ((entity instanceof Infantry) && !(entity instanceof BattleArmor)) {
+        if (entity.isConventionalInfantry()) {
             panInfArmor.initialize();
-            add(panInfArmor,
-                    GBC.eop().anchor(GridBagConstraints.CENTER));
+            add(panInfArmor, GBC.eop().anchor(GridBagConstraints.CENTER));
         }
 
         // Set up searchlight
@@ -397,8 +395,7 @@ public class EquipChoicePanel extends JPanel {
         if (null != m_bombs) {
             m_bombs.applyChoice();
         }
-        if ((entity instanceof Infantry)
-                && !(entity instanceof BattleArmor)) {
+        if (entity.isConventionalInfantry()) {
             panInfArmor.applyChoice();
         }
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1954,19 +1954,19 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 if ((target == null) || target.equals(ce)) {
                     clientgui.doAlertDialog(
                             Messages.getString("MovementDisplay.CantDFA"),
-                            Messages.getString("MovementDisplay.NoTarget")); //$NON-NLS-1$ //$NON-NLS-2$
+                            Messages.getString("MovementDisplay.NoTarget"));
                     clear();
                     computeMovementEnvelope(ce);
                     return;
                 }
 
                 // check if it's a valid DFA
-                ToHitData toHit = DfaAttackAction.toHit(clientgui.getClient()
-                                                                 .getGame(), cen, target, cmd);
+                ToHitData toHit = DfaAttackAction.toHit(clientgui.getClient().getGame(), cen, target, cmd);
                 if (toHit.getValue() != TargetRoll.IMPOSSIBLE) {
                     // if yes, ask them if they want to DFA
-                    if (clientgui.doYesNoDialog(Messages.getString("MovementDisplay.DFADialog.title",
-                            target.getDisplayName()),
+                    if (clientgui.doYesNoDialog(
+                            Messages.getString("MovementDisplay.DFADialog.title",
+                                    target.getDisplayName()),
                             Messages.getString("MovementDisplay.DFADialog.message",
                                     toHit.getValueAsString(), Compute.oddsAbove(toHit.getValue()),
                                     toHit.getDesc(),
@@ -1982,13 +1982,11 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     return;
                 }
                 // if not valid, tell why
-                clientgui.doAlertDialog(
-                        Messages.getString("MovementDisplay.CantDFA"), //$NON-NLS-1$
-                        toHit.getDesc());
+                clientgui.doAlertDialog(Messages.getString("MovementDisplay.CantDFA"), toHit.getDesc());
                 clear();
                 return;
             }
-            butDone.setText("<html><b>" + Messages.getString("MovementDisplay.Move") + "</b></html>"); //$NON-NLS-1$
+            butDone.setText("<html><b>" + Messages.getString("MovementDisplay.Move") + "</b></html>");
             updateProneButtons();
             updateRACButton();
             updateSearchlightButton();

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1965,29 +1965,13 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                                                                  .getGame(), cen, target, cmd);
                 if (toHit.getValue() != TargetRoll.IMPOSSIBLE) {
                     // if yes, ask them if they want to DFA
-                    if (clientgui
-                            .doYesNoDialog(
-                                    Messages.getString(
-                                            "MovementDisplay.DFADialog.title",
-                                            new Object[] { target
-                                                    .getDisplayName() }), //$NON-NLS-1$
-                                    Messages.getString(
-                                            "MovementDisplay.DFADialog.message", new Object[] {//$NON-NLS-1$
-                                                    toHit.getValueAsString(),
-                                                    Double.valueOf(
-                                                            Compute.oddsAbove(toHit
-                                                                    .getValue())),
-                                                    toHit.getDesc(),
-                                                    Integer.valueOf(
-                                                            DfaAttackAction
-                                                                    .getDamageFor(
-                                                                            ce,
-                                                                            (target instanceof Infantry)
-                                                                                    && !(target instanceof BattleArmor))),
-                                                    toHit.getTableDesc(),
-                                                    Integer.valueOf(
-                                                            DfaAttackAction
-                                                                    .getDamageTakenBy(ce)) }))) {
+                    if (clientgui.doYesNoDialog(Messages.getString("MovementDisplay.DFADialog.title",
+                            target.getDisplayName()),
+                            Messages.getString("MovementDisplay.DFADialog.message",
+                                    toHit.getValueAsString(), Compute.oddsAbove(toHit.getValue()),
+                                    toHit.getDesc(),
+                                    DfaAttackAction.getDamageFor(ce, target.isConventionalInfantry()),
+                                    toHit.getTableDesc(), DfaAttackAction.getDamageTakenBy(ce)))) {
                         // if they answer yes, DFA the target
                         cmd.getLastStep().setTarget(target);
                         ready();

--- a/megamek/src/megamek/client/ui/swing/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PhysicalDisplay.java
@@ -420,49 +420,32 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
         final Entity en = ce();
         final boolean isAptPiloting = (en.getCrew() != null)
                 && en.hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING);
-        final boolean canZweihander = null != en
-                && (en instanceof BipedMech) 
-                && ((BipedMech)en).canZweihander()
+        final boolean canZweihander = (en instanceof BipedMech)
+                && ((BipedMech) en).canZweihander()
                 && Compute.isInArc(en.getPosition(), en.getSecondaryFacing(), target, en.getForwardArc());;
         final boolean isMeleeMaster = (en.getCrew() != null)
                 && en.hasAbility(OptionsConstants.PILOT_MELEE_MASTER);
+
+        final ToHitData leftArm = PunchAttackAction.toHit(clientgui.getClient().getGame(), cen,
+                target, PunchAttackAction.LEFT, false);
+        final ToHitData rightArm = PunchAttackAction.toHit(clientgui.getClient().getGame(), cen,
+                target, PunchAttackAction.RIGHT, false);
         
-              
-        final ToHitData leftArm = PunchAttackAction.toHit(clientgui.getClient()
-                .getGame(), cen, target, PunchAttackAction.LEFT, false);
-        final ToHitData rightArm = PunchAttackAction.toHit(clientgui
-                .getClient().getGame(), cen, target, PunchAttackAction.RIGHT, false);
-        
-        final double punchOddsRight = Compute.oddsAbove(rightArm.getValue(),
-                isAptPiloting);
+        final double punchOddsRight = Compute.oddsAbove(rightArm.getValue(), isAptPiloting);
         final int punchDmgRight = PunchAttackAction.getDamageFor(en,
-                PunchAttackAction.RIGHT, (target instanceof Infantry)
-                        && !(target instanceof BattleArmor), false);
+                PunchAttackAction.RIGHT, target.isConventionalInfantry(), false);
         
-        final double punchOddsLeft = Compute.oddsAbove(leftArm.getValue(),
-                isAptPiloting);
-        final int punchDmgLeft = PunchAttackAction.getDamageFor(en,
-                PunchAttackAction.LEFT, (target instanceof Infantry)
-                        && !(target instanceof BattleArmor), false);
+        final double punchOddsLeft = Compute.oddsAbove(leftArm.getValue(), isAptPiloting);
+        final int punchDmgLeft = PunchAttackAction.getDamageFor(en, PunchAttackAction.LEFT,
+                target.isConventionalInfantry(), false);
         
-        String title = Messages.getString("PhysicalDisplay.PunchDialog.title", //$NON-NLS-1$
-                new Object[] { target.getDisplayName() }); 
-        String message = Messages
-                .getString("PhysicalDisplay.PunchDialog.message", //$NON-NLS-1$ 
-                        new Object[] {
-                                rightArm.getValueAsString(),
-                                punchOddsRight,
-                                rightArm.getDesc(),
-                                punchDmgRight,
-                                rightArm.getTableDesc(),
-                                leftArm.getValueAsString(),
-                                punchOddsLeft,
-                                leftArm.getDesc(),
-                                punchDmgLeft,
-                                leftArm.getTableDesc() });
+        String title = Messages.getString("PhysicalDisplay.PunchDialog.title", target.getDisplayName());
+        String message = Messages.getString("PhysicalDisplay.PunchDialog.message",
+                rightArm.getValueAsString(), punchOddsRight, rightArm.getDesc(), punchDmgRight,
+                rightArm.getTableDesc(), leftArm.getValueAsString(), punchOddsLeft,
+                leftArm.getDesc(), punchDmgLeft, leftArm.getTableDesc());
         if (isMeleeMaster) {
-            message = Messages.getString("PhysicalDisplay.MeleeMaster") + "\n\n"
-                    + message;
+            message = Messages.getString("PhysicalDisplay.MeleeMaster") + "\n\n" + message;
         }
         if (clientgui.doYesNoDialog(title, message)) {
             // check for retractable blade that can be extended in each arm
@@ -474,12 +457,10 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
                             .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RETRACTABLE_BLADES)
                     && (leftArm.getValue() != TargetRoll.IMPOSSIBLE)
                     && ((Mech) ce()).hasRetractedBlade(Mech.LOC_LARM)) {
-                leftBladeExtend = clientgui.doYesNoDialog(Messages
-                        .getString("PhysicalDisplay.ExtendBladeDialog.title"),
-                        Messages.getString(
-                                "PhysicalDisplay.ExtendBladeDialog.message",
-                                new Object[] { ce().getLocationName(
-                                        Mech.LOC_LARM) }));
+                leftBladeExtend = clientgui.doYesNoDialog(
+                        Messages.getString("PhysicalDisplay.ExtendBladeDialog.title"),
+                        Messages.getString("PhysicalDisplay.ExtendBladeDialog.message",
+                                ce().getLocationName(Mech.LOC_LARM)));
             }
             if ((en instanceof Mech)
                     && (target instanceof Entity)
@@ -487,11 +468,10 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
                     && clientgui.getClient().getGame().getOptions()
                             .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RETRACTABLE_BLADES)
                     && ((Mech) en).hasRetractedBlade(Mech.LOC_RARM)) {
-                rightBladeExtend = clientgui.doYesNoDialog(Messages
-                        .getString("PhysicalDisplay.ExtendBladeDialog"
-                                + ".title"), Messages.getString(
-                        "PhysicalDisplay.ExtendBladeDialog.message",
-                        new Object[] { en.getLocationName(Mech.LOC_RARM) }));
+                rightBladeExtend = clientgui.doYesNoDialog(
+                        Messages.getString("PhysicalDisplay.ExtendBladeDialog" + ".title"),
+                        Messages.getString("PhysicalDisplay.ExtendBladeDialog.message",
+                                en.getLocationName(Mech.LOC_RARM)));
             }
             
             boolean zweihandering = false;
@@ -499,16 +479,14 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
             if(canZweihander) {
                 
                 //need to choose a primary arm. Do it based on highest predicted damage     		
-                ToHitData leftArmZwei = PunchAttackAction.toHit(clientgui.getClient()
-                        .getGame(), cen, target, PunchAttackAction.LEFT, true);
-                ToHitData rightArmZwei = PunchAttackAction.toHit(clientgui
-                        .getClient().getGame(), cen, target, PunchAttackAction.RIGHT, true);
-                int damageRightZwei = PunchAttackAction.getDamageFor(en,
-                        PunchAttackAction.RIGHT, (target instanceof Infantry)
-                                && !(target instanceof BattleArmor), true);
-                int damageLeftZwei = PunchAttackAction.getDamageFor(en,
-                        PunchAttackAction.LEFT, (target instanceof Infantry)
-                                && !(target instanceof BattleArmor), true);
+                ToHitData leftArmZwei = PunchAttackAction.toHit(clientgui.getClient().getGame(),
+                        cen, target, PunchAttackAction.LEFT, true);
+                ToHitData rightArmZwei = PunchAttackAction.toHit(clientgui.getClient().getGame(),
+                        cen, target, PunchAttackAction.RIGHT, true);
+                int damageRightZwei = PunchAttackAction.getDamageFor(en, PunchAttackAction.RIGHT,
+                        target.isConventionalInfantry(), true);
+                int damageLeftZwei = PunchAttackAction.getDamageFor(en, PunchAttackAction.LEFT,
+                        target.isConventionalInfantry(), true);
                 double oddsLeft = Compute.oddsAbove(leftArmZwei.getValue(), isAptPiloting);
                 double oddsRight = Compute.oddsAbove(rightArmZwei.getValue(), isAptPiloting);
                 ToHitData toHitZwei = rightArmZwei;
@@ -521,19 +499,15 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
                     armChosenZwei = PunchAttackAction.LEFT;
                 } 
                               
-                zweihandering = clientgui.doYesNoDialog(Messages
-                        .getString("PhysicalDisplay.ZweihanderPunchDialog.title"),
+                zweihandering = clientgui.doYesNoDialog(
+                        Messages.getString("PhysicalDisplay.ZweihanderPunchDialog.title"),
                         Messages.getString("PhysicalDisplay.ZweihanderPunchDialog.message",
-                            new Object[] { 
-                                    toHitZwei.getValueAsString(),
-                                    oddsZwei,
-                                    toHitZwei.getDesc(),
-                                    damageZwei,
-                                    toHitZwei.getTableDesc()}));
+                                toHitZwei.getValueAsString(), oddsZwei, toHitZwei.getDesc(),
+                                damageZwei, toHitZwei.getTableDesc()));
             }
             
-            if(zweihandering) {
-                if(armChosenZwei==PunchAttackAction.LEFT) {
+            if (zweihandering) {
+                if (armChosenZwei==PunchAttackAction.LEFT) {
                     leftArm.addModifier(TargetRoll.IMPOSSIBLE, "zweihandering with other arm");
                 } else {
                     rightArm.addModifier(TargetRoll.IMPOSSIBLE, "zweihandering with other arm");
@@ -666,24 +640,14 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
         
         final double kickOdds = Compute.oddsAbove(attackLeg.getValue(),
                 isAptPiloting);
-        final int kickDmg = KickAttackAction.getDamageFor(en, attackSide,
-                (target instanceof Infantry)
-                        && !(target instanceof BattleArmor));
+        final int kickDmg = KickAttackAction.getDamageFor(en, attackSide, target.isConventionalInfantry());
         
-        String title = Messages.getString("PhysicalDisplay.KickDialog.title", //$NON-NLS-1$ 
-                new Object[]{target.getDisplayName()});
-        String message = Messages
-                .getString("PhysicalDisplay.KickDialog.message", //$NON-NLS-1$ 
-                        new Object[] {
-                                attackLeg.getValueAsString(),
-                                kickOdds,
-                                attackLeg.getDesc(),
-                                kickDmg,
-                                attackLeg.getTableDesc() });
+        String title = Messages.getString("PhysicalDisplay.KickDialog.title", target.getDisplayName());
+        String message = Messages.getString("PhysicalDisplay.KickDialog.message",
+                attackLeg.getValueAsString(), kickOdds, attackLeg.getDesc(), kickDmg, attackLeg.getTableDesc());
         
         if (isMeleeMaster) {
-            message = Messages.getString("PhysicalDisplay.MeleeMaster") + "\n\n"
-                    + message;
+            message = Messages.getString("PhysicalDisplay.MeleeMaster") + "\n\n" + message;
         }
         
         if (clientgui.doYesNoDialog(title, message)) {
@@ -945,33 +909,26 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
             String[] names = new String[clubs.size()];
             for (int loop = 0; loop < names.length; loop++) {
                 Mounted club = clubs.get(loop);
-                boolean targetConvInf = (target instanceof Infantry)
-                        && !(target instanceof BattleArmor);
-                final ToHitData toHit = ClubAttackAction.toHit(clientgui
-                        .getClient().getGame(), cen, target, club, ash
-                        .getAimTable(), false);
+                final ToHitData toHit = ClubAttackAction.toHit(clientgui.getClient().getGame(), cen,
+                        target, club, ash.getAimTable(), false);
                 final int dmg = ClubAttackAction.getDamageFor(ce(), club,
-                        targetConvInf, false);
+                        target.isConventionalInfantry(), false);
                 // Need to do this outside getDamageFor, as it only returns int
                 String dmgString = dmg + "";
-                if ((((MiscType) club.getType()).hasSubType(MiscType.S_COMBINE)
-                        || ((MiscType) club.getType()).hasSubType(MiscType.S_CHAINSAW)
-                        || ((MiscType) club.getType()).hasSubType(MiscType.S_DUAL_SAW))
-                        && targetConvInf) {
+                if ((club.getType().hasSubType(MiscType.S_COMBINE)
+                        || club.getType().hasSubType(MiscType.S_CHAINSAW)
+                        || club.getType().hasSubType(MiscType.S_DUAL_SAW))
+                        && target.isConventionalInfantry()) {
                     dmgString = "1d6";
                 }
-                names[loop] = Messages.getString(
-                                "PhysicalDisplay.ChooseClubDialog.line", //$NON-NLS-1$
-                                new Object[] { club.getName(),
-                                        toHit.getValueAsString(), dmgString });
+                names[loop] = Messages.getString("PhysicalDisplay.ChooseClubDialog.line",
+                        club.getName(), toHit.getValueAsString(), dmgString);
             }
 
-            String input = (String) JOptionPane
-                    .showInputDialog(
-                            clientgui,
-                            Messages.getString("PhysicalDisplay.ChooseClubDialog.message"), //$NON-NLS-1$
-                            Messages.getString("PhysicalDisplay.ChooseClubDialog.title"), //$NON-NLS-1$
-                            JOptionPane.QUESTION_MESSAGE, null, names, null);
+            String input = (String) JOptionPane.showInputDialog(clientgui,
+                    Messages.getString("PhysicalDisplay.ChooseClubDialog.message"),
+                    Messages.getString("PhysicalDisplay.ChooseClubDialog.title"),
+                    JOptionPane.QUESTION_MESSAGE, null, names, null);
             if (input != null) {
                 for (int i = 0; i < clubs.size(); i++) {
                     if (input.equals(names[i])) {
@@ -1007,61 +964,45 @@ public class PhysicalDisplay extends StatusBarPhaseDisplay {
                 && en.hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING);
         final boolean isMeleeMaster = (en.getCrew() != null)
                 && en.hasAbility(OptionsConstants.PILOT_MELEE_MASTER);
-        final boolean canZweihander = null != en
-                && (en instanceof BipedMech) 
-                && ((BipedMech)en).canZweihander()
+        final boolean canZweihander = (en instanceof BipedMech)
+                && ((BipedMech) en).canZweihander()
                 && Compute.isInArc(en.getPosition(), en.getSecondaryFacing(), target, en.getForwardArc());
-                
+
         final ToHitData toHit = ClubAttackAction.toHit(clientgui.getClient()
                 .getGame(), cen, target, club, ash.getAimTable(), false);
-        boolean targetConvInf = (target instanceof Infantry)
-                && !(target instanceof BattleArmor);
         final double clubOdds = Compute.oddsAbove(toHit.getValue(),
                 isAptPiloting);
-        final int clubDmg = ClubAttackAction.getDamageFor(en, club,
-                targetConvInf, false);
+        final int clubDmg = ClubAttackAction.getDamageFor(en, club, target.isConventionalInfantry(), false);
         // Need to do this outside getDamageFor, as it only returns int
         String dmgString = clubDmg + "";
-        if ((((MiscType) club.getType()).hasSubType(MiscType.S_COMBINE)
-                || ((MiscType) club.getType()).hasSubType(MiscType.S_CHAINSAW)
-                || ((MiscType) club.getType()).hasSubType(MiscType.S_DUAL_SAW))
-                && targetConvInf) {
+        if ((club.getType().hasSubType(MiscType.S_COMBINE)
+                || club.getType().hasSubType(MiscType.S_CHAINSAW)
+                || club.getType().hasSubType(MiscType.S_DUAL_SAW))
+                && target.isConventionalInfantry()) {
             dmgString = "1d6";
         }
-        String title = Messages.getString("PhysicalDisplay.ClubDialog.title", //$NON-NLS-1$ 
-                new Object[] { target.getDisplayName() });
-        String message = Messages
-                .getString("PhysicalDisplay.ClubDialog.message", //$NON-NLS-1$ 
-                        new Object[] { 
-                                toHit.getValueAsString(),
-                                clubOdds,
-                                toHit.getDesc(),
-                                dmgString,
-                                toHit.getTableDesc() });
+        String title = Messages.getString("PhysicalDisplay.ClubDialog.title", target.getDisplayName());
+        String message = Messages.getString("PhysicalDisplay.ClubDialog.message",
+                toHit.getValueAsString(), clubOdds, toHit.getDesc(), dmgString, toHit.getTableDesc());
         
         if (isMeleeMaster) {
-            message = Messages.getString("PhysicalDisplay.MeleeMaster") + "\n\n"
-                    + message;
+            message = Messages.getString("PhysicalDisplay.MeleeMaster") + "\n\n" + message;
         }
         
         if (clientgui.doYesNoDialog(title, message)) {
             boolean zweihandering = false;
             if(canZweihander) {
-                ToHitData toHitZwei = ClubAttackAction.toHit(clientgui.getClient()
-                        .getGame(), cen, target, club, ash.getAimTable(), true);
-                zweihandering = clientgui.doYesNoDialog(Messages
-                        .getString("PhysicalDisplay.ZweihanderClubDialog.title"),
+                ToHitData toHitZwei = ClubAttackAction.toHit(clientgui.getClient().getGame(), cen,
+                        target, club, ash.getAimTable(), true);
+                zweihandering = clientgui.doYesNoDialog(Messages.getString("PhysicalDisplay.ZweihanderClubDialog.title"),
                         Messages.getString("PhysicalDisplay.ZweihanderClubDialog.message",
-                                new Object[] { 
-                                        toHitZwei.getValueAsString(),
-                                        Compute.oddsAbove(toHit.getValue(),
-                                                isAptPiloting),
-                                        toHitZwei.getDesc(),
-                                        ClubAttackAction.getDamageFor(en, club,
-                                                targetConvInf, true),
-                                        toHitZwei.getTableDesc() }));
+                                toHitZwei.getValueAsString(),
+                                Compute.oddsAbove(toHit.getValue(), isAptPiloting),
+                                toHitZwei.getDesc(),
+                                ClubAttackAction.getDamageFor(en, club, target.isConventionalInfantry(), true),
+                                toHitZwei.getTableDesc()));
             }
-            
+
             disableButtons();
             // declare searchlight, if possible
             if (GUIPreferences.getInstance().getAutoDeclareSearchlight()) {

--- a/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
@@ -44,7 +44,6 @@ import megamek.client.ui.Messages;
 
 import megamek.common.ASFBay;
 import megamek.common.Aero;
-import megamek.common.BattleArmor;
 import megamek.common.Bay;
 import megamek.common.CriticalSlot;
 import megamek.common.DockingCollar;
@@ -159,7 +158,7 @@ public class UnitEditorDialog extends JDialog {
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.fill = GridBagConstraints.BOTH;
         panMain.add(panArmor, gridBagConstraints);
-        if (!((entity instanceof Infantry) && !(entity instanceof BattleArmor))) {
+        if (!entity.isConventionalInfantry()) {
             gridBagConstraints.gridy = 1;
             gridBagConstraints.weighty = 1.0;
             panMain.add(new JScrollPane(panSystem), gridBagConstraints);
@@ -174,11 +173,9 @@ public class UnitEditorDialog extends JDialog {
         getContentPane().add(panMain, BorderLayout.CENTER);
 
         JButton butOK = new JButton(Messages.getString("Okay"));
-        butOK.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnOkayActionPerformed(evt);
-                setVisible(false);
-            }
+        butOK.addActionListener(evt -> {
+            btnOkayActionPerformed(evt);
+            setVisible(false);
         });
         JButton butCancel = new JButton(Messages.getString("Cancel"));
         butCancel.addActionListener(new java.awt.event.ActionListener() {
@@ -201,8 +198,7 @@ public class UnitEditorDialog extends JDialog {
         if (entity instanceof Aero) {
             initAeroArmorPanel();
             return;
-        } else if ((entity instanceof Infantry)
-                && !(entity instanceof BattleArmor)) {
+        } else if (entity.isConventionalInfantry()) {
             initInfantryArmorPanel();
             return;
         }
@@ -1212,9 +1208,8 @@ public class UnitEditorDialog extends JDialog {
                 } else {
                     entity.setInternal(internal, i);
                 }
-                if ((entity instanceof Infantry)
-                        && !(entity instanceof BattleArmor)) {
-                    ((Infantry) entity).applyDamage();
+                if (entity.isConventionalInfantry()) {
+                    entity.applyDamage();
                 }
             }
             if (null != spnArmor[i]) {

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -46,7 +46,6 @@ import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.client.ui.swing.widget.UnitDisplaySkinSpecification;
 import megamek.common.Aero;
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.Configuration;
 import megamek.common.Coords;
@@ -1437,22 +1436,17 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
         wArcHeatR.setText(Integer.toString(entity.getHeatInArc(
                 mounted.getLocation(), mounted.isRearMounted())));
 
-        if (wtype instanceof InfantryWeapon && !wtype.hasFlag(WeaponType.F_TAG)) {
+        if ((wtype instanceof InfantryWeapon) && !wtype.hasFlag(WeaponType.F_TAG)) {
             wDamageTrooperL.setVisible(true);
             wDamageTrooperR.setVisible(true);
             InfantryWeapon inftype = (InfantryWeapon) wtype;
-            if ((entity instanceof Infantry)
-                && !(entity instanceof BattleArmor)) {
-                wDamageTrooperR
-                        .setText(Double.toString((double) Math
-                                .round(((Infantry) entity)
-                                               .getDamagePerTrooper() * 1000) / 1000));
+            if (entity.isConventionalInfantry()) {
+                wDamageTrooperR.setText(Double.toString((double) Math.round(
+                        ((Infantry) entity).getDamagePerTrooper() * 1000) / 1000));
             } else {
-                wDamageTrooperR.setText(Double.toString(inftype
-                                                                .getInfantryDamage()));
+                wDamageTrooperR.setText(Double.toString(inftype.getInfantryDamage()));
             }
-            // what a nightmare to set up all the range info for infantry
-            // weapons
+            // what a nightmare to set up all the range info for infantry weapons
             wMinL.setVisible(false);
             wShortL.setVisible(false);
             wMedL.setVisible(false);

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3262,7 +3262,6 @@ public class Aero extends Entity implements IAero, IBomber {
     public TargetRoll getStealthModifier(int range, Entity ae) {
         TargetRoll result = null;
 
-        boolean isInfantry = (ae instanceof Infantry) && !(ae instanceof BattleArmor);
         // Stealth or null sig must be active.
         if (!isStealthActive()) {
             result = new TargetRoll(0, "stealth not active");
@@ -3273,14 +3272,14 @@ public class Aero extends Entity implements IAero, IBomber {
             switch (range) {
             case RangeType.RANGE_MINIMUM:
             case RangeType.RANGE_SHORT:
-                if (!isInfantry) {
+                if (!ae.isConventionalInfantry()) {
                     result = new TargetRoll(0, "stealth");
                 } else {
                     result = new TargetRoll(0, "infantry ignore stealth");
                 }
                 break;
             case RangeType.RANGE_MEDIUM:
-                if (!isInfantry) {
+                if (!ae.isConventionalInfantry()) {
                     result = new TargetRoll(1, "stealth");
                 } else {
                     result = new TargetRoll(0, "infantry ignore stealth");
@@ -3289,7 +3288,7 @@ public class Aero extends Entity implements IAero, IBomber {
             case RangeType.RANGE_LONG:
             case RangeType.RANGE_EXTREME:
             case RangeType.RANGE_LOS:
-                if (!isInfantry) {
+                if (!ae.isConventionalInfantry()) {
                     result = new TargetRoll(2, "stealth");
                 } else {
                     result = new TargetRoll(0, "infantry ignore stealth");

--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -11,7 +11,6 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megamek.common;
 
 import java.text.NumberFormat;
@@ -21,7 +20,6 @@ import java.util.Vector;
 
 import megamek.MegaMek;
 import megamek.common.options.OptionsConstants;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
@@ -39,9 +37,6 @@ import megamek.common.weapons.infantry.InfantryWeapon;
  * compiler catches my "= for ==" errors.
  */
 public class BattleArmor extends Infantry {
-    /**
-     *
-     */
     private static final long serialVersionUID = 4594311535026187825L;
     /*
      * Infantry have no critical slot limitations. IS squads usually have 4 men,
@@ -1340,27 +1335,24 @@ public class BattleArmor extends Infantry {
         }
 
         // Stealthy units alreay have their to-hit mods defined.
-        if (isStealthy
-                && !((ae instanceof Infantry) && !(ae instanceof BattleArmor))
-                && !hasMyomerBooster()) {
+        if (isStealthy && !ae.isConventionalInfantry() && !hasMyomerBooster()) {
             switch (range) {
-            case RangeType.RANGE_MINIMUM:
-            case RangeType.RANGE_SHORT:
-                result = new TargetRoll(shortStealthMod, stealthName);
-                break;
-            case RangeType.RANGE_MEDIUM:
-                result = new TargetRoll(mediumStealthMod, stealthName);
-                break;
-            case RangeType.RANGE_LONG:
-            case RangeType.RANGE_EXTREME:
-            case RangeType.RANGE_LOS:
-                result = new TargetRoll(longStealthMod, stealthName);
-                break;
-            case RangeType.RANGE_OUT:
-                break;
-            default:
-                throw new IllegalArgumentException(
-                        "Unknown range constant: " + range);
+                case RangeType.RANGE_MINIMUM:
+                case RangeType.RANGE_SHORT:
+                    result = new TargetRoll(shortStealthMod, stealthName);
+                    break;
+                case RangeType.RANGE_MEDIUM:
+                    result = new TargetRoll(mediumStealthMod, stealthName);
+                    break;
+                case RangeType.RANGE_LONG:
+                case RangeType.RANGE_EXTREME:
+                case RangeType.RANGE_LOS:
+                    result = new TargetRoll(longStealthMod, stealthName);
+                    break;
+                case RangeType.RANGE_OUT:
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown range constant: " + range);
             }
         }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -3477,21 +3477,17 @@ public class Compute {
 
             // For each valid ammo bin
             for (Mounted abin : shooter.getAmmo()) {
-                if (shooter.loadWeapon(shooter.getEquipment(atk.getWeaponId()),
-                                       abin)) {
+                if (shooter.loadWeapon(shooter.getEquipment(atk.getWeaponId()), abin)) {
                     if (abin.getUsableShotsLeft() > 0) {
                         abin_type = (AmmoType) abin.getType();
                         if (!AmmoType.canDeliverMinefield(abin_type)) {
 
                             // Load weapon with specified bin
-                            shooter.loadWeapon(
-                                    shooter.getEquipment(atk.getWeaponId()),
-                                    abin);
+                            shooter.loadWeapon(shooter.getEquipment(atk.getWeaponId()), abin);
                             atk.setAmmoId(shooter.getEquipmentNum(abin));
 
                             // Get expected damage
-                            ex_damage = Compute.getExpectedDamage(cgame, atk,
-                                                                  false);
+                            ex_damage = Compute.getExpectedDamage(cgame, atk, false);
 
                             // Calculate any modifiers due to ammo type
                             ammo_multiple = 1.0;
@@ -3512,12 +3508,7 @@ public class Compute {
                                             || (abin_type.getAmmoType() == AmmoType.T_AC_IMP)
                                             || (abin_type.getAmmoType() == AmmoType.T_PAC))
                                             && (abin_type.getMunitionType() == AmmoType.M_FLECHETTE))) {
-                                ammo_multiple = 0.0;
-                                if (target instanceof Infantry) {
-                                    if (!(target instanceof BattleArmor)) {
-                                        ammo_multiple = 2.0;
-                                    }
-                                }
+                                ammo_multiple = target.isConventionalInfantry() ? 2.0 : 0.0;
                             }
 
                             // LBX cluster rounds work better against units
@@ -3526,12 +3517,11 @@ public class Compute {
                             // Other ammo that deliver lots of small
                             // submunitions should be tested for here too
                             if (((abin_type.getAmmoType() == AmmoType.T_AC_LBX)
-                                 || (abin_type.getAmmoType() == AmmoType.T_AC_LBX_THB) || (abin_type
-                                                                                                   .getAmmoType() ==
-                                                                                           AmmoType.T_SBGAUSS))
-                                && (abin_type.getMunitionType() == AmmoType.M_CLUSTER)) {
+                                    || (abin_type.getAmmoType() == AmmoType.T_AC_LBX_THB)
+                                    || (abin_type.getAmmoType() == AmmoType.T_SBGAUSS))
+                                    && (abin_type.getMunitionType() == AmmoType.M_CLUSTER)) {
                                 if (target.getArmorRemainingPercent() <= 0.25) {
-                                    ammo_multiple = 1.0 + (wtype.getRackSize() / 10);
+                                    ammo_multiple = 1.0 + (wtype.getRackSize() / 10.0);
                                 }
                                 if (target instanceof Tank) {
                                     ammo_multiple += 1.0;
@@ -4208,8 +4198,7 @@ public class Compute {
                 visualRange = visualRange / 2;
             } else if (te.isChameleonShieldActive()) {
                 visualRange = visualRange / 2;
-            } else if ((te instanceof Infantry) && !(te instanceof BattleArmor)
-                       && ((Infantry) te).hasSneakCamo()) {
+            } else if (te.isConventionalInfantry() && ((Infantry) te).hasSneakCamo()) {
                 visualRange = visualRange / 2;
             }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2206,14 +2206,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 }
                 break;
             case INF_UMU:
-            	/* non-mechanized SCUBA infantry have a maximum depth of 2 */
-            	if (this instanceof Infantry && ((Infantry)this).hasSpecialization(Infantry.SCUBA)
-            			&& hex.containsTerrain(Terrains.WATER)) {
-            		minAlt = Math.max(hex.floor(), -2);
-            	} else {
-            		minAlt = hex.floor();
-            	}
-            	break;
+                /* non-mechanized SCUBA infantry have a maximum depth of 2 */
+                if (this instanceof Infantry && ((Infantry)this).hasSpecialization(Infantry.SCUBA)
+                        && hex.containsTerrain(Terrains.WATER)) {
+                    minAlt = Math.max(hex.floor(), -2);
+                } else {
+                    minAlt = hex.floor();
+                }
+                break;
             case SUBMARINE:
             case BIPED_SWIM:
             case QUAD_SWIM:
@@ -2351,11 +2351,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 .containsTerrain(Terrains.WATER))
                    || ((getMovementMode() == EntityMovementMode.QUAD_SWIM) && hasUMU())
                    || ((getMovementMode() == EntityMovementMode.BIPED_SWIM) && hasUMU())) {
-        	if (this instanceof Infantry && ((Infantry)this).hasSpecialization(Infantry.SCUBA)
-        			&& getMovementMode() == EntityMovementMode.INF_UMU) {
-        		return assumedAlt >= Math.max(hex.floor(), -2)
-        				&& (assumedAlt <= hex.surface());
-        	}
+            if (this instanceof Infantry && ((Infantry)this).hasSpecialization(Infantry.SCUBA)
+                    && getMovementMode() == EntityMovementMode.INF_UMU) {
+                return assumedAlt >= Math.max(hex.floor(), -2)
+                        && (assumedAlt <= hex.surface());
+            }
             return ((assumedAlt >= hex.floor()) && (assumedAlt <= hex.surface()));
         } else if ((getMovementMode() == EntityMovementMode.HYDROFOIL)
                    || (getMovementMode() == EntityMovementMode.NAVAL)) {
@@ -2584,7 +2584,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * imparts some kind of permanent effect to the entity.
      */
     public void postProcessFacingChange() {
-    	
+
     }
 
     /**
@@ -2844,7 +2844,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Returns this entity's original jumping mp.
      */
     public int getOriginalJumpMP() {
-    	return getOriginalJumpMP(false);
+        return getOriginalJumpMP(false);
     }
 
     public int getOriginalJumpMP(boolean ignoreModularArmor) {
@@ -5361,12 +5361,12 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
         // check for Manei Domini implants
         if (((hasAbility(OptionsConstants.MD_CYBER_IMP_AUDIO)
-        	|| hasAbility(OptionsConstants.MD_CYBER_IMP_VISUAL)
-        	|| hasAbility(OptionsConstants.MD_MM_IMPLANTS))
-        		&& isConventionalInfantry())
-            || (hasAbility(OptionsConstants.MD_MM_IMPLANTS)
-            		&& (hasAbility(OptionsConstants.MD_VDNI)
-			|| hasAbility(OptionsConstants.MD_BVDNI)))) {
+                || hasAbility(OptionsConstants.MD_CYBER_IMP_VISUAL)
+                || hasAbility(OptionsConstants.MD_MM_IMPLANTS))
+                && isConventionalInfantry())
+                || (hasAbility(OptionsConstants.MD_MM_IMPLANTS)
+                && (hasAbility(OptionsConstants.MD_VDNI)
+                || hasAbility(OptionsConstants.MD_BVDNI)))) {
             return !checkECM || !ComputeECM.isAffectedByECM(this, getPosition(), getPosition());
         }
         // check for quirk
@@ -5393,13 +5393,13 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         }
         // check for Manei Domini implants
         int cyberBonus = 0;
-        if ((hasAbility(OptionsConstants.MD_CYBER_IMP_AUDIO)
-        		|| hasAbility(OptionsConstants.MD_MM_IMPLANTS))
-        		|| hasAbility(OptionsConstants.MD_CYBER_IMP_VISUAL)
-                	&& isConventionalInfantry()
+        if (((hasAbility(OptionsConstants.MD_CYBER_IMP_AUDIO)
+                || hasAbility(OptionsConstants.MD_MM_IMPLANTS))
+                || hasAbility(OptionsConstants.MD_CYBER_IMP_VISUAL)
+                && isConventionalInfantry())
                 || (hasAbility(OptionsConstants.MD_MM_IMPLANTS)
-                	&& (hasAbility(OptionsConstants.MD_VDNI)
-    			|| hasAbility(OptionsConstants.MD_BVDNI)))) {
+                && (hasAbility(OptionsConstants.MD_VDNI)
+                || hasAbility(OptionsConstants.MD_BVDNI)))) {
             cyberBonus = 2;
         }
 
@@ -6624,12 +6624,12 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     }
                 }
             } else if (ams.getType().hasFlag(WeaponType.F_PDBAY)) {
-            	//Point defense bays are assigned to the attack with the greatest threat
-            	//Unlike single AMS, PD bays can gang up on 1 attack
+                //Point defense bays are assigned to the attack with the greatest threat
+                //Unlike single AMS, PD bays can gang up on 1 attack
                 WeaponAttackAction waa = Compute.getHighestExpectedDamage(game,
                         vAttacksInArc, true);
                     if (waa != null) {
-                    	waa.addCounterEquipment(ams);
+                        waa.addCounterEquipment(ams);
                     }
             } else {
             //Otherwise, find the most dangerous salvo by expected damage and target it
@@ -7977,7 +7977,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         component.setGame(game);
         transports.add(component);
         if (isOmniPod) {
-        	omniPodTransports.add(component);
+            omniPodTransports.add(component);
         }
     }
 
@@ -8110,42 +8110,42 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         // Walk through this entity's transport components;
         // find those that can load the unit.
         // load the unit into the best match.
-    	int choice = 0;
-    	for (Transporter nextbay : transports) {
-    		if (nextbay.canLoad(unit) && (unit.getElevation() == getElevation())) {
-    			if (nextbay instanceof DockingCollar) {
-    				choice = 3;
-    			}
-    			if (nextbay instanceof ASFBay) {
-    				choice = 2;
-    			}
-    			if (nextbay instanceof SmallCraftBay) {
-    			choice = 1;
-    			}
-    		}
-    	}
-    	if (choice == 3) {
-    		for (Transporter nextbay : transports) {
-    			while (nextbay instanceof DockingCollar) {
-    				((DockingCollar) nextbay).recover(unit);
-    				return;
-    			}
-    		}
-    	}else if (choice == 2) {
-    		for (Bay nextbay : getTransportBays()) {
-    			while (nextbay instanceof ASFBay) {
-    				((ASFBay) nextbay).recover(unit);
-    				return;
-    			}
-    		}
-    	} else if (choice == 1) {
-    		for (Bay nextbay : getTransportBays()) {
-    			while (nextbay instanceof SmallCraftBay) {
-    				((SmallCraftBay) nextbay).recover(unit);
-    				return;
-    			}
-    		}
-    	}
+        int choice = 0;
+        for (Transporter nextbay : transports) {
+            if (nextbay.canLoad(unit) && (unit.getElevation() == getElevation())) {
+                if (nextbay instanceof DockingCollar) {
+                    choice = 3;
+                }
+                if (nextbay instanceof ASFBay) {
+                    choice = 2;
+                }
+                if (nextbay instanceof SmallCraftBay) {
+                choice = 1;
+                }
+            }
+        }
+        if (choice == 3) {
+            for (Transporter nextbay : transports) {
+                while (nextbay instanceof DockingCollar) {
+                    ((DockingCollar) nextbay).recover(unit);
+                    return;
+                }
+            }
+        }else if (choice == 2) {
+            for (Bay nextbay : getTransportBays()) {
+                while (nextbay instanceof ASFBay) {
+                    ((ASFBay) nextbay).recover(unit);
+                    return;
+                }
+            }
+        } else if (choice == 1) {
+            for (Bay nextbay : getTransportBays()) {
+                while (nextbay instanceof SmallCraftBay) {
+                    ((SmallCraftBay) nextbay).recover(unit);
+                    return;
+                }
+            }
+        }
     }
 
 
@@ -8553,7 +8553,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public boolean isPodMountedTransport(Transporter t) {
-    	return omniPodTransports.contains(t);
+        return omniPodTransports.contains(t);
     }
 
     public Vector<Bay> getTransportBays() {
@@ -8812,11 +8812,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             }
             if (isOmni() && ((next instanceof TroopSpace)
                     || (next instanceof Bay))) {
-            	if (omniPodTransports.contains(next)) {
-            		result.append(" (Pod)");
-            	} else {
-            		result.append(" (Fixed)");
-            	}
+                if (omniPodTransports.contains(next)) {
+                    result.append(" (Pod)");
+                } else {
+                    result.append(" (Fixed)");
+                }
             }
             // Add a newline character between strings.
             if (iter.hasMoreElements()) {
@@ -9285,8 +9285,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public boolean canSpot() {
         return isActive() && !isOffBoard() && 
-        		(moved != EntityMovementType.MOVE_SPRINT) && 
-        		(moved != EntityMovementType.MOVE_VTOL_SPRINT);
+                (moved != EntityMovementType.MOVE_SPRINT) &&
+                (moved != EntityMovementType.MOVE_VTOL_SPRINT);
     }
 
     @Override
@@ -12609,14 +12609,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * @return the initiative bonus this Entity grants for MD implants
      */
-	/*
-	 * This has been removed in IO see pg 78
-	 *
-	 * public int getMDIniBonus() { if
-	 * (crew.getOptions().booleanOption(OptionsConstants.MD_COMM_IMPLANT) ||
-	 * crew.getOptions().booleanOption(OptionsConstants.MD_BOOST_COMM_IMPLANT))
-	 * { return 1; } return 0; }
-	 */
+    /*
+     * This has been removed in IO see pg 78
+     *
+     * public int getMDIniBonus() { if
+     * (crew.getOptions().booleanOption(OptionsConstants.MD_COMM_IMPLANT) ||
+     * crew.getOptions().booleanOption(OptionsConstants.MD_BOOST_COMM_IMPLANT))
+     * { return 1; } return 0; }
+     */
 
     /**
      * @return the initiative bonus this Entity grants for quirks
@@ -13226,9 +13226,9 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
 
     public int getBattleForcePoints() {
-    	double bv = calculateBattleValue(true, true);
-    	int points = (int) Math.round(bv / 100);
-    	return Math.max(1, points);
+        double bv = calculateBattleValue(true, true);
+        int points = (int) Math.round(bv / 100);
+        return Math.max(1, points);
     }
 
     /**
@@ -13236,42 +13236,42 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * string.
      */
     public String getMovementModeAsBattleForceString() {
-    	switch (getMovementMode()) {
-    	case NONE:
-    	case BIPED:
-    	case BIPED_SWIM:
-    	case QUAD:
-    	case QUAD_SWIM:
-    		return "";
-    	case TRACKED:
-    		return "t";
-    	case WHEELED:
-    		return "w";
-    	case HOVER:
-    		return "h";
-    	case VTOL:
-    		return "v";
-    	case NAVAL:
-    	case HYDROFOIL:
-    		return "n";
-    	case SUBMARINE:
-    	case INF_UMU:
-    		return "s";
-    	case INF_LEG:
-    		return "f";
-    	case INF_MOTORIZED:
-    		return "m";
-    	case INF_JUMP:
-    		return "j";
-    	case WIGE:
-    		return "g";
-    	case AERODYNE:
-    		return "a";
-    	case SPHEROID:
-    		return "p";
-    	default:
-    		return "ERROR";
-    	}
+        switch (getMovementMode()) {
+        case NONE:
+        case BIPED:
+        case BIPED_SWIM:
+        case QUAD:
+        case QUAD_SWIM:
+            return "";
+        case TRACKED:
+            return "t";
+        case WHEELED:
+            return "w";
+        case HOVER:
+            return "h";
+        case VTOL:
+            return "v";
+        case NAVAL:
+        case HYDROFOIL:
+            return "n";
+        case SUBMARINE:
+        case INF_UMU:
+            return "s";
+        case INF_LEG:
+            return "f";
+        case INF_MOTORIZED:
+            return "m";
+        case INF_JUMP:
+            return "j";
+        case WIGE:
+            return "g";
+        case AERODYNE:
+            return "a";
+        case SPHEROID:
+            return "p";
+        default:
+            return "ERROR";
+        }
     }
 
     /**
@@ -13280,7 +13280,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * while BattleForce rounds this to the nearest integer.
      */
     public double getBaseBattleForceMovement() {
-    	return getOriginalWalkMP();
+        return getOriginalWalkMP();
     }
 
     /**
@@ -13289,46 +13289,46 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return
      */
     public void setBattleForceMovement(Map<String,Integer> movement) {
-    	int baseMove = (int)Math.round(getBaseBattleForceMovement());
-    	int jumpMove = getOriginalJumpMP();
-    	if (jumpMove == baseMove && getMovementModeAsBattleForceString().length() == 0) {
-    		movement.put("j", baseMove);
-    	} else {
-    		movement.put(getMovementModeAsBattleForceString(), baseMove);
-    		if (jumpMove >= baseMove) {
-    			movement.put("j", jumpMove);
-    		} else if (jumpMove > 0) {
-    			movement.put("j", (int)Math.round(jumpMove * 0.66));
-    		}
-    	}
-    	int umu = getAllUMUCount();
-    	if (umu > 0) {
-    		movement.put("s", umu);
-    	}
+        int baseMove = (int)Math.round(getBaseBattleForceMovement());
+        int jumpMove = getOriginalJumpMP();
+        if (jumpMove == baseMove && getMovementModeAsBattleForceString().length() == 0) {
+            movement.put("j", baseMove);
+        } else {
+            movement.put(getMovementModeAsBattleForceString(), baseMove);
+            if (jumpMove >= baseMove) {
+                movement.put("j", jumpMove);
+            } else if (jumpMove > 0) {
+                movement.put("j", (int)Math.round(jumpMove * 0.66));
+            }
+        }
+        int umu = getAllUMUCount();
+        if (umu > 0) {
+            movement.put("s", umu);
+        }
     }
 
     /**
      * Doubles base movement. Aero overrides this.
      */
     public void setAlphaStrikeMovement(Map<String,Integer> movement) {
-    	int baseMove = (int)Math.round(getBaseBattleForceMovement() * 2);
-    	int jumpMove = getOriginalJumpMP();
-    	if (jumpMove == baseMove) {
-    		movement.put("j", baseMove);
-    	} else {
-    		movement.put(getMovementModeAsBattleForceString(), baseMove);
-    		if (jumpMove > 0) {
-    			movement.put("j", jumpMove * 2);
-    		}
-    	}
-    	int umu = getAllUMUCount();
-    	if (umu > 0) {
-    		movement.put("s", umu * 2);
-    	}
+        int baseMove = (int)Math.round(getBaseBattleForceMovement() * 2);
+        int jumpMove = getOriginalJumpMP();
+        if (jumpMove == baseMove) {
+            movement.put("j", baseMove);
+        } else {
+            movement.put(getMovementModeAsBattleForceString(), baseMove);
+            if (jumpMove > 0) {
+                movement.put("j", jumpMove * 2);
+            }
+        }
+        int umu = getAllUMUCount();
+        if (umu > 0) {
+            movement.put("s", umu * 2);
+        }
     }
 
     public int getBattleForceArmorPoints() {
-    	return (int)Math.round(getBattleForceArmorPointsRaw());
+        return (int)Math.round(getBattleForceArmorPointsRaw());
     }
 
     /**
@@ -13338,48 +13338,48 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return      The armor value of this entity
      */
     public double getBattleForceArmorPointsRaw() {
-    	double armorPoints = 0;
+        double armorPoints = 0;
 
-    	for (int loc = 0; loc < locations(); loc++) {
-    		double armorMod = 1;
-    		switch (getArmorType(loc)) {
-    		case EquipmentType.T_ARMOR_COMMERCIAL:
-    			armorMod = .5;
-    			break;
-    		case EquipmentType.T_ARMOR_INDUSTRIAL:
-    		case EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL:
-    			armorMod = getBARRating(0) / 10;
-    			break;
-    		case EquipmentType.T_ARMOR_FERRO_LAMELLOR:
-    			armorMod = 1.2;
-    			break;
-    		case EquipmentType.T_ARMOR_HARDENED:
-    			armorMod = 1.5;
-    			break;
-    		case EquipmentType.T_ARMOR_REFLECTIVE:
-    		case EquipmentType.T_ARMOR_REACTIVE:
-    			armorMod = .75;
-    			break;
-    		}
-    		armorPoints += Math.ceil(getArmor(loc) * armorMod);
+        for (int loc = 0; loc < locations(); loc++) {
+            double armorMod = 1;
+            switch (getArmorType(loc)) {
+            case EquipmentType.T_ARMOR_COMMERCIAL:
+                armorMod = .5;
+                break;
+            case EquipmentType.T_ARMOR_INDUSTRIAL:
+            case EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL:
+                armorMod = getBARRating(0) / 10;
+                break;
+            case EquipmentType.T_ARMOR_FERRO_LAMELLOR:
+                armorMod = 1.2;
+                break;
+            case EquipmentType.T_ARMOR_HARDENED:
+                armorMod = 1.5;
+                break;
+            case EquipmentType.T_ARMOR_REFLECTIVE:
+            case EquipmentType.T_ARMOR_REACTIVE:
+                armorMod = .75;
+                break;
+            }
+            armorPoints += Math.ceil(getArmor(loc) * armorMod);
 
-    	}
-    	if (this.hasModularArmor()) {
-    		// Modular armor is always "regular" armor
-    		for (Mounted mount : this.getEquipment()) {
-    			if (!mount.isDestroyed()
-    					&& (mount.getType() instanceof MiscType)
-    					&& ((MiscType) mount.getType())
-    					.hasFlag(MiscType.F_MODULAR_ARMOR)) {
-    				armorPoints += 10;
-    			}
-    		}
-    	}
+        }
+        if (this.hasModularArmor()) {
+            // Modular armor is always "regular" armor
+            for (Mounted mount : this.getEquipment()) {
+                if (!mount.isDestroyed()
+                        && (mount.getType() instanceof MiscType)
+                        && ((MiscType) mount.getType())
+                        .hasFlag(MiscType.F_MODULAR_ARMOR)) {
+                    armorPoints += 10;
+                }
+            }
+        }
 
-    	if (isCapitalScale()) {
-    		return (int)Math.round(armorPoints * 0.33);
-    	}
-    	return (int) Math.round(armorPoints / 30);
+        if (isCapitalScale()) {
+            return (int)Math.round(armorPoints * 0.33);
+        }
+        return (int) Math.round(armorPoints / 30);
     }
 
     /**
@@ -13388,7 +13388,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return
      */
     public String getBattleForceDamageThresholdString() {
-    	return "";
+        return "";
     }
 
     /**
@@ -13397,7 +13397,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return
      */
     public int getBattleForceStructurePoints() {
-    	return 0;
+        return 0;
     }
 
     /**
@@ -13405,11 +13405,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return
      */
     public int getNumBattleForceWeaponsLocations() {
-    	return 1;
+        return 1;
     }
 
     public int getNumAlphaStrikeWeaponsLocations() {
-    	return getNumBattleForceWeaponsLocations();
+        return getNumBattleForceWeaponsLocations();
     }
 
     /**
@@ -13418,7 +13418,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return - the damage multiplier for this location; 0 for exclusion
      */
     public double getBattleForceLocationMultiplier(int index, int location, boolean rearMounted) {
-    	return 1.0;
+        return 1.0;
     }
 
     /**
@@ -13426,15 +13426,15 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * in AS, and warships, which have only four arcs in AS.
      */
     public double getAlphaStrikeLocationMultiplier(int index, int location, boolean rearMounted) {
-    	return getBattleForceLocationMultiplier(index, location, rearMounted);
+        return getBattleForceLocationMultiplier(index, location, rearMounted);
     }
 
     public boolean isBattleForceTurretLocation(int index) {
-    	return false;
+        return false;
     }
 
     public boolean isBattleForceRearLocation(int index) {
-    	return false;
+        return false;
     }
 
     /**
@@ -13443,18 +13443,18 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return
      */
     public String getBattleForceLocationName(int index) {
-    	if (isBattleForceTurretLocation(index)) {
-    		return "TUR";
-    	}
-    	return "";
+        if (isBattleForceTurretLocation(index)) {
+            return "TUR";
+        }
+        return "";
     }
 
     public String getAlphaStrikeLocationName(int index) {
-    	return getBattleForceLocationName(index);
+        return getBattleForceLocationName(index);
     }
 
     public boolean useForAlphaStrikePointCalc(int loc) {
-    	return loc == 0 || isBattleForceTurretLocation(loc);
+        return loc == 0 || isBattleForceTurretLocation(loc);
     }
 
     /**
@@ -13463,7 +13463,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return - total heat generated by firing all weapons
      */
     public int getBattleForceTotalHeatGeneration(boolean allowRear) {
-    	return 0;
+        return 0;
     }
 
     /**
@@ -13473,270 +13473,270 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return
      */
     public int getBattleForceTotalHeatGeneration(int location) {
-    	return 0;
+        return 0;
     }
 
     public void addBattleForceSpecialAbilities(Map<BattleForceSPA,Integer> specialAbilities) {
-    	for (Mounted m : getEquipment()) {
-    		if (!(m.getType() instanceof MiscType)) {
-    			continue;
-    		}
-    		if (m.getType().hasFlag(MiscType.F_BAP)) {
-    			specialAbilities.put(BattleForceSPA.RCN, null);
-    			if (m.getType().hasFlag(MiscType.F_BLOODHOUND)) {
-    				specialAbilities.put(BattleForceSPA.BH, null);
-    			} else if (m.getType().hasFlag(MiscType.F_BA_EQUIPMENT)) {
-    				specialAbilities.put(BattleForceSPA.LPRB, null);
-    			} else if (m.getType().hasFlag(MiscType.F_WATCHDOG)) {
-    				specialAbilities.put(BattleForceSPA.WAT, null);
-    				specialAbilities.put(BattleForceSPA.LPRB, null);
-    				specialAbilities.put(BattleForceSPA.ECM, null);
-    			} else {
-    				specialAbilities.put(BattleForceSPA.PRB, null);
-    			}
-    			if (m.getType().hasFlag(MiscType.F_NOVA)) {
-    				specialAbilities.put(BattleForceSPA.NOVA, null);
-    				specialAbilities.put(BattleForceSPA.ECM, null);
-    				specialAbilities.put(BattleForceSPA.MHQ, 3); // count half-tons
-    			}
-    		} else if (m.getType().hasFlag(MiscType.F_ECM)) {
-    			if (m.getType().hasFlag(MiscType.F_ANGEL_ECM)) {
-    				specialAbilities.put(BattleForceSPA.AECM, null);
-    			} else if (m.getType().hasFlag(MiscType.F_SINGLE_HEX_ECM)) {
-    				specialAbilities.put(BattleForceSPA.LECM, null);
-    			} else {
-    				specialAbilities.put(BattleForceSPA.ECM, null);
-    			}
-    		} else if (m.getType().hasFlag(MiscType.F_BOOBY_TRAP)) {
-    			specialAbilities.put(BattleForceSPA.BT, null);
-    		} else if (m.getType().hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
-    				|| m.getType().hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
-    				|| m.getType().hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)) {
-    			specialAbilities.put(BattleForceSPA.BRID, null);
-    		} else if (m.getType().hasFlag(MiscType.F_C3S)) {
-    			if (m.getType().hasFlag(MiscType.F_C3SBS)) {
-    				specialAbilities.put(BattleForceSPA.C3BSS, null);
-    				specialAbilities.merge(BattleForceSPA.MHQ, 4, Integer::sum);
-    			} else if (m.getType().hasFlag(MiscType.F_C3EM)) {
-    				specialAbilities.merge(BattleForceSPA.C3EM, 1, Integer::sum);
-    				specialAbilities.merge(BattleForceSPA.MHQ, 4, Integer::sum);
-    			} else {
-    				specialAbilities.put(BattleForceSPA.C3S, null);
-    				specialAbilities.merge(BattleForceSPA.MHQ, 2, Integer::sum);
-    			}
-    		} else if (m.getType().hasFlag(MiscType.F_C3I)) {
-    			if ((getEntityType() & ETYPE_AERO) == ETYPE_AERO) {
-    				specialAbilities.put(BattleForceSPA.NC3, null);
-    			} else {
-    				specialAbilities.put(BattleForceSPA.C3I, null);
-    				if (m.getType().hasFlag(MiscType.F_BA_EQUIPMENT)) {
-    					specialAbilities.merge(BattleForceSPA.MHQ, 4, Integer::sum);
-    				} else {
-    					specialAbilities.merge(BattleForceSPA.MHQ, 5, Integer::sum);
-    				}
-    			}
-    		} else if (m.getType().hasFlag(MiscType.F_CASE)) {
-    			specialAbilities.put(BattleForceSPA.CASE, null);
+        for (Mounted m : getEquipment()) {
+            if (!(m.getType() instanceof MiscType)) {
+                continue;
+            }
+            if (m.getType().hasFlag(MiscType.F_BAP)) {
+                specialAbilities.put(BattleForceSPA.RCN, null);
+                if (m.getType().hasFlag(MiscType.F_BLOODHOUND)) {
+                    specialAbilities.put(BattleForceSPA.BH, null);
+                } else if (m.getType().hasFlag(MiscType.F_BA_EQUIPMENT)) {
+                    specialAbilities.put(BattleForceSPA.LPRB, null);
+                } else if (m.getType().hasFlag(MiscType.F_WATCHDOG)) {
+                    specialAbilities.put(BattleForceSPA.WAT, null);
+                    specialAbilities.put(BattleForceSPA.LPRB, null);
+                    specialAbilities.put(BattleForceSPA.ECM, null);
+                } else {
+                    specialAbilities.put(BattleForceSPA.PRB, null);
+                }
+                if (m.getType().hasFlag(MiscType.F_NOVA)) {
+                    specialAbilities.put(BattleForceSPA.NOVA, null);
+                    specialAbilities.put(BattleForceSPA.ECM, null);
+                    specialAbilities.put(BattleForceSPA.MHQ, 3); // count half-tons
+                }
+            } else if (m.getType().hasFlag(MiscType.F_ECM)) {
+                if (m.getType().hasFlag(MiscType.F_ANGEL_ECM)) {
+                    specialAbilities.put(BattleForceSPA.AECM, null);
+                } else if (m.getType().hasFlag(MiscType.F_SINGLE_HEX_ECM)) {
+                    specialAbilities.put(BattleForceSPA.LECM, null);
+                } else {
+                    specialAbilities.put(BattleForceSPA.ECM, null);
+                }
+            } else if (m.getType().hasFlag(MiscType.F_BOOBY_TRAP)) {
+                specialAbilities.put(BattleForceSPA.BT, null);
+            } else if (m.getType().hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
+                    || m.getType().hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
+                    || m.getType().hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)) {
+                specialAbilities.put(BattleForceSPA.BRID, null);
+            } else if (m.getType().hasFlag(MiscType.F_C3S)) {
+                if (m.getType().hasFlag(MiscType.F_C3SBS)) {
+                    specialAbilities.put(BattleForceSPA.C3BSS, null);
+                    specialAbilities.merge(BattleForceSPA.MHQ, 4, Integer::sum);
+                } else if (m.getType().hasFlag(MiscType.F_C3EM)) {
+                    specialAbilities.merge(BattleForceSPA.C3EM, 1, Integer::sum);
+                    specialAbilities.merge(BattleForceSPA.MHQ, 4, Integer::sum);
+                } else {
+                    specialAbilities.put(BattleForceSPA.C3S, null);
+                    specialAbilities.merge(BattleForceSPA.MHQ, 2, Integer::sum);
+                }
+            } else if (m.getType().hasFlag(MiscType.F_C3I)) {
+                if ((getEntityType() & ETYPE_AERO) == ETYPE_AERO) {
+                    specialAbilities.put(BattleForceSPA.NC3, null);
+                } else {
+                    specialAbilities.put(BattleForceSPA.C3I, null);
+                    if (m.getType().hasFlag(MiscType.F_BA_EQUIPMENT)) {
+                        specialAbilities.merge(BattleForceSPA.MHQ, 4, Integer::sum);
+                    } else {
+                        specialAbilities.merge(BattleForceSPA.MHQ, 5, Integer::sum);
+                    }
+                }
+            } else if (m.getType().hasFlag(MiscType.F_CASE)) {
+                specialAbilities.put(BattleForceSPA.CASE, null);
             } else if (m.getType().hasFlag(MiscType.F_CASEP)) { //in BF seems to work the same as CASE
                 specialAbilities.put(BattleForceSPA.CASE, null);
-    		} else if (m.getType().hasFlag(MiscType.F_CASEII)) {
-    			specialAbilities.put(BattleForceSPA.CASEII, null);
-    		} else if (m.getType().hasFlag(MiscType.F_DRONE_OPERATING_SYSTEM)) {
-    			specialAbilities.put(BattleForceSPA.DRO, null);
-    		} else if (m.getType().hasFlag(MiscType.F_DRONE_CARRIER_CONTROL)) {
-    			specialAbilities.merge(BattleForceSPA.DCC, (int) m.getSize(), Integer::sum);
-    		} else if (m.getType().hasFlag(MiscType.F_EJECTION_SEAT)) {
-    			specialAbilities.put(BattleForceSPA.ES, null);
-    		} else if (m.getType().hasFlag(MiscType.F_ECM)) {
-    			specialAbilities.put(BattleForceSPA.ECM, null);
-    		} else if (m.getType().hasFlag(MiscType.F_BULLDOZER)) {
-    			specialAbilities.put(BattleForceSPA.ENG, null);
-    		} else if (m.getType().hasFlag(MiscType.F_CLUB)) {
-    			specialAbilities.put(BattleForceSPA.MEL, null);
-    			if ((m.getType().getSubType() &
-    					(MiscType.S_BACKHOE | MiscType.S_PILE_DRIVER
-    							| MiscType.S_MINING_DRILL | MiscType.S_ROCK_CUTTER
-    							| MiscType.S_WRECKING_BALL)) != 0) {
-    				specialAbilities.put(BattleForceSPA.ENG, null);
-    			} else if ((m.getType().getSubType() &
-    					(MiscType.S_DUAL_SAW | MiscType.S_CHAINSAW
-    							| MiscType.S_BUZZSAW)) != 0) {
-    				specialAbilities.put(BattleForceSPA.SAW, null);
-    			}
-    		} else if (m.getType().hasFlag(MiscType.F_FIRE_RESISTANT)) {
-    			specialAbilities.put(BattleForceSPA.FR, null);
-    		} else if (m.getType().hasFlag(MiscType.F_MOBILE_HPG)) {
-    			specialAbilities.put(BattleForceSPA.HPG, null);
-    		} else if (m.getType().hasFlag(MiscType.F_COMMUNICATIONS)) {
-    			specialAbilities.merge(BattleForceSPA.MHQ, (int) m.getTonnage() * 2,
-    					Integer::sum);
-    			if (m.getTonnage() >= getWeight() / 20.0) {
-    				specialAbilities.put(BattleForceSPA.RCN, null);
-    			}
-    		} else if (m.getType().hasFlag(MiscType.F_SENSOR_DISPENSER)) {
-    			specialAbilities.merge(BattleForceSPA.RSD, 1, Integer::sum);
-    			specialAbilities.put(BattleForceSPA.RCN, null);
-    		} else if (m.getType().hasFlag(MiscType.F_LOOKDOWN_RADAR)
-    				|| m.getType().hasFlag(MiscType.F_RECON_CAMERA)
-    				|| m.getType().hasFlag(MiscType.F_HIRES_IMAGER)
-    				|| m.getType().hasFlag(MiscType.F_HYPERSPECTRAL_IMAGER)
-    				|| m.getType().hasFlag(MiscType.F_INFRARED_IMAGER)) {
-    		} else if (m.getType().hasFlag(MiscType.F_SEARCHLIGHT)) {
-    			specialAbilities.put(BattleForceSPA.SRCH, null);
-    		} else if (m.getType().hasFlag(MiscType.F_RADICAL_HEATSINK)) {
-    			specialAbilities.put(BattleForceSPA.RHS, null);
-    		} else if (m.getType().hasFlag(MiscType.F_EMERGENCY_COOLANT_SYSTEM)) {
-    			specialAbilities.put(BattleForceSPA.ECS, null);
-    		} else if (m.getType().hasFlag(MiscType.F_VIRAL_JAMMER_DECOY)) {
-    			specialAbilities.put(BattleForceSPA.DJ, null);
-    		} else if (m.getType().hasFlag(MiscType.F_VIRAL_JAMMER_HOMING)) {
-    			specialAbilities.put(BattleForceSPA.HJ, null);
-    		}
-    	}
+            } else if (m.getType().hasFlag(MiscType.F_CASEII)) {
+                specialAbilities.put(BattleForceSPA.CASEII, null);
+            } else if (m.getType().hasFlag(MiscType.F_DRONE_OPERATING_SYSTEM)) {
+                specialAbilities.put(BattleForceSPA.DRO, null);
+            } else if (m.getType().hasFlag(MiscType.F_DRONE_CARRIER_CONTROL)) {
+                specialAbilities.merge(BattleForceSPA.DCC, (int) m.getSize(), Integer::sum);
+            } else if (m.getType().hasFlag(MiscType.F_EJECTION_SEAT)) {
+                specialAbilities.put(BattleForceSPA.ES, null);
+            } else if (m.getType().hasFlag(MiscType.F_ECM)) {
+                specialAbilities.put(BattleForceSPA.ECM, null);
+            } else if (m.getType().hasFlag(MiscType.F_BULLDOZER)) {
+                specialAbilities.put(BattleForceSPA.ENG, null);
+            } else if (m.getType().hasFlag(MiscType.F_CLUB)) {
+                specialAbilities.put(BattleForceSPA.MEL, null);
+                if ((m.getType().getSubType() &
+                        (MiscType.S_BACKHOE | MiscType.S_PILE_DRIVER
+                                | MiscType.S_MINING_DRILL | MiscType.S_ROCK_CUTTER
+                                | MiscType.S_WRECKING_BALL)) != 0) {
+                    specialAbilities.put(BattleForceSPA.ENG, null);
+                } else if ((m.getType().getSubType() &
+                        (MiscType.S_DUAL_SAW | MiscType.S_CHAINSAW
+                                | MiscType.S_BUZZSAW)) != 0) {
+                    specialAbilities.put(BattleForceSPA.SAW, null);
+                }
+            } else if (m.getType().hasFlag(MiscType.F_FIRE_RESISTANT)) {
+                specialAbilities.put(BattleForceSPA.FR, null);
+            } else if (m.getType().hasFlag(MiscType.F_MOBILE_HPG)) {
+                specialAbilities.put(BattleForceSPA.HPG, null);
+            } else if (m.getType().hasFlag(MiscType.F_COMMUNICATIONS)) {
+                specialAbilities.merge(BattleForceSPA.MHQ, (int) m.getTonnage() * 2,
+                        Integer::sum);
+                if (m.getTonnage() >= getWeight() / 20.0) {
+                    specialAbilities.put(BattleForceSPA.RCN, null);
+                }
+            } else if (m.getType().hasFlag(MiscType.F_SENSOR_DISPENSER)) {
+                specialAbilities.merge(BattleForceSPA.RSD, 1, Integer::sum);
+                specialAbilities.put(BattleForceSPA.RCN, null);
+            } else if (m.getType().hasFlag(MiscType.F_LOOKDOWN_RADAR)
+                    || m.getType().hasFlag(MiscType.F_RECON_CAMERA)
+                    || m.getType().hasFlag(MiscType.F_HIRES_IMAGER)
+                    || m.getType().hasFlag(MiscType.F_HYPERSPECTRAL_IMAGER)
+                    || m.getType().hasFlag(MiscType.F_INFRARED_IMAGER)) {
+            } else if (m.getType().hasFlag(MiscType.F_SEARCHLIGHT)) {
+                specialAbilities.put(BattleForceSPA.SRCH, null);
+            } else if (m.getType().hasFlag(MiscType.F_RADICAL_HEATSINK)) {
+                specialAbilities.put(BattleForceSPA.RHS, null);
+            } else if (m.getType().hasFlag(MiscType.F_EMERGENCY_COOLANT_SYSTEM)) {
+                specialAbilities.put(BattleForceSPA.ECS, null);
+            } else if (m.getType().hasFlag(MiscType.F_VIRAL_JAMMER_DECOY)) {
+                specialAbilities.put(BattleForceSPA.DJ, null);
+            } else if (m.getType().hasFlag(MiscType.F_VIRAL_JAMMER_HOMING)) {
+                specialAbilities.put(BattleForceSPA.HJ, null);
+            }
+        }
 
-    	if (isOmni()) {
-    		specialAbilities.put(BattleForceSPA.OMNI, null);
-    	}
+        if (isOmni()) {
+            specialAbilities.put(BattleForceSPA.OMNI, null);
+        }
 
-    	//TODO: Variable Range targeting is not implemented
+        //TODO: Variable Range targeting is not implemented
 
-    	if (!hasPatchworkArmor()) {
-    		switch (getArmorType(0)) {
-    		case EquipmentType.T_ARMOR_COMMERCIAL:
-    		case EquipmentType.T_ARMOR_INDUSTRIAL:
-    		case EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL:
-    			specialAbilities.put(BattleForceSPA.BAR, null);
-    			break;
-    		case EquipmentType.T_ARMOR_FERRO_LAMELLOR:
-    			specialAbilities.put(BattleForceSPA.CR, null);
-    			break;
-    		case EquipmentType.T_ARMOR_STEALTH:
-    		case EquipmentType.T_ARMOR_STEALTH_VEHICLE:
-    			specialAbilities.put(BattleForceSPA.STL, null);
-    			specialAbilities.put(BattleForceSPA.ECM, null);
-    			break;
-    		case EquipmentType.T_ARMOR_BA_STEALTH:
-    		case EquipmentType.T_ARMOR_BA_STEALTH_BASIC:
-    		case EquipmentType.T_ARMOR_BA_STEALTH_IMP:
-    		case EquipmentType.T_ARMOR_BA_STEALTH_PROTOTYPE:
-    			specialAbilities.put(BattleForceSPA.STL, null);
-    			specialAbilities.put(BattleForceSPA.LECM, null);
-    			break;
-    		case EquipmentType.T_ARMOR_ANTI_PENETRATIVE_ABLATION:
-    			specialAbilities.put(BattleForceSPA.ABA, null);
-    			break;
-    		case EquipmentType.T_ARMOR_BALLISTIC_REINFORCED:
-    			specialAbilities.put(BattleForceSPA.BRA, null);
-    			break;
-    		case EquipmentType.T_ARMOR_BA_FIRE_RESIST:
-    			specialAbilities.put(BattleForceSPA.FR, null);
-    			break;
-    		case EquipmentType.T_ARMOR_IMPACT_RESISTANT:
-    			specialAbilities.put(BattleForceSPA.IRA, null);
-    			break;
-    		case EquipmentType.T_ARMOR_REACTIVE:
-    			specialAbilities.put(BattleForceSPA.RCA, null);
-    			break;
-    		case EquipmentType.T_ARMOR_REFLECTIVE:
-    			specialAbilities.put(BattleForceSPA.RFA, null);
-    			break;
-    		}
-    	}
+        if (!hasPatchworkArmor()) {
+            switch (getArmorType(0)) {
+            case EquipmentType.T_ARMOR_COMMERCIAL:
+            case EquipmentType.T_ARMOR_INDUSTRIAL:
+            case EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL:
+                specialAbilities.put(BattleForceSPA.BAR, null);
+                break;
+            case EquipmentType.T_ARMOR_FERRO_LAMELLOR:
+                specialAbilities.put(BattleForceSPA.CR, null);
+                break;
+            case EquipmentType.T_ARMOR_STEALTH:
+            case EquipmentType.T_ARMOR_STEALTH_VEHICLE:
+                specialAbilities.put(BattleForceSPA.STL, null);
+                specialAbilities.put(BattleForceSPA.ECM, null);
+                break;
+            case EquipmentType.T_ARMOR_BA_STEALTH:
+            case EquipmentType.T_ARMOR_BA_STEALTH_BASIC:
+            case EquipmentType.T_ARMOR_BA_STEALTH_IMP:
+            case EquipmentType.T_ARMOR_BA_STEALTH_PROTOTYPE:
+                specialAbilities.put(BattleForceSPA.STL, null);
+                specialAbilities.put(BattleForceSPA.LECM, null);
+                break;
+            case EquipmentType.T_ARMOR_ANTI_PENETRATIVE_ABLATION:
+                specialAbilities.put(BattleForceSPA.ABA, null);
+                break;
+            case EquipmentType.T_ARMOR_BALLISTIC_REINFORCED:
+                specialAbilities.put(BattleForceSPA.BRA, null);
+                break;
+            case EquipmentType.T_ARMOR_BA_FIRE_RESIST:
+                specialAbilities.put(BattleForceSPA.FR, null);
+                break;
+            case EquipmentType.T_ARMOR_IMPACT_RESISTANT:
+                specialAbilities.put(BattleForceSPA.IRA, null);
+                break;
+            case EquipmentType.T_ARMOR_REACTIVE:
+                specialAbilities.put(BattleForceSPA.RCA, null);
+                break;
+            case EquipmentType.T_ARMOR_REFLECTIVE:
+                specialAbilities.put(BattleForceSPA.RFA, null);
+                break;
+            }
+        }
 
-    	if (getAmmo().size() > 0) {
-    		if (isClan()) {
-    			specialAbilities.put(BattleForceSPA.CASE, null);
-    		}
-    	} else {
-    		specialAbilities.put(BattleForceSPA.ENE, null);
-    	}
+        if (getAmmo().size() > 0) {
+            if (isClan()) {
+                specialAbilities.put(BattleForceSPA.CASE, null);
+            }
+        } else {
+            specialAbilities.put(BattleForceSPA.ENE, null);
+        }
 
-    	if (getAmmo().stream().map(m -> (AmmoType)m.getType())
-    			.anyMatch(at -> at.hasFlag(AmmoType.F_TELE_MISSILE))) {
-    		specialAbilities.put(BattleForceSPA.TELE, null);
-    	}
+        if (getAmmo().stream().map(m -> (AmmoType)m.getType())
+                .anyMatch(at -> at.hasFlag(AmmoType.F_TELE_MISSILE))) {
+            specialAbilities.put(BattleForceSPA.TELE, null);
+        }
 
-    	if (hasEngine()) {
-    		if (getEngine().getEngineType() == Engine.STEAM
-    				&& getEngine().getEngineType() == Engine.FUEL_CELL) {
-    			specialAbilities.put(BattleForceSPA.EE, null);
-    		} else if (getEngine().getEngineType() == Engine.STEAM) {
-    			specialAbilities.put(BattleForceSPA.FC, null);
-    		} else {
-    			specialAbilities.put(BattleForceSPA.EEE, null);
-    		}
-    	}
+        if (hasEngine()) {
+            if (getEngine().getEngineType() == Engine.STEAM
+                    && getEngine().getEngineType() == Engine.FUEL_CELL) {
+                specialAbilities.put(BattleForceSPA.EE, null);
+            } else if (getEngine().getEngineType() == Engine.STEAM) {
+                specialAbilities.put(BattleForceSPA.FC, null);
+            } else {
+                specialAbilities.put(BattleForceSPA.EEE, null);
+            }
+        }
 
-    	for (Transporter t : getTransports()) {
-    		if (t instanceof ASFBay) {
-    			specialAbilities.merge(BattleForceSPA.AT, (int)((ASFBay)t).getCapacity(), Integer::sum);
-    			specialAbilities.merge(BattleForceSPA.ATxD, ((ASFBay)t).getDoors(), Integer::sum);
-    			specialAbilities.put(BattleForceSPA.MFB, null);
-    		} else if (t instanceof CargoBay) {
-    			specialAbilities.merge(BattleForceSPA.CT, (int)((CargoBay)t).getCapacity(), Integer::sum);
-    			specialAbilities.merge(BattleForceSPA.CTxD, ((CargoBay)t).getDoors(), Integer::sum);
-    		} else if (t instanceof DockingCollar) {
-    			specialAbilities.merge(BattleForceSPA.DT, 1, Integer::sum);
-    		} else if (t instanceof InfantryBay) {
-    			// We do not record number of doors for infantry
-    			specialAbilities.merge(BattleForceSPA.IT, (int)((InfantryBay)t).getCapacity(), Integer::sum);
-    		} else if (t instanceof MechBay) {
-    			specialAbilities.merge(BattleForceSPA.MT, (int)((MechBay)t).getCapacity(), Integer::sum);
-    			specialAbilities.merge(BattleForceSPA.MTxD, ((MechBay)t).getDoors(), Integer::sum);
-    			specialAbilities.put(BattleForceSPA.MFB, null);
-    		} else if (t instanceof ProtomechBay) {
-    			specialAbilities.merge(BattleForceSPA.PT, (int)((ProtomechBay)t).getCapacity(), Integer::sum);
-    			specialAbilities.merge(BattleForceSPA.PTxD, ((ProtomechBay)t).getDoors(), Integer::sum);
-    			specialAbilities.put(BattleForceSPA.MFB, null);
-    		} else if (t instanceof SmallCraftBay) {
-    			specialAbilities.merge(BattleForceSPA.ST, (int)((SmallCraftBay)t).getCapacity(), Integer::sum);
-    			specialAbilities.merge(BattleForceSPA.STxD, ((SmallCraftBay)t).getDoors(), Integer::sum);
-    			specialAbilities.put(BattleForceSPA.MFB, null);
-    		} else if (t instanceof LightVehicleBay) {
-    			specialAbilities.merge(BattleForceSPA.VTM, (int)((LightVehicleBay)t).getCapacity(), Integer::sum);
-    			specialAbilities.merge(BattleForceSPA.VTMxD, ((LightVehicleBay)t).getDoors(), Integer::sum);
-    			specialAbilities.put(BattleForceSPA.MFB, null);
-    		} else if (t instanceof HeavyVehicleBay) {
-    			specialAbilities.merge(BattleForceSPA.VTH, (int)((HeavyVehicleBay)t).getCapacity(), Integer::sum);
-    			specialAbilities.merge(BattleForceSPA.VTHxD, ((HeavyVehicleBay)t).getDoors(), Integer::sum);
-    			specialAbilities.put(BattleForceSPA.MFB, null);
-    		}
-    	}
+        for (Transporter t : getTransports()) {
+            if (t instanceof ASFBay) {
+                specialAbilities.merge(BattleForceSPA.AT, (int)((ASFBay)t).getCapacity(), Integer::sum);
+                specialAbilities.merge(BattleForceSPA.ATxD, ((ASFBay)t).getDoors(), Integer::sum);
+                specialAbilities.put(BattleForceSPA.MFB, null);
+            } else if (t instanceof CargoBay) {
+                specialAbilities.merge(BattleForceSPA.CT, (int)((CargoBay)t).getCapacity(), Integer::sum);
+                specialAbilities.merge(BattleForceSPA.CTxD, ((CargoBay)t).getDoors(), Integer::sum);
+            } else if (t instanceof DockingCollar) {
+                specialAbilities.merge(BattleForceSPA.DT, 1, Integer::sum);
+            } else if (t instanceof InfantryBay) {
+                // We do not record number of doors for infantry
+                specialAbilities.merge(BattleForceSPA.IT, (int)((InfantryBay)t).getCapacity(), Integer::sum);
+            } else if (t instanceof MechBay) {
+                specialAbilities.merge(BattleForceSPA.MT, (int)((MechBay)t).getCapacity(), Integer::sum);
+                specialAbilities.merge(BattleForceSPA.MTxD, ((MechBay)t).getDoors(), Integer::sum);
+                specialAbilities.put(BattleForceSPA.MFB, null);
+            } else if (t instanceof ProtomechBay) {
+                specialAbilities.merge(BattleForceSPA.PT, (int)((ProtomechBay)t).getCapacity(), Integer::sum);
+                specialAbilities.merge(BattleForceSPA.PTxD, ((ProtomechBay)t).getDoors(), Integer::sum);
+                specialAbilities.put(BattleForceSPA.MFB, null);
+            } else if (t instanceof SmallCraftBay) {
+                specialAbilities.merge(BattleForceSPA.ST, (int)((SmallCraftBay)t).getCapacity(), Integer::sum);
+                specialAbilities.merge(BattleForceSPA.STxD, ((SmallCraftBay)t).getDoors(), Integer::sum);
+                specialAbilities.put(BattleForceSPA.MFB, null);
+            } else if (t instanceof LightVehicleBay) {
+                specialAbilities.merge(BattleForceSPA.VTM, (int)((LightVehicleBay)t).getCapacity(), Integer::sum);
+                specialAbilities.merge(BattleForceSPA.VTMxD, ((LightVehicleBay)t).getDoors(), Integer::sum);
+                specialAbilities.put(BattleForceSPA.MFB, null);
+            } else if (t instanceof HeavyVehicleBay) {
+                specialAbilities.merge(BattleForceSPA.VTH, (int)((HeavyVehicleBay)t).getCapacity(), Integer::sum);
+                specialAbilities.merge(BattleForceSPA.VTHxD, ((HeavyVehicleBay)t).getDoors(), Integer::sum);
+                specialAbilities.put(BattleForceSPA.MFB, null);
+            }
+        }
 
-    	topLoop: for (int location = 0; location < locations(); location++) {
-    		for (int slot = 0; slot < getNumberOfCriticals(location); slot++) {
-    			CriticalSlot crit = getCritical(location, slot);
-    			if (null != crit) {
-    				if (crit.isArmored()) {
-    					specialAbilities.put(BattleForceSPA.ARM, null);
-    					break topLoop;
-    				} else if (crit.getType() == CriticalSlot.TYPE_EQUIPMENT) {
-    					Mounted mount = crit.getMount();
-    					if (mount.isArmored()) {
-    						specialAbilities.put(BattleForceSPA.ARM, null);
-    						break topLoop;
-    					}
-    				}
-    			}
-    		}
-    	}
+        topLoop: for (int location = 0; location < locations(); location++) {
+            for (int slot = 0; slot < getNumberOfCriticals(location); slot++) {
+                CriticalSlot crit = getCritical(location, slot);
+                if (null != crit) {
+                    if (crit.isArmored()) {
+                        specialAbilities.put(BattleForceSPA.ARM, null);
+                        break topLoop;
+                    } else if (crit.getType() == CriticalSlot.TYPE_EQUIPMENT) {
+                        Mounted mount = crit.getMount();
+                        if (mount.isArmored()) {
+                            specialAbilities.put(BattleForceSPA.ARM, null);
+                            break topLoop;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     public int getBattleForceSize() {
-    	// the default BF Size is for ground Combat elements. Other types will
-    	// need to override this
-    	// The tables are on page 356 of StartOps
-    	if (getWeight() < 40) {
-    		return 1;
-    	}
-    	if (getWeight() < 60) {
-    		return 2;
-    	}
-    	if (getWeight() < 80) {
-    		return 3;
-    	}
+        // the default BF Size is for ground Combat elements. Other types will
+        // need to override this
+        // The tables are on page 356 of StartOps
+        if (getWeight() < 40) {
+            return 1;
+        }
+        if (getWeight() < 60) {
+            return 2;
+        }
+        if (getWeight() < 80) {
+            return 3;
+        }
 
-    	return 4;
+        return 4;
     }
 
     @Override

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -5349,19 +5349,12 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 if (!m.isInoperable()) {
                     // Beagle Isn't affected by normal ECM
                     if (type.getName().equals("Beagle Active Probe")) {
-
-                        if ((game != null)
-                            && checkECM
-                            && ComputeECM.isAffectedByAngelECM(this,
-                                                               getPosition(), getPosition())) {
-                            return false;
-                        }
-                        return true;
+                        return (game == null)
+                                || !checkECM
+                                || !ComputeECM.isAffectedByAngelECM(this, getPosition(), getPosition());
                     }
-                    return !checkECM
-                           || (game == null)
-                           || !ComputeECM.isAffectedByECM(this, getPosition(),
-                                                          getPosition());
+                    return !checkECM || (game == null)
+                            || !ComputeECM.isAffectedByECM(this, getPosition(), getPosition());
                 }
             }
         }
@@ -5370,21 +5363,15 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if (((hasAbility(OptionsConstants.MD_CYBER_IMP_AUDIO)
         	|| hasAbility(OptionsConstants.MD_CYBER_IMP_VISUAL)
         	|| hasAbility(OptionsConstants.MD_MM_IMPLANTS))
-        		&& (this instanceof Infantry) && !(this instanceof BattleArmor))
+        		&& isConventionalInfantry())
             || (hasAbility(OptionsConstants.MD_MM_IMPLANTS)
             		&& (hasAbility(OptionsConstants.MD_VDNI)
-			|| hasAbility(OptionsConstants.MD_BVDNI))))
-
-        {
-            return !checkECM
-                   || !ComputeECM.isAffectedByECM(this, getPosition(),
-                                                  getPosition());
+			|| hasAbility(OptionsConstants.MD_BVDNI)))) {
+            return !checkECM || !ComputeECM.isAffectedByECM(this, getPosition(), getPosition());
         }
         // check for quirk
         if (hasQuirk(OptionsConstants.QUIRK_POS_IMPROVED_SENSORS)) {
-            return !checkECM
-                   || !ComputeECM.isAffectedByECM(this, getPosition(),
-                                                  getPosition());
+            return !checkECM || !ComputeECM.isAffectedByECM(this, getPosition(), getPosition());
         }
         // check for SPA
         if (hasAbility(OptionsConstants.MISC_EAGLE_EYES)) {
@@ -5406,10 +5393,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         }
         // check for Manei Domini implants
         int cyberBonus = 0;
-        if (((hasAbility(OptionsConstants.MD_CYBER_IMP_AUDIO)
+        if ((hasAbility(OptionsConstants.MD_CYBER_IMP_AUDIO)
         		|| hasAbility(OptionsConstants.MD_MM_IMPLANTS))
         		|| hasAbility(OptionsConstants.MD_CYBER_IMP_VISUAL)
-                	&& (this instanceof Infantry) && !(this instanceof BattleArmor))
+                	&& isConventionalInfantry()
                 || (hasAbility(OptionsConstants.MD_MM_IMPLANTS)
                 	&& (hasAbility(OptionsConstants.MD_VDNI)
     			|| hasAbility(OptionsConstants.MD_BVDNI)))) {

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -203,7 +203,7 @@ public class EntityListFile {
 
             // Record destroyed locations.
             if (!(entity instanceof Aero)
-                    && !((entity instanceof Infantry) && !(entity instanceof BattleArmor))
+                    && !entity.isConventionalInfantry()
                     && (entity.getOInternal(loc) != IArmorState.ARMOR_NA)
                     && (entity.getInternalForReal(loc) <= 0)) {
                 isDestroyed = true;
@@ -211,7 +211,7 @@ public class EntityListFile {
 
             //exact zeroes for BA should not be treated as destroyed as MHQ uses this to signify
             //suits without pilots
-            if(entity instanceof BattleArmor && entity.getInternalForReal(loc) >= 0) {
+            if (entity instanceof BattleArmor && entity.getInternalForReal(loc) >= 0) {
                 isDestroyed = false;
             }
 
@@ -224,7 +224,7 @@ public class EntityListFile {
             // Destroyed locations have lost all their armor and IS.
             if (!isDestroyed && !isPseudoLocation) {
                 int currentArmor;
-                if (entity instanceof BattleArmor){
+                if (entity instanceof BattleArmor) {
                     currentArmor = entity.getArmor(loc);
                 } else {
                     currentArmor = entity.getArmorForReal(loc);
@@ -823,14 +823,13 @@ public class EntityListFile {
                 output.write("\" camoFileName=\"");
                 output.write(entity.getCamoFileName());
             }
-            if(entity instanceof MechWarrior && !((MechWarrior)entity).getPickedUpByExternalIdAsString().equals("-1")) {
+            if (entity instanceof MechWarrior && !((MechWarrior) entity).getPickedUpByExternalIdAsString().equals("-1")) {
                 output.write("\" pickUpId=\"");
-                output.write(((MechWarrior)entity).getPickedUpByExternalIdAsString());
+                output.write(((MechWarrior) entity).getPickedUpByExternalIdAsString());
             }
 
             // Save some values for conventional infantry
-            if ((entity instanceof Infantry)
-                    && !(entity instanceof BattleArmor)) {
+            if (entity.isConventionalInfantry()) {
                 Infantry inf = (Infantry) entity;
                 if (inf.getArmorDamageDivisor() != 1) {
                     output.write("\" " + MULParser.ARMOR_DIVISOR + "=\"");

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -2210,10 +2210,7 @@ public class Infantry extends Entity {
      * @return true if this is a conventional infantry unit with non-mechanized SCUBA specialization
      */
     public boolean isNonMechSCUBA() {
-    	if (this instanceof BattleArmor) {
-    		return false;
-    	}
-    	return getMovementMode() == EntityMovementMode.INF_UMU;
+    	return isConventionalInfantry() && (getMovementMode() == EntityMovementMode.INF_UMU);
     }
 
     public void setPrimaryWeapon(InfantryWeapon w) {
@@ -2227,7 +2224,7 @@ public class Infantry extends Entity {
 
     public void setSecondaryWeapon(InfantryWeapon w) {
         secondW = w;
-        if(null == w) {
+        if (null == w) {
             secondName = null;
         } else {
             secondName = w.getName();
@@ -2286,7 +2283,7 @@ public class Infantry extends Entity {
     public void setMovementMode(EntityMovementMode movementMode) {
         super.setMovementMode(movementMode);
         //movement mode will determine base mp
-        if (!(this instanceof BattleArmor)) {
+        if (isConventionalInfantry()) {
             setOriginalJumpMP(0);
             switch (getMovementMode()) {
                 case INF_MOTORIZED:

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -749,8 +749,7 @@ public class MULParser {
         }
 
         // Load some values for conventional infantry
-        if ((entity instanceof Infantry)
-                && !(entity instanceof BattleArmor)) {
+        if (entity.isConventionalInfantry()) {
             Infantry inf = (Infantry) entity;
             String armorDiv = entityTag.getAttribute(ARMOR_DIVISOR);
             if (armorDiv.length() > 0) {
@@ -780,7 +779,7 @@ public class MULParser {
             }
             
             String infSquadNum = entityTag.getAttribute(INF_SQUAD_NUM);
-            if(infSquadNum.length() > 0) {
+            if (infSquadNum.length() > 0) {
                 inf.setSquadN(Integer.parseInt(infSquadNum));
                 inf.autoSetInternal();
             }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -76,7 +76,7 @@ public abstract class Mech extends Entity {
 
     public static final int ACTUATOR_FOOT = 14;
 
-    public static final String systemNames[] = { "Life Support", "Sensors",
+    public static final String[] systemNames = { "Life Support", "Sensors",
             "Cockpit", "Engine", "Gyro", null, null, "Shoulder", "Upper Arm",
             "Lower Arm", "Hand", "Hip", "Upper Leg", "Lower Leg", "Foot"};
 
@@ -5947,11 +5947,9 @@ public abstract class Mech extends Entity {
             return new TargetRoll(mmod, "void signature");
         }
 
-        boolean isInfantry = (ae instanceof Infantry)
-                && !(ae instanceof BattleArmor);
+        final boolean isInfantry = ae.isConventionalInfantry();
         // Stealth or null sig must be active.
-        if (!isStealthActive() && !isNullSigActive()
-                && !isChameleonShieldActive()) {
+        if (!isStealthActive() && !isNullSigActive() && !isChameleonShieldActive()) {
             result = new TargetRoll(0, "stealth not active");
         }
         // Determine the modifier based upon the range.
@@ -6009,8 +6007,7 @@ public abstract class Mech extends Entity {
                 case RangeType.RANGE_OUT:
                     break;
                 default:
-                    throw new IllegalArgumentException(
-                            "Unknown range constant: " + range);
+                    throw new IllegalArgumentException("Unknown range constant: " + range);
             }
         }
 

--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -285,8 +285,8 @@ public class PlanetaryConditions implements Serializable {
      * to-hit penalty for weather
      */
     public int getWeatherHitPenalty(Entity en) {
-        if(((weatherConditions == WE_LIGHT_RAIN) || (weatherConditions == WE_LIGHT_SNOW))
-                && (en instanceof Infantry) && !(en instanceof BattleArmor)) {
+        if (((weatherConditions == WE_LIGHT_RAIN) || (weatherConditions == WE_LIGHT_SNOW))
+                && en.isConventionalInfantry()) {
             return 1;
         }
         else if((weatherConditions == WE_MOD_RAIN) || (weatherConditions == WE_HEAVY_RAIN)
@@ -547,7 +547,7 @@ public class PlanetaryConditions implements Serializable {
             }
             break;
         case (WI_MOD_GALE):
-            if((en instanceof Infantry) && !(en instanceof BattleArmor)) {
+            if (en.isConventionalInfantry()) {
                 mod -= 1;
             }
             break;
@@ -609,13 +609,13 @@ public class PlanetaryConditions implements Serializable {
             return "tornado";
         }
         if ((windStrength == WI_TORNADO_F13)
-                && (((en instanceof Infantry) && !(en instanceof BattleArmor))
+                && (en.isConventionalInfantry()
                         || ((en.getMovementMode() == EntityMovementMode.HOVER)
                     || (en.getMovementMode() == EntityMovementMode.WIGE)
                     || (en.getMovementMode() == EntityMovementMode.VTOL)))) {
             return "tornado";
         }
-        if((windStrength == WI_STORM) && ((en instanceof Infantry) && !(en instanceof BattleArmor))) {
+        if((windStrength == WI_STORM) && en.isConventionalInfantry()) {
             return "storm";
         }
         if ((temperature > 50 || temperature < -30) && en.doomedInExtremeTemp()) {

--- a/megamek/src/megamek/common/Sensor.java
+++ b/megamek/src/megamek/common/Sensor.java
@@ -221,7 +221,6 @@ public class Sensor implements Serializable {
     }
 
     public int getModsForStealth(Entity te) {
-
         int mod = 0;
 
         // first if we have seismic/magscan/IR we don't have to mod anything
@@ -232,14 +231,9 @@ public class Sensor implements Serializable {
             return mod;
         }
 
-        boolean hasSneak = (te instanceof Infantry)
-                && !(te instanceof BattleArmor)
-                && (((Infantry) te).hasSneakCamo()
-                        || ((Infantry) te).hasSneakIR() || ((Infantry) te)
-                            .hasDEST());
-        boolean hasSneakECM = (te instanceof Infantry)
-                && !(te instanceof BattleArmor)
-                && ((Infantry) te).hasSneakECM();
+        boolean hasSneak = te.isConventionalInfantry() && (((Infantry) te).hasSneakCamo()
+                || ((Infantry) te).hasSneakIR() || ((Infantry) te).hasDEST());
+        boolean hasSneakECM = te.isConventionalInfantry() && ((Infantry) te).hasSneakECM();
 
         // these are cumulative, so lets just plow through the table on pg. 224
         // (ick)

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3798,8 +3798,6 @@ public class Tank extends Entity {
     public TargetRoll getStealthModifier(int range, Entity ae) {
         TargetRoll result = null;
 
-        boolean isInfantry = (ae instanceof Infantry)
-                && !(ae instanceof BattleArmor);
         // Stealth or null sig must be active.
         if (!isStealthActive()) {
             result = new TargetRoll(0, "stealth not active");
@@ -3809,7 +3807,7 @@ public class Tank extends Entity {
             switch (range) {
                 case RangeType.RANGE_MINIMUM:
                 case RangeType.RANGE_SHORT:
-                    if (isStealthActive() && !isInfantry) {
+                    if (isStealthActive() && !ae.isConventionalInfantry()) {
                         result = new TargetRoll(0, "stealth");
                     } else {
                         // must be infantry
@@ -3817,7 +3815,7 @@ public class Tank extends Entity {
                     }
                     break;
                 case RangeType.RANGE_MEDIUM:
-                    if (isStealthActive() && !isInfantry) {
+                    if (isStealthActive() && !ae.isConventionalInfantry()) {
                         result = new TargetRoll(1, "stealth");
                     } else {
                         // must be infantry
@@ -3827,7 +3825,7 @@ public class Tank extends Entity {
                 case RangeType.RANGE_LONG:
                 case RangeType.RANGE_EXTREME:
                 case RangeType.RANGE_LOS:
-                    if (isStealthActive() && !isInfantry) {
+                    if (isStealthActive() && !ae.isConventionalInfantry()) {
                         result = new TargetRoll(2, "stealth");
                     } else {
                         // must be infantry
@@ -3837,8 +3835,7 @@ public class Tank extends Entity {
                 case RangeType.RANGE_OUT:
                     break;
                 default:
-                    throw new IllegalArgumentException(
-                            "Unknown range constant: " + range);
+                    throw new IllegalArgumentException("Unknown range constant: " + range);
             }
         }
 

--- a/megamek/src/megamek/common/actions/AbstractAttackAction.java
+++ b/megamek/src/megamek/common/actions/AbstractAttackAction.java
@@ -237,16 +237,13 @@ public abstract class AbstractAttackAction extends AbstractEntityAction
 
 
         //now check for general hit bonuses for heat
-        if((te != null) 
-                && !((attacker instanceof Infantry) 
-                        && !(attacker instanceof BattleArmor))) {
-            int heatBonus = game.getPlanetaryConditions().getLightHeatBonus(
-                    te.heat);
-            if(heatBonus < 0) {
+        if ((te != null) && !attacker.isConventionalInfantry()) {
+            int heatBonus = game.getPlanetaryConditions().getLightHeatBonus(te.heat);
+            if (heatBonus < 0) {
                 toHit.addModifier(heatBonus, "target excess heat at night");
             }
         }
-        
+
         if ((toHit.getValue() > 0) && (null != attacker.getCrew())
                 && attacker.hasAbility(OptionsConstants.UNOFF_BLIND_FIGHTER)) {
             toHit.addModifier(-1, "blind fighter");

--- a/megamek/src/megamek/common/actions/PhysicalAttackAction.java
+++ b/megamek/src/megamek/common/actions/PhysicalAttackAction.java
@@ -167,8 +167,7 @@ public class PhysicalAttackAction extends AbstractAttackAction {
         // Infantry squads are also hard to hit -- including for other infantry,
         // it seems (the rule is "all attacks"). However, this only applies to
         // proper squads deployed as such.
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)
-            && ((Infantry) target).isSquad()) {
+        if (target.isConventionalInfantry() && ((Infantry) target).isSquad()) {
             toHit.addModifier(1, "infantry squad target");
         }
 

--- a/megamek/src/megamek/common/actions/ProtomechPhysicalAttackAction.java
+++ b/megamek/src/megamek/common/actions/ProtomechPhysicalAttackAction.java
@@ -67,8 +67,7 @@ public class ProtomechPhysicalAttackAction extends AbstractAttackAction {
         } else if (entity.hasWorkingMisc(MiscType.F_PROTOMECH_MELEE)) {
             toReturn += Math.ceil(entity.getWeight() / 5.0);
         }
-        if (((Protomech) entity).isEDPCharged() && (target instanceof Infantry)
-                && !(target instanceof BattleArmor)) {
+        if (((Protomech) entity).isEDPCharged() && target.isConventionalInfantry()) {
             toReturn++;
             // TODO: add another +1 to damage if target is cybernetically
             // enhanced

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -2868,7 +2868,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         // Electro-Magnetic Interference
-        if (game.getPlanetaryConditions().hasEMI() && !((ae instanceof Infantry) && !(ae instanceof BattleArmor))) {
+        if (game.getPlanetaryConditions().hasEMI() && !ae.isConventionalInfantry()) {
             toHit.addModifier(2, Messages.getString("WeaponAttackAction.EMI"));
         }
         return toHit;
@@ -3914,7 +3914,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             toHit.addModifier(-1, Messages.getString("WeaponAttackAction.Vdni"));
         }
 
-        if ((ae instanceof Infantry) && !(ae instanceof BattleArmor)) {
+        if (ae.isConventionalInfantry()) {
             // check for pl-masc
             // the rules are a bit vague, but assume that if the infantry didn't
             // move or jumped, then they shouldn't get the penalty
@@ -4155,7 +4155,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_GHOST_TARGET) && !isIndirect
                 && !isArtilleryIndirect && !isArtilleryDirect) {
             int ghostTargetMod = Compute.getGhostTargetNumber(ae, ae.getPosition(), target.getPosition());
-            if ((ghostTargetMod > -1) && !((ae instanceof Infantry) && !(ae instanceof BattleArmor))) {
+            if ((ghostTargetMod > -1) && !ae.isConventionalInfantry()) {
                 int bapMod = 0;
                 if (ae.hasBAP()) {
                     bapMod = 1;
@@ -4264,17 +4264,17 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // Battle Armor targets are hard for Meks and Tanks to hit.
-        if (!isAttackerInfantry && (te != null) && (te instanceof BattleArmor)) {
+        if (!isAttackerInfantry && (te instanceof BattleArmor)) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.BaTarget"));
         }
 
         // infantry squads are also hard to hit
-        if (te != null && (te instanceof Infantry) && !(te instanceof BattleArmor) && ((Infantry) te).isSquad()) {
+        if ((te != null) && te.isConventionalInfantry() && ((Infantry) te).isSquad()) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.SquadTarget"));
         }
 
         // Ejected MechWarriors are harder to hit
-        if ((te != null) && (te instanceof MechWarrior)) {
+        if (te instanceof MechWarrior) {
             toHit.addModifier(2, Messages.getString("WeaponAttackAction.MwTarget"));
         }
         

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -12,7 +12,6 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megamek.common.loaders;
 
 import java.util.*;
@@ -326,31 +325,31 @@ public class BLKFile {
         }
         
         if (dataFile.exists("manufacturer")) {
-        	e.getFluff().setManufacturer(dataFile.getDataAsString("manufacturer")[0]);
+            e.getFluff().setManufacturer(dataFile.getDataAsString("manufacturer")[0]);
         }
 
         if (dataFile.exists("primaryFactory")) {
-        	e.getFluff().setPrimaryFactory(dataFile.getDataAsString("primaryFactory")[0]);
+            e.getFluff().setPrimaryFactory(dataFile.getDataAsString("primaryFactory")[0]);
         }
         
         if (dataFile.exists("systemManufacturers")) {
-        	for (String line : dataFile.getDataAsString("systemManufacturers")) {
-        		String[] fields = line.split(":");
-        		EntityFluff.System comp = EntityFluff.System.parse(fields[0]);
-        		if ((null != comp) && (fields.length > 1)) {
-        			e.getFluff().setSystemManufacturer(comp, fields[1]);
-        		}
-        	}
+            for (String line : dataFile.getDataAsString("systemManufacturers")) {
+                String[] fields = line.split(":");
+                EntityFluff.System comp = EntityFluff.System.parse(fields[0]);
+                if ((null != comp) && (fields.length > 1)) {
+                    e.getFluff().setSystemManufacturer(comp, fields[1]);
+                }
+            }
         }
 
         if (dataFile.exists("systemModels")) {
-        	for (String line : dataFile.getDataAsString("systemModels")) {
-        		String[] fields = line.split(":");
-        		EntityFluff.System comp = EntityFluff.System.parse(fields[0]);
-        		if ((null != comp) && (fields.length > 1)) {
-        			e.getFluff().setSystemModel(comp, fields[1]);
-        		}
-        	}
+            for (String line : dataFile.getDataAsString("systemModels")) {
+                String[] fields = line.split(":");
+                EntityFluff.System comp = EntityFluff.System.parse(fields[0]);
+                if ((null != comp) && (fields.length > 1)) {
+                    e.getFluff().setSystemModel(comp, fields[1]);
+                }
+            }
         }
 
         if (dataFile.exists("imagepath")) {
@@ -818,12 +817,12 @@ public class BLKFile {
         
         List<String> list = t.getFluff().createSystemManufacturersList();
         if (!list.isEmpty()) {
-        	blk.writeBlockData("systemManufacturers", list);
+            blk.writeBlockData("systemManufacturers", list);
         }
 
         list = t.getFluff().createSystemModelsList();
         if (!list.isEmpty()) {
-        	blk.writeBlockData("systemModels", list);
+            blk.writeBlockData("systemModels", list);
         }
 
         if (t.getFluff().getMMLImagePath().trim().length() > 0) {
@@ -895,7 +894,7 @@ public class BLKFile {
             
             EquipmentType et = infantry.getArmorKit();
             if (et != null) {
-            	blk.writeBlockData("armorKit", et.getInternalName());
+                blk.writeBlockData("armorKit", et.getInternalName());
             }
             if (infantry.getArmorDamageDivisor() != 1) {
                 blk.writeBlockData("armordivisor",
@@ -924,14 +923,14 @@ public class BLKFile {
             }
             ArrayList<String> augmentations = new ArrayList<>();
             for (Enumeration<IOption> e = infantry.getCrew().getOptions(PilotOptions.MD_ADVANTAGES);
-            		e.hasMoreElements();) {
-            	final IOption o = e.nextElement();
-            	if (o.booleanValue()) {
-            		augmentations.add(o.getName());
-            	}
+                    e.hasMoreElements();) {
+                final IOption o = e.nextElement();
+                if (o.booleanValue()) {
+                    augmentations.add(o.getName());
+                }
             }
             if (augmentations.size() > 0) {
-            	blk.writeBlockData("augmentation", augmentations.toArray(new String[augmentations.size()]));
+                blk.writeBlockData("augmentation", augmentations.toArray(new String[augmentations.size()]));
             }
         } else {
             blk.writeBlockData("tonnage", t.getWeight());
@@ -1096,14 +1095,14 @@ public class BLKFile {
             // Walk the array of transporters.
             for (String transporter : transporters) {
                 transporter = transporter.toLowerCase();
-            	boolean isPod = transporter.endsWith(":omni");
-            	transporter = transporter.replace(":omni", "");
-            	boolean hasARTS = transporter.startsWith("arts");
-            	if (hasARTS) {
-            	    transporter = transporter.substring(4);
+                boolean isPod = transporter.endsWith(":omni");
+                transporter = transporter.replace(":omni", "");
+                boolean hasARTS = transporter.startsWith("arts");
+                if (hasARTS) {
+                    transporter = transporter.substring(4);
                 }
 
-            	// TroopSpace:
+                // TroopSpace:
                 if (transporter.startsWith("troopspace:")) {
                     // Everything after the ':' should be the space's size.
                     double fsize = Double.parseDouble(transporter.substring(11));

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -593,7 +593,7 @@ public class BLKFile {
         }
         blk.writeBlockData("transporters", transporter_array);
 
-        if (!((t instanceof Infantry) && !(t instanceof BattleArmor))) {
+        if (!t.isConventionalInfantry()) {
             if (t instanceof Aero){
                 blk.writeBlockData("SafeThrust", t.getOriginalWalkMP());
             } else {
@@ -774,7 +774,7 @@ public class BLKFile {
             }
         }
         for (int i = 0; i < numLocs; i++) {
-            if (!(((t instanceof Infantry) && !(t instanceof BattleArmor)) && (i == Infantry.LOC_INFANTRY))) {
+            if (!(t.isConventionalInfantry() && (i == Infantry.LOC_INFANTRY))) {
                 blk.writeBlockData(t.getLocationName(i) + " Equipment", eq.get(i));
             }
         }

--- a/megamek/src/megamek/common/options/WeaponQuirks.java
+++ b/megamek/src/megamek/common/options/WeaponQuirks.java
@@ -145,7 +145,7 @@ public class WeaponQuirks extends AbstractOptions {
             }
         }
 
-        if (en instanceof Infantry && !(en instanceof BattleArmor)) {
+        if (en.isConventionalInfantry()) {
             return false;
         }
 

--- a/megamek/src/megamek/common/weapons/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/ACAPHandler.java
@@ -1,32 +1,26 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sep 25, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.HitData;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -35,11 +29,9 @@ import megamek.server.Server.DamageType;
 
 /**
  * @author Andrew Hunter
+ * Created on Sep 25, 2004
  */
 public class ACAPHandler extends ACWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -4251291510045646817L;
 
     /**
@@ -94,8 +86,7 @@ public class ACAPHandler extends ACWeaponHandler {
         }
         // Resolve damage normally.
         nDamage = nDamPerHit * Math.min(nCluster, hits);
-        if (bDirect
-            && (!(target instanceof Infantry) || (target instanceof BattleArmor))) {
+        if (bDirect && !target.isConventionalInfantry()) {
             hit.makeDirectBlow(toHit.getMoS() / 3);
         }
 

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -43,10 +43,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class ATMHandler extends MissileWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -2536312899803153911L;
 
     /**
@@ -108,7 +104,7 @@ public class ATMHandler extends MissileWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // don't need to check for BAs, because BA can't mount ATMs
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
         int hits;
@@ -184,7 +180,7 @@ public class ATMHandler extends MissileWeaponHandler {
     protected int calcStandardAndExtendedAmmoHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 Report r = new Report(3325);

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -1,19 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sep 24, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -25,14 +21,12 @@ import java.util.Vector;
 
 import megamek.MegaMek;
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.EntitySelector;
 import megamek.common.IGame;
 import megamek.common.INarcPod;
-import megamek.common.Infantry;
 import megamek.common.LosEffects;
 import megamek.common.Minefield;
 import megamek.common.Mounted;
@@ -51,13 +45,8 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -1277649123562229298L;
     boolean handledAmmoAndReport = false;
-
 
     /**
      * This consructor may only be used for deserialization.
@@ -65,7 +54,6 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
     protected ArtilleryBayWeaponIndirectFireHandler() {
         super();
     }
-    
 
     /**
      * @param t
@@ -623,7 +611,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
     protected int calcDamagePerHit() {
         double toReturn = wtype.getDamage();
         // area effect damage is double
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             toReturn /= 0.5;
         }
 

--- a/megamek/src/megamek/common/weapons/BPodHandler.java
+++ b/megamek/src/megamek/common/weapons/BPodHandler.java
@@ -1,19 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Oct 15, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -30,12 +26,9 @@ import megamek.server.Server;
 
 /**
  * @author Jason Tighe
+ * Created on Oct 15, 2004
  */
 public class BPodHandler extends AmmoWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -6710600713016145831L;
 
     /**
@@ -81,7 +74,7 @@ public class BPodHandler extends AmmoWeaponHandler {
     protected int calcDamagePerHit() {
         double toReturn = 0;
         // we default to direct fire weapons for anti-infantry damage
-        if (target instanceof Infantry && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             toReturn = Compute.d6();
             if (((Infantry) target).isMechanized()) {
                 toReturn /= 3;

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -45,12 +45,8 @@ import megamek.server.Server;
  * @author Sebastian Brocks, modified by Greg
  */
 public class CLIATMHandler extends ATMHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 5476183194060709574L;
-    boolean isAngelECMAffected = false;
+    boolean isAngelECMAffected;
 
     /**
      * @param t
@@ -60,8 +56,7 @@ public class CLIATMHandler extends ATMHandler {
      */
     public CLIATMHandler(ToHitData t, WeaponAttackAction w, IGame g, Server s) {
         super(t, w, g, s);
-        isAngelECMAffected = ComputeECM.isAffectedByAngelECM(ae, ae.getPosition(),
-                                                             target.getPosition());
+        isAngelECMAffected = ComputeECM.isAffectedByAngelECM(ae, ae.getPosition(), target.getPosition());
     }
 
     /*
@@ -157,12 +152,11 @@ public class CLIATMHandler extends ATMHandler {
      * @see megamek.common.weapons.WeaponHandler#calcHits(java.util.Vector)
      */
     protected int calcMissileHits(Vector<Report> vPhaseReport) {
-
         AmmoType atype = (AmmoType) ammo.getType();
 
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 Report r = new Report(3325);

--- a/megamek/src/megamek/common/weapons/CLLBXPrototypeHandler.java
+++ b/megamek/src/megamek/common/weapons/CLLBXPrototypeHandler.java
@@ -1,19 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Oct 15, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -32,12 +28,9 @@ import megamek.server.Server;
 
 /**
  * @author Andrew Hunter
+ * Created on Oct 15, 2004
  */
 public class CLLBXPrototypeHandler extends LBXHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -7348571086193319403L;
 
     /**
@@ -61,7 +54,7 @@ public class CLLBXPrototypeHandler extends LBXHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs can't mount LBXs
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
 

--- a/megamek/src/megamek/common/weapons/CenturionWeaponSystemHandler.java
+++ b/megamek/src/megamek/common/weapons/CenturionWeaponSystemHandler.java
@@ -1,19 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sept 5, 2005
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -23,7 +19,6 @@ import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -35,13 +30,9 @@ import megamek.server.Server;
  * which is found in Jihad Conspiracies Interstellar Players 2, pg 127.
  * 
  * @author arlith
- *
+ * Created on Sept 5, 2005
  */ 
 public class CenturionWeaponSystemHandler extends EnergyWeaponHandler {
-
-    /**
-     * 
-     */
     private static final long serialVersionUID = -5226841653686213141L;
 
     /**
@@ -64,11 +55,10 @@ public class CenturionWeaponSystemHandler extends EnergyWeaponHandler {
         return 0;
     }
 
-    protected void handleEntityDamage(Entity entityTarget,
-            Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
-            int bldgAbsorbs) {
-        super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits, 
-                nCluster, bldgAbsorbs);
+    @Override
+    protected void handleEntityDamage(Entity entityTarget, Vector<Report> vPhaseReport,
+                                      Building bldg, int hits, int nCluster, int bldgAbsorbs) {
+        super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits, nCluster, bldgAbsorbs);
 
         // Report that this unit has been hit by CWS
         Report r = new Report(7510);
@@ -78,8 +68,7 @@ public class CenturionWeaponSystemHandler extends EnergyWeaponHandler {
         vPhaseReport.add(r);
 
         // CWS has no effect against infantry
-        if ((entityTarget instanceof Infantry) 
-                && !(entityTarget instanceof BattleArmor)){
+        if (entityTarget.isConventionalInfantry()) {
             // No Effect
             r = new Report(7515);
             r.subject = entityTarget.getId();
@@ -89,13 +78,13 @@ public class CenturionWeaponSystemHandler extends EnergyWeaponHandler {
         }
         
         // If the Entity is shutdown, it will remain shutdown next turn
-        if (entityTarget.isShutDown()){
+        if (entityTarget.isShutDown()) {
             r = new Report(7511);
             r.subject = entityTarget.getId();
             r.addDesc(entityTarget);
             r.indent(3);
             vPhaseReport.add(r);
-            if (entityTarget.getTaserShutdownRounds() < 1){
+            if (entityTarget.getTaserShutdownRounds() < 1) {
                 entityTarget.setTaserShutdownRounds(1);
             }
         } else { // Otherwise, there's a shutdown check
@@ -139,7 +128,7 @@ public class CenturionWeaponSystemHandler extends EnergyWeaponHandler {
                 r.choose(false);
                 vPhaseReport.add(r);
                 // okay, now mark shut down
-                if (entityTarget instanceof BattleArmor){
+                if (entityTarget instanceof BattleArmor) {
                     r = new Report(3706);
                     r.addDesc(entityTarget);
                     r.indent(4);

--- a/megamek/src/megamek/common/weapons/FlamerHandler.java
+++ b/megamek/src/megamek/common/weapons/FlamerHandler.java
@@ -1,19 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sep 23, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -26,7 +22,6 @@ import megamek.common.Entity;
 import megamek.common.EquipmentMode;
 import megamek.common.HitData;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.ToHitData;
@@ -36,11 +31,9 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * Created on Sep 23, 2004
  */
 public class FlamerHandler extends WeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -7348456582587703751L;
 
     /**
@@ -103,13 +96,12 @@ public class FlamerHandler extends WeaponHandler {
     @Override
     protected int calcDamagePerHit() {
         int toReturn = super.calcDamagePerHit();
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             // pain shunted infantry get half damage
             if (((Entity) target).hasAbility(OptionsConstants.MD_PAIN_SHUNT)) {
                 toReturn = (int) Math.floor(toReturn / 2.0);
             }
-        } else if ((target instanceof BattleArmor)
-                && ((BattleArmor) target).isFireResistant()) {
+        } else if ((target instanceof BattleArmor) && ((BattleArmor) target).isFireResistant()) {
             toReturn = 0;
         }
         return toReturn;

--- a/megamek/src/megamek/common/weapons/FluidGunCoolHandler.java
+++ b/megamek/src/megamek/common/weapons/FluidGunCoolHandler.java
@@ -1,25 +1,20 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sep 23, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Entity;
@@ -35,11 +30,9 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * Created on Sep 23, 2004
  */
 public class FluidGunCoolHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = 4856089237895318515L;
 
     /**
@@ -47,25 +40,21 @@ public class FluidGunCoolHandler extends AmmoWeaponHandler {
      * @param waa
      * @param g
      */
-    public FluidGunCoolHandler(ToHitData toHit, WeaponAttackAction waa,
-            IGame g, Server s) {
+    public FluidGunCoolHandler(ToHitData toHit, WeaponAttackAction waa, IGame g, Server s) {
         super(toHit, waa, g, s);
     }
 
     @Override
-    protected void handleEntityDamage(Entity entityTarget,
-            Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
-            int bldgAbsorbs) {
-        if ((entityTarget instanceof Infantry)
-                && !(entityTarget instanceof BattleArmor)) {
+    protected void handleEntityDamage(Entity entityTarget, Vector<Report> vPhaseReport,
+                                      Building bldg, int hits, int nCluster, int bldgAbsorbs) {
+        if (entityTarget.isConventionalInfantry()) {
             // 1 point direct-fire ballistic
             nDamPerHit = Compute.directBlowInfantryDamage(1,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_DIRECT_FIRE,
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null);
-            super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
-                    nCluster, bldgAbsorbs);
+            super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits, nCluster, bldgAbsorbs);
         }
         Report r = new Report(3390);
         r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/GRHandler.java
+++ b/megamek/src/megamek/common/weapons/GRHandler.java
@@ -1,23 +1,18 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Oct 19, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.IGame;
 import megamek.common.Infantry;
@@ -29,12 +24,9 @@ import megamek.server.Server;
 
 /**
  * @author Jason Tighe
+ * Created on Oct 19, 2004
  */
 public class GRHandler extends AmmoWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -6599352761593455842L;
 
     /**
@@ -57,7 +49,7 @@ public class GRHandler extends AmmoWeaponHandler {
         double toReturn = wtype.getDamage(nRange);
 
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)
-            && nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG]) {
+                && nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG]) {
             toReturn -= 1;
         }
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE)
@@ -65,14 +57,14 @@ public class GRHandler extends AmmoWeaponHandler {
             toReturn = (int) Math.floor(toReturn * .75);
         }
 
-        if (target instanceof Infantry && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             toReturn = Compute.directBlowInfantryDamage(
                     toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
+            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
         }
         
         toReturn = applyGlancingBlowModifier(toReturn, false);

--- a/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
@@ -1,25 +1,20 @@
-/**
+/*
  * MegaMek - Copyright (C) 2007 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sep 24, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.IGame;
 import megamek.common.Infantry;
@@ -30,11 +25,9 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * Created on Sep 24, 2004
  */
 public class HAGWeaponHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -8193801876308832102L;
 
     /**
@@ -64,7 +57,7 @@ public class HAGWeaponHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             double toReturn = wtype.getRackSize();
             toReturn = Compute.directBlowInfantryDamage(
                     toReturn, bDirect ? toHit.getMoS() / 3 : 0,
@@ -86,7 +79,7 @@ public class HAGWeaponHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs can't mount HAGs
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
         int nHits;

--- a/megamek/src/megamek/common/weapons/LBXHandler.java
+++ b/megamek/src/megamek/common/weapons/LBXHandler.java
@@ -1,19 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Oct 15, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -34,11 +30,9 @@ import megamek.server.Server;
 
 /**
  * @author Andrew Hunter
+ * Created on Oct 15, 2004
  */
 public class LBXHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = 6803847280685526644L;
 
     /**
@@ -96,7 +90,7 @@ public class LBXHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs can't mount LBXs
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
 

--- a/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -19,7 +19,6 @@ import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Mech;
 import megamek.common.Report;
 import megamek.common.Tank;
@@ -34,10 +33,6 @@ import megamek.server.Server.DamageType;
  * @author Sebastian Brocks
  */
 public class LRMAntiTSMHandler extends LRMHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 5702089152489814687L;
 
     /**
@@ -62,7 +57,7 @@ public class LRMAntiTSMHandler extends LRMHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 return ((BattleArmor) ae).getShootingStrength();

--- a/megamek/src/megamek/common/weapons/LRMFragHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMFragHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -20,7 +20,6 @@ import megamek.common.Building;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.ToHitData;
@@ -32,10 +31,6 @@ import megamek.server.Server.DamageType;
  * @author Sebastian Brocks
  */
 public class LRMFragHandler extends LRMHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 2308151080895016663L;
 
     /**
@@ -66,15 +61,14 @@ public class LRMFragHandler extends LRMHandler {
             toReturn *= ((BattleArmor) ae).getShootingStrength();
         }
         // against infantry, we have 1 hit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             toReturn = wtype.getRackSize();
             if (bDirect) {
-                toReturn += toHit.getMoS() / 3;
+                toReturn += toHit.getMoS() / 3.0;
             }
         }
 
-        if (((target instanceof Entity) && !(target instanceof Infantry))
-                || (target instanceof BattleArmor)) {
+        if ((target instanceof Entity) && !target.isConventionalInfantry()) {
             toReturn = 0;
         }
 

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2007 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -24,7 +24,6 @@ import megamek.common.ComputeECM;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Mech;
 import megamek.common.Minefield;
 import megamek.common.MiscType;
@@ -42,10 +41,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class LRMHandler extends MissileWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -9160255801810263821L;
 
     /**
@@ -111,7 +106,7 @@ public class LRMHandler extends MissileWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 Report r = new Report(3325);

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -36,10 +36,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class LRMSwarmHandler extends LRMHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 7962873403915683220L;
     private int swarmMissilesNowLeft = 0;
     private boolean handledHeat = false;
@@ -426,7 +422,7 @@ public class LRMSwarmHandler extends LRMHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 return ((BattleArmor) ae).getShootingStrength();

--- a/megamek/src/megamek/common/weapons/MGHandler.java
+++ b/megamek/src/megamek/common/weapons/MGHandler.java
@@ -1,26 +1,21 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Oct 20, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.IGame;
 import megamek.common.Infantry;
@@ -35,12 +30,9 @@ import megamek.server.Server.DamageType;
 
 /**
  * @author Andrew Hunter
+ * Created on Oct 20, 2004
  */
 public class MGHandler extends AmmoWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 5635871269404561702L;
 
     private int nRapidDamHeatPerHit;
@@ -133,8 +125,7 @@ public class MGHandler extends AmmoWeaponHandler {
         Report r = new Report(3220);
         r.subject = subjectId;
         vPhaseReport.add(r);
-        if (weapon.isRapidfire()
-            && !((target instanceof Infantry) && !(target instanceof BattleArmor))) {
+        if (weapon.isRapidfire() && !target.isConventionalInfantry()) {
             r.newlines = 0;
             r = new Report(3225);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/MPodHandler.java
+++ b/megamek/src/megamek/common/weapons/MPodHandler.java
@@ -1,28 +1,22 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Oct 15, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -30,11 +24,9 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * Created on Oct 15, 2004
  */
 public class MPodHandler extends LBXHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -1591751929178217495L;
 
     /**
@@ -58,7 +50,7 @@ public class MPodHandler extends LBXHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
         int shots = 15;

--- a/megamek/src/megamek/common/weapons/MekMortarAirburstHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarAirburstHandler.java
@@ -25,7 +25,6 @@ import megamek.common.HitData;
 import megamek.common.IGame;
 import megamek.common.IHex;
 import megamek.common.IPlayer;
-import megamek.common.Infantry;
 import megamek.common.Mounted;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
@@ -197,8 +196,7 @@ public class MekMortarAirburstHandler extends AmmoWeaponHandler {
                 vPhaseReport.addAll(newReports);
             } else {
                 // Conventional Inf take burst-fire damage
-                if ((target instanceof Infantry) 
-                        && !(target instanceof BattleArmor)) {
+                if (target.isConventionalInfantry()) {
                     // Infantry take a bit more damage
                     int damage = 0;
                     // Roll 1d6 for each shell

--- a/megamek/src/megamek/common/weapons/MekMortarAntiPersonnelHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarAntiPersonnelHandler.java
@@ -1,26 +1,24 @@
-/**
+/*
  * MegaMek - Copyright (C) 2007 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
@@ -31,9 +29,6 @@ import megamek.server.Server;
  * @author arlith
  */
 public class MekMortarAntiPersonnelHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -2073773899108954657L;
     
     String sSalvoType = " shell(s) ";
@@ -73,8 +68,7 @@ public class MekMortarAntiPersonnelHandler extends AmmoWeaponHandler {
             r.subject = subjectId;
             r.add(missilesHit);
             r.add(sSalvoType);
-            if ((target instanceof Infantry)
-                    && !(target instanceof BattleArmor)) {
+            if (target.isConventionalInfantry()) {
                 r.add("");
             } else {
                 r.add(toHit.getTableDesc());
@@ -118,7 +112,7 @@ public class MekMortarAntiPersonnelHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             int damage;
             int numDice = 1;
             if (bDirect) {
@@ -132,14 +126,14 @@ public class MekMortarAntiPersonnelHandler extends AmmoWeaponHandler {
         return 1;
     }
     
-    protected void handleEntityDamage(Entity entityTarget,
-            Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
-            int bldgAbsorbs) {
+    @Override
+    protected void handleEntityDamage(Entity entityTarget, Vector<Report> vPhaseReport,
+                                      Building bldg, int hits, int nCluster, int bldgAbsorbs) {
         super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
                 nCluster, bldgAbsorbs);
         
         // We need to roll damage for each hit against infantry
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             nDamPerHit = calcDamagePerHit();
         }
     }

--- a/megamek/src/megamek/common/weapons/MekMortarHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarHandler.java
@@ -1,21 +1,20 @@
-/**
+/*
  * MegaMek - Copyright (C) 2007 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.HitData;
 import megamek.common.IGame;
@@ -30,10 +29,6 @@ import megamek.server.Server;
  * @author Jason Tighe
  */
 public class MekMortarHandler extends AmmoWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -2073773899108954657L;
     String sSalvoType = " shell(s) ";
 
@@ -57,7 +52,7 @@ public class MekMortarHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
 

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -44,10 +44,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class MissileWeaponHandler extends AmmoWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -4801130911083653548L;
     boolean advancedAMS = false;
     boolean advancedPD = false;
@@ -79,14 +75,14 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 Report r = new Report(3325);
                 r.subject = subjectId;
                 int shootingStrength = 1;
                 if ((weapon.getLocation() == BattleArmor.LOC_SQUAD)
-                        && !(weapon.isSquadSupportWeapon())){
+                        && !(weapon.isSquadSupportWeapon())) {
                     shootingStrength = ((BattleArmor) ae).getShootingStrength();
                 }
                 r.add(wtype.getRackSize() * shootingStrength);
@@ -316,7 +312,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),

--- a/megamek/src/megamek/common/weapons/NarcExplosiveHandler.java
+++ b/megamek/src/megamek/common/weapons/NarcExplosiveHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -30,10 +30,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class NarcExplosiveHandler extends MissileWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -1655014339855184419L;
 
     /**
@@ -58,7 +54,7 @@ public class NarcExplosiveHandler extends MissileWeaponHandler {
         getAMSHitsMod(vPhaseReport);
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 return ((BattleArmor) ae).getShootingStrength();

--- a/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -25,7 +25,6 @@ import megamek.common.EquipmentType;
 import megamek.common.HitData;
 import megamek.common.IAimingModes;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.LosEffects;
 import megamek.common.Mech;
 import megamek.common.Report;
@@ -37,9 +36,6 @@ import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 public class PlasmaCannonHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = 2304364403526293671L;
 
     /**
@@ -324,22 +320,19 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs can't mount Plasma Cannons
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
-        }
-        if (target.tracksHeat()) {
+        } else if (target.tracksHeat()) {
             return 1;
-        }
-        if ((target instanceof BattleArmor)
-                && ((BattleArmor) target).isFireResistant()) {
+        } else if ((target instanceof BattleArmor) && ((BattleArmor) target).isFireResistant()) {
             return 0;
+        } else {
+            return Compute.d6(3);
         }
-        return Compute.d6(3);
     }
 
     @Override
-    protected void handleIgnitionDamage(Vector<Report> vPhaseReport,
-            Building bldg, int hits) {
+    protected void handleIgnitionDamage(Vector<Report> vPhaseReport, Building bldg, int hits) {
         if (!bSalvo) {
             // hits!
             Report r = new Report(2270);

--- a/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
@@ -54,18 +54,13 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
      * need to adjust the <code>target</code> state variable so damage is
      * applied properly.
      * 
-     * @param entityTarget
-     *            The target Entity
+     * @param entityTarget  The target Entity
      * @param vPhaseReport
      * @param hit
      * @param bldg
      * @param hits
      * @param nCluster
      * @param bldgAbsorbs
-     * 
-     * @see megamek.common.weapons.WeaponHandler#handlePartialCoverHit(Entity
-     *      entityTarget, Vector<Report> vPhaseReport, HitData hit, Building
-     *      bldg, int hits, int nCluster, int bldgAbsorbs)
      */
     @Override
     protected void handlePartialCoverHit(Entity entityTarget,
@@ -320,9 +315,7 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs can't mount Plasma Cannons
-        if (target.isConventionalInfantry()) {
-            return 1;
-        } else if (target.tracksHeat()) {
+        if (target.isConventionalInfantry() || target.tracksHeat()) {
             return 1;
         } else if ((target instanceof BattleArmor) && ((BattleArmor) target).isFireResistant()) {
             return 0;

--- a/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
@@ -1,21 +1,20 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.Aero;
 import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Compute;
@@ -25,7 +24,6 @@ import megamek.common.EquipmentType;
 import megamek.common.HitData;
 import megamek.common.IGame;
 import megamek.common.Infantry;
-import megamek.common.Mech;
 import megamek.common.RangeType;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
@@ -35,9 +33,6 @@ import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 public class PlasmaRifleHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -2092721653693187140L;
 
     /**
@@ -140,7 +135,7 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
             return 1;
         }
         int toReturn = 5;
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             toReturn = Compute.d6(2);
         }
         bSalvo = true;

--- a/megamek/src/megamek/common/weapons/PopUpMineLauncherHandler.java
+++ b/megamek/src/megamek/common/weapons/PopUpMineLauncherHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -22,7 +22,6 @@ import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.HitData;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Mech;
 import megamek.common.Report;
 import megamek.common.Tank;
@@ -32,9 +31,6 @@ import megamek.server.Server;
 import megamek.server.Server.DamageType;
 
 public class PopUpMineLauncherHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -6179453250580148965L;
 
     /**
@@ -57,7 +53,7 @@ public class PopUpMineLauncherHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 return ((BattleArmor) ae).getShootingStrength();

--- a/megamek/src/megamek/common/weapons/PrototypeLBXHandler.java
+++ b/megamek/src/megamek/common/weapons/PrototypeLBXHandler.java
@@ -1,28 +1,22 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Oct 15, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -30,11 +24,9 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * Created on Oct 15, 2004
  */
 public class PrototypeLBXHandler extends LBXHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = -5200908977142584431L;
 
     /**
@@ -58,7 +50,7 @@ public class PrototypeLBXHandler extends LBXHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs can't mount LBXs
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
         int shotMod = getClusterModifiers(true);

--- a/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
@@ -1,21 +1,20 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Entity;
@@ -34,10 +33,6 @@ import megamek.server.Server.DamageType;
  * @author Jason Tighe
  */
 public class RifleWeaponHandler extends AmmoWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 7468287406174862534L;
 
     private HitData hit;
@@ -70,19 +65,17 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
+            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
         }
-        Entity te = null;
+        Entity te;
         if (target instanceof Entity) {
             te = (Entity) target;
             hit = te.rollHitLocation(toHit.getHitTable(), toHit.getSideTable(),
                     waa.getAimedLocation(), waa.getAimingMode(),
                     toHit.getCover());
             hit.setAttackerId(getAttackerId());
-            if (!(te instanceof BattleArmor)
-                    && !(te instanceof Infantry)
-                    && (!te.hasBARArmor(hit.getLocation()) || (te
-                            .getBARRating(hit.getLocation()) >= 8))) {
+            if (!(te instanceof Infantry)
+                    && (!te.hasBARArmor(hit.getLocation()) || (te.getBARRating(hit.getLocation()) >= 8))) {
                 toReturn = Math.max(0, toReturn - 3);
             }
         }

--- a/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -19,7 +19,6 @@ import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
@@ -32,10 +31,6 @@ import megamek.server.Server.DamageType;
  * @author Sebastian Brocks
  */
 public class SRMAntiTSMHandler extends SRMHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 6380017303917455020L;
 
     /**
@@ -60,7 +55,7 @@ public class SRMAntiTSMHandler extends SRMHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 return ((BattleArmor) ae).getShootingStrength();

--- a/megamek/src/megamek/common/weapons/SRMFragHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMFragHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -20,7 +20,6 @@ import megamek.common.Building;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.ToHitData;
@@ -32,10 +31,6 @@ import megamek.server.Server.DamageType;
  * @author Sebastian Brocks
  */
 public class SRMFragHandler extends SRMHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -2281133981582906299L;
 
     /**
@@ -69,14 +64,13 @@ public class SRMFragHandler extends SRMHandler {
         if (target.isConventionalInfantry()) {
             toReturn *= wtype.getRackSize();
             if (bDirect) {
-                toReturn += toHit.getMoS() / 3;
+                toReturn += toHit.getMoS() / 3.0;
             }
             
             toReturn = applyGlancingBlowModifier(toReturn, true);
         }
 
-        if (((target instanceof Entity) && !(target instanceof Infantry))
-                || (target instanceof BattleArmor)) {
+        if ((target instanceof Entity) && !target.isConventionalInfantry()) {
             toReturn = 0;
         }
         return (int) Math.ceil(toReturn);

--- a/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -33,10 +33,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class SRMInfernoHandler extends SRMHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 826674238068613732L;
 
     /**
@@ -193,18 +189,16 @@ public class SRMInfernoHandler extends SRMHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit with all missiles
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 Report r = new Report(3325);
                 r.subject = subjectId;
-                r.add(wtype.getRackSize()
-                        * ((BattleArmor) ae).getShootingStrength());
+                r.add(wtype.getRackSize() * ((BattleArmor) ae).getShootingStrength());
                 r.add(sSalvoType);
                 r.add(toHit.getTableDesc());
                 vPhaseReport.add(r);
-                return ((BattleArmor) ae).getShootingStrength()
-                        * wtype.getRackSize();
+                return ((BattleArmor) ae).getShootingStrength() * wtype.getRackSize();
             }
             Report r = new Report(3325);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -35,7 +35,6 @@ import megamek.server.Server.DamageType;
  * @author Jason Tighe
  */
 public class SRMTandemChargeHandler extends SRMHandler {
-
     private static final long serialVersionUID = 6292692766500970690L;
 
     /**
@@ -156,8 +155,7 @@ public class SRMTandemChargeHandler extends SRMHandler {
                 hit.makeGlancingBlow();
             }
             
-            if (bDirect
-                    && (!(target instanceof Infantry) || (target instanceof BattleArmor))) {
+            if (bDirect && !target.isConventionalInfantry()) {
                 hit.makeDirectBlow(toHit.getMoS() / 3);
             }
 

--- a/megamek/src/megamek/common/weapons/StreakHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -35,10 +35,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class StreakHandler extends MissileWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 4122111574368642492L;
     boolean isAngelECMAffected = ComputeECM.isAffectedByAngelECM(ae,
             ae.getPosition(), target.getPosition());
@@ -60,13 +56,12 @@ public class StreakHandler extends MissileWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
-            int toReturn = Compute.directBlowInfantryDamage(
+        if (target.isConventionalInfantry()) {
+            return Compute.directBlowInfantryDamage(
                     wtype.getRackSize() * 2, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
-            return toReturn;
         }
         return 2;
     }
@@ -90,7 +85,7 @@ public class StreakHandler extends MissileWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (ae instanceof BattleArmor) {
                 bSalvo = true;
                 return ((BattleArmor) ae).getShootingStrength();

--- a/megamek/src/megamek/common/weapons/StreakLRMHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakLRMHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2007 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
@@ -31,10 +30,6 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.server.Server;
 
 public class StreakLRMHandler extends StreakHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -3848472655779311898L;
 
     /**
@@ -54,13 +49,12 @@ public class StreakLRMHandler extends StreakHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        if (target instanceof Infantry && !(target instanceof BattleArmor)) {
-            int toReturn = Compute.directBlowInfantryDamage(
+        if (target.isConventionalInfantry()) {
+            return Compute.directBlowInfantryDamage(
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
-            return toReturn;
         }
         return 1;
     }
@@ -83,10 +77,8 @@ public class StreakLRMHandler extends StreakHandler {
      * megamek.common.Entity, boolean)
      */
     @Override
-    protected boolean specialResolution(Vector<Report> vPhaseReport,
-            Entity entityTarget) {
-        if (!bMissed
-                && target.getTargetType() == Targetable.TYPE_MINEFIELD_CLEAR) {
+    protected boolean specialResolution(Vector<Report> vPhaseReport, Entity entityTarget) {
+        if (!bMissed && (target.getTargetType() == Targetable.TYPE_MINEFIELD_CLEAR)) {
             Report r = new Report(3255);
             r.indent(1);
             r.subject = subjectId;
@@ -94,7 +86,7 @@ public class StreakLRMHandler extends StreakHandler {
             Coords coords = target.getPosition();
             Enumeration<Minefield> minefields = game.getMinefields(coords)
                     .elements();
-            ArrayList<Minefield> mfRemoved = new ArrayList<Minefield>();
+            ArrayList<Minefield> mfRemoved = new ArrayList<>();
             while (minefields.hasMoreElements()) {
                 Minefield mf = minefields.nextElement();
                 if (server.clearMinefield(mf, ae,

--- a/megamek/src/megamek/common/weapons/TSEMPHandler.java
+++ b/megamek/src/megamek/common/weapons/TSEMPHandler.java
@@ -1,19 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sept 5, 2005
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -43,12 +39,9 @@ import megamek.server.Server;
  * which is found in FM:3145 pg 255.
  * 
  * @author arlith
- *
+ * Created on Sept 5, 2005
  */ 
 public class TSEMPHandler extends EnergyWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = 5545991061428671743L;
 
     /**
@@ -102,8 +95,7 @@ public class TSEMPHandler extends EnergyWeaponHandler {
         vPhaseReport.add(r);
 
         // TSEMP has no effect against infantry
-        if ((entityTarget instanceof Infantry) 
-                && !(entityTarget instanceof BattleArmor)){
+        if (entityTarget.isConventionalInfantry()) {
             // No Effect
             r = new Report(7415);
             r.subject = entityTarget.getId();

--- a/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
@@ -1,22 +1,21 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
@@ -34,10 +33,6 @@ import megamek.server.Server;
  * @author Sebastian Brocks
  */
 public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 6329291710822071023L;
 
     /**
@@ -70,7 +65,7 @@ public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
             toReturn /= 2;
             toReturn = Math.floor(toReturn);
         }
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),

--- a/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
@@ -1,26 +1,21 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sep 29, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
@@ -35,11 +30,9 @@ import megamek.server.Server;
 
 /**
  * @author Andrew Hunter
+ * Created on Sep 29, 2004
  */
 public class UltraWeaponHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = 7551194199079004134L;
     int howManyShots;
     private final boolean twoRollsUltra; // Tracks whether or not this is an
@@ -107,7 +100,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs can't mount UACS/RACs
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             return 1;
         }
 
@@ -186,7 +179,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
     protected int calcDamagePerHit() {
         double toReturn = wtype.getDamage();
         // infantry get hit by all shots
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             if (howManyShots > 1) { // Is this a cluser attack?
                 // Compute maximum damage potential for cluster weapons
                 toReturn = howManyShots * wtype.getDamage();

--- a/megamek/src/megamek/common/weapons/VGLWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/VGLWeaponHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Vector;
 
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.BuildingTarget;
 import megamek.common.Compute;
@@ -75,7 +74,7 @@ public class VGLWeaponHandler extends AmmoWeaponHandler {
         // Determine what coords get hit
         AmmoType atype = (AmmoType) ammo.getType();
         int facing = weapon.getFacing();
-        ArrayList<Coords> affectedCoords = new ArrayList<Coords>(3);
+        ArrayList<Coords> affectedCoords = new ArrayList<>(3);
         int af = ae.getFacing();
         if (ae.isSecondaryArcWeapon(ae.getEquipmentNum(weapon))) {
             af = ae.getSecondaryFacing();
@@ -164,18 +163,15 @@ public class VGLWeaponHandler extends AmmoWeaponHandler {
                             waa.getAimingMode(), toHit.getCover());
                     hit.setAttackerId(getAttackerId());
                     
-                    Vector<Report> dmgReports = new Vector<Report>();
+                    Vector<Report> dmgReports = new Vector<>();
                     // Infantry take 2D6 burst damage
-                    if (!inBuilding && (entTarget instanceof Infantry) 
-                            && !(entTarget instanceof BattleArmor)) {
+                    if (!inBuilding && entTarget.isConventionalInfantry()) {
                         int infDmg = Compute.directBlowInfantryDamage(0, 0,
                                 WeaponType.WEAPON_BURST_2D6,
                                 ((Infantry) entTarget).isMechanized(),
                                 toHit.getThruBldg() != null);
-                        dmgReports = 
-                                server.damageEntity(entTarget, hit, infDmg);
-                    } else if (inBuilding && (entTarget instanceof Infantry) 
-                            && !(entTarget instanceof BattleArmor)) {
+                        dmgReports = server.damageEntity(entTarget, hit, infDmg);
+                    } else if (inBuilding && entTarget.isConventionalInfantry()) {
                         r = new Report(3417);
                         r.addDesc(entTarget);
                         r.indent(2);

--- a/megamek/src/megamek/common/weapons/VehicleFlamerCoolHandler.java
+++ b/megamek/src/megamek/common/weapons/VehicleFlamerCoolHandler.java
@@ -1,25 +1,20 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-/*
- * Created on Sep 23, 2004
- *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Entity;
@@ -35,11 +30,9 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * Created on Sep 23, 2004
  */
 public class VehicleFlamerCoolHandler extends AmmoWeaponHandler {
-    /**
-     *
-     */
     private static final long serialVersionUID = 4856089237895318515L;
 
     /**
@@ -47,25 +40,22 @@ public class VehicleFlamerCoolHandler extends AmmoWeaponHandler {
      * @param waa
      * @param g
      */
-    public VehicleFlamerCoolHandler(ToHitData toHit, WeaponAttackAction waa,
-            IGame g, Server s) {
+    public VehicleFlamerCoolHandler(ToHitData toHit, WeaponAttackAction waa, IGame g, Server s) {
         super(toHit, waa, g, s);
     }
 
     @Override
-    protected void handleEntityDamage(Entity entityTarget,
-            Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
+    protected void handleEntityDamage(Entity entityTarget, Vector<Report> vPhaseReport,
+                                      Building bldg, int hits, int nCluster,
             int bldgAbsorbs) {
-        if ((entityTarget instanceof Infantry)
-                && !(entityTarget instanceof BattleArmor)) {
+        if (entityTarget.isConventionalInfantry()) {
             // 1 point direct-fire ballistic
             nDamPerHit = Compute.directBlowInfantryDamage(1,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_DIRECT_FIRE,
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null);
-            super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
-                    nCluster, bldgAbsorbs);
+            super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits, nCluster, bldgAbsorbs);
         }
         Report r = new Report(3390);
         r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1227,25 +1227,23 @@ public class WeaponHandler implements AttackHandler, Serializable {
         }
 
         // we default to direct fire weapons for anti-infantry damage
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
+            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
         }
 
-        toReturn = applyGlancingBlowModifier(toReturn, 
-                            (target instanceof Infantry) && !(target instanceof BattleArmor));
+        toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());
 
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)
                 && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG])) {
             toReturn = (int) Math.floor(toReturn * .75);
         }
-        if (game.getOptions().booleanOption(
-                OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE)
+        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE)
                 && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
             toReturn = (int) Math.floor(toReturn * .5);
         }

--- a/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
@@ -61,7 +61,8 @@ public class BALBXHandler extends WeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        // TODO : Windchild : Was I bugged?
+        if (target.isConventionalInfantry()) {
             bSalvo = true;
             Report r = new Report(3325);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
@@ -1,15 +1,15 @@
-/**
+/*
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common.weapons.battlearmor;
 
@@ -26,13 +26,9 @@ import megamek.common.weapons.WeaponHandler;
 import megamek.server.Server;
 
 public class BALBXHandler extends WeaponHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -6378056043285522609L;
 
-    String sSalvoType = " pellet(s) ";
+    private static final String sSalvoType = " pellet(s) ";
 
     public BALBXHandler(ToHitData t, WeaponAttackAction w, IGame g, Server s) {
         super(t, w, g, s);
@@ -61,18 +57,15 @@ public class BALBXHandler extends WeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        // TODO : Windchild : Was I bugged?
         if (target.isConventionalInfantry()) {
             bSalvo = true;
             Report r = new Report(3325);
             r.subject = subjectId;
-            r.add(wtype.getRackSize()
-                    * ((BattleArmor) ae).getShootingStrength());
+            r.add(wtype.getRackSize() * ((BattleArmor) ae).getShootingStrength());
             r.add(sSalvoType);
             r.add(" ");
             vPhaseReport.add(r);
             return ((BattleArmor) ae).getShootingStrength();
-
         }
         int missilesHit;
         int nMissilesModifier = getClusterModifiers(true);
@@ -80,11 +73,9 @@ public class BALBXHandler extends WeaponHandler {
         if (allShotsHit()) {
             missilesHit = wtype.getRackSize() * ((BattleArmor) ae).getShootingStrength();
         } else {
-
             missilesHit = Compute.missilesHit(wtype.getRackSize()
                     * ((BattleArmor) ae).getShootingStrength(),
                     nMissilesModifier, weapon.isHotLoaded(), false, false);
-
         }
 
         if (missilesHit > 0) {
@@ -113,5 +104,4 @@ public class BALBXHandler extends WeaponHandler {
         bSalvo = true;
         return missilesHit;
     }
-
 }

--- a/megamek/src/megamek/common/weapons/battlearmor/BAMGHandler.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BAMGHandler.java
@@ -111,8 +111,7 @@ public class BAMGHandler extends WeaponHandler {
         Report r = new Report(3220);
         r.subject = subjectId;
         vPhaseReport.add(r);
-        if (weapon.isRapidfire()
-                && !((target instanceof Infantry) && !(target instanceof BattleArmor))) {
+        if (weapon.isRapidfire() && !target.isConventionalInfantry()) {
             r.newlines = 0;
             r = new Report(3225);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
@@ -116,7 +116,7 @@ public class InfantryWeaponHandler extends WeaponHandler {
             damage += 0.14;
         }
         int damageDealt = (int) Math.round(damage * troopersHit);
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor) && wtype.hasFlag(WeaponType.F_INF_BURST)) {
+        if (target.isConventionalInfantry() && wtype.hasFlag(WeaponType.F_INF_BURST)) {
             damageDealt += Compute.d6();
         }
         if ((target instanceof Infantry) && ((Infantry)target).isMechanized()) {
@@ -142,7 +142,7 @@ public class InfantryWeaponHandler extends WeaponHandler {
                 + " damage.");
         r.newlines = 0;
         vPhaseReport.addElement(r);
-        if((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
             //this is a little strange, but I can't just do this in calcDamagePerHit because
             //that is called up before misses are determined and will lead to weird reporting
             nDamPerHit = damageDealt;

--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -208,8 +208,7 @@ public class ScenarioLoader {
                     MegaMek.getLogger().error(String.format("\tInvalid location specified %d", specDamage.loc));
                 } else {
                     // Infantry only take damage to "internal"
-                    if (specDamage.internal
-                        || ((damagePlan.entity instanceof Infantry) && !(damagePlan.entity instanceof BattleArmor))) {
+                    if (specDamage.internal || damagePlan.entity.isConventionalInfantry()) {
                         if (damagePlan.entity.getOInternal(specDamage.loc) > specDamage.setArmorTo) {
                             damagePlan.entity.setInternal(specDamage.setArmorTo, specDamage.loc);
                             MegaMek.getLogger().debug(String.format("\tSet armor value for (internal %s) to %d",

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -14556,21 +14556,16 @@ public class Server implements Runnable {
 
         // Walk through ALL entities in the triggering entity's hex.
         for (Entity target : game.getEntitiesVector(entity.getPosition())) {
-
             // Is this an unarmored infantry platoon?
-            if ((target instanceof Infantry)
-                && !(target instanceof BattleArmor)) {
-
+            if (target.isConventionalInfantry()) {
                 // Roll d6-1 for damage.
                 final int damage = Math.max(1, Compute.d6() - 1);
 
                 // Damage the platoon.
-                addReport(damageEntity(target, new HitData(
-                        Infantry.LOC_INFANTRY), damage));
+                addReport(damageEntity(target, new HitData(Infantry.LOC_INFANTRY), damage));
 
                 // Damage from AP Pods is applied immediately.
                 target.applyDamage();
-
             } // End target-is-unarmored
 
             // Nope, the target is immune.
@@ -14633,7 +14628,7 @@ public class Server implements Runnable {
         addReport(r);
 
         // Is this an unarmored infantry platoon?
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
+        if (target.isConventionalInfantry()) {
 
             // Roll d6 for damage.
             final int damage = Compute.d6();
@@ -15483,7 +15478,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+                if (te.isConventionalInfantry()) {
                     damage = (int) Math.ceil(damage / 2.0);
                 } else {
                     damage = (int) Math.floor(damage / 2.0);
@@ -15750,7 +15745,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+                if (te.isConventionalInfantry()) {
                     damage = (int) Math.ceil(damage / 2.0);
                 } else {
                     damage = (int) Math.floor(damage / 2.0);
@@ -16004,8 +15999,7 @@ public class Server implements Runnable {
             } else {
                 if (glancing) {
                     // Round up glancing blows against conventional infantry
-                    if ((te instanceof Infantry)
-                        && !(te instanceof BattleArmor)) {
+                    if (te.isConventionalInfantry()) {
                         damage = (int) Math.ceil(damage / 2.0);
                     } else {
                         damage = (int) Math.floor(damage / 2.0);
@@ -16195,7 +16189,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+                if (te.isConventionalInfantry()) {
                     damage = (int) Math.ceil(damage / 2.0);
                 } else {
                     damage = (int) Math.floor(damage / 2.0);
@@ -16627,7 +16621,7 @@ public class Server implements Runnable {
         if (directBlow) {
             hits += toHit.getMoS() / 3;
         }
-        if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+        if (te.isConventionalInfantry()) {
             r = new Report(4149);
             r.subject = ae.getId();
             r.add(hits);
@@ -16655,7 +16649,7 @@ public class Server implements Runnable {
             // BA get hit separately by each attacking BA trooper
             int damage = Math.min(ae.getVibroClaws(), hits);
             // conventional infantry get hit in one lump
-            if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+            if (te.isConventionalInfantry()) {
                 damage = hits;
             }
             hits -= damage;
@@ -16977,7 +16971,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+                if (te.isConventionalInfantry()) {
                     damage = (int) Math.ceil(damage / 2.0);
                 } else {
                     damage = (int) Math.floor(damage / 2.0);
@@ -18288,7 +18282,7 @@ public class Server implements Runnable {
         int damageTaken = RamAttackAction.getDamageTakenBy(aero, te);
         if (glancing) {
             // Round up glancing blows against conventional infantry
-            if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+            if (te.isConventionalInfantry()) {
                 damage = (int) Math.ceil(damage / 2.0);
             } else {
                 damage = (int) Math.floor(damage / 2.0);
@@ -18389,7 +18383,7 @@ public class Server implements Runnable {
         if (glancing) {
             // Glancing Blow rule doesn't state whether damage to attacker on charge
             // or DFA is halved as well, assume yes. TODO : Check with PM
-            if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+            if (te.isConventionalInfantry()) {
                 damage = (int) Math.ceil(damage / 2.0);
             } else {
                 damage = (int) Math.floor(damage / 2.0);
@@ -18960,7 +18954,7 @@ public class Server implements Runnable {
         } else { // Target isn't building.
 
             if (glancing) {
-                if ((te instanceof Infantry) && !(te instanceof BattleArmor)) {
+                if (te.isConventionalInfantry()) {
                     damage = (int) Math.ceil(damage / 2.0);
                 } else {
                     damage = (int) Math.floor(damage / 2.0);
@@ -33141,9 +33135,7 @@ public class Server implements Runnable {
             ClubAttackAction caa = (ClubAttackAction) aaa;
             toHit = caa.toHit(game);
             damage = ClubAttackAction.getDamageFor(ae, caa.getClub(),
-                    (caa.getTarget(game) instanceof Infantry)
-                    && !(caa.getTarget(game) instanceof BattleArmor),
-                    caa.isZweihandering());
+                    caa.getTarget(game).isConventionalInfantry(), caa.isZweihandering());
             if (caa.getTargetType() == Targetable.TYPE_BUILDING) {
                 EquipmentType clubType = caa.getClub().getType();
                 if (clubType.hasSubType(MiscType.S_BACKHOE)
@@ -33164,14 +33156,12 @@ public class Server implements Runnable {
             DfaAttackAction daa = (DfaAttackAction) aaa;
             toHit = daa.toHit(game);
             damage = DfaAttackAction.getDamageFor(ae,
-                    (daa.getTarget(game) instanceof Infantry)
-                    && !(daa.getTarget(game) instanceof BattleArmor));
+                    daa.getTarget(game).isConventionalInfantry());
         } else if (aaa instanceof KickAttackAction) {
             KickAttackAction kaa = (KickAttackAction) aaa;
             toHit = kaa.toHit(game);
             damage = KickAttackAction.getDamageFor(ae, kaa.getLeg(),
-                    (kaa.getTarget(game) instanceof Infantry)
-                    && !(kaa.getTarget(game) instanceof BattleArmor));
+                    kaa.getTarget(game).isConventionalInfantry());
         } else if (aaa instanceof ProtomechPhysicalAttackAction) {
             ProtomechPhysicalAttackAction paa = (ProtomechPhysicalAttackAction) aaa;
             toHit = paa.toHit(game);
@@ -33185,13 +33175,9 @@ public class Server implements Runnable {
             paa.setArm(PunchAttackAction.RIGHT);
             ToHitData toHitRight = paa.toHit(game);
             damage = PunchAttackAction.getDamageFor(ae, PunchAttackAction.LEFT,
-                    (paa.getTarget(game) instanceof Infantry)
-                    && !(paa.getTarget(game) instanceof BattleArmor),
-                    paa.isZweihandering());
+                    paa.getTarget(game).isConventionalInfantry(), paa.isZweihandering());
             damageRight = PunchAttackAction.getDamageFor(ae, PunchAttackAction.RIGHT,
-                    (paa.getTarget(game) instanceof Infantry)
-                    && !(paa.getTarget(game) instanceof BattleArmor),
-                    paa.isZweihandering());
+                    paa.getTarget(game).isConventionalInfantry(), paa.isZweihandering());
             paa.setArm(arm);
             // If we're punching while prone (at a Tank,
             // duh), then we can only use one arm.
@@ -34950,7 +34936,7 @@ public class Server implements Runnable {
             int bldgElev = hex.containsTerrain(Terrains.BLDG_ELEV)
                     ? hex.terrainLevel(Terrains.BLDG_ELEV) : 0;
             entity.setElevation(fallHeight + bldgElev);
-            if ((entity instanceof Infantry) && !(entity instanceof BattleArmor)) {
+            if (entity.isConventionalInfantry()) {
                 HitData hit = new HitData(Infantry.LOC_INFANTRY);
                 addReport(damageEntity(entity, hit, 1));
                 // LAMs that convert to fighter mode on the landing turn are processed as crashes regardless of roll

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -18917,7 +18917,7 @@ public class Server implements Runnable {
             // Damage any infantry in the hex.
             addReport(damageInfantryIn(bldg, damage, target.getPosition()));
         } else { // Target isn't building.
-            if (glancing) {
+            if (glancing && (te != null)) {
                 damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             }
             if (directBlow) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -14598,8 +14598,7 @@ public class Server implements Runnable {
             return;
         }
         EquipmentType equip = mount.getType();
-        if (!(equip instanceof WeaponType)
-            || !equip.hasFlag(WeaponType.F_B_POD)) {
+        if (!(equip instanceof WeaponType) || !equip.hasFlag(WeaponType.F_B_POD)) {
             MegaMek.getLogger().error("Expecting to find an B Pod at " + podId + " on the unit, "
                     + entity.getDisplayName() + " but found " + equip.getName() + " instead!!!");
             return;
@@ -14629,18 +14628,14 @@ public class Server implements Runnable {
 
         // Is this an unarmored infantry platoon?
         if (target.isConventionalInfantry()) {
-
             // Roll d6 for damage.
             final int damage = Compute.d6();
 
             // Damage the platoon.
-            addReport(damageEntity(target, new HitData(Infantry.LOC_INFANTRY),
-                                   damage));
+            addReport(damageEntity(target, new HitData(Infantry.LOC_INFANTRY), damage));
 
             // Damage from AP Pods is applied immediately.
             target.applyDamage();
-
-            // End target-is-unarmored
         } else if (target instanceof BattleArmor) {
             // 20 damage in 5 point clusters
             final int damage = 5;
@@ -14653,11 +14648,9 @@ public class Server implements Runnable {
 
             // Damage from B Pods is applied immediately.
             target.applyDamage();
-        }
-
-        // Nope, the target is immune.
-        // Don't make a log entry for the triggering entity.
-        else if (!entity.equals(target)) {
+        } else if (!entity.equals(target)) {
+            // Nope, the target is immune.
+            // Don't make a log entry for the triggering entity.
             r = new Report(3020);
             r.indent(2);
             r.subject = target.getId();
@@ -15478,11 +15471,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if (te.isConventionalInfantry()) {
-                    damage = (int) Math.ceil(damage / 2.0);
-                } else {
-                    damage = (int) Math.floor(damage / 2.0);
-                }
+                damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             }
             if (directBlow) {
                 damage += toHit.getMoS() / 3;
@@ -15493,7 +15482,7 @@ public class Server implements Runnable {
                     (paa.getArm() == PunchAttackAction.LEFT) ?  Mech.LOC_LARM : Mech.LOC_RARM);
             DamageType damageType = DamageType.NONE;
             addReport(damageEntity(te, hit, damage, false, damageType, false,
-                                   false, throughFront));
+                    false, throughFront));
             if (target instanceof VTOL) {
                 // destroy rotor
                 addReport(applyCriticalHit(te, VTOL.LOC_ROTOR,
@@ -15745,11 +15734,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if (te.isConventionalInfantry()) {
-                    damage = (int) Math.ceil(damage / 2.0);
-                } else {
-                    damage = (int) Math.floor(damage / 2.0);
-                }
+                damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             }
             if (directBlow) {
                 damage += toHit.getMoS() / 3;
@@ -15999,11 +15984,7 @@ public class Server implements Runnable {
             } else {
                 if (glancing) {
                     // Round up glancing blows against conventional infantry
-                    if (te.isConventionalInfantry()) {
-                        damage = (int) Math.ceil(damage / 2.0);
-                    } else {
-                        damage = (int) Math.floor(damage / 2.0);
-                    }
+                    damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
                 }
                 if (directBlow) {
                     damage += toHit.getMoS() / 3;
@@ -16189,11 +16170,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if (te.isConventionalInfantry()) {
-                    damage = (int) Math.ceil(damage / 2.0);
-                } else {
-                    damage = (int) Math.floor(damage / 2.0);
-                }
+                damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             }
             if (directBlow) {
                 damage += toHit.getMoS() / 3;
@@ -16971,11 +16948,7 @@ public class Server implements Runnable {
         } else {
             if (glancing) {
                 // Round up glancing blows against conventional infantry
-                if (te.isConventionalInfantry()) {
-                    damage = (int) Math.ceil(damage / 2.0);
-                } else {
-                    damage = (int) Math.floor(damage / 2.0);
-                }
+                damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             }
             if (directBlow) {
                 damage += toHit.getMoS() / 3;
@@ -16990,8 +16963,8 @@ public class Server implements Runnable {
             if (target instanceof VTOL) {
                 // destroy rotor
                 addReport(applyCriticalHit(te, VTOL.LOC_ROTOR,
-                                           new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                                                            VTOL.CRIT_ROTOR_DESTROYED), false, 0, false));
+                        new CriticalSlot(CriticalSlot.TYPE_SYSTEM, VTOL.CRIT_ROTOR_DESTROYED),
+                        false, 0, false));
             }
         }
 
@@ -18282,11 +18255,7 @@ public class Server implements Runnable {
         int damageTaken = RamAttackAction.getDamageTakenBy(aero, te);
         if (glancing) {
             // Round up glancing blows against conventional infantry
-            if (te.isConventionalInfantry()) {
-                damage = (int) Math.ceil(damage / 2.0);
-            } else {
-                damage = (int) Math.floor(damage / 2.0);
-            }
+            damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             damageTaken = (int) Math.floor(damageTaken / 2.0);
         }
 
@@ -18383,17 +18352,13 @@ public class Server implements Runnable {
         if (glancing) {
             // Glancing Blow rule doesn't state whether damage to attacker on charge
             // or DFA is halved as well, assume yes. TODO : Check with PM
-            if (te.isConventionalInfantry()) {
-                damage = (int) Math.ceil(damage / 2.0);
-            } else {
-                damage = (int) Math.floor(damage / 2.0);
-            }
+            damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             damageTaken = (int) Math.floor(damageTaken / 2.0);
         }
         boolean bDirect = false;
         int directBlowCritMod = toHit.getMoS() / 3;
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
-            && ((toHit.getMoS() / 3) >= 1)) {
+                && ((toHit.getMoS() / 3) >= 1)) {
             damage += toHit.getMoS() / 3;
             bDirect = false;
         }
@@ -18952,13 +18917,8 @@ public class Server implements Runnable {
             // Damage any infantry in the hex.
             addReport(damageInfantryIn(bldg, damage, target.getPosition()));
         } else { // Target isn't building.
-
             if (glancing) {
-                if (te.isConventionalInfantry()) {
-                    damage = (int) Math.ceil(damage / 2.0);
-                } else {
-                    damage = (int) Math.floor(damage / 2.0);
-                }
+                damage = (int) (te.isConventionalInfantry() ? Math.ceil(damage / 2.0) : Math.floor(damage / 2.0));
             }
             if (directBlow) {
                 damage += toHit.getMoS() / 3;
@@ -33155,8 +33115,7 @@ public class Server implements Runnable {
         } else if (aaa instanceof DfaAttackAction) {
             DfaAttackAction daa = (DfaAttackAction) aaa;
             toHit = daa.toHit(game);
-            damage = DfaAttackAction.getDamageFor(ae,
-                    daa.getTarget(game).isConventionalInfantry());
+            damage = DfaAttackAction.getDamageFor(ae, daa.getTarget(game).isConventionalInfantry());
         } else if (aaa instanceof KickAttackAction) {
             KickAttackAction kaa = (KickAttackAction) aaa;
             toHit = kaa.toHit(game);


### PR DESCRIPTION
This is the MegaMek part of a full repository swapover from using instanceof to determine if a unit is conventional infantry to the isConventionalInfantry method, which returns true for Infantry and all inheritors outside of BattleArmor and inheritors. It does not rely on the other two branches.

To Review:
Whitespace differences off (I found tab spacing in Entity and fixed some other whitespace issues, so this will also heavily drop the number of line changes)

Logic:
(Infantry && !BattleArmor): isConventionalInfantry
(!Infantry || BattleArmor): !isConventionalInfantry