### PR TITLE
2681: Fixing GameTurn Entity Check NPE

### DIFF
--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -98,7 +98,7 @@ public class GameTurn implements Serializable {
                 && !(useValidNonInfantryCheck && (game.getPhase() == IGame.Phase.PHASE_MOVEMENT)
                 // This next bit enforces the "A players Infantry/ProtoMechs move after that player's other units" options.
                 && (((entity instanceof Infantry) && game.getOptions().booleanOption(OptionsConstants.INIT_INF_MOVE_LATER))
-                || ((entity instanceof Protomech)&& game.getOptions().booleanOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)))
+                || ((entity instanceof Protomech) && game.getOptions().booleanOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)))
                 && game.checkForValidNonInfantryAndOrProtomechs(playerId));
     }    
 
@@ -367,11 +367,9 @@ public class GameTurn implements Serializable {
         public boolean isValidEntity(final Entity entity, final IGame game,
                                      final boolean useValidNonInfantryCheck) {
             // The entity must pass the requirements of the parent class and be in the mask.
-            return ((getClassCode(entity) & mask) != 0)
-                    && super.isValidEntity(entity, game, useValidNonInfantryCheck);
+            return super.isValidEntity(entity, game, useValidNonInfantryCheck)
+                    && isValidClass(getClassCode(entity));
         }
-        
-        
 
         /**
          * Determine if entities of the given class get to move.
@@ -391,6 +389,7 @@ public class GameTurn implements Serializable {
             return mask;
         }
         
+        @Override
         public String toString() {
             return super.toString() + " mask: " + mask;
         }

--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -93,21 +93,13 @@ public class GameTurn implements Serializable {
      * @return <code>true</code> if the specified entity can take this turn.
      *         <code>false</code> if the entity is not valid for this turn.
      */
-    public boolean isValidEntity(Entity entity, IGame game, 
-            boolean useValidNonInfantryCheck) {
-
-        return (entity != null) && (entity.getOwnerId() == playerId)
-            && entity.isSelectableThisTurn()
-            // This next bit enforces the "A players Infantry/Protos
-            // move after that players other units" options.
-            && !(useValidNonInfantryCheck &&
-                 (game.getPhase() == IGame.Phase.PHASE_MOVEMENT)
-                 && (((entity instanceof Infantry) && 
-                      game.getOptions().booleanOption(OptionsConstants.INIT_INF_MOVE_LATER)) 
-                    || 
-                    ((entity instanceof Protomech) && 
-                     game.getOptions().booleanOption(OptionsConstants.INIT_PROTOS_MOVE_LATER))) 
-                 && game.checkForValidNonInfantryAndOrProtomechs(playerId));
+    public boolean isValidEntity(final Entity entity, final IGame game, final boolean useValidNonInfantryCheck) {
+        return (entity != null) && (entity.getOwnerId() == playerId) && entity.isSelectableThisTurn()
+                && !(useValidNonInfantryCheck && (game.getPhase() == IGame.Phase.PHASE_MOVEMENT)
+                // This next bit enforces the "A players Infantry/ProtoMechs move after that player's other units" options.
+                && (((entity instanceof Infantry) && game.getOptions().booleanOption(OptionsConstants.INIT_INF_MOVE_LATER))
+                || ((entity instanceof Protomech)&& game.getOptions().booleanOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)))
+                && game.checkForValidNonInfantryAndOrProtomechs(playerId));
     }    
 
     /**
@@ -314,48 +306,40 @@ public class GameTurn implements Serializable {
      * @return the <code>int</code> code for the entity's class.
      */
     public static int getClassCode(Entity entity) {
-        int classCode = 0;
         // Start with subclasses of Aero
-        if ( entity instanceof SpaceStation ) {
-            classCode = GameTurn.CLASS_SPACE_STATION;
-        } else if ( entity instanceof Warship ) {
-            classCode = GameTurn.CLASS_WARSHIP;
-        }  else if ( entity instanceof Jumpship ) {
-            classCode = GameTurn.CLASS_JUMPSHIP;
-        } else if ( entity instanceof Dropship) {
-            if(entity.isAirborne()) {
-                classCode = GameTurn.CLASS_DROPSHIP;
-            } else {
-                classCode = GameTurn.CLASS_TANK;
-            }
-        } else if ( entity instanceof SmallCraft && entity.isAirborne()) {
-            classCode = GameTurn.CLASS_SMALL_CRAFT;
+        if (entity instanceof SpaceStation) {
+            return CLASS_SPACE_STATION;
+        } else if (entity instanceof Warship) {
+            return CLASS_WARSHIP;
+        }  else if (entity instanceof Jumpship) {
+            return CLASS_JUMPSHIP;
+        } else if (entity instanceof Dropship) {
+            return entity.isAirborne() ? CLASS_DROPSHIP : CLASS_TANK;
+        } else if (entity instanceof SmallCraft && entity.isAirborne()) {
+            return CLASS_SMALL_CRAFT;
         // Anything else that's still airborne is treated as an Aero 
-        // (VTOLs aren't considered airborne, since it's based on altitude and 
-        //      not elevation)
+        // (VTOLs aren't considered airborne, since it's based on altitude and not elevation)
         } else if (entity.isAirborne()) {
-                classCode = GameTurn.CLASS_AERO;            
+            return CLASS_AERO;
         } else if (entity instanceof Infantry) {
-            classCode = GameTurn.CLASS_INFANTRY;
+            return CLASS_INFANTRY;
         } else if (entity instanceof Protomech) {
-            classCode = GameTurn.CLASS_PROTOMECH;
+            return CLASS_PROTOMECH;
         } else if (entity instanceof Tank || entity.isAero()) {
-            classCode = GameTurn.CLASS_TANK;
+            return CLASS_TANK;
         } else if (entity instanceof Mech) {
-            classCode = GameTurn.CLASS_MECH;
+            return CLASS_MECH;
         } else if (entity instanceof GunEmplacement) {
-            classCode = GameTurn.CLASS_GUN_EMPLACEMENT;
+            return CLASS_GUN_EMPLACEMENT;
+        } else {
+            return 0;
         }
-        return classCode;
     }
 
     /**
      * A type of game turn that allows only certain types of units to move.
      */
     public static class EntityClassTurn extends GameTurn {
-        /**
-         *
-         */
         private static final long serialVersionUID = 1305684619846966124L;
         private final int mask;
 
@@ -380,13 +364,11 @@ public class GameTurn implements Serializable {
          * @return <code>true</code> if the entity can be moved.
          */
         @Override
-        public boolean isValidEntity(Entity entity, IGame game, 
-                boolean useValidNonInfantryCheck) {
-            // The entity must be in the mask, and pass
-            // the requirements of the parent class.
-            return ((GameTurn.getClassCode(entity) & mask) != 0)
-                    && super.isValidEntity(entity, game, 
-                            useValidNonInfantryCheck);
+        public boolean isValidEntity(final Entity entity, final IGame game,
+                                     final boolean useValidNonInfantryCheck) {
+            // The entity must pass the requirements of the parent class and be in the mask.
+            return ((getClassCode(entity) & mask) != 0)
+                    && super.isValidEntity(entity, game, useValidNonInfantryCheck);
         }
         
         

--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -24,6 +24,7 @@ package megamek.common;
 import java.io.Serializable;
 import java.util.Iterator;
 
+import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
 
 /**
@@ -93,10 +94,11 @@ public class GameTurn implements Serializable {
      * @return <code>true</code> if the specified entity can take this turn.
      *         <code>false</code> if the entity is not valid for this turn.
      */
-    public boolean isValidEntity(final Entity entity, final IGame game, final boolean useValidNonInfantryCheck) {
+    public boolean isValidEntity(final @Nullable Entity entity, final IGame game,
+                                 final boolean useValidNonInfantryCheck) {
         return (entity != null) && (entity.getOwnerId() == playerId) && entity.isSelectableThisTurn()
-                && !(useValidNonInfantryCheck && (game.getPhase() == IGame.Phase.PHASE_MOVEMENT)
                 // This next bit enforces the "A players Infantry/ProtoMechs move after that player's other units" options.
+                && !(useValidNonInfantryCheck && (game.getPhase() == IGame.Phase.PHASE_MOVEMENT)
                 && (((entity instanceof Infantry) && game.getOptions().booleanOption(OptionsConstants.INIT_INF_MOVE_LATER))
                 || ((entity instanceof Protomech) && game.getOptions().booleanOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)))
                 && game.checkForValidNonInfantryAndOrProtomechs(playerId));
@@ -364,7 +366,7 @@ public class GameTurn implements Serializable {
          * @return <code>true</code> if the entity can be moved.
          */
         @Override
-        public boolean isValidEntity(final Entity entity, final IGame game,
+        public boolean isValidEntity(final @Nullable Entity entity, final IGame game,
                                      final boolean useValidNonInfantryCheck) {
             // The entity must pass the requirements of the parent class and be in the mask.
             return super.isValidEntity(entity, game, useValidNonInfantryCheck)
@@ -525,9 +527,8 @@ public class GameTurn implements Serializable {
          * Returns true if the player and entity are both valid.
          */
         @Override
-        public boolean isValid(int playerId, Entity entity, IGame game) {
-            return ((null != entity) && (entity.getOwnerId() == playerId) && isValidEntity(
-                    entity, game));
+        public boolean isValid(final int playerId, final @Nullable Entity entity, final IGame game) {
+            return isValidEntity(entity, game) && (entity.getOwnerId() == playerId);
         }
 
         /**

--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -305,7 +305,7 @@ public class GameTurn implements Serializable {
      * @param entity the <code>Entity</code> whose class code is needed.
      * @return the <code>int</code> code for the entity's class.
      */
-    public static int getClassCode(Entity entity) {
+    public static int getClassCode(final Entity entity) {
         // Start with subclasses of Aero
         if (entity instanceof SpaceStation) {
             return CLASS_SPACE_STATION;
@@ -315,7 +315,7 @@ public class GameTurn implements Serializable {
             return CLASS_JUMPSHIP;
         } else if (entity instanceof Dropship) {
             return entity.isAirborne() ? CLASS_DROPSHIP : CLASS_TANK;
-        } else if (entity instanceof SmallCraft && entity.isAirborne()) {
+        } else if ((entity instanceof SmallCraft) && entity.isAirborne()) {
             return CLASS_SMALL_CRAFT;
         // Anything else that's still airborne is treated as an Aero 
         // (VTOLs aren't considered airborne, since it's based on altitude and not elevation)
@@ -325,12 +325,12 @@ public class GameTurn implements Serializable {
             return CLASS_INFANTRY;
         } else if (entity instanceof Protomech) {
             return CLASS_PROTOMECH;
-        } else if (entity instanceof Tank || entity.isAero()) {
+        } else if (entity instanceof GunEmplacement) {
+            return CLASS_GUN_EMPLACEMENT;
+        } else if ((entity instanceof Tank) || entity.isAero()) {
             return CLASS_TANK;
         } else if (entity instanceof Mech) {
             return CLASS_MECH;
-        } else if (entity instanceof GunEmplacement) {
-            return CLASS_GUN_EMPLACEMENT;
         } else {
             return 0;
         }


### PR DESCRIPTION
This fixes #2681 and a second GunEmplacement instanceof bug I found while looking into the issue.

The first commit is code cleanup, the second fixes the incorrect ordering on the null check, the third fixes an incorrect order, the fourth reorders a check to remove a repeat entity null check, adds Nullable annotations, and fixes a mistake with a comment during cleanup.