### PR TITLE
Mitigate dfa related npes

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4161,7 +4161,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         // Convert the choices into a List of targets.
         ArrayList<Targetable> targets = new ArrayList<Targetable>();
         for (Entity ent : game.getEntitiesVector(pos)) {
-            if (!ce.equals(ent)) {
+            if ((ce == null) || !ce.equals(ent)) {
                 targets.add(ent);
             }
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -7542,10 +7542,12 @@ public class Server implements Runnable {
                     int targetType;
                     int targetID;
                     
-                    // if it's a valid target, then simply
+                    // if it's a valid target, then simply pass along the type and ID
                     if (target != null) {    
                         targetID = target.getTargetId();
                         targetType = target.getTargetType();
+                    // if the target has become invalid somehow, or was incorrectly declared in the first place
+                    // log the error, then put some defaults in for the DFA and proceed as if the target had been moved/destroyed
                     } else {
                         String errorMessage = "Illegal DFA by " + entity.getDisplayName() + " against non-existent entity at " + step.getTargetPosition(); 
                         sendServerChat(errorMessage);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -7538,13 +7538,20 @@ public class Server implements Runnable {
                 if (entity.canDFA()) {
                     checkExtremeGravityMovement(entity, step, lastStepMoveType, curPos, cachedGravityLimit);
                     Targetable target = step.getTarget(game);
-                    DfaAttackAction daa = new DfaAttackAction(entity.getId(),
-                            target.getTargetType(), target.getTargetId(),
-                            target.getPosition());
-                    entity.setDisplacementAttack(daa);
-                    entity.setElevation(step.getElevation());
-                    game.addCharge(daa);
-                    charge = daa;
+                    
+                    if (target != null) {                    
+                        DfaAttackAction daa = new DfaAttackAction(entity.getId(),
+                                target.getTargetType(), target.getTargetId(),
+                                target.getPosition());
+                        entity.setDisplacementAttack(daa);
+                        entity.setElevation(step.getElevation());
+                        game.addCharge(daa);
+                        charge = daa;
+                    } else {
+                        String errorMessage = "Illegal DFA by " + entity.getDisplayName() + " against non-existent entity at " + step.getTargetPosition(); 
+                        sendServerChat(errorMessage);
+                        MegaMek.getLogger().error(errorMessage);
+                    }
                 } else {
                     sendServerChat("Illegal DFA!! I don't think "
                             + entity.getDisplayName()
@@ -7557,6 +7564,7 @@ public class Server implements Runnable {
                             + ", or if that is already the case, submit a bug report at https://github.com/MegaMek/megamek/issues");
                     return;
                 }
+                
                 break;
             }
 


### PR DESCRIPTION
"Fixes" #2613 

I haven't been able to find the underlying cause, but this code change does prevent the game from locking up when processing a DFA with an invalid target (one that the server thinks has been destroyed - it's unlikely but theoretically possible that a unit being targeted for a DFA gets destroyed in the movement phase). The attack will be resolved as if the DFA's target has disappeared, including resolving any stacking violations, etc. 

Two other changes: fix for a client-side lockup when picking an action target in case the "currently selected entity" comes back as null, and, when processing a DFA, look up the relevant building only in the context where that variable is used.

