### PR TITLE
Report tooltips for target number calculations

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2704,6 +2704,7 @@ RandomSkillDialog.cForceClose=Force Piloting to be Gunnery+1
 #Report Display
 ReportDisplay.Done=Done
 ReportDisplay.Reroll=Reroll
+ReportDisplay.Details=Details
 
 #Ruler
 Ruler.Close=Close

--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -289,10 +289,14 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
         clientgui.getClient().getGame().removeGameListener(this);
     }
 
+    private JComponent activePane() {
+        return (JComponent) ((JScrollPane) tabs.getSelectedComponent()).getViewport().getView();
+    }
+
     @Override
     public void hyperlinkUpdate(HyperlinkEvent evt) {
+        String evtDesc = evt.getDescription();
         if (evt.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-            String evtDesc = evt.getDescription();
             if (evtDesc.startsWith("#entity")) {
                 String idString = evtDesc.substring(evtDesc.indexOf(":") + 1);
                 int id;
@@ -311,6 +315,13 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
                 JOptionPane.showMessageDialog(clientgui, desc, Messages.getString("ReportDisplay.Details"),
                         JOptionPane.PLAIN_MESSAGE);
             }
+        } else if (evt.getEventType() == HyperlinkEvent.EventType.ENTERED) {
+            if (evtDesc.startsWith("#toHit")) {
+                String desc = evtDesc.substring(evtDesc.indexOf(":") + 1);
+                activePane().setToolTipText(desc);
+            }
+        } else if (evt.getEventType() == HyperlinkEvent.EventType.EXITED) {
+            activePane().setToolTipText(null);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -308,7 +308,8 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
                 }
             } else if (evtDesc.startsWith("#toHit")) {
                 String desc = evtDesc.substring(evtDesc.indexOf(":") + 1);
-                JOptionPane.showMessageDialog(clientgui, desc);
+                JOptionPane.showMessageDialog(clientgui, desc, Messages.getString("ReportDisplay.Details"),
+                        JOptionPane.PLAIN_MESSAGE);
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -31,6 +31,7 @@ import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.common.Entity;
 import megamek.common.IGame;
+import megamek.common.Report;
 import megamek.common.event.GamePhaseChangeEvent;
 
 public class ReportDisplay extends AbstractPhaseDisplay implements
@@ -297,8 +298,8 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
     public void hyperlinkUpdate(HyperlinkEvent evt) {
         String evtDesc = evt.getDescription();
         if (evt.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-            if (evtDesc.startsWith("#entity")) {
-                String idString = evtDesc.substring(evtDesc.indexOf(":") + 1);
+            if (evtDesc.startsWith(Report.ENTITY_LINK)) {
+                String idString = evtDesc.substring(Report.ENTITY_LINK.length());
                 int id;
                 try {
                     id = Integer.parseInt(idString);
@@ -310,14 +311,14 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
                     clientgui.mechD.displayEntity(ent);
                     clientgui.setDisplayVisible(true);
                 }
-            } else if (evtDesc.startsWith("#toHit")) {
-                String desc = evtDesc.substring(evtDesc.indexOf(":") + 1);
+            } else if (evtDesc.startsWith(Report.TOOLTIP_LINK)) {
+                String desc = evtDesc.substring(Report.TOOLTIP_LINK.length());
                 JOptionPane.showMessageDialog(clientgui, desc, Messages.getString("ReportDisplay.Details"),
                         JOptionPane.PLAIN_MESSAGE);
             }
         } else if (evt.getEventType() == HyperlinkEvent.EventType.ENTERED) {
-            if (evtDesc.startsWith("#toHit")) {
-                String desc = evtDesc.substring(evtDesc.indexOf(":") + 1);
+            if (evtDesc.startsWith(Report.TOOLTIP_LINK)) {
+                String desc = evtDesc.substring(Report.TOOLTIP_LINK.length());
                 activePane().setToolTipText(desc);
             }
         } else if (evt.getEventType() == HyperlinkEvent.EventType.EXITED) {

--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -18,16 +18,7 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import javax.swing.AbstractAction;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JTextPane;
-import javax.swing.JViewport;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.text.html.HTMLEditorKit;
@@ -315,6 +306,9 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
                     clientgui.mechD.displayEntity(ent);
                     clientgui.setDisplayVisible(true);
                 }
+            } else if (evtDesc.startsWith("#toHit")) {
+                String desc = evtDesc.substring(evtDesc.indexOf(":") + 1);
+                JOptionPane.showMessageDialog(clientgui, desc);
             }
         }
     }

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -102,6 +102,11 @@ public class Report implements Serializable {
 
     /** Number of spaces to use per indentation level. */
     private static final int DEFAULT_INDENTATION = 4;
+
+    /** Prefix for entity hyperlinks */
+    public static final String ENTITY_LINK = "#entity:";
+    /** Prefix for tooltip text */
+    public static final String TOOLTIP_LINK = "#tooltip:";
     
     /** Required - associates this object with its text. */
     public int messageId = Report.MESSAGE_NONE;
@@ -288,8 +293,8 @@ public class Report implements Serializable {
     }
 
     public void add(ToHitData toHit) {
-        tagData.addElement(String.format("<font color='0xffffff'><a href='#toHit:%s'>%d</a></font>",
-                toHit.getDesc(), toHit.getValue()));
+        tagData.addElement(String.format("<font color='0xffffff'><a href='%s%s'>%d</a></font>",
+                TOOLTIP_LINK, toHit.getDesc(), toHit.getValue()));
     }
 
     /**
@@ -318,7 +323,7 @@ public class Report implements Serializable {
             if ((indentation <= Report.DEFAULT_INDENTATION) || showImage) {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
-            add("<font color='0xffffff'><a href=\"#entity:" + entity.getId()
+            add("<font color='0xffffff'><a href=\"" + ENTITY_LINK + entity.getId()
                     + "\">" + entity.getShortName() + "</a></font>", true);
             add("<B><font color='" + entity.getOwner().getColour().getHexString(0x00F0F0F0) + "'>"
                     + entity.getOwner().getName() + "</font></B>");

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -287,6 +287,11 @@ public class Report implements Serializable {
         tagData.addElement(data);
     }
 
+    public void add(ToHitData toHit) {
+        tagData.addElement(String.format("<font color='0xffffff'><a href='#toHit:%s'>%d</a></font>",
+                toHit.getDesc(), toHit.getValue()));
+    }
+
     /**
      * Indicate which of two possible messages should be substituted for the
      * <code>&lt;msg:<i>n</i>,<i>m</i>&gt; tag.  An argument of

--- a/megamek/src/megamek/common/weapons/AR10Handler.java
+++ b/megamek/src/megamek/common/weapons/AR10Handler.java
@@ -156,7 +156,7 @@ public class AR10Handler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
             }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -314,7 +314,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
@@ -157,7 +157,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -117,7 +117,7 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -290,7 +290,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -149,7 +149,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -202,7 +202,7 @@ public class BayWeaponHandler extends WeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 
@@ -454,7 +454,7 @@ public class BayWeaponHandler extends WeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -166,7 +166,7 @@ public class BombAttackHandler extends WeaponHandler {
                     r = new Report(3150);
                     r.newlines = 0;
                     r.subject = subjectId;
-                    r.add(typeModifiedToHit.getValue());
+                    r.add(typeModifiedToHit);
                     vPhaseReport.addElement(r);
                 }
 

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -531,7 +531,7 @@ public class CLIATMHandler extends ATMHandler {
                 r = new Report(3150);
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(toHit.getValue());
+                r.add(toHit);
                 vPhaseReport.addElement(r);
             }
 
@@ -705,7 +705,7 @@ public class CLIATMHandler extends ATMHandler {
                 r = new Report(3150);
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(toHit.getValue());
+                r.add(toHit);
                 vPhaseReport.addElement(r);
             }
 

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -167,7 +167,7 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 
@@ -652,7 +652,7 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
@@ -256,7 +256,7 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -189,7 +189,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -115,7 +115,7 @@ public class LRMSwarmHandler extends LRMHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/MekMortarAirburstHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarAirburstHandler.java
@@ -109,7 +109,7 @@ public class MekMortarAirburstHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/MekMortarFlareHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarFlareHandler.java
@@ -115,7 +115,7 @@ public class MekMortarFlareHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/MekMortarSmokeHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarSmokeHandler.java
@@ -116,7 +116,7 @@ public class MekMortarSmokeHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/MissileBayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileBayWeaponHandler.java
@@ -333,7 +333,7 @@ public class MissileBayWeaponHandler extends AmmoBayWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/MissileMineClearanceHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileMineClearanceHandler.java
@@ -111,7 +111,7 @@ public class MissileMineClearanceHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -808,7 +808,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
@@ -110,7 +110,7 @@ public class SRMInfernoHandler extends SRMHandler {
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(toHit.getValue());
+            r.add(toHit);
             vPhaseReport.addElement(r);
         }
 

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -907,7 +907,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
                 r = new Report(3150);
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(toHit.getValue());
+                r.add(toHit);
                 vPhaseReport.addElement(r);
             }
 


### PR DESCRIPTION
Embeds the to-hit calculation details for weapons fire in the round report. Hovering over the target number shows a tooltip, and clicking on it shows a popup message box. So far I have only done this for weapons fire (report 3150) as the first installment. Other target number calculations to follow.

Tooltip example:
![to_hit_popup](https://user-images.githubusercontent.com/16927464/111724411-2e835280-8833-11eb-9f51-da6685b45145.png)

Popup example:
![Screenshot from 2021-03-18 21-42-51](https://user-images.githubusercontent.com/16927464/111724386-23c8bd80-8833-11eb-8e88-402d34c5619c.png)


Start of #136