### PR TITLE
tone down protomech AC ammo explosion damage

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -4020,7 +4020,7 @@ public class AmmoType extends EquipmentType {
         ammo.setInternalName("Clan ProtoMech AC/2 Ammo");
         ammo.addLookupName("CLProtoAC2Ammo");
         ammo.addLookupName("CLProtoAC2 Ammo");
-        ammo.damagePerShot = 2;
+        ammo.damagePerShot = 1;
         ammo.rackSize = 2;
         ammo.ammoType = AmmoType.T_PAC;
         ammo.shots = 40;
@@ -4045,7 +4045,7 @@ public class AmmoType extends EquipmentType {
         ammo.setInternalName("Clan ProtoMech AC/4 Ammo");
         ammo.addLookupName("CLProtoAC4Ammo");
         ammo.addLookupName("CLProtoAC4 Ammo");
-        ammo.damagePerShot = 4;
+        ammo.damagePerShot = 1;
         ammo.rackSize = 4;
         ammo.ammoType = AmmoType.T_PAC;
         ammo.shots = 20;
@@ -4070,7 +4070,7 @@ public class AmmoType extends EquipmentType {
         ammo.setInternalName("Clan ProtoMech AC/8 Ammo");
         ammo.addLookupName("CLProtoAC8Ammo");
         ammo.addLookupName("CLProtoAC8 Ammo");
-        ammo.damagePerShot = 8;
+        ammo.damagePerShot = 1;
         ammo.rackSize = 8;
         ammo.ammoType = AmmoType.T_PAC;
         ammo.shots = 10;


### PR DESCRIPTION
This fixes the behavior reported in #2747 by bringing protomech AC "damage per shot" in line with all the other autocannon ammo types. The PACs still deal their "rack size" in damage.