### PR TITLE
enable air-launched Arrow IV

### DIFF
--- a/megamek/src/megamek/common/IBomber.java
+++ b/megamek/src/megamek/common/IBomber.java
@@ -117,9 +117,7 @@ public interface IBomber {
 
                 // some bombs need an associated weapon and if so
                 // they need a weapon for each bomb
-                if ((null != BombType.getBombWeaponName(type))
-                        && (type != BombType.B_ARROW)
-                        && (type != BombType.B_HOMING)) {
+                if ((null != BombType.getBombWeaponName(type))) {
                     Mounted m = null;
                     try {
                         m = ((Entity)this).addBomb(EquipmentType.get(BombType

--- a/megamek/src/megamek/common/IBomber.java
+++ b/megamek/src/megamek/common/IBomber.java
@@ -117,7 +117,7 @@ public interface IBomber {
 
                 // some bombs need an associated weapon and if so
                 // they need a weapon for each bomb
-                if ((null != BombType.getBombWeaponName(type))) {
+                if (null != BombType.getBombWeaponName(type)) {
                     Mounted m = null;
                     try {
                         m = ((Entity)this).addBomb(EquipmentType.get(BombType

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -54,7 +54,6 @@ import megamek.common.LandAirMech;
 import megamek.common.LosEffects;
 import megamek.common.Mech;
 import megamek.common.MechWarrior;
-import megamek.common.MinefieldTarget;
 import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.PlanetaryConditions;
@@ -1753,8 +1752,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                                     return Messages.getString("WeaponAttackAction.OnlyArrowArty");
                                 }
                             }
-                        } else if (wtype.getAmmoType() != AmmoType.T_ARROW_IV &&
-                                wtype.getAmmoType() != AmmoType.T_ARROW_IV_BOMB) {
+                        } else if ((wtype.getAmmoType() != AmmoType.T_ARROW_IV) &&
+                                (wtype.getAmmoType() != AmmoType.T_ARROW_IV_BOMB)) {
                             //For Fighters, LAMs, Small Craft and VTOLs
                             return Messages.getString("WeaponAttackAction.OnlyArrowArty");
                         }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1753,7 +1753,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                                     return Messages.getString("WeaponAttackAction.OnlyArrowArty");
                                 }
                             }
-                        } else if (wtype.getAmmoType() != AmmoType.T_ARROW_IV) {
+                        } else if (wtype.getAmmoType() != AmmoType.T_ARROW_IV &&
+                                wtype.getAmmoType() != AmmoType.T_ARROW_IV_BOMB) {
                             //For Fighters, LAMs, Small Craft and VTOLs
                             return Messages.getString("WeaponAttackAction.OnlyArrowArty");
                         }

--- a/megamek/src/megamek/common/weapons/bombs/BombArrowIV.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombArrowIV.java
@@ -20,11 +20,12 @@ package megamek.common.weapons.bombs;
 import megamek.common.AmmoType;
 import megamek.common.BombType;
 import megamek.common.weapons.AmmoWeapon;
+import megamek.common.weapons.artillery.ArtilleryWeapon;
 
 /**
  * @author Jay Lawson
  */
-public class BombArrowIV extends AmmoWeapon {
+public class BombArrowIV extends ArtilleryWeapon {
 
     /**
      * 


### PR DESCRIPTION
Aerospace fighters can now both equip *and* use air-launched Arrow IV missiles, both homing and non-homing variety. Turns out most of the code relevant to airborne Arrow IV was already mostly implemented, just removing an artificial restriction, made an update to the "toHitIsImpossible" method and change the Bomb Arrow IV to be an artillery weapon.

Fixes #547