### PR TITLE
Issue #2722: Add a UI to enable/disable showing IPs in chat

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -865,6 +865,8 @@ CommonSettingsDialog.floatingIso=Floating isometric (no hex sides in isometric m
 CommonSettingsDialog.mmSymbol=Use StratOps unit symbols in the Minimap
 CommonSettingsDialog.useSoftCenter=Use smooth transitioning when selecting units on the board
 CommonSettingsDialog.useSoftCenterTip=Instead of an instant snap, the view is smoothly transitioned
+CommonSettingsDialog.showIPAddressesInChat=Show IP Addresses in Chat (WARNING: Security Sensitive)
+CommonSettingsDialog.showIPAddressesInChat.tooltip=<html>If enabled, all server and client IP addresses will be logged in the public chat box.<br>Enabling this can allow information disclosure, such as private IP addresses of the server.</html>
 
 #Nag Suppression Dialog
 ConfirmDialog.dontBother=Do not bother me again

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -217,6 +217,7 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JCheckBox generateNames;
     private JCheckBox showUnitId;
     private JComboBox<String> displayLocale;
+    private JCheckBox showIPAddressesInChat;
 
     private JCheckBox showDamageLevel;
     private JCheckBox showDamageDecal;
@@ -733,6 +734,27 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(stampFormat);
         comps.add(row);
 
+        // Horizontal Line and Spacer
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(new Dimension(0, 10)));
+        comps.add(row);
+
+        Sep = new JSeparator(SwingConstants.HORIZONTAL);
+        row = new ArrayList<>();
+        row.add(Sep);
+        comps.add(row);
+        
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(new Dimension(0, 5)));
+        comps.add(row);
+        // -------------- 
+
+        showIPAddressesInChat = new JCheckBox(Messages.getString("CommonSettingsDialog.showIPAddressesInChat"));
+        showIPAddressesInChat.setToolTipText(Messages.getString("CommonSettingsDialog.showIPAddressesInChat.tooltip"));
+        row = new ArrayList<>();
+        row.add(showIPAddressesInChat);
+        comps.add(row);
+
         return createSettingsPanel(comps);
     }
 
@@ -788,6 +810,7 @@ public class CommonSettingsDialog extends ClientDialog implements
             stampFilenames.setSelected(cs.stampFilenames());
             stampFormat.setEnabled(stampFilenames.isSelected());
             stampFormat.setText(cs.getStampFormat());
+            showIPAddressesInChat.setSelected(cs.getShowIPAddressesInChat());
 
             defaultAutoejectDisabled.setSelected(cs.defaultAutoejectDisabled());
             useAverageSkills.setSelected(cs.useAverageSkills());
@@ -1004,6 +1027,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         // cs.setGameLogMaxSize(Integer.parseInt(gameLogMaxSize.getText()));
         cs.setStampFilenames(stampFilenames.isSelected());
         cs.setStampFormat(stampFormat.getText());
+        cs.setShowIPAddressesInChat(showIPAddressesInChat.isSelected());
 
         cs.setDefaultAutoejectDisabled(defaultAutoejectDisabled.isSelected());
         cs.setUseAverageSkills(useAverageSkills.isSelected());

--- a/megamek/src/megamek/common/preference/IClientPreferences.java
+++ b/megamek/src/megamek/common/preference/IClientPreferences.java
@@ -166,4 +166,5 @@ public interface IClientPreferences extends IPreferenceStore {
 
     boolean getShowIPAddressesInChat();
 
+    void setShowIPAddressesInChat(boolean value);
 }


### PR DESCRIPTION
This adds the UI to enable/disable showing IPs in the public chat box:
![image](https://user-images.githubusercontent.com/8238690/111661346-564bc980-87e5-11eb-8489-b5b265a82d20.png)

In retrospect, this appears to be reasonable for inclusion in the stable branch as well as I don't think that UI has changed since 0.49 landed.

Resolves #2722.