### PR TITLE
Distance Null Coordinate NPE

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1677,12 +1677,10 @@ public class Compute {
             }
         }
 
-        if (Compute.isGroundToAir(attacker, target)
-                && (target instanceof Entity)) {
+        if (Compute.isGroundToAir(attacker, target) && (target instanceof Entity)) {
             // distance is determined by closest point on flight path
-            distance = attacker.getPosition().distance(
-                    getClosestFlightPath(attacker.getId(),
-                            attacker.getPosition(), (Entity) target));
+            distance = attacker.getPosition().distance(getClosestFlightPath(attacker.getId(),
+                    attacker.getPosition(), (Entity) target));
 
             // if the ground attacker uses weapon bays and we are on a
             // ground map, then we will divide this distance by 16
@@ -1703,7 +1701,7 @@ public class Compute {
 
         // If the attack is completely inside a building, add the difference
         // in elevations between the attacker and target to the range.
-        // TODO: should the player be explcitly notified?
+        // TODO: should the player be explicitly notified?
         if (Compute.isInSameBuilding(game, attacker, target)) {
             int aElev = attacker.getElevation();
             int tElev = target.getElevation();
@@ -1746,8 +1744,7 @@ public class Compute {
      * @param te
      * @return
      */
-    public static Coords getClosestFlightPath(int attackerId, Coords aPos, Entity te) {
-
+    public static @Nullable Coords getClosestFlightPath(int attackerId, Coords aPos, Entity te) {
         Coords finalPos = te.getPosition();
         if (te.getPlayerPickedPassThrough(attackerId) != null) {
             finalPos = te.getPlayerPickedPassThrough(attackerId);

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1624,8 +1624,7 @@ public class Compute {
      *
      * @return the effective distance
      */
-    public static int effectiveDistance(IGame game, Entity attacker,
-                                        Targetable target) {
+    public static int effectiveDistance(IGame game, Entity attacker, Targetable target) {
         return Compute.effectiveDistance(game, attacker, target, false);
     }
 
@@ -1636,35 +1635,30 @@ public class Compute {
      *
      * @return the effective distance
      */
-    public static int effectiveDistance(IGame game, Entity attacker,
-                                        Targetable target, boolean useGroundDistance) {
-
+    public static int effectiveDistance(IGame game, Entity attacker, Targetable target,
+                                        boolean useGroundDistance) {
         if (Compute.isAirToGround(attacker, target)
                 || (attacker.isBomber() && target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB)) {
             // always a distance of zero
             return 0;
         }
 
-        Vector<Coords> attackPos = new Vector<Coords>();
+        Vector<Coords> attackPos = new Vector<>();
         attackPos.add(attacker.getPosition());
-        Vector<Coords> targetPos = new Vector<Coords>();
+        Vector<Coords> targetPos = new Vector<>();
         targetPos.add(target.getPosition());
         // if a grounded dropship is the attacker, then it gets to choose the
         // best secondary position for LoS
-        if ((attacker instanceof Dropship) && !attacker.isAirborne()
-            && !attacker.isSpaceborne()) {
-            attackPos = new Vector<Coords>();
+        if ((attacker instanceof Dropship) && !attacker.isAirborne() && !attacker.isSpaceborne()) {
+            attackPos = new Vector<>();
             for (int key : attacker.getSecondaryPositions().keySet()) {
                 attackPos.add(attacker.getSecondaryPositions().get(key));
             }
         }
-        if ((target instanceof Entity) && (target instanceof Dropship)
-            && !((Entity) target).isAirborne()
-            && !((Entity) target).isSpaceborne()) {
-            targetPos = new Vector<Coords>();
-            for (int key : ((Entity) target).getSecondaryPositions().keySet()) {
-                targetPos.add(((Entity) target).getSecondaryPositions()
-                                               .get(key));
+        if ((target instanceof Dropship) && !target.isAirborne() && !((Entity) target).isSpaceborne()) {
+            targetPos = new Vector<>();
+            for (final int key : target.getSecondaryPositions().keySet()) {
+                targetPos.add(target.getSecondaryPositions().get(key));
             }
         }
         int distance = Integer.MAX_VALUE;
@@ -1694,8 +1688,7 @@ public class Compute {
 
         // if this is an air-to-air attack on the ground map, then divide
         // distance by 16
-        if (Compute.isAirToAir(attacker, target) && game.getBoard().onGround()
-            && !useGroundDistance) {
+        if (Compute.isAirToAir(attacker, target) && game.getBoard().onGround() && !useGroundDistance) {
             distance = (int) Math.ceil(distance / 16.0);
         }
 
@@ -1735,14 +1728,11 @@ public class Compute {
     }
 
     /**
-     * Returns the closest position along <code>te</codeE>'s flight path to
-     * <code>aPos</code>.  In the case of multiple equi-distance positions, the
-     * first one is picked unless <code>te</code>'s playerPickedPassThrough
-     * position is non-null.
-     *
-     * @param aPos
-     * @param te
-     * @return
+     * @param aPos the attacker's position
+     * @param te the target entity
+     * @return the closest position along <code>te</codeE>'s flight path to <code>aPos</code>. In
+     * the case of multiple equi-distance positions, the first one is picked unless
+     * <code>te</code>'s playerPickedPassThrough position is non-null.
      */
     public static @Nullable Coords getClosestFlightPath(int attackerId, Coords aPos, Entity te) {
         Coords finalPos = te.getPosition();

--- a/megamek/src/megamek/common/Coords.java
+++ b/megamek/src/megamek/common/Coords.java
@@ -255,7 +255,7 @@ public class Coords implements Serializable {
 
     /**
      * @param d the destination coordinate.
-     * @return Returns the degree direction of another Coords
+     * @return the degree direction of another Coords
      */
     public int degree(Coords d) {
         return (int) Math.round((180 / Math.PI) * radian(d));

--- a/megamek/src/megamek/common/Coords.java
+++ b/megamek/src/megamek/common/Coords.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
 import megamek.client.bot.princess.BotGeometry.HexLine;
+import megamek.common.annotations.Nullable;
 
 /**
  * Coords stores x and y values. Since these are hexes, coordinates with odd x
@@ -253,17 +254,20 @@ public class Coords implements Serializable {
     }
 
     /**
-     * Returns the degree direction of another Coords.
-     * 
      * @param d the destination coordinate.
+     * @return Returns the degree direction of another Coords
      */
     public int degree(Coords d) {
         return (int) Math.round((180 / Math.PI) * radian(d));
     }
 
-    /** Returns the distance to the given Coords c. */
-    public int distance(Coords c) {
-        return distance(c.getX(), c.getY());
+    /**
+     * @param coordinates the coordinates to get the distance to, or null
+     * @return the distance from these coordinates to the provided coordinates, or Integer.MAX_VALUE
+     * if the provided coordinates are null
+     */
+    public int distance(final @Nullable Coords coordinates) {
+        return (coordinates == null) ? Integer.MAX_VALUE : distance(coordinates.getX(), coordinates.getY());
     }
 
     /** Returns the distance to the coordinate given as distx, disty. */

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11865,7 +11865,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         playerPickedPassThrough.put(attackerId, c);
     }
 
-    public Coords getPlayerPickedPassThrough(int attackerId) {
+    public @Nullable Coords getPlayerPickedPassThrough(int attackerId) {
         if (playerPickedPassThrough == null) {
             playerPickedPassThrough = new HashMap<>();
         }


### PR DESCRIPTION
This prevents a NPE when distance checking null coordinates, adds a few nullable notes, and removes a few unnecessary casts.

If this NPEs out during calculation (mine did it before the physical phase), it blocks turn progression... and a reload does not fix it.