### PR TITLE
prevent phantom buildings from crashing bot deployment

### DIFF
--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import megamek.client.bot.princess.CardinalEdge;
+import megamek.common.Building;
 import megamek.common.BulldozerMovePath;
 import megamek.common.Coords;
 import megamek.common.Entity;
@@ -365,6 +366,12 @@ public class BoardClusterTracker {
         if (!hex.containsTerrain(Terrains.BLDG_CF) && !hex.containsExit(Terrains.FUEL_TANK_CF)) {
             return false;
         } else if (relevantMovementType == MovementType.Walker) {
+            Building building = board.getBuildingAt(coords);
+            
+            if (building == null) {
+                return false;
+            }
+            
             int buildingCF = board.getBuildingAt(coords).getCurrentCF(coords);
             
             return entity.getWeight() > buildingCF;            

--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -366,7 +366,7 @@ public class BoardClusterTracker {
         if (!hex.containsTerrain(Terrains.BLDG_CF) && !hex.containsExit(Terrains.FUEL_TANK_CF)) {
             return false;
         } else if (relevantMovementType == MovementType.Walker) {
-            Building building = board.getBuildingAt(coords);
+            final Building building = board.getBuildingAt(coords);
             
             if (building == null) {
                 return false;

--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -372,7 +372,7 @@ public class BoardClusterTracker {
                 return false;
             }
             
-            int buildingCF = board.getBuildingAt(coords).getCurrentCF(coords);
+            int buildingCF = building.getCurrentCF(coords);
             
             return entity.getWeight() > buildingCF;            
         } else if ((relevantMovementType != MovementType.Flyer) &&


### PR DESCRIPTION
Fixes #2609

This error was caused by the presence of a building terrain type in a hex, but no CF. Likely this was due to a malformed map definition.