### PR TITLE
Base Components: Making One Touch Expandable Default for Split Panes

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
@@ -107,7 +107,7 @@ public abstract class AbstractDialog extends JDialog implements WindowListener {
 
     /**
      * This MUST be called at the end of initialization to finalize it. This is the key method for
-     * this being the abstract basis for all other dialog
+     * this being the abstract basis for all other dialogs.
      */
     protected void finalizeInitialization() {
         pack();

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractSplitPane.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractSplitPane.java
@@ -25,6 +25,8 @@ import megamek.client.ui.preferences.PreferencesNode;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.util.ResourceBundle;
 
 /**
@@ -80,7 +82,7 @@ public abstract class AbstractSplitPane extends JSplitPane {
     protected void initialize() {
         setLeftComponent(createLeftComponent());
         setRightComponent(createRightComponent());
-        setPreferences();
+        finalizeInitialization();
     }
 
     /**
@@ -92,6 +94,15 @@ public abstract class AbstractSplitPane extends JSplitPane {
      * @return the created right component
      */
     protected abstract Component createRightComponent();
+
+    /**
+     * This MUST be called at the end of initialization to finalize it. This is the key method for
+     * this being the abstract basis for all other split panes
+     */
+    protected void finalizeInitialization() {
+        setOneTouchExpandable(true);
+        setPreferences();
+    }
 
     /**
      * This is used to set preferences based on the preference node for this class. It is overridden


### PR DESCRIPTION
This fixes something I missed when working on the PR, and moves to setting it in a finalize method (as is the standard)