### PR TITLE
Reduce shield DA for missing hand actuator

### DIFF
--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1510,6 +1510,9 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         if (!entity.hasWorkingSystem(Mech.ACTUATOR_UPPER_ARM, location)) {
             base--;
         }
+        if (!entity.hasWorkingSystem(Mech.ACTUATOR_HAND, location)) {
+            base--;
+        }
 
         return Math.max(0, base - damageTaken);
     }


### PR DESCRIPTION
The damage absorption value of a shield is reduced by one for each missing arm or hand actuator. MM is only checking arm actuators.

Partial fix for #2710 