### PR TITLE
Fix broken PlanetaryConditions tests after merge

### DIFF
--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -618,11 +618,10 @@ public class PlanetaryConditions implements Serializable {
         if ((windStrength == WI_TORNADO_F4) && !(en instanceof Mech)) {
             return "tornado";
         }
-        if ((windStrength == WI_TORNADO_F13)
-                && (en.isConventionalInfantry()
-                        || ((en.getMovementMode() == EntityMovementMode.HOVER)
-                    || (en.getMovementMode() == EntityMovementMode.WIGE)
-                    || (en.getMovementMode() == EntityMovementMode.VTOL)))) {
+        if ((windStrength == WI_TORNADO_F13) && (en.isConventionalInfantry()
+            || ((en.getMovementMode() == EntityMovementMode.HOVER)
+            || (en.getMovementMode() == EntityMovementMode.WIGE)
+            || (en.getMovementMode() == EntityMovementMode.VTOL)))) {
             return "tornado";
         }
         if((windStrength == WI_STORM) && en.isConventionalInfantry()) {

--- a/megamek/unittests/megamek/common/PlanetaryConditionsTest.java
+++ b/megamek/unittests/megamek/common/PlanetaryConditionsTest.java
@@ -90,6 +90,7 @@ public class PlanetaryConditionsTest {
         planetaryConditions = new PlanetaryConditions();
         planetaryConditions.setWindStrength(PlanetaryConditions.WI_TORNADO_F13);
         mockEntity = mock(Infantry.class);
+        when(mockEntity.isConventionalInfantry()).thenReturn(true);
         when(mockGame.getPlanetaryConditions()).thenReturn(planetaryConditions);
         assertEquals("tornado", planetaryConditions.whyDoomed(mockEntity, mockGame));
         reset(mockEntity, mockGame);
@@ -108,6 +109,7 @@ public class PlanetaryConditionsTest {
         planetaryConditions = new PlanetaryConditions();
         planetaryConditions.setWindStrength(PlanetaryConditions.WI_STORM);
         mockEntity = mock(Infantry.class);
+        when(mockEntity.isConventionalInfantry()).thenReturn(true);
         when(mockGame.getPlanetaryConditions()).thenReturn(planetaryConditions);
         assertEquals("storm", planetaryConditions.whyDoomed(mockEntity, mockGame));
         reset(mockEntity, mockGame);


### PR DESCRIPTION
When merging the PlanetaryConditions test PR into master, some tests broke when the change to isConventionalInfantry was implemented.