### PR TITLE
enable Princess to find clubs

### DIFF
--- a/megamek/src/megamek/client/bot/PhysicalCalculator.java
+++ b/megamek/src/megamek/client/bot/PhysicalCalculator.java
@@ -27,6 +27,7 @@ import megamek.common.IHex;
 import megamek.common.INarcPod;
 import megamek.common.Infantry;
 import megamek.common.Mech;
+import megamek.common.MechWarrior;
 import megamek.common.Mounted;
 import megamek.common.Protomech;
 import megamek.common.Tank;
@@ -281,17 +282,28 @@ public final class PhysicalCalculator {
         }
 
         for (Entity target : game.getEntitiesVector()) {
-
+            // don't consider myself
             if (target.equals(entity)) {
                 continue;
             }
+            
+            // don't consider friendly targets
             if (!target.isEnemyOf(entity)) {
                 continue;
             }
+            
+            // don't consider targets not on the board
             if (target.getPosition() == null) {
                 continue;
             }
+            
+            // don't consider targets beyond melee range
             if (Compute.effectiveDistance(game, entity, target) > 1) {
+                continue;
+            }
+            
+            // don't bother stomping mechwarriors
+            if (target instanceof MechWarrior) {
                 continue;
             }
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -3224,6 +3224,7 @@ public class FireControl {
     /**
      * Return a "Find Club" action, if the unit in question can find a club.
      */
+    @Nullable
     public FindClubAction getFindClubAction(Entity shooter) {
         if (FindClubAction.canMechFindClub(shooter.getGame(), shooter.getId())) {
             FindClubAction findClubAction = new FindClubAction(shooter.getId());

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -63,6 +63,7 @@ import megamek.common.ToHitData;
 import megamek.common.VTOL;
 import megamek.common.WeaponType;
 import megamek.common.actions.EntityAction;
+import megamek.common.actions.FindClubAction;
 import megamek.common.actions.RepairWeaponMalfunctionAction;
 import megamek.common.actions.SearchlightAttackAction;
 import megamek.common.actions.SpotAction;
@@ -3220,6 +3221,18 @@ public class FireControl {
         return unjamVector;
     }
 
+    /**
+     * Return a "Find Club" action, if the unit in question can find a club.
+     */
+    public FindClubAction getFindClubAction(Entity shooter) {
+        if (FindClubAction.canMechFindClub(shooter.getGame(), shooter.getId())) {
+            FindClubAction findClubAction = new FindClubAction(shooter.getId());
+            return findClubAction;
+        }
+        
+        return null;
+    }
+    
     /**
      * Given a firing plan, calculate the best target to light up with a searchlight
      */

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -59,6 +59,7 @@ import megamek.common.Mounted;
 import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.EntityAction;
+import megamek.common.actions.FindClubAction;
 import megamek.common.actions.SearchlightAttackAction;
 import megamek.common.MoveStep;
 import megamek.common.PilotingRollData;
@@ -715,22 +716,32 @@ public class Princess extends BotClient {
             }
             
             // if I have decided to skip firing, let's consider unjamming some weapons or turrets anyway
-            if(skipFiring) {
-                Vector<EntityAction> unjamPlan = getFireControl(shooter).getUnjamWeaponPlan(shooter);
+            if (skipFiring) {
+                Vector<EntityAction> miscPlan = getFireControl(shooter).getUnjamWeaponPlan(shooter);
                 
-                if(unjamPlan.size() == 0) {
+                // if we didn't produce an "unjam weapon" plan, consider spotting and lighting
+                // things up with a searchlight
+                if (miscPlan.size() == 0) {
                 	EntityAction spotAction = getFireControl(shooter).getSpotAction(null, shooter, fireControlState);
-                	if(spotAction != null) {
-                		unjamPlan.add(spotAction);
+                	if (spotAction != null) {
+                	    miscPlan.add(spotAction);
                 	}
                 	
                 	SearchlightAttackAction searchLightAction = getFireControl(shooter).getSearchLightAction(shooter, null);
-                    if(searchLightAction != null) {
-                        unjamPlan.add(searchLightAction);
+                    if (searchLightAction != null) {
+                        miscPlan.add(searchLightAction);
                     }
                 }
                 
-                sendAttackData(shooter.getId(), unjamPlan);
+                // if we have absolutely nothing else to do, see if we can find a club
+                if (miscPlan.size() == 0) {
+                    FindClubAction findClubAction = getFireControl(shooter).getFindClubAction(shooter);
+                    if (findClubAction != null) {
+                        miscPlan.add(findClubAction);
+                    }
+                }
+                
+                sendAttackData(shooter.getId(), miscPlan);
                 return;
             }
             

--- a/megamek/src/megamek/common/actions/FindClubAction.java
+++ b/megamek/src/megamek/common/actions/FindClubAction.java
@@ -54,7 +54,7 @@ public class FindClubAction extends AbstractEntityAction {
      */
     public static boolean canMechFindClub(IGame game, int entityId) {
         final Entity entity = game.getEntity(entityId);
-        if (null == entity.getPosition()) {
+        if (null == entity || null == entity.getPosition()) {
             return false;
         }
         final IHex hex = game.getBoard().getHex(entity.getPosition());

--- a/megamek/src/megamek/common/actions/FindClubAction.java
+++ b/megamek/src/megamek/common/actions/FindClubAction.java
@@ -54,7 +54,7 @@ public class FindClubAction extends AbstractEntityAction {
      */
     public static boolean canMechFindClub(IGame game, int entityId) {
         final Entity entity = game.getEntity(entityId);
-        if (null == entity || null == entity.getPosition()) {
+        if ((null == entity) || null == (entity.getPosition())) {
             return false;
         }
         final IHex hex = game.getBoard().getHex(entity.getPosition());


### PR DESCRIPTION
Enables the bot to:
- pick up clubs (in the very rare situation where it has absolutely nothing better to do in the firing phase)
- use club attacks (again, in the very rare situation where it has absolutely nothing better to do in the physical phase)
- stop splattering ejected mechwarriors with physical attacks

Also improved defensiveness of some code.