### PR TITLE
Fix NPE when saving unit cache

### DIFF
--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -277,12 +277,7 @@ public class MechSummaryCache {
 
         // save updated cache back to disk
         if (bNeedsUpdate) {
-            try {
-                saveCache();
-            } catch (Exception e) {
-                loadReport.append(" Unable to save mech cache\n");
-                MegaMek.getLogger().error(e);
-            }
+            saveCache(vMechs);
         }
     }
 
@@ -349,17 +344,19 @@ public class MechSummaryCache {
         }
     }
 
-    private void saveCache() throws Exception {
+    private void saveCache(List<MechSummary> data) {
         loadReport.append("Saving unit cache.\n");
         File unit_cache_path = new MegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile();
-        ObjectOutputStream wr = new ObjectOutputStream(
-                new BufferedOutputStream(new FileOutputStream(unit_cache_path)));
-        wr.writeObject(m_data.length);
-        for (MechSummary element : m_data) {
-            wr.writeObject(element);
+        try (ObjectOutputStream wr = new ObjectOutputStream(
+                new BufferedOutputStream(new FileOutputStream(unit_cache_path)))) {
+            wr.writeObject(data.size());
+            for (MechSummary element : data) {
+                wr.writeObject(element);
+            }
+        } catch (Exception e) {
+            loadReport.append(" Unable to save mech cache\n");
+            MegaMek.getLogger().error(e);
         }
-        wr.flush();
-        wr.close();
     }
 
     private void refreshCache(long lastCheck, boolean ignoreUnofficial) {


### PR DESCRIPTION
Take 2. I changed the order that some things were done thinking I was streamlining and ended up throwing an exception when trying to save the unit cache by using a field that hasn't been initialized. This fixes that by using the list that will later be converted to an array for storage. It also fixes a potential resource leak.