### PR TITLE
Issue #2625: Change the default toggle chat to backquote / grave

### DIFF
--- a/megamek/docs/Default Key Binds.txt
+++ b/megamek/docs/Default Key Binds.txt
@@ -5,7 +5,7 @@ VIEW->CLIENT SETTINGS->KEY BINDS
 Toggle in-game keyboard shortcuts helper----- Ctrl-K
 
 GENERAL COMMANDS
-Toggle Chat----- Enter
+Toggle Chat----- ` (Backquote/Grave)
 Toggle Chat Command ----- /
 Undo----- Backspace
 Cancel----- Escape

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -45,8 +45,8 @@
     </KeyBind>
 
     <KeyBind>
-        <command>toggleChat</command> <!-- Enter -->
-        <keyCode>10</keyCode>
+        <command>toggleChat</command> <!-- Backquote/grave -->
+        <keyCode>192</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -33,7 +33,7 @@ public enum KeyCommandBind {
     // Toggles isometric view on/off
     TOGGLE_ISO("toggleIso",false, KeyEvent.VK_T, 0),// Default: T
     // Activates chat box
-    TOGGLE_CHAT("toggleChat",false, KeyEvent.VK_ENTER, 0), // Default: Enter
+    TOGGLE_CHAT("toggleChat",false, KeyEvent.VK_BACK_QUOTE, 0), // Default: ` (back quote/grave)
     // Activates chat box and adds the command character (/)
     TOGGLE_CHAT_CMD("toggleChatCmd", false, KeyEvent.VK_SLASH, 0), // Default: /
     // Change facing one hexside to the left


### PR DESCRIPTION
This is an opinionated follow on to #2631 that changes the default toggle chat key to backquote / grave. I'm not a fan of using plain ENTER as the default key as that has meanings all over the place in GUI land (such as "clicking the currently focused button"). Users that wish to have the old behavior can change the default key to ENTER, but going forward our app would be more accessible by default.

Fixes #2625 in another way.