### PR TITLE
more thorough destroyed location equipment destruction

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11476,25 +11476,28 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     engineHitsThisPhase++;
                 }
                 
+                boolean mountOneIsHittable = (cs.getMount() != null) && cs.getMount().getType().isHittable();
+                boolean mountTwoIsHittable = (cs.getMount2() != null) && cs.getMount2().getType().isHittable();
+                
                 if (blownOff) {
                     cs.setMissing(true);
                     
-                    if (cs.getMount() != null) {
+                    if (mountOneIsHittable) {
                         cs.getMount().setMissing(true);
                     }
                     
-                    if (cs.getMount2() != null) {
+                    if (mountTwoIsHittable) {
                         cs.getMount2().setMissing(true);
                     }
                     
                 } else {
                     cs.setHit(true);
                     
-                    if (cs.getMount() != null) {
+                    if (mountOneIsHittable) {
                         cs.getMount().setHit(true);
                     }
                     
-                    if (cs.getMount2() != null) {
+                    if (mountTwoIsHittable) {
                         cs.getMount2().setHit(true);
                     }
                 }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11462,19 +11462,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 setArmor(IArmorState.ARMOR_DOOMED, loc, true);
             }
         }
-        // equipment marked missing
-        for (Mounted mounted : getEquipment()) {
-            if (((mounted.getLocation() == loc) && mounted.getType()
-                                                          .isHittable())
-                || (mounted.isSplit() && (mounted.getSecondLocation() == loc))) {
-                if (blownOff) {
-                    mounted.setMissing(true);
-                } else {
-                    mounted.setHit(true);
-                }
-            }
-        }
+
         // all critical slots set as missing
+        // while we're here, if something is mounted in those crits, set it as hit, 
+        // instead of looping through all equipment in the unit
         for (int i = 0; i < getNumberOfCriticals(loc); i++) {
             final CriticalSlot cs = getCritical(loc, i);
             if (cs != null) {
@@ -11484,13 +11475,32 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     && !cs.isDamaged()) {
                     engineHitsThisPhase++;
                 }
+                
                 if (blownOff) {
                     cs.setMissing(true);
+                    
+                    if (cs.getMount() != null) {
+                        cs.getMount().setMissing(true);
+                    }
+                    
+                    if (cs.getMount2() != null) {
+                        cs.getMount2().setMissing(true);
+                    }
+                    
                 } else {
                     cs.setHit(true);
+                    
+                    if (cs.getMount() != null) {
+                        cs.getMount().setHit(true);
+                    }
+                    
+                    if (cs.getMount2() != null) {
+                        cs.getMount2().setHit(true);
+                    }
                 }
             }
         }
+        
         // dependent locations destroyed, unless they are already destroyed
         if ((getDependentLocation(loc) != Entity.LOC_NONE)
             && !(getInternal(getDependentLocation(loc)) < 0)) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11476,8 +11476,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     engineHitsThisPhase++;
                 }
                 
-                boolean mountOneIsHittable = (cs.getMount() != null) && cs.getMount().getType().isHittable();
-                boolean mountTwoIsHittable = (cs.getMount2() != null) && cs.getMount2().getType().isHittable();
+                final boolean mountOneIsHittable = (cs.getMount() != null) && cs.getMount().getType().isHittable();
+                final boolean mountTwoIsHittable = (cs.getMount2() != null) && cs.getMount2().getType().isHittable();
                 
                 if (blownOff) {
                     cs.setMissing(true);


### PR DESCRIPTION
Fixes behaviors reported in #2585 and #2586, and probably a host of other similar behaviors besides.

The previous approach was to loop through all equipment on a unit, and, if it's mounted in the destroyed location, set hit/missing flag appropriately. However, this approach misses systems that are mounted all across a mech, such as chameleon, null sig, void sig, etc. 

Now, we take advantage of the fact that each critical slot has a piece of equipment associated with it (or two, sometimes for "compact" things?), and hit those pieces of equipment instead.