### PR TITLE
launch fighters

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1029,7 +1029,8 @@ public class Princess extends BotClient {
             if ((entity.isOffBoard() 
                     || (null == entity.getPosition())
                     || entity.isUnloadedThisTurn()
-                    || !getGame().getTurn().isValidEntity(entity, getGame(), true))) {
+                    || !getGame().getTurn().isValidEntity(entity, getGame()))
+                            && !getGame().isPhaseSimultaneous()){
                 msg.append("cannot be moved.");
                 continue;
             }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2113,7 +2113,7 @@ public class Princess extends BotClient {
     private void launchFighters(MovePath path) {
         // if my objective is to cross the board, even though it's tempting, I won't be leaving the infantry
         // behind. They're not that good at screening against high speed pursuit anyway.
-        if(getBehaviorSettings().shouldGoHome()) {
+        if (getBehaviorSettings().shouldGoHome()) {
             return;
         }
         
@@ -2122,7 +2122,7 @@ public class Princess extends BotClient {
         Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity, pathEndpoint, getGame(), false);
 
         // if there are no enemies on the board, then we're not launching anything.
-        if((null == closestEnemy) || (closestEnemy.getTargetType() != Targetable.TYPE_ENTITY)) {
+        if ((null == closestEnemy) || (closestEnemy.getTargetType() != Targetable.TYPE_ENTITY)) {
             return;
         }
         
@@ -2133,11 +2133,11 @@ public class Princess extends BotClient {
         // grouping launched craft by bay to limit launches to 'safe' rate.
         Vector<Bay> fighterBays = movingEntity.getFighterBays();
         
-        for(int bayIndex = 0; bayIndex < fighterBays.size(); bayIndex++) {
+        for (int bayIndex = 0; bayIndex < fighterBays.size(); bayIndex++) {
             Bay bay = fighterBays.get(bayIndex);
             
-            for(Entity loadedEntity : bay.getLaunchableUnits()) {
-                unitsToLaunch.putIfAbsent(bayIndex, new Vector<Integer>());
+            for (Entity loadedEntity : bay.getLaunchableUnits()) {
+                unitsToLaunch.putIfAbsent(bayIndex, new Vector<>());
                 
                 // for now, just launch fighters at the 'safe' rate
                 if (unitsToLaunch.get(bayIndex).size() < bay.getSafeLaunchRate()) {

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -38,6 +39,7 @@ import megamek.client.bot.princess.UnitBehavior.BehaviorType;
 import megamek.client.ui.SharedUtility;
 import megamek.common.AmmoType;
 import megamek.common.BattleArmor;
+import megamek.common.Bay;
 import megamek.common.Building;
 import megamek.common.BuildingTarget;
 import megamek.common.BulldozerMovePath;
@@ -1027,8 +1029,7 @@ public class Princess extends BotClient {
             if ((entity.isOffBoard() 
                     || (null == entity.getPosition())
                     || entity.isUnloadedThisTurn()
-                    || !getGame().getTurn().isValidEntity(entity, getGame()))
-                            && !getGame().isPhaseSimultaneous()){
+                    || !getGame().getTurn().isValidEntity(entity, getGame(), true))) {
                 msg.append("cannot be moved.");
                 continue;
             }
@@ -1976,6 +1977,7 @@ public class Princess extends BotClient {
         evadeIfNotFiring(retval, expectedDamage >= 0);
         turnOnSearchLight(retval, expectedDamage >= 0);
         unloadTransportedInfantry(retval);
+        launchFighters(retval);
         unjamRAC(retval);
         
         // if we are using vector movement, there's a whole bunch of post-processing that happens to
@@ -2057,7 +2059,7 @@ public class Princess extends BotClient {
         Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity, pathEndpoint, getGame(), false);
 
         // if there are no enemies on the board, then we're not unloading anything.
-        // infantry can't clear hexes, so let's not use th
+        // infantry can't clear hexes, so let's not unload them for that purpose
         if((null == closestEnemy) || (closestEnemy.getTargetType() == Targetable.TYPE_HEX_CLEAR)) {
             return;
         }
@@ -2066,6 +2068,11 @@ public class Princess extends BotClient {
         
         // loop through all entities carried by the current entity
         for(Transporter transport : movingEntity.getTransports()) {
+            // this operation is intended for entities on the ground
+            if (transport instanceof Bay) {
+                continue;
+            }
+            
             for(Entity loadedEntity : transport.getLoadedUnits()) {
                 // there's really no good reason for Princess to disconnect trailers.
                 // Let's skip those for now. We don't want to create a bogus 'unload' step for them anyhow.
@@ -2095,6 +2102,55 @@ public class Princess extends BotClient {
                     return; // we can only unload one infantry unit per hex per turn, so once we've unloaded, we're done. 
                 }
             }
+        }
+    }
+    
+    /**
+     * Helper function that adds an "launch" step for units that are transporting 
+     * launchable units in some kind of bay.
+     */
+    private void launchFighters(MovePath path) {
+        // if my objective is to cross the board, even though it's tempting, I won't be leaving the infantry
+        // behind. They're not that good at screening against high speed pursuit anyway.
+        if(getBehaviorSettings().shouldGoHome()) {
+            return;
+        }
+        
+        Entity movingEntity = path.getEntity();
+        Coords pathEndpoint = path.getFinalCoords();
+        Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity, pathEndpoint, getGame(), false);
+
+        // if there are no enemies on the board, then we're not launching anything.
+        if((null == closestEnemy) || (closestEnemy.getTargetType() != Targetable.TYPE_ENTITY)) {
+            return;
+        }
+        
+        TreeMap<Integer, Vector<Integer>> unitsToLaunch = new TreeMap<>();
+        boolean executeLaunch = false;
+        
+        // loop through all fighter (or smallcraft) bays in the current entity
+        // grouping launched craft by bay to limit launches to 'safe' rate.
+        Vector<Bay> fighterBays = movingEntity.getFighterBays();
+        
+        for(int bayIndex = 0; bayIndex < fighterBays.size(); bayIndex++) {
+            Bay bay = fighterBays.get(bayIndex);
+            
+            for(Entity loadedEntity : bay.getLaunchableUnits()) {
+                unitsToLaunch.putIfAbsent(bayIndex, new Vector<Integer>());
+                
+                // for now, just launch fighters at the 'safe' rate
+                if (unitsToLaunch.get(bayIndex).size() < bay.getSafeLaunchRate()) {
+                    unitsToLaunch.get(bayIndex).add(loadedEntity.getId());
+                    executeLaunch = true;
+                } else {
+                    break;
+                }
+            }
+        }
+        
+        // only add the step if we're actually launching something
+        if (executeLaunch) {
+            path.addStep(MoveStepType.LAUNCH, unitsToLaunch);
         }
     }
     

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -3625,7 +3625,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     continue;
                 }
                 int numChoices = choiceDialog.getChoices().length;
-                if ((numChoices > (doors * 2))
+                if ((numChoices > currentBay.getSafeLaunchRate())
                     && GUIPreferences.getInstance().getNagForLaunchDoors()) {
                     int aerosPerDoor = numChoices / doors;
                     int remainder = numChoices % doors;

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -673,5 +673,12 @@ public class Bay implements Transporter, ITechnology {
     public long getCost() {
         return 0;
     }
+    
+    /**
+     * @return Safe launch rate for this particular bay: # of intact doors x 2
+     */
+    public int getSafeLaunchRate() {
+        return getCurrentDoors() * 2;
+    }
 
  } // End package class TroopSpace implements Transporter


### PR DESCRIPTION
This creates a specialized function that lets the bot launch fighters from carriers at a "proper" rate (rather than one per turn, sticking to the 'safe' launch rate of two fighters per bay door per turn).

Also changes the bot's "can this unit move this turn" criteria to match exactly what Server thinks they should be, to fix a game stopper bug that occurs when the bot is using battle armor/infantry with the "infantry don't count for movement initiative" setting.