### PR TITLE
prevent turn skip on game load

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -698,7 +698,7 @@ public class Game implements Serializable, IGame {
      * Returns true if there is a turn after the current one
      */
     public boolean hasMoreTurns() {
-        return turnVector.size() > (turnIndex + 1);
+        return turnVector.size() > turnIndex;
     }
 
     /**


### PR DESCRIPTION
An off-by-one error would result in an entity's turn being skipped on game load if the entity was the only/last entity eligible for that phase.