### PR TITLE
enable the bot to consider sitting still or going to hull down

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -266,7 +266,7 @@ public class PathEnumerator {
             } else if (!mover.isAero() && mover.isAirborne()) {
                 paths.add(new MovePath(game, mover));
             } else { // Non-Aero movement
-            	// TODO: Will this cause Princess to never use MASC?
+                // TODO: Will this cause Princess to never use MASC?
                 LongestPathFinder lpf = LongestPathFinder
                         .newInstanceOfLongestPath(mover.getRunMPwithoutMASC(),
                                 MoveStepType.FORWARDS, getGame());
@@ -298,7 +298,7 @@ public class PathEnumerator {
                 // so let's not do this unless we're debugging
                 /* for(MovePath path : paths) {
 	                    getOwner().getLogger().debug(path.toString());
-	                }*/
+                }*/
                 
                 // Try climbing over obstacles and onto bridges
                 adjustPathsForBridges(paths);

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -37,6 +37,7 @@ import megamek.common.IGame;
 import megamek.common.IHex;
 import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
+import megamek.common.logging.LogLevel;
 import megamek.common.Targetable;
 import megamek.common.Terrains;
 import megamek.common.pathfinder.AbstractPathFinder.Filter;
@@ -49,6 +50,7 @@ import megamek.common.pathfinder.DestructionAwareDestinationPathfinder;
 import megamek.common.pathfinder.InfantryPathFinder;
 import megamek.common.pathfinder.LongestPathFinder;
 import megamek.common.pathfinder.NewtonianAerospacePathFinder;
+import megamek.common.pathfinder.PronePathFinder;
 import megamek.common.pathfinder.ShortestPathFinder;
 import megamek.common.pathfinder.SpheroidPathFinder;
 
@@ -264,7 +266,7 @@ public class PathEnumerator {
             } else if (!mover.isAero() && mover.isAirborne()) {
                 paths.add(new MovePath(game, mover));
             } else { // Non-Aero movement
-                // TODO: Will this cause Princess to never use MASC?
+            	// TODO: Will this cause Princess to never use MASC?
                 LongestPathFinder lpf = LongestPathFinder
                         .newInstanceOfLongestPath(mover.getRunMPwithoutMASC(),
                                 MoveStepType.FORWARDS, getGame());
@@ -277,9 +279,14 @@ public class PathEnumerator {
                 lpf.run(new MovePath(getGame(), mover));
                 paths.addAll(lpf.getLongestComputedPaths());
 
+                // add all moves that involve the entity remaining prone 
+                PronePathFinder ppf = new PronePathFinder();
+                ppf.run(new MovePath(getGame(), mover));
+                paths.addAll(ppf.getPronePaths());
+                
                 //add jumping moves
                 if (mover.getJumpMP() > 0) {
-                    ShortestPathFinder spf = ShortestPathFinder
+                	ShortestPathFinder spf = ShortestPathFinder
                             .newInstanceOfOneToAll(mover.getJumpMP(),
                                     MoveStepType.FORWARDS, getGame());
                     spf.run((new MovePath(game, mover))
@@ -287,9 +294,11 @@ public class PathEnumerator {
                     paths.addAll(spf.getAllComputedPathsUncategorized());
                 }
 
-                for(MovePath path : paths) {
-                    this.owner.getLogger().debug(path.toString());
-                }
+                // calling .debug is expensive even if we don't actually log anything
+                // so let's not do this unless we're debugging
+                /* for(MovePath path : paths) {
+	                    getOwner().getLogger().debug(path.toString());
+	                }*/
                 
                 // Try climbing over obstacles and onto bridges
                 adjustPathsForBridges(paths);

--- a/megamek/src/megamek/common/pathfinder/PronePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/PronePathFinder.java
@@ -1,3 +1,17 @@
+/*
+ * MegaMek - Copyright (C) 2021 Ben Mazur (bmazur@sev.org)
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+
 package megamek.common.pathfinder;
 
 import java.util.ArrayList;
@@ -9,37 +23,38 @@ import megamek.common.MovePath.MoveStepType;
 import megamek.common.options.OptionsConstants;
 
 /**
- * This class handles pathfinding for situations where the unit is
- * prone and wants to remain prone for whatever reason
- * (no leg, getting up will result in exposure to fire, etc) 
+ * This class handles pathfinding for situations where the unit is prone and
+ * wants to remain prone for whatever reason (no leg, getting up will result in
+ * exposure to fire, etc)
+ * 
  * @author NickAragua
  */
 public class PronePathFinder {
-	private List<MovePath> pronePaths;
-	
-	public List<MovePath> getPronePaths() {
-		return pronePaths;
-	}
-	
-	public void run(MovePath startingEdge) {
-		pronePaths = new ArrayList<>();
-		
-		// if we're prone, consider staying that way
-		if (startingEdge.getFinalProne()) {
-			pronePaths.add(startingEdge);
-			pronePaths.addAll(AeroPathUtil.generateValidRotations(startingEdge));
-			
-			// if we can go hull down, consider doing so - going "hull down" from prone
-			// doesn't require a PSR.
-			if (startingEdge.getGame().getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_HULL_DOWN) &&
-					startingEdge.getEntity().canGoHullDown()) {
-				MovePath hullDown = startingEdge.clone().addStep(MoveStepType.HULL_DOWN);
-				
-				if (hullDown.isMoveLegal()) {
-					pronePaths.add(hullDown);
-					pronePaths.addAll(AeroPathUtil.generateValidRotations(hullDown));
-				}
-			}
-		}
-	}
+    private List<MovePath> pronePaths;
+
+    public List<MovePath> getPronePaths() {
+        return pronePaths;
+    }
+
+    public void run(MovePath startingEdge) {
+        pronePaths = new ArrayList<>();
+
+        // if we're prone, consider staying that way
+        if (startingEdge.getFinalProne()) {
+            pronePaths.add(startingEdge);
+            pronePaths.addAll(AeroPathUtil.generateValidRotations(startingEdge));
+
+            // if we can go hull down, consider doing so - going "hull down" from prone
+            // doesn't require a PSR.
+            if (startingEdge.getGame().getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_HULL_DOWN)
+                    && startingEdge.getEntity().canGoHullDown()) {
+                MovePath hullDown = startingEdge.clone().addStep(MoveStepType.HULL_DOWN);
+
+                if (hullDown.isMoveLegal()) {
+                    pronePaths.add(hullDown);
+                    pronePaths.addAll(AeroPathUtil.generateValidRotations(hullDown));
+                }
+            }
+        }
+    }
 }

--- a/megamek/src/megamek/common/pathfinder/PronePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/PronePathFinder.java
@@ -1,0 +1,45 @@
+package megamek.common.pathfinder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import megamek.client.bot.princess.AeroPathUtil;
+import megamek.common.MovePath;
+import megamek.common.MovePath.MoveStepType;
+import megamek.common.options.OptionsConstants;
+
+/**
+ * This class handles pathfinding for situations where the unit is
+ * prone and wants to remain prone for whatever reason
+ * (no leg, getting up will result in exposure to fire, etc) 
+ * @author NickAragua
+ */
+public class PronePathFinder {
+	private List<MovePath> pronePaths;
+	
+	public List<MovePath> getPronePaths() {
+		return pronePaths;
+	}
+	
+	public void run(MovePath startingEdge) {
+		pronePaths = new ArrayList<>();
+		
+		// if we're prone, consider staying that way
+		if (startingEdge.getFinalProne()) {
+			pronePaths.add(startingEdge);
+			pronePaths.addAll(AeroPathUtil.generateValidRotations(startingEdge));
+			
+			// if we can go hull down, consider doing so - going "hull down" from prone
+			// doesn't require a PSR.
+			if (startingEdge.getGame().getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_HULL_DOWN) &&
+					startingEdge.getEntity().canGoHullDown()) {
+				MovePath hullDown = startingEdge.clone().addStep(MoveStepType.HULL_DOWN);
+				
+				if (hullDown.isMoveLegal()) {
+					pronePaths.add(hullDown);
+					pronePaths.addAll(AeroPathUtil.generateValidRotations(hullDown));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added a very simple "stay on the ground" pathfinder that generates a few possible paths for a mech that's prone - either turn in place or attempt to go 'hull down' then turn in place.

The reason for the latter being that going from prone to hull down is a guaranteed success, and then going from hull down to upright will never result in a fall.

This enables the bot to consider not trying to get up on very high odds of failure, fixing #2694 