### PR TITLE
Offboard Artillery Target Not Found NPE

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1,7 +1,7 @@
 /*
 * MegaMek -
 * Copyright (C) 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 Ben Mazur (bmazur@sev.org)
-* Copyright (C) 2018 The MegaMek Team
+* Copyright (C) 2018-2021 - The MegaMek Team. All Rights Reserved.
 *
 * This program is free software; you can redistribute it and/or modify it under
 * the terms of the GNU General Public License as published by the Free Software
@@ -13,7 +13,6 @@
 * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
 * details.
 */
-
 package megamek.client.ui.swing.boardview;
 
 import java.awt.AlphaComposite;
@@ -184,8 +183,6 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
     private static final long serialVersionUID = -5582195884759007416L;
 
-    static final int TRANSPARENT = 0xFFFF00FF;
-
     private static final int BOARD_HEX_CLICK = 1;
     private static final int BOARD_HEX_DOUBLECLICK = 2;
     private static final int BOARD_HEX_DRAG = 3;
@@ -194,7 +191,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     // the dimensions of megamek's hex images
     public static final int HEX_W = HexTileset.HEX_W;
     public static final int HEX_H = HexTileset.HEX_H;
-    public static final int HEX_DIAG = (int)Math.round(Math.sqrt(HEX_W * HEX_W + HEX_H * HEX_H));
+    public static final int HEX_DIAG = (int) Math.round(Math.sqrt(HEX_W * HEX_W + HEX_H * HEX_H));
 
     private static final int HEX_WC = HEX_W - (HEX_W / 4);
     static final int HEX_ELEV = 12;
@@ -213,8 +210,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     public static final int [] allDirections = {0,1,2,3,4,5};
 
     // Set to TRUE to draw hexes with isometric elevation.
-    private boolean drawIsometric = GUIPreferences.getInstance()
-                                                  .getIsometricEnabled();
+    private boolean drawIsometric = GUIPreferences.getInstance().getIsometricEnabled();
 
     int DROPSHDW_DIST = 20;
 
@@ -230,13 +226,14 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     // line width of the fly over lines
     static final int FLY_OVER_LINE_WIDTH = 3;
 
-    private static Font FONT_7 = new Font("SansSerif", Font.PLAIN, 7); //$NON-NLS-1$
-    private static Font FONT_8 = new Font("SansSerif", Font.PLAIN, 8); //$NON-NLS-1$
-    private static Font FONT_9 = new Font("SansSerif", Font.PLAIN, 9); //$NON-NLS-1$
-    private static Font FONT_10 = new Font("SansSerif", Font.PLAIN, 10); //$NON-NLS-1$
-    private static Font FONT_12 = new Font("SansSerif", Font.PLAIN, 12); //$NON-NLS-1$
+    // FIXME : Fonts shouldn't ever be handled like this for accessibility reasons
+    private static Font FONT_7 = new Font("SansSerif", Font.PLAIN, 7);
+    private static Font FONT_8 = new Font("SansSerif", Font.PLAIN, 8);
+    private static Font FONT_9 = new Font("SansSerif", Font.PLAIN, 9);
+    private static Font FONT_10 = new Font("SansSerif", Font.PLAIN, 10);
+    private static Font FONT_12 = new Font("SansSerif", Font.PLAIN, 12);
 
-    Dimension hex_size = null;
+    Dimension hex_size;
 
     private Font font_note = FONT_10;
     private Font font_hexnum = FONT_10;
@@ -261,10 +258,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     private boolean shouldScroll = false;
 
     // entity sprites
-    private Queue<EntitySprite> entitySprites = new PriorityQueue<EntitySprite>();
-    private Queue<IsometricSprite> isometricSprites = new PriorityQueue<IsometricSprite>();
+    private Queue<EntitySprite> entitySprites = new PriorityQueue<>();
+    private Queue<IsometricSprite> isometricSprites = new PriorityQueue<>();
 
-    private ArrayList<FlareSprite> flareSprites = new ArrayList<FlareSprite>();
+    private ArrayList<FlareSprite> flareSprites = new ArrayList<>();
     /**
      * A Map that maps an Entity ID and a secondary position to a Sprite. Note
      * that the key is a List where the first entry will be the Entity ID and
@@ -290,29 +287,29 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     private CursorSprite secondLOSSprite;
 
     // sprite for current movement
-    ArrayList<StepSprite> pathSprites = new ArrayList<StepSprite>();
+    ArrayList<StepSprite> pathSprites = new ArrayList<>();
 
-    private ArrayList<Coords> strafingCoords = new ArrayList<Coords>(5);
+    private ArrayList<Coords> strafingCoords = new ArrayList<>(5);
 
-    private ArrayList<FiringSolutionSprite> firingSprites = new ArrayList<FiringSolutionSprite>();
+    private ArrayList<FiringSolutionSprite> firingSprites = new ArrayList<>();
 
     private ArrayList<MovementEnvelopeSprite> moveEnvSprites = new ArrayList<>();
     private ArrayList<MovementModifierEnvelopeSprite> moveModEnvSprites = new ArrayList<>();
 
     // vector of sprites for all firing lines
-    ArrayList<AttackSprite> attackSprites = new ArrayList<AttackSprite>();
+    ArrayList<AttackSprite> attackSprites = new ArrayList<>();
 
     // vector of sprites for all movement paths (using vectored movement)
-    private ArrayList<MovementSprite> movementSprites = new ArrayList<MovementSprite>();
+    private ArrayList<MovementSprite> movementSprites = new ArrayList<>();
 
     // vector of sprites for C3 network lines
-    private ArrayList<C3Sprite> c3Sprites = new ArrayList<C3Sprite>();
+    private ArrayList<C3Sprite> c3Sprites = new ArrayList<>();
 
     // list of sprites for declared VTOL/airmech bombing/strafing targets
     private ArrayList<VTOLAttackSprite> vtolAttackSprites = new ArrayList<>();
 
     // vector of sprites for aero flyover lines
-    private ArrayList<FlyOverSprite> flyOverSprites = new ArrayList<FlyOverSprite>();
+    private ArrayList<FlyOverSprite> flyOverSprites = new ArrayList<>();
 
     // List of sprites for the weapon field of fire
     private ArrayList<HexSprite> fieldofFireSprites = new ArrayList<>();
@@ -324,7 +321,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     public int fieldofFireWpUnderwater = 0;
     private static final String[] rangeTexts = { "min", "S", "M", "L", "E" };
 
-    TilesetManager tileManager = null;
+    TilesetManager tileManager;
 
     // polygons for a few things
     static Polygon hexPoly;
@@ -373,18 +370,16 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
     // Initial scale factor for sprites and map
     float scale = 1.00f;
-    private ImageCache<Integer, Image> scaledImageCache =
-            new ImageCache<Integer, Image>();
-    private ImageCache<Integer, BufferedImage> shadowImageCache =
-            new ImageCache<Integer, BufferedImage>();
+    private ImageCache<Integer, Image> scaledImageCache = new ImageCache<>();
+    private ImageCache<Integer, BufferedImage> shadowImageCache = new ImageCache<>();
 
-    private Set<Integer> animatedImages = new HashSet<Integer>();
+    private Set<Integer> animatedImages = new HashSet<>();
 
     // Displayables (Chat box, etc.)
-    ArrayList<IDisplayable> displayables = new ArrayList<IDisplayable>();
+    ArrayList<IDisplayable> displayables = new ArrayList<>();
 
     // Move units step by step
-    private ArrayList<MovingUnit> movingUnits = new ArrayList<MovingUnit>();
+    private ArrayList<MovingUnit> movingUnits = new ArrayList<>();
 
     private long moveWait = 0;
 
@@ -2157,32 +2152,32 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
         // Draw incoming artillery sprites - requires server to update client's
         // view of game
-        for (Enumeration<ArtilleryAttackAction> attacks = game
-                .getArtilleryAttacks(); attacks.hasMoreElements(); ) {
-            ArtilleryAttackAction a = attacks.nextElement();
-            Coords c = a.getTarget(game).getPosition();
+        for (Enumeration<ArtilleryAttackAction> attacks = game.getArtilleryAttacks();
+             attacks.hasMoreElements(); ) {
+            final ArtilleryAttackAction attack = attacks.nextElement();
+            final Targetable target = attack.getTarget(game);
+            if (target == null) {
+                continue;
+            }
+            final Coords c = target.getPosition();
             // Is the Coord within the viewing area?
             if ((c.getX() >= drawX) && (c.getX() <= (drawX + drawWidth))
-                && (c.getY() >= drawY) && (c.getY() <= (drawY + drawHeight))) {
-
+                    && (c.getY() >= drawY) && (c.getY() <= (drawY + drawHeight))) {
                 Point p = getHexLocation(c);
-                artyIconImage = tileManager
-                        .getArtilleryTarget(TilesetManager.ARTILLERY_INCOMING);
+                artyIconImage = tileManager.getArtilleryTarget(TilesetManager.ARTILLERY_INCOMING);
                 g.drawImage(getScaledImage(artyIconImage, true), p.x, p.y, this);
             }
         }
 
         // Draw pre-designated auto-hit hexes
-        if (localPlayer != null) // Could be null, like in map-editor
-        {
+        if (localPlayer != null) { // Could be null, like in map-editor
             for (Coords c : localPlayer.getArtyAutoHitHexes()) {
                 // Is the Coord within the viewing area?
                 if ((c.getX() >= drawX) && (c.getX() <= (drawX + drawWidth))
                     && (c.getY() >= drawY) && (c.getY() <= (drawY + drawHeight))) {
 
                     Point p = getHexLocation(c);
-                    artyIconImage = tileManager
-                            .getArtilleryTarget(TilesetManager.ARTILLERY_AUTOHIT);
+                    artyIconImage = tileManager.getArtilleryTarget(TilesetManager.ARTILLERY_AUTOHIT);
                     g.drawImage(getScaledImage(artyIconImage, true), p.x, p.y, this);
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -57,7 +57,6 @@ import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
 import java.awt.image.Kernel;
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -1025,10 +1024,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 try {
                     SwingUtilities.invokeLater(redrawWorker);
                 } catch (Exception ie) {
-                    System.err.print("Error scheduleRedrawTimer "); //$NON-NLS-1$
-                    System.err.print(ie.getMessage());
-                    System.err.print(": "); //$NON-NLS-1$
-                    System.err.println("ignoring");
+                    MegaMek.getLogger().error("Ignoring error: " + ie.getMessage());
                 }
             }
         };
@@ -1040,10 +1036,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         try {
             SwingUtilities.invokeLater(redrawWorker);
         } catch (Exception ie) {
-            System.err.print("Error scheduleRedraw "); //$NON-NLS-1$
-            System.err.print(ie.getMessage());
-            System.err.print(": "); //$NON-NLS-1$
-            System.err.println("ignoring");
+            MegaMek.getLogger().error("Ignoring error: " + ie.getMessage());
         }
     }
 
@@ -1189,9 +1182,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
 
         if (!isTileImagesLoaded()) {
-            g.drawString(Messages.getString("BoardView1.loadingImages"), 20, 50); //$NON-NLS-1$
+            g.drawString(Messages.getString("BoardView1.loadingImages"), 20, 50);
             if (!tileManager.isStarted()) {
-                System.out.println("boardview1: loading images for board"); //$NON-NLS-1$
+                MegaMek.getLogger().info("Loading images for board");
                 tileManager.loadNeededImages(game);
             }
             // wait 1 second, then repaint
@@ -1219,9 +1212,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     }
                     if ((xRem > 0) || (yRem > 0)) {
                         try {
-                            g.drawImage(
-                                    bvBgImage.getSubimage(xRem, yRem, w - xRem,
-                                            h - yRem),
+                            g.drawImage(bvBgImage.getSubimage(xRem, yRem, w - xRem, h - yRem),
                                     clipping.x + x, clipping.y + y, this);
                         } catch (Exception e) {
                             // if we somehow messed up the math, log the error and simply act as if we have no background image.
@@ -1230,7 +1221,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                             String errorData = String.format("Error drawing background image. Raster Bounds: %.2f, %.2f, width:%.2f, height:%.2f, Attempted Draw Coordinates: %d, %d, width:%d, height:%d",
                                     rasterBounds.getMinX(), rasterBounds.getMinY(), rasterBounds.getWidth(), rasterBounds.getHeight(),
                                     xRem, yRem, w - xRem, h - yRem);
-                            MegaMek.getLogger().error(this, errorData);
+                            MegaMek.getLogger().error(errorData);
                         }
                     } else {
                         g.drawImage(bvBgImage, clipping.x + x, clipping.y + y,
@@ -1266,8 +1257,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
 
         // Field of Fire
-        if (!useIsometric()
-                && GUIPreferences.getInstance().getShowFieldOfFire()) {
+        if (!useIsometric() && GUIPreferences.getInstance().getShowFieldOfFire()) {
             drawSprites(g, fieldofFireSprites);
         }
 
@@ -1297,8 +1287,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             drawDeployment(g);
         }
 
-        if ((game.getPhase() == IGame.Phase.PHASE_SET_ARTYAUTOHITHEXES)
-                && (showAllDeployment)) {
+        if ((game.getPhase() == IGame.Phase.PHASE_SET_ARTYAUTOHITHEXES) && showAllDeployment) {
             drawAllDeployment(g);
         }
 
@@ -1327,8 +1316,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         drawSprites(g, attackSprites);
 
         // draw movement vectors.
-        if (game.useVectorMove()
-            && (game.getPhase() == IGame.Phase.PHASE_MOVEMENT)) {
+        if (game.useVectorMove() && (game.getPhase() == IGame.Phase.PHASE_MOVEMENT)) {
             drawSprites(g, movementSprites);
         }
 
@@ -1336,8 +1324,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         drawSprites(g, pathSprites);
 
         // draw firing solution sprites, but only during the firing phase
-        if ((game.getPhase() == Phase.PHASE_FIRING) ||
-            (game.getPhase() == Phase.PHASE_OFFBOARD)) {
+        if ((game.getPhase() == Phase.PHASE_FIRING) || (game.getPhase() == Phase.PHASE_OFFBOARD)) {
             drawSprites(g, firingSprites);
         }
 
@@ -1779,14 +1766,13 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
 
                         // Buildings Shadow
-                        if (hex.containsTerrain(Terrains.BUILDING))
-                        {
+                        if (hex.containsTerrain(Terrains.BUILDING)) {
                             int h = hex.terrainLevel(Terrains.BLDG_ELEV);
                             if ((shadowcaster+h-shadowed) > 0) {
                                 p1.setLocation(p0);
-                                for (int i = 0; i<n*(shadowcaster+h-shadowed); i++) {
-                                    g.drawImage(lastSuper, (int)p1.getX(), (int)p1.getY(), null);
-                                    p1.setLocation(p1.getX()+deltaX, p1.getY()+deltaY);
+                                for (int i = 0; i < (n * (shadowcaster + h - shadowed)); i++) {
+                                    g.drawImage(lastSuper, (int) p1.getX(), (int) p1.getY(), null);
+                                    p1.setLocation(p1.getX() + deltaX, p1.getY() + deltaY);
                                 }
                             }
                         }
@@ -1795,28 +1781,26 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     if (hex.containsTerrain(Terrains.BRIDGE)) {
                         supers = tileManager.orthoFor(hex);
                         if (supers.isEmpty()) break;
-                        Image maskB = createBlurredShadow(supers.get(supers.size()-1));
+                        Image maskB = createBlurredShadow(supers.get(supers.size() - 1));
                         if (maskB == null) {
                             clearShadowMap();
                             return;
                         }
                         int h = hex.terrainLevel(Terrains.BRIDGE_ELEV);
-                        p1.setLocation(p0.getX()+deltaX*n*(shadowcaster+h-shadowed),
-                                p0.getY()+deltaY*n*(shadowcaster+h-shadowed));
+                        p1.setLocation(p0.getX() + deltaX * n * (shadowcaster + h - shadowed),
+                                p0.getY() + deltaY * n * (shadowcaster + h - shadowed));
                         // the shadowmask is translucent, therefore draw n times
                         // stupid hack
-                        for (int i=0;i<n;i++)
-                            g.drawImage(maskB, (int)p1.getX(), (int)p1.getY(), null);
+                        for (int i = 0; i < n; i++)
+                            g.drawImage(maskB, (int) p1.getX(), (int) p1.getY(), null);
                     }
-
                 }
             }
             g.setClip(saveClip);
         }
 
-        long tT5 = System.nanoTime()-stT;
-        System.out.println("Time to prepare the shadow map: "+tT5/1e6+" ms");
-
+        long tT5 = System.nanoTime() - stT;
+        MegaMek.getLogger().info("Time to prepare the shadow map: " + tT5 / 1e6 + " ms");
     }
 
     public void clearShadowMap() {
@@ -1853,8 +1837,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             Coords cp = sprite.getPosition();
             // This can potentially be an expensive operation
             Rectangle spriteBounds = sprite.getBounds();
-            if (cp.equals(c) && view.intersects(spriteBounds)
-                    && !sprite.isHidden()) {
+            if (cp.equals(c) && view.intersects(spriteBounds) && !sprite.isHidden()) {
                 if (!sprite.isReady()) {
                     sprite.prepare();
                 }
@@ -2803,43 +2786,36 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
         // Set the text color according to Preferences or Light Gray in space
         g.setColor(guip.getMapTextColor());
-        if (game.getBoard().inSpace())
+        if (game.getBoard().inSpace()) {
             g.setColor(Color.LIGHT_GRAY);
+        }
 
         // draw special stuff for the hex
-        final Collection<SpecialHexDisplay> shdList = game.getBoard()
-                .getSpecialHexDisplay(c);
+        final Collection<SpecialHexDisplay> shdList = game.getBoard().getSpecialHexDisplay(c);
         try {
             if (shdList != null) {
                 for (SpecialHexDisplay shd : shdList) {
-                    if (shd.drawNow(game.getPhase(), game.getRoundCount(),
-                            localPlayer)) {
-                        scaledImage = getScaledImage(shd.getType()
-                                .getDefaultImage(), true);
+                    if (shd.drawNow(game.getPhase(), game.getRoundCount(), localPlayer)) {
+                        scaledImage = getScaledImage(shd.getType().getDefaultImage(), true);
                         g.drawImage(scaledImage, 0, 0, this);
                     }
                 }
             }
-        } catch (IllegalArgumentException e) {
-            System.err.println("Illegal argument exception, probably "
-                    + "can't load file.");
-            e.printStackTrace();
-            drawCenteredString("Loading Error", 0, 0
-                    + (int) (50 * scale), font_note, g);
+        } catch (Exception e) {
+            MegaMek.getLogger().error("Exception, probably can't load file.", e);
+            drawCenteredString("Loading Error", 0, (int) (50 * scale), font_note, g);
             return;
         }
 
         // write hex coordinate unless deactivated or scale factor too small
-        if (guip.getBoolean(GUIPreferences.ADVANCED_SHOW_COORDS)
-                && (scale >= 0.5)) {
-            drawCenteredString(c.getBoardNum(), 0, 0
-                    + (int) (12 * scale), font_hexnum, g);
+        if (guip.getBoolean(GUIPreferences.ADVANCED_SHOW_COORDS) && (scale >= 0.5)) {
+            drawCenteredString(c.getBoardNum(), 0, (int) (12 * scale), font_hexnum, g);
         }
 
         if (getDisplayInvalidHexInfo() && !hex.isValid(null)) {
-            Point hexCenter = new Point((int)(HEX_W / 2 * scale), (int)(HEX_H / 2 * scale));
-            drawCenteredText(g, Messages.getString("BoardEditor.INVALID"), hexCenter, Color.RED, false,
-                    new Font("SansSerif", Font.BOLD, 14));
+            Point hexCenter = new Point((int) (HEX_W / 2 * scale), (int) (HEX_H / 2 * scale));
+            drawCenteredText(g, Messages.getString("BoardEditor.INVALID"), hexCenter, Color.RED,
+                    false, new Font("SansSerif", Font.BOLD, 14));
         }
 
         // write terrain level / water depth / building height
@@ -3127,7 +3103,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     p2.x - (int) (HEX_ELEV * scale) }, new int[] { p1.y, p2.y,
                     p2.y }, 3);
             if ((p2.x - (int) (HEX_ELEV * scale)) < 0) {
-                System.out.println("Negative X value!: " + (p2.x - (int) (HEX_ELEV * scale)));
+                MegaMek.getLogger().info("Negative X value!: " + (p2.x - (int) (HEX_ELEV * scale)));
             }
             g.setColor(new Color(0, 0, 0, 0.4f));
             g.fillPolygon(shadow1);*/
@@ -3145,17 +3121,17 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                             p1.y + fudge + scaledDelta }, 4);
 
             if ((p1.y + fudge) < 0) {
-                System.out.println("Negative Y value (Fudge)!: " + (p1.y + fudge));
+                MegaMek.getLogger().info("Negative Y value (Fudge)!: " + (p1.y + fudge));
             }
             if ((p2.y + fudge) < 0) {
-                System.out.println("Negative Y value (Fudge)!: " + (p2.y + fudge));
+                MegaMek.getLogger().info("Negative Y value (Fudge)!: " + (p2.y + fudge));
             }
 
             if ((p2.y + fudge + scaledDelta) < 0) {
-                System.out.println("Negative Y value!: " + (p2.y + fudge + scaledDelta));
+                MegaMek.getLogger().info("Negative Y value!: " + (p2.y + fudge + scaledDelta));
             }
             if (( p1.y + fudge + scaledDelta) < 0) {
-                System.out.println("Negative Y value!: " + ( p1.y + fudge + scaledDelta));
+                MegaMek.getLogger().info("Negative Y value!: " + ( p1.y + fudge + scaledDelta));
             }
             g.setColor(color);
             g.drawPolygon(p);
@@ -5328,8 +5304,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         + IGame.Phase.getDisplayableName(e.getOldPhase()) + ".png");
                 try {
                     ImageIO.write(getEntireBoardImage(false), "png", imgFile);
-                } catch (IOException e1) {
-                    e1.printStackTrace();
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             }
 
@@ -6195,10 +6171,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             File file;
             if (bvSkinSpec.backgrounds.size() > 0) {
                 file = new MegaMekFile(Configuration.widgetsDir(),
-                                bvSkinSpec.backgrounds.get(0)).getFile();
+                        bvSkinSpec.backgrounds.get(0)).getFile();
                 if (!file.exists()) {
-                    System.err.println("BoardView1 Error: icon doesn't exist: "
-                                       + file.getAbsolutePath());
+                    MegaMek.getLogger().error("BoardView1 Error: icon doesn't exist: "
+                            + file.getAbsolutePath());
                 } else {
                     bvBgImage = (BufferedImage) ImageUtil.loadImageFromFile(
                             file.getAbsolutePath());
@@ -6207,26 +6183,20 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             }
             if (bvSkinSpec.backgrounds.size() > 1) {
                 file = new MegaMekFile(Configuration.widgetsDir(),
-                                bvSkinSpec.backgrounds.get(1)).getFile();
+                        bvSkinSpec.backgrounds.get(1)).getFile();
                 if (!file.exists()) {
-                    System.err.println("BoardView1 Error: icon doesn't exist: "
-                                       + file.getAbsolutePath());
+                    MegaMek.getLogger().error("BoardView1 Error: icon doesn't exist: "
+                            + file.getAbsolutePath());
                 } else {
-                    scrollPaneBgImg = ImageUtil.loadImageFromFile(
-                            file.getAbsolutePath());
+                    scrollPaneBgImg = ImageUtil.loadImageFromFile(file.getAbsolutePath());
                 }
             }
         } catch (Exception e) {
-            System.out.println("Error loading BoardView background images!");
-            System.out.println(e.getMessage());
+            MegaMek.getLogger().error("Error loading BoardView background images!", e);
         }
 
         // Place the board viewer in a set of scrollbars.
         scrollpane = new JScrollPane(this) {
-
-            /**
-             *
-             */
             private static final long serialVersionUID = 5973610449428194319L;
 
             @Override
@@ -6450,7 +6420,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 try {
                     tracker.waitForID(0);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    MegaMek.getLogger().error(e);
                 }
                 if (tracker.isErrorAny()) {
                     return null;
@@ -6470,7 +6440,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             try {
                 tracker.waitForID(1);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
             tracker.removeImage(scaled);
             // Cache the image if the flag is set
@@ -6805,9 +6775,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         int boardY = (int)((c.getY() + 0.0) / board.getSubBoardHeight());
         int linIdx = boardY * board.getNumBoardsWidth() + boardX;
         if (linIdx < 0 || linIdx > boardBackgrounds.size() - 1) {
-            System.out.println("Error computing linear index or "
-                    + "missing background images "
-                    + "in BoardView1.getBoardBackgroundHexImage!");
+            MegaMek.getLogger().error("Error computing linear index or missing background images in BoardView1.getBoardBackgroundHexImage!");
             return null;
         }
         Image bgImg = getScaledImage(boardBackgrounds.get(linIdx), true);

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1231,8 +1231,8 @@ public class Game implements Serializable, IGame {
                 default:
                     return null;
             }
-        } catch (IllegalArgumentException t) {
-            MegaMek.getLogger().error(t);
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
             return null;
         }
     }
@@ -1240,9 +1240,9 @@ public class Game implements Serializable, IGame {
     /**
      * Returns the entity with the given id number, if any.
      */
-
-    public Entity getEntity(int id) {
-        return entityIds.get(Integer.valueOf(id));
+    @Override
+    public @Nullable Entity getEntity(final int id) {
+        return entityIds.get(id);
     }
 
     /**

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -3503,7 +3503,7 @@ public class Game implements Serializable, IGame {
 
     @Override
     public void setPlanetaryConditions(final @Nullable PlanetaryConditions conditions) {
-        if (null == conditions) {
+        if (conditions == null) {
             MegaMek.getLogger().error("Can't set the planetary conditions to null!");
         } else {
             planetaryConditions.alterConditions(conditions);

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -35,6 +35,7 @@ import megamek.common.GameTurn.SpecificEntityTurn;
 import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.actions.AttackAction;
 import megamek.common.actions.EntityAction;
+import megamek.common.annotations.Nullable;
 import megamek.common.event.GameBoardChangeEvent;
 import megamek.common.event.GameBoardNewEvent;
 import megamek.common.event.GameEndEvent;
@@ -1200,7 +1201,8 @@ public class Game implements Serializable, IGame {
     /**
      * Returns the appropriate target for this game given a type and id
      */
-    public Targetable getTarget(int nType, int nID) {
+    @Override
+    public @Nullable Targetable getTarget(int nType, int nID) {
         try {
             switch (nType) {
                 case Targetable.TYPE_ENTITY:
@@ -1215,24 +1217,22 @@ public class Game implements Serializable, IGame {
                 case Targetable.TYPE_HEX_SCREEN:
                 case Targetable.TYPE_HEX_AERO_BOMB:
                 case Targetable.TYPE_HEX_TAG:
-                    return new HexTarget(HexTarget.idToCoords(nID), board,
-                                         nType);
+                    return new HexTarget(HexTarget.idToCoords(nID), nType);
                 case Targetable.TYPE_FUEL_TANK:
                 case Targetable.TYPE_FUEL_TANK_IGNITE:
                 case Targetable.TYPE_BUILDING:
                 case Targetable.TYPE_BLDG_IGNITE:
                 case Targetable.TYPE_BLDG_TAG:
-                    return new BuildingTarget(BuildingTarget.idToCoords(nID),
-                                              board, nType);
+                    return new BuildingTarget(BuildingTarget.idToCoords(nID), board, nType);
                 case Targetable.TYPE_MINEFIELD_CLEAR:
-                    return new MinefieldTarget(MinefieldTarget.idToCoords(nID),
-                                               board);
+                    return new MinefieldTarget(MinefieldTarget.idToCoords(nID), board);
                 case Targetable.TYPE_INARC_POD:
                     return INarcPod.idToInstance(nID);
                 default:
                     return null;
             }
         } catch (IllegalArgumentException t) {
+            MegaMek.getLogger().error(t);
             return null;
         }
     }

--- a/megamek/src/megamek/common/IGame.java
+++ b/megamek/src/megamek/common/IGame.java
@@ -670,7 +670,7 @@ public interface IGame {
     /**
      * Returns the appropriate target for this game given a type and id
      */
-    abstract Targetable getTarget(int nType, int nID);
+    @Nullable Targetable getTarget(int nType, int nID);
 
     /**
      * Returns the entity with the given id number, if any.

--- a/megamek/src/megamek/common/IGame.java
+++ b/megamek/src/megamek/common/IGame.java
@@ -314,9 +314,9 @@ public interface IGame {
     /**
      * sets the game options
      *
-     * @param options
+     * @param options the options to set
      */
-    abstract void setOptions(GameOptions options);
+    void setOptions(final @Nullable GameOptions options);
 
     /**
      * @return the game board
@@ -675,7 +675,7 @@ public interface IGame {
     /**
      * Returns the entity with the given id number, if any.
      */
-    abstract Entity getEntity(int id);
+    @Nullable Entity getEntity(final int id);
 
     /**
      * looks for an entity by id number even if out of the game
@@ -1507,7 +1507,7 @@ public interface IGame {
 
     abstract PlanetaryConditions getPlanetaryConditions();
 
-    abstract void setPlanetaryConditions(PlanetaryConditions conditions);
+    void setPlanetaryConditions(final @Nullable PlanetaryConditions conditions);
 
     /**
      * Get a set of Coords illuminated by searchlights.
@@ -1526,7 +1526,7 @@ public interface IGame {
     /**
      * Setter for the list of Coords illuminated by search lights.
      */
-    abstract void setIlluminatedPositions(HashSet<Coords> ip);
+    void setIlluminatedPositions(final @Nullable HashSet<Coords> ip);
 
     /**
      * Add a new hex to the collection of Coords illuminated by searchlights.

--- a/megamek/src/megamek/common/actions/AbstractAttackAction.java
+++ b/megamek/src/megamek/common/actions/AbstractAttackAction.java
@@ -1,44 +1,38 @@
-/**
+/*
  * MegaMek - Copyright (C) 2000,2001,2002,2003,2004 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
-
 package megamek.common.actions;
-
-import java.util.Enumeration;
 
 import megamek.client.Client;
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Entity;
 import megamek.common.Game;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Mech;
 import megamek.common.Mounted;
 import megamek.common.PlanetaryConditions;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
+import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
+
+import java.util.Enumeration;
 
 /**
  * Abstract superclass for any action where an entity is attacking another
  * entity.
  */
-public abstract class AbstractAttackAction extends AbstractEntityAction
-        implements AttackAction {
-    /**
-     *
-     */
+public abstract class AbstractAttackAction extends AbstractEntityAction implements AttackAction {
     private static final long serialVersionUID = -897197664652217134L;
     private int targetType;
     private int targetId;
@@ -72,8 +66,8 @@ public abstract class AbstractAttackAction extends AbstractEntityAction
         this.targetId = targetId;
     }
 
-    public Targetable getTarget(IGame g) {
-        return g.getTarget(getTargetType(), getTargetId());
+    public @Nullable Targetable getTarget(final IGame game) {
+        return game.getTarget(getTargetType(), getTargetId());
     }
 
     /**


### PR DESCRIPTION
This fixes a NPE noted on Discord whereby an artillery target may return null. While doing this I also updated a bunch of the logging to use the logger instead of System.err and System.out and added some more nullable annotations.

To Review: Whitespace differences off.
I accidentally merged the first two commits together (cleaning up a few things in BoardView1 and the core bugfix), so I've noted where in BoardView1 the fix is located. View the first two commits separately from the rest.
Commit 1: Core fix and some light cleanup in BoardView1
Commit 2: adds the nullable annotation to Game::getEntity (which may return a null value)
Commit 3: Logging update for Game and BoardView1, fixing a few formatting issues.
Commit 4: Adding nullable annotations to 