### PR TITLE
Issue #2597: Add thread safety to duplicate name hash

### DIFF
--- a/megamek/src/megamek/common/EjectedCrew.java
+++ b/megamek/src/megamek/common/EjectedCrew.java
@@ -45,9 +45,7 @@ public class EjectedCrew extends Infantry {
         //setWeight(1); // Copied from original MechWarrior code, but does this really do anything?
 
         // Generate the display name, then add the original ride's name.
-        StringBuffer newName = new StringBuffer(getDisplayName());
-        newName.append(" of ").append(originalRide.getDisplayName());
-        displayName = newName.toString();
+        setDisplayName(getDisplayName() + " " + originalRide.getDisplayName());
 
         // Finish initializing this unit.
         setOwner(originalRide.getOwner());
@@ -90,8 +88,7 @@ public class EjectedCrew extends Infantry {
         setModel(originalRide.getDisplayName());
 
         // Generate the display name, then add the original ride's name.
-        String newName = new String(getDisplayName() + " of " + originalRide.getDisplayName());
-        displayName = newName;
+        setDisplayName(getDisplayName() + " of " + originalRide.getDisplayName());
         
         initializeInternal(escapedThisRound, Infantry.LOC_INFANTRY);
         
@@ -118,10 +115,6 @@ public class EjectedCrew extends Infantry {
         setChassis(VEE_EJECT_NAME);
         setModel(crew.getName());
         //setWeight(1);
-
-        // Generate the display name, then add the original ride's name.
-        StringBuffer newName = new StringBuffer(getDisplayName());
-        displayName = newName.toString();
 
         // Finish initializing this unit.
         setOwner(owner);

--- a/megamek/src/megamek/common/EjectedCrew.java
+++ b/megamek/src/megamek/common/EjectedCrew.java
@@ -45,7 +45,7 @@ public class EjectedCrew extends Infantry {
         //setWeight(1); // Copied from original MechWarrior code, but does this really do anything?
 
         // Generate the display name, then add the original ride's name.
-        setDisplayName(getDisplayName() + " " + originalRide.getDisplayName());
+        setDisplayName(getDisplayName() + " of " + originalRide.getDisplayName());
 
         // Finish initializing this unit.
         setOwner(originalRide.getOwner());

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2541,14 +2541,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return A display name for the entity.
      */
     private String createDisplayName(int duplicateMarker) {
-        StringBuilder nbuf = new StringBuilder();
-        nbuf.append(createShortName(duplicateMarker));
+        StringBuilder builder = new StringBuilder();
+        builder.append(createShortName(duplicateMarker));
 
         if (getOwner() != null) {
-            nbuf.append(" (").append(getOwner().getName()).append(")");
+            builder.append(" (").append(getOwner().getName()).append(")");
         }
 
-        return nbuf.toString();
+        return builder.toString();
     }
 
     /**
@@ -2581,18 +2581,18 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return A short name for the entity.
      */
     private String createShortName(int duplicateMarker) {
-        StringBuilder nbuf = new StringBuilder();
-        nbuf.append(getShortNameRaw());
+        StringBuilder builder = new StringBuilder();
+        builder.append(getShortNameRaw());
         // if show unit id is on, append the id
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            nbuf.append(" ID:").append(getId());
+            builder.append(" ID:").append(getId());
         } else if (duplicateMarker > 1) {
             // if not, and a player has more than one unit with the same name,
             // append "#N" after the model to differentiate.
-            nbuf.append(" #" + duplicateMarker);
+            builder.append(" #" + duplicateMarker);
         }
 
-        return nbuf.toString();
+        return builder.toString();
     }
 
     public String getShortNameRaw() {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -239,9 +239,13 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     protected int initialBV = -1;
 
-    protected String displayName = null;
-    protected String shortName = null;
-    public int duplicateMarker = 1;
+    /**
+     * Protects: displayName, shortName, duplicateMarker.
+     */
+    private final transient Object nameLock = new Object();
+    private String displayName = null;
+    private String shortName = null;
+    private int duplicateMarker = 1;
 
     protected transient IPlayer owner;
     protected int ownerId;
@@ -962,8 +966,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public void setId(int id) {
         this.id = id;
-        displayName = null;
-        shortName = null;
+        synchronized (nameLock) {
+            displayName = null;
+            shortName = null;
+        }
     }
 
     /**
@@ -2449,6 +2455,55 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
+     * Gets the marker used to disambiguate this entity
+     * from others with the same name. These are monotonically
+     * increasing values, starting from one.
+     */
+    public int getDuplicateMarker() {
+        synchronized (nameLock) {
+            return duplicateMarker;
+        }
+    }
+
+    /**
+     * Sets the marker used to disambiguate this entity
+     * from others with the same name. These are monotonically
+     * increasing values, starting from one.
+     * @param duplicateMarker A marker to disambiguate this entity
+     *                        from others with the same name.
+     */
+    public void setDuplicateMarker(int duplicateMarker) {
+        synchronized (nameLock) {
+            this.duplicateMarker = duplicateMarker;
+            if (duplicateMarker > 1) {
+                shortName = createShortName(duplicateMarker);
+                displayName = createDisplayName(duplicateMarker);
+            }
+        }
+    }
+
+    /**
+     * Updates the marker used to disambiguate this entity
+     * from others with the same name after one of them has
+     * been removed from the game.
+     * @param removedMarker The marker of the removed entity.
+     * @return A value indicating whether or not this entity
+     *         updated its duplicate marker.
+     */
+    public boolean updateDuplicateMarkerAfterDelete(int removedMarker) {
+        synchronized (nameLock) {
+            if (duplicateMarker > removedMarker) {
+                duplicateMarker--;
+                shortName = createShortName(duplicateMarker);
+                displayName = createDisplayName(duplicateMarker);
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    /**
      * Returns the display name for this entity.
      */
     @Override
@@ -2460,33 +2515,40 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
+     * Sets the display name for this entity.
+     * @param displayName The new display name.
+     */
+    protected void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
      * Generates the display name for this entity.
      * <p/>
      * Sub-classes are allowed to override this method. The display name is in
      * the format [Chassis] [Model] ([Player Name]).
      */
     public void generateDisplayName() {
-        StringBuffer nbuf = new StringBuffer();
-        nbuf.append(chassis);
-        if ((model != null) && (model.length() > 0)) {
-            nbuf.append(" ").append(model);
+        synchronized (nameLock) {
+            displayName = createDisplayName(duplicateMarker);
         }
-        // if show unit id is on, append the id
-        if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            nbuf.append(" ID:").append(getId());
-        } else if (duplicateMarker > 1) {
-            // if not, and a player has more than one unit with the same name,
-            // append "#N" after the model to differentiate.
-            nbuf.append(" #" + duplicateMarker);
-        }
+     }
+
+    /**
+     * Creates a display name for the entity.
+     * @param duplicateMarker A number used to disambiguate two entities with
+     *                        the same name.
+     * @return A display name for the entity.
+     */
+    private String createDisplayName(int duplicateMarker) {
+        StringBuilder nbuf = new StringBuilder();
+        nbuf.append(createShortName(duplicateMarker));
+
         if (getOwner() != null) {
             nbuf.append(" (").append(getOwner().getName()).append(")");
         }
-        if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            nbuf.append(" ID:").append(getId());
-        }
 
-        displayName = nbuf.toString();
+        return nbuf.toString();
     }
 
     /**
@@ -2507,11 +2569,20 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * the format [Chassis] [Model].
      */
     public void generateShortName() {
-        StringBuffer nbuf = new StringBuffer();
-        nbuf.append(chassis);
-        if ((model != null) && (model.length() > 0)) {
-            nbuf.append(" ").append(model);
+        synchronized (nameLock) {
+            shortName = createShortName(duplicateMarker);
         }
+    }
+
+    /**
+     * Creates a short name for the entity.
+     * @param duplicateMarker A number used to disambiguate two entities with
+     *                        the same name.
+     * @return A short name for the entity.
+     */
+    private String createShortName(int duplicateMarker) {
+        StringBuilder nbuf = new StringBuilder();
+        nbuf.append(getShortNameRaw());
         // if show unit id is on, append the id
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
             nbuf.append(" ID:").append(getId());
@@ -2521,16 +2592,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             nbuf.append(" #" + duplicateMarker);
         }
 
-        shortName = nbuf.toString();
+        return nbuf.toString();
     }
 
     public String getShortNameRaw() {
-        StringBuffer nbuf = new StringBuffer();
-        nbuf.append(chassis);
-        if ((model != null) && (model.length() > 0)) {
-            nbuf.append(" ").append(model);
+        if ((model == null) || (model.length() == 0)) {
+            return chassis;
         }
-        return nbuf.toString();
+        return chassis + " " + model;
     }
 
     /**

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -242,7 +242,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * Protects: displayName, shortName, duplicateMarker.
      */
-    private final transient Object nameLock = new Object();
     private String displayName = null;
     private String shortName = null;
     private int duplicateMarker = 1;
@@ -966,10 +965,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public void setId(int id) {
         this.id = id;
-        synchronized (nameLock) {
-            displayName = null;
-            shortName = null;
-        }
+        displayName = null;
+        shortName = null;
     }
 
     /**
@@ -2459,10 +2456,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * from others with the same name. These are monotonically
      * increasing values, starting from one.
      */
-    public int getDuplicateMarker() {
-        synchronized (nameLock) {
-            return duplicateMarker;
-        }
+    public synchronized int getDuplicateMarker() {
+        return duplicateMarker;
     }
 
     /**
@@ -2472,13 +2467,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @param duplicateMarker A marker to disambiguate this entity
      *                        from others with the same name.
      */
-    public void setDuplicateMarker(int duplicateMarker) {
-        synchronized (nameLock) {
-            this.duplicateMarker = duplicateMarker;
-            if (duplicateMarker > 1) {
-                shortName = createShortName(duplicateMarker);
-                displayName = createDisplayName(duplicateMarker);
-            }
+    public synchronized void setDuplicateMarker(int duplicateMarker) {
+        this.duplicateMarker = duplicateMarker;
+        if (duplicateMarker > 1) {
+            shortName = createShortName(duplicateMarker);
+            displayName = createDisplayName(duplicateMarker);
         }
     }
 
@@ -2490,17 +2483,15 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return A value indicating whether or not this entity
      *         updated its duplicate marker.
      */
-    public boolean updateDuplicateMarkerAfterDelete(int removedMarker) {
-        synchronized (nameLock) {
-            if (duplicateMarker > removedMarker) {
-                duplicateMarker--;
-                shortName = createShortName(duplicateMarker);
-                displayName = createDisplayName(duplicateMarker);
-                return true;
-            }
-
-            return false;
+    public synchronized boolean updateDuplicateMarkerAfterDelete(int removedMarker) {
+        if (duplicateMarker > removedMarker) {
+            duplicateMarker--;
+            shortName = createShortName(duplicateMarker);
+            displayName = createDisplayName(duplicateMarker);
+            return true;
         }
+
+        return false;
     }
 
     /**
@@ -2528,10 +2519,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Sub-classes are allowed to override this method. The display name is in
      * the format [Chassis] [Model] ([Player Name]).
      */
-    public void generateDisplayName() {
-        synchronized (nameLock) {
-            displayName = createDisplayName(duplicateMarker);
-        }
+    public synchronized void generateDisplayName() {
+        displayName = createDisplayName(duplicateMarker);
      }
 
     /**
@@ -2568,10 +2557,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Sub-classes are allowed to override this method. The display name is in
      * the format [Chassis] [Model].
      */
-    public void generateShortName() {
-        synchronized (nameLock) {
-            shortName = createShortName(duplicateMarker);
-        }
+    public synchronized void generateShortName() {
+        shortName = createShortName(duplicateMarker);
     }
 
     /**

--- a/megamek/src/megamek/common/EscapePods.java
+++ b/megamek/src/megamek/common/EscapePods.java
@@ -45,8 +45,7 @@ public class EscapePods extends SmallCraft {
         setModel(originalRide.getDisplayName());
 
         // Generate the display name, then add the original ride's name.
-        String newName = new String(POD_EJECT_NAME + originalRide.getDisplayName());
-        displayName = newName;
+        setDisplayName(POD_EJECT_NAME + originalRide.getDisplayName());
         
         //Pods and boats have an SI of 1 each
         initializeSI(nPods);

--- a/megamek/src/megamek/common/UnitNameTracker.java
+++ b/megamek/src/megamek/common/UnitNameTracker.java
@@ -14,10 +14,10 @@
 
 package megamek.common;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import megamek.common.annotations.Nullable;
@@ -28,14 +28,14 @@ import megamek.common.annotations.Nullable;
  * @implNote This API is not thread safe.
  */
 public class UnitNameTracker {
-    private final Map<String, Set<Entity>> entityMap = new HashMap<>();
+    private final Map<String, List<Entity>> entityMap = new HashMap<>();
 
     /**
      * Adds an entity to the name tracker.
      * @param entity The entity to track for name collisions.
      */
     public void add(Entity entity) {
-        Set<Entity> entities = entityMap.computeIfAbsent(entity.getShortNameRaw(), k -> new HashSet<>());
+        List<Entity> entities = entityMap.computeIfAbsent(entity.getShortNameRaw(), k -> new ArrayList<>());
         entities.add(entity);
         entity.setDuplicateMarker(entities.size());
     }
@@ -61,7 +61,7 @@ public class UnitNameTracker {
         int removedDuplicateMarker = entity.getDuplicateMarker();
 
         // Decrease the number of duplicate names, removing it if there was only one left
-        Set<Entity> entities = entityMap.get(rawName);
+        List<Entity> entities = entityMap.get(rawName);
         if ((entities == null) || !entities.remove(entity)) {
             return false;
         }

--- a/megamek/src/megamek/common/UnitNameTracker.java
+++ b/megamek/src/megamek/common/UnitNameTracker.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 - The MegaMek Team
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+
+package megamek.common;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import megamek.common.annotations.Nullable;
+
+/**
+ * Provides a means to track unit names for collisions.
+ * 
+ * @implNote This API is not thread safe.
+ */
+public class UnitNameTracker {
+    private final Map<String, Set<Entity>> entityMap = new HashMap<>();
+
+    /**
+     * Adds an entity to the name tracker.
+     * @param entity The entity to track for name collisions.
+     */
+    public void add(Entity entity) {
+        Set<Entity> entities = entityMap.computeIfAbsent(entity.getShortNameRaw(), k -> new HashSet<>());
+        entities.add(entity);
+        entity.setDuplicateMarker(entities.size());
+    }
+
+    /**
+     * Removes an entity from the name tracker.
+     * @param entity The entity to remove from the name tracker.
+     * @return A value indicating whether or not the entity was removed.
+     */
+    public boolean remove(Entity entity) {
+        return remove(entity, null);
+    }
+
+    /**
+     * Removes an entity from the name tracker.
+     * @param entity The entity to remove from the name tracker.
+     * @param onEntityUpdated An optional function to execute when an entity is updated
+     *                        due to a duplicate name change.
+     * @return A value indicating whether or not the entity was removed.
+     */
+    public boolean remove(Entity entity, @Nullable Consumer<Entity> onEntityUpdated) {
+        String rawName = entity.getShortNameRaw();
+        int removedDuplicateMarker = entity.getDuplicateMarker();
+
+        // Decrease the number of duplicate names, removing it if there was only one left
+        Set<Entity> entities = entityMap.get(rawName);
+        if ((entities == null) || !entities.remove(entity)) {
+            return false;
+        }
+
+        // If there are more than one entities with this raw name,
+        // go through the list of matching entities and update their
+        // duplicate number
+        for (Entity e : entities) {
+            boolean updated = e.updateDuplicateMarkerAfterDelete(removedDuplicateMarker);
+            if (updated && (onEntityUpdated != null)) {
+                onEntityUpdated.accept(e);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Clears the unit name tracker of all tracked entities.
+     */
+    public void clear() {
+        entityMap.clear();
+    }
+}

--- a/megamek/unittests/megamek/common/UnitNameTrackerTest.java
+++ b/megamek/unittests/megamek/common/UnitNameTrackerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2021 - The MegaMek Team
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+
+package megamek.common;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+public class UnitNameTrackerTest {
+    @Test
+    public void addEntitySetsDuplicateMarkerCorrectly() {
+        String shortNameRaw = "Mech MEK-01X";
+
+        Entity mockEntity = createEntity(shortNameRaw);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity);
+
+        verify(mockEntity, times(1)).setDuplicateMarker(eq(1));
+    }
+
+    @Test
+    public void addMultipleUnrelatedEntitiesSetsDuplicateMarkerCorrectly() {
+        String shortNameRaw0 = "Mech MEK-01X";
+        String shortNameRaw1 = "Mech MEK-02X";
+
+        Entity mockEntity0 = createEntity(shortNameRaw0);
+        Entity mockEntity1 = createEntity(shortNameRaw1);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity0);
+        tracker.add(mockEntity1);
+
+        verify(mockEntity0, times(1)).setDuplicateMarker(eq(1));
+        verify(mockEntity1, times(1)).setDuplicateMarker(eq(1));
+    }
+
+    @Test
+    public void addMultipleRelatedEntitiesSetsDuplicateMarkerCorrectly() {
+        String shortNameRaw = "Mech MEK-01X";
+
+        Entity mockEntity0 = createEntity(shortNameRaw);
+        Entity mockEntity1 = createEntity(shortNameRaw);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity0);
+        tracker.add(mockEntity1);
+
+        verify(mockEntity0, times(1)).setDuplicateMarker(eq(1));
+        verify(mockEntity1, times(1)).setDuplicateMarker(eq(2));
+    }
+
+    @Test
+    public void removeEntityUpdatesDuplicateMarker() {
+        String shortNameRaw = "Mech MEK-01X";
+
+        Entity mockEntity0 = createEntity(shortNameRaw);
+        Entity mockEntity1 = createEntity(shortNameRaw);
+        Entity mockEntity2 = createEntity(shortNameRaw);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity0);
+        tracker.add(mockEntity1);
+        tracker.add(mockEntity2);
+
+        verify(mockEntity0, times(1)).setDuplicateMarker(eq(1));
+        verify(mockEntity1, times(1)).setDuplicateMarker(eq(2));
+        verify(mockEntity2, times(1)).setDuplicateMarker(eq(3));
+
+        tracker.remove(mockEntity0);
+
+        verify(mockEntity1, times(1)).updateDuplicateMarkerAfterDelete(eq(1));
+        verify(mockEntity2, times(1)).updateDuplicateMarkerAfterDelete(eq(1));
+    }
+    
+    @Test
+    public void removeEntityUpdatesDuplicateMarker2() {
+        String shortNameRaw = "Mech MEK-01X";
+
+        Entity mockEntity0 = createEntity(shortNameRaw);
+        Entity mockEntity1 = createEntity(shortNameRaw);
+        Entity mockEntity2 = createEntity(shortNameRaw);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity0);
+        tracker.add(mockEntity1);
+        tracker.add(mockEntity2);
+
+        verify(mockEntity0, times(1)).setDuplicateMarker(eq(1));
+        verify(mockEntity1, times(1)).setDuplicateMarker(eq(2));
+        verify(mockEntity2, times(1)).setDuplicateMarker(eq(3));
+
+        tracker.remove(mockEntity1);
+
+        verify(mockEntity0, times(1)).updateDuplicateMarkerAfterDelete(eq(2));
+        verify(mockEntity2, times(1)).updateDuplicateMarkerAfterDelete(eq(2));
+    }
+
+    @Test
+    public void removeEntityUpdatesDuplicateMarker3() {
+        String shortNameRaw = "Mech MEK-01X";
+
+        Entity mockEntity0 = createEntity(shortNameRaw);
+        Entity mockEntity1 = createEntity(shortNameRaw);
+        Entity mockEntity2 = createEntity(shortNameRaw);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity0);
+        tracker.add(mockEntity1);
+
+        verify(mockEntity0, times(1)).setDuplicateMarker(eq(1));
+        verify(mockEntity1, times(1)).setDuplicateMarker(eq(2));
+
+        tracker.remove(mockEntity0);
+
+        verify(mockEntity1, times(1)).updateDuplicateMarkerAfterDelete(eq(1));
+
+        tracker.add(mockEntity2);
+
+        // This entity is now #2 as the original number 2 became number 1
+        verify(mockEntity2, times(1)).setDuplicateMarker(eq(2));
+    }
+
+    @Test
+    public void removeEntityOnlyAffectsRelatedEntities() {
+        String shortNameRaw0 = "Mech MEK-01X";
+        String shortNameRaw1 = "Mech MEK-01Y";
+
+        Entity mockEntity0 = createEntity(shortNameRaw0);
+        Entity mockEntity1 = createEntity(shortNameRaw0);
+        Entity mockEntityUnrelated = createEntity(shortNameRaw1);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity0);
+        tracker.add(mockEntity1);
+        tracker.add(mockEntityUnrelated);
+
+        verify(mockEntity0, times(1)).setDuplicateMarker(eq(1));
+        verify(mockEntity1, times(1)).setDuplicateMarker(eq(2));
+        verify(mockEntityUnrelated, times(1)).setDuplicateMarker(eq(1));
+
+        tracker.remove(mockEntity0);
+
+        verify(mockEntity1, times(1)).updateDuplicateMarkerAfterDelete(eq(1));
+
+        // Should not update unrelated entity
+        verify(mockEntityUnrelated, times(0)).updateDuplicateMarkerAfterDelete(anyInt());
+    }
+
+    @Test
+    public void clearEntities() {
+        String shortNameRaw = "Mech MEK-01X";
+
+        Entity mockEntity0 = createEntity(shortNameRaw);
+        Entity mockEntity1 = createEntity(shortNameRaw);
+        Entity mockEntity2 = createEntity(shortNameRaw);
+
+        UnitNameTracker tracker = new UnitNameTracker();
+
+        tracker.add(mockEntity0);
+        tracker.add(mockEntity1);
+
+        verify(mockEntity0, times(1)).setDuplicateMarker(eq(1));
+        verify(mockEntity1, times(1)).setDuplicateMarker(eq(2));
+
+        tracker.clear();
+
+        tracker.add(mockEntity2);
+
+        // There are no entities being tracked, so this should be #1
+        verify(mockEntity2, times(1)).setDuplicateMarker(eq(1));
+    }
+
+    private Entity createEntity(String shortNameRaw) {
+        Entity mockEntity = mock(Entity.class);
+        when(mockEntity.getShortNameRaw()).thenReturn(shortNameRaw);
+        doAnswer(inv -> {
+            int marker = (int) inv.getArgument(0);
+            when(mockEntity.getDuplicateMarker()).thenReturn(marker);
+            return null;
+        }).when(mockEntity).setDuplicateMarker(anyInt());
+        return mockEntity;
+    }
+}


### PR DESCRIPTION
The duplicate name protection code used a `Hashtable` which is thread safe, however, performing multiple operations is not atomic. This switches to use a lock to synchronize access to duplicate name generation. This also adds a lock to synchronize setting the short and display names. This makes both operations atomic and idempotent.

I don't think this is necessary for 0.48.