### PR TITLE
prevent error logging from crashing game

### DIFF
--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1261,8 +1261,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
             return 0;
         }
         // um, otherwise, I'm not sure
-        System.err.println("mounted: unable to determine explosion damage for "
-                + getName());
+        MegaMek.getLogger().error("mounted: unable to determine explosion damage for " + typeName);
         return 0;
     }
 


### PR DESCRIPTION
Probably fixes #2662

getName() in Mounted throws a null reference exception when the Mounted has a null type for some reason, so we avoid using it. Also update the logging mechanism to not print to console.