### PR TITLE
Use correct target number for chain whip trip with active TSM

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -17042,7 +17042,6 @@ public class Server implements Runnable {
             addNewLines();
 
             int loc = hit.getLocation();
-            int toHitNumber = toHit.getValue();
 
             boolean mightTrip = (te instanceof Mech)
                     && te.locationIsLeg(loc)
@@ -17070,23 +17069,25 @@ public class Server implements Runnable {
 
             if (mightTrip) {
                 roll = Compute.d6(2);
-
+                int toHitValue = toHit.getValue();
+                String toHitDesc = toHit.getDesc();
                 if ((ae instanceof Mech) && (((Mech) ae).hasTSM() && (ae.heat >= 9))
                         && (!((Mech) te).hasTSM() || ((((Mech) te).hasTSM()) && (te.heat < 9)))) {
-                    toHitNumber -= 2;
+                    toHitValue -= 2;
+                    toHitDesc += " -2 (TSM Active Bonus)";
                 }
 
                 r = new Report(4450);
                 r.subject = ae.getId();
                 r.add(ae.getShortName());
                 r.add(te.getShortName());
-                r.add(toHitNumber);
+                r.addDataWithTooltip(String.valueOf(toHitValue), toHitDesc);
                 r.add(roll);
                 r.indent(2);
                 r.newlines = 0;
                 addReport(r);
 
-                if (roll >= toHit.getValue()) {
+                if (roll >= toHitValue) {
                     r = new Report(2270);
                     r.subject = ae.getId();
                     r.newlines = 0;


### PR DESCRIPTION
Fixes an unreported bug I noticed while working on tooltips for the reports. A successful chain whip attack against a mech or protomech's legs result in a free second physical attack to trip the opponent. If the attacker has active TSM and the target doesn't, the attack is made at -2 to hit (TO:AU&E, 101). The modified target number is computed and used in the report, but the roll is being compared to the unmodified number.

The Dasher II 4 is a mech with both a chain whip and TSM, useful for testing.