### PR TITLE
Compute: Adding Individual Dice and Individual Rolls Methods

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -13,7 +13,6 @@
 * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
 * details.
 */
-
 package megamek.common;
 
 import java.util.ArrayList;
@@ -194,6 +193,54 @@ public class Compute {
             }
         }
         return roll.getIntValue();
+    }
+
+    /**
+     * Input is in format "ndf", so this can handle 2d6 or 3d10
+     * @param number the number of dice to roll
+     * @param faces  the number of faces on those dice
+     * @return an Integer list of every dice roll, with index 0 containing the summed result
+     */
+    public static List<Integer> individualDice(final int number, final int faces) {
+        final List<Integer> individualRolls = new ArrayList<>();
+        int result = 0, roll;
+        individualRolls.add(result);
+
+        for (int i = 0; i < number; i++) {
+            roll = randomInt(faces) + 1;
+            individualRolls.add(roll);
+            result += roll;
+        }
+
+        individualRolls.set(0, result);
+
+        return individualRolls;
+    }
+
+    /**
+     * Input is in format "c ndf", so that this can handle 10 rolls of 3d6
+     * @param count  the count of sets of dice to roll
+     * @param number the number of dice to roll per set
+     * @param faces  the number of faces per die
+     * @return an Integer list of every summed dice roll, with index 0 containing the summed result
+     */
+    public static List<Integer> individualRolls(int count, int number, int faces) {
+        List<Integer> individualRolls = new ArrayList<>();
+        int result = 0, roll;
+        individualRolls.add(result);
+
+        for (int x = 0; x < count; x++) {
+            roll = 0;
+            for (int y = 0; y < number; y++) {
+                roll += randomInt(faces) + 1;
+            }
+            individualRolls.add(roll);
+            result += roll;
+        }
+
+        individualRolls.set(0, result);
+
+        return individualRolls;
     }
 
     /**


### PR DESCRIPTION
Both are fully tested but merged as unused. The first method is required for handling Edge according to MechWarrior: Destiny.