### PR TITLE
more robust orphan cleanup

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1392,6 +1392,10 @@ public class Game implements Serializable, IGame {
      * (probably due to double-blind) ignore it.
      */
     public synchronized void removeEntity(int id, int condition) {
+        // always attempt to remove the entity with this ID from the entities collection
+        // as it may have gotten stuck there.
+        entities.removeIf(ent -> (ent.getId() == id));
+        
         Entity toRemove = getEntity(id);
         if (toRemove == null) {
             // This next statement has been cluttering up double-blind
@@ -1402,7 +1406,6 @@ public class Game implements Serializable, IGame {
             return;
         }
 
-        entities.remove(toRemove);
         entityIds.remove(Integer.valueOf(id));
         removeEntityPositionLookup(toRemove);
 


### PR DESCRIPTION
For some reason, the game's entities collection got out of sync with the rest of its entity management collections, so an entity destroyed in the physical phase was showing up in the game (though with 0 CT structure) when loading a save game made in the end phase.

This change makes game more aggressive about keeping the entities collection clear of entities being removed.