### PR TITLE
change club modifier

### DIFF
--- a/megamek/src/megamek/common/actions/ClubAttackAction.java
+++ b/megamek/src/megamek/common/actions/ClubAttackAction.java
@@ -236,7 +236,7 @@ public class ClubAttackAction extends PhysicalAttackAction {
         } else if (clubType.hasSubType(MiscType.S_SHIELD_LARGE)) {
             return -4;
         } else {
-            return 1;
+            return -1;
         }
     }
 


### PR DESCRIPTION
Fixes #2740 

I looked through both TW and BMM, and the club modifier is indeed, -1, rather than +1, but has been +1 for quite a while. I guess nobody noticed because using a club isn't that advantageous.