### PR TITLE
Use armor tech base instead of unit when calculating weight

### DIFF
--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -2021,21 +2021,13 @@ public class Jumpship extends Aero {
         }
 
         // now I need to determine base armor points by type and weight
-        double baseArmor = 0.8;
-        if (isClan()) {
-            baseArmor = 1.0;
-        }
+        boolean clan = TechConstants.isClan(getArmorTechLevel(firstArmorIndex()));
+        double baseArmor = clan ? 1.0 : 0.8;
 
         if (weight >= 250000) {
-            baseArmor = 0.4;
-            if (isClan()) {
-                baseArmor = 0.5;
-            }
+            baseArmor = clan ? 0.5 : 0.4;
         } else if (weight >= 150000) {
-            baseArmor = 0.6;
-            if (isClan()) {
-                baseArmor = 0.7;
-            }
+            baseArmor = clan ? 0.7 : 0.6;
         }
 
         if (armorType[0] == EquipmentType.T_ARMOR_LC_FERRO_IMP) {

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -698,8 +698,10 @@ public class TestAdvancedAerospace extends TestAero {
         boolean correct = true;
         double maxArmor = maxArmorWeight(vessel);
         if (vessel.getLabArmorTonnage() > maxArmor) {
-            buff.append("Total armor," + vessel.getLabArmorTonnage() + 
-                    " tons, is greater than the maximum: " + maxArmor + "\n");
+            buff.append("Total armor, ")
+                    .append(vessel.getLabArmorTonnage())
+                    .append(" tons, is greater than the maximum: ")
+                    .append(maxArmor).append("\n");
             correct = false;
         }
 

--- a/megamek/unittests/megamek/common/JumpshipTest.java
+++ b/megamek/unittests/megamek/common/JumpshipTest.java
@@ -1,0 +1,40 @@
+package megamek.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class JumpshipTest {
+
+    @Test
+    public void calculateArmorWeightISWithClanArmor() {
+        final Jumpship ship = new Jumpship();
+        ship.setWeight(100000); // 1.0 for Clan, 0.8 for IS
+        ship.set0SI(1);
+        ship.setTechLevel(TechConstants.T_IS_ADVANCED);
+        ship.setMixedTech(true);
+        ship.setArmorType(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_AEROSPACE, true));
+        ship.setArmorTechLevel(TechConstants.T_CLAN_ADVANCED);
+        for (int loc = 0; loc < 6; loc++) {
+            ship.initializeArmor(100, loc);
+        }
+
+        assertEquals(600.0, ship.getArmorWeight(ship.locations()), 0.1);
+    }
+
+    @Test
+    public void calculateArmorWeightClanWithISArmor() {
+        final Jumpship ship = new Jumpship();
+        ship.setWeight(100000); // 1.0 for Clan, 0.8 for IS
+        ship.set0SI(1);
+        ship.setTechLevel(TechConstants.T_CLAN_ADVANCED);
+        ship.setMixedTech(true);
+        ship.setArmorType(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_AEROSPACE, false));
+        ship.setArmorTechLevel(TechConstants.T_IS_ADVANCED);
+        for (int loc = 0; loc < 6; loc++) {
+            ship.initializeArmor(100, loc);
+        }
+
+        assertEquals(RoundWeight.nextHalfTon(600.0 / 0.8), ship.getArmorWeight(ship.locations()), 0.1);
+    }
+}


### PR DESCRIPTION
A mixed tech jumpship/warship/space station calculates armor weight incorrectly for validation when the armor tech base differs from the unit tech base. It should use the tech base of the armor when calculating points per ton instead of the unit tech base.

Fixes MegaMek/megameklab#872