### PR TITLE
Issue #2722: Do not send IP addresses in chat by default

### DIFF
--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -53,6 +53,7 @@ class ClientPreferences extends PreferenceStoreProxy implements
         store.setDefault(MAP_HEIGHT, 1);
         store.setDefault(DEBUG_OUTPUT_ON,false);
         store.setDefault(MEMORY_DUMP_ON,false);
+        store.setDefault(IP_ADDRESSES_IN_CHAT, false);
         setLocale(store.getString(LOCALE));
         setMekHitLocLog();
     }
@@ -253,6 +254,14 @@ class ClientPreferences extends PreferenceStoreProxy implements
 
     public void setGUIName(String guiName) {
         store.setValue(GUI_NAME, guiName);
+    }
+
+    public boolean getShowIPAddressesInChat() {
+        return store.getBoolean(IP_ADDRESSES_IN_CHAT);
+    }
+
+    public void setShowIPAddressesInChat(boolean value) {
+        store.setValue(IP_ADDRESSES_IN_CHAT, value);
     }
 
     protected Locale locale = null;

--- a/megamek/src/megamek/common/preference/IClientPreferences.java
+++ b/megamek/src/megamek/common/preference/IClientPreferences.java
@@ -54,7 +54,7 @@ public interface IClientPreferences extends IPreferenceStore {
     public static final String BOARD_HEIGHT = "BoardHeight";
     public static final String MAP_WIDTH = "MapWidth";
     public static final String MAP_HEIGHT = "MapHeight";
-    public static final String IP_ADDRESSES_IN_CHAT = "IPAdressesInChat";
+    public static final String IP_ADDRESSES_IN_CHAT = "IPAddressesInChat";
 
     boolean getPrintEntityChange();
 

--- a/megamek/src/megamek/common/preference/IClientPreferences.java
+++ b/megamek/src/megamek/common/preference/IClientPreferences.java
@@ -54,6 +54,7 @@ public interface IClientPreferences extends IPreferenceStore {
     public static final String BOARD_HEIGHT = "BoardHeight";
     public static final String MAP_WIDTH = "MapWidth";
     public static final String MAP_HEIGHT = "MapHeight";
+    public static final String IP_ADDRESSES_IN_CHAT = "IPAdressesInChat";
 
     boolean getPrintEntityChange();
 
@@ -162,5 +163,7 @@ public interface IClientPreferences extends IPreferenceStore {
     int getMapWidth();
 
     int getMapHeight();
+
+    boolean getShowIPAddressesInChat();
 
 }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -905,9 +905,10 @@ public class Server implements Runnable {
         try {
             InetAddress[] addresses = InetAddress.getAllByName(InetAddress
                     .getLocalHost().getHostName());
-            for (InetAddress addresse : addresses) {
+            for (InetAddress address : addresses) {
+                MegaMek.getLogger().info("s: machine IP " + address.getHostAddress());
                 sendServerChat(connId,
-                               "Machine IP is " + addresse.getHostAddress());
+                               "Machine IP is " + address.getHostAddress());
             }
         } catch (UnknownHostException e) {
             // oh well.

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -902,29 +902,38 @@ public class Server implements Runnable {
         // send current game info
         sendCurrentInfo(connId);
 
+        final boolean showIPAddressesInChat = PreferenceManager.getClientPreferences().getShowIPAddressesInChat();
+
         try {
             InetAddress[] addresses = InetAddress.getAllByName(InetAddress
                     .getLocalHost().getHostName());
             for (InetAddress address : addresses) {
                 MegaMek.getLogger().info("s: machine IP " + address.getHostAddress());
-                sendServerChat(connId,
-                               "Machine IP is " + address.getHostAddress());
+                if (showIPAddressesInChat) {
+                    sendServerChat(connId,
+                            "Machine IP is " + address.getHostAddress());
+                }
             }
         } catch (UnknownHostException e) {
             // oh well.
         }
 
-        // Send the port we're listening on. Only useful for the player
-        // on the server machine to check.
-        sendServerChat(connId,
-                       "Listening on port " + serverSocket.getLocalPort());
+        MegaMek.getLogger().info("s: listening on port " + serverSocket.getLocalPort());
+        if (showIPAddressesInChat) {
+            // Send the port we're listening on. Only useful for the player
+            // on the server machine to check.
+            sendServerChat(connId,
+                        "Listening on port " + serverSocket.getLocalPort());
+        }
 
         // Get the player *again*, because they may have disconnected.
         player = getPlayer(connId);
         if (null != player) {
             String who = player.getName() + " connected from " + getClient(connId).getInetAddress();
             MegaMek.getLogger().info("s: player #" + connId + ", " + who);
-            sendServerChat(who);
+            if (showIPAddressesInChat) {
+                sendServerChat(who);
+            }
 
         } // Found the player
 

--- a/megamek/src/megamek/server/commands/WhoCommand.java
+++ b/megamek/src/megamek/server/commands/WhoCommand.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ *         - Copyright (C) 2021 The MegaMek Team
  *
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the Free
@@ -12,24 +13,16 @@
  *  for more details.
  */
 
-/*
- * WhoCommand.java
- *
- * Created on March 30, 2002, 7:35 PM
- */
-
 package megamek.server.commands;
 
 import java.util.Enumeration;
 
 import megamek.common.net.IConnection;
+import megamek.common.preference.PreferenceManager;
 import megamek.server.Server;
 
 /**
  * Lists all the players connected and some info about them.
- * 
- * @author Ben
- * @version
  */
 public class WhoCommand extends ServerCommand {
 
@@ -42,21 +35,26 @@ public class WhoCommand extends ServerCommand {
     @Override
     public void run(int connId, String[] args) {
         server.sendServerChat(connId, "Listing all connections...");
-        server
-                .sendServerChat(connId,
-                        "[id#] : [name], [address], [pending], [bytes sent], [bytes received]");
+        server.sendServerChat(
+                connId, "[id#] : [name], [address], [pending], [bytes sent], [bytes received]");
+
+        final boolean includeIPAddress = PreferenceManager.getClientPreferences().getShowIPAddressesInChat();
         for (Enumeration<IConnection> i = server.getConnections(); i.hasMoreElements();) {
             IConnection conn = i.nextElement();
-            StringBuffer cb = new StringBuffer();
-            cb.append(conn.getId()).append(" : ");
-            cb.append(server.getPlayer(conn.getId()).getName()).append(", ");
-            cb.append(conn.getInetAddress());
-            cb.append(", ").append(conn.hasPending()).append(", ");
-            cb.append(conn.bytesSent());
-            cb.append(", ").append(conn.bytesReceived());
-            server.sendServerChat(connId, cb.toString());
+            server.sendServerChat(connId, getConnectionDescription(conn, includeIPAddress));
         }
+
         server.sendServerChat(connId, "end list");
     }
 
+    private String getConnectionDescription(IConnection conn, boolean includeIPAddress) {
+        StringBuilder cb = new StringBuilder();
+        cb.append(conn.getId()).append(" : ");
+        cb.append(server.getPlayer(conn.getId()).getName()).append(", ");
+        cb.append(includeIPAddress ? conn.getInetAddress() : "<hidden>");
+        cb.append(", ").append(conn.hasPending()).append(", ");
+        cb.append(conn.bytesSent());
+        cb.append(", ").append(conn.bytesReceived());
+        return cb.toString();
+    }
 }


### PR DESCRIPTION
This PR does two things w.r.t. IP addresses:
1. Ensures they are all logged (server IP and port and client IPs)
2. Ensures they are not sent in chat publicly by default

Resolves #2722 

I've tried to keep this as simple as possible so it is stable backport compatible.