### PR TITLE
Scenario Additions (Planetary Cond. / Dialog skip)

### DIFF
--- a/megamek/data/scenarios/Example.mms
+++ b/megamek/data/scenarios/Example.mms
@@ -32,12 +32,12 @@ Maps=RANDOM,RANDOM
 GameOptionsFile=Example_options.xml
 # The Game Options can be fixed. In this case the Game Options Dialog shown before the 
 # scenario starts is skipped. 
-FixedGameOptions=1
+FixedGameOptions=true
 
 # Planetary Conditions ------------------------------------------
 # Planetary Conditions can be fixed. In this case the Planetary Conditions Dialog shown before the 
 # scenario starts is skipped. 
-FixedPlanetaryConditions=1
+FixedPlanetaryConditions=true
 # Temperature: Only integer values are allowed
 PlanetaryConditionsTemperature=-14
 PlanetaryConditionsGravity=1.12
@@ -55,13 +55,26 @@ PlanetaryConditionsWindDir=2
 PlanetaryConditionsAtmosphere=2
 # Fog: Default = No Fog; 1 = Light Fog; 2 = Heavy Fog
 PlanetaryConditionsFog=1
+# Shifting Wind
+# Strength: Default = off; default min. Wind = 0 (see Wind above); default max. Wind = 6
+# Direction: Default = off;
+PlanetaryConditionsWindShiftingStr=true
+PlanetaryConditionsWindMin=1
+PlanetaryConditionsWindMax=3
+PlanetaryConditionsWindShiftingDir=true
+# Blowing Sand: Default = off
+PlanetaryConditionsBlowingSand=true
+# EMI: Default = off
+PlanetaryConditionsEMI=true
+# Allow Terrain Changes: Default = on
+PlanetaryConditionsAllowTerrainChanges=false
 
 # Faction (= Player) list ---------------------------------------
 # A scenario can be set to single player style. In this case the first player is
 # the human player and all other players are Princess bots. This will skip the 
 # Player/Camo assignment dialog and the "Host game" dialog and directly connect
 # to a localhost Server and use the correct player name. 
-SinglePlayer=1
+SinglePlayer=true
 # The player name used to log into the server MUST match this name to play as
 # that faction.  Player names can *not* include spaces.
 Factions=PlayerA,PlayerB,PlayerC

--- a/megamek/data/scenarios/Example.mms
+++ b/megamek/data/scenarios/Example.mms
@@ -1,10 +1,6 @@
 # 
 #  A MegaMek Scenario file
 #
-# Future features for the scenario language
-#    Alternate victory conditions
-#    Staggered entry (reinforcements)
-#    Specified critical slot damage
 #
 
 # Versionstamp required to be recognized as a Scenario file
@@ -16,6 +12,7 @@ Name=Example Scenario
 # Scenario description
 Description=This is an example scenario to show different scenario features
 
+# Map Setup ------------------------------------------------------
 # Size of the map in mapboards
 BoardWidth=2
 BoardHeight=1
@@ -27,10 +24,46 @@ RandomDirs=MapSet2,MapSet3,MapSet4,MapSet5,MapSet6,MapSet7
 # Any unspecified boards will be set to RANDOM
 Maps=RANDOM,RANDOM
 
-# Faction list
+# Game/Rule Options ----------------------------------------------
+# This is an xml file which can be created by copying your
+# mmconf/gameoptions.xml
+# path is specified relative to the scenario file
+# This is one way to set victory conditions
+GameOptionsFile=Example_options.xml
+# The Game Options can be fixed. In this case the Game Options Dialog shown before the 
+# scenario starts is skipped. 
+FixedGameOptions=1
+
+# Planetary Conditions ------------------------------------------
+# Planetary Conditions can be fixed. In this case the Planetary Conditions Dialog shown before the 
+# scenario starts is skipped. 
+FixedPlanetaryConditions=1
+# Temperature: Only integer values are allowed
+PlanetaryConditionsTemperature=-14
+PlanetaryConditionsGravity=1.12
+# Light: Default = Daylight; 1 = Dusk; 2 = Full Moon Night; 3 = Moonless Night; 4 = Pitch Black
+PlanetaryConditionsLight=1
+# Weather: Default = None; 1/2/3/4 = Light/Moderate/Heavy/Gusting Rain; 5 = Downpour; 
+# 6/7/9 Light/Moderate/Heavy Snow; 8 = Snow Flurries; 10 = Sleet; 11 = Blizzard;
+# 12 = Ice Storm; 13/14 = Light/Heavy Hail
+PlanetaryConditionsWeather=13
+# Wind: Default = None; 1/2/3 = Light/Moderate/Strong Gale; 4 = Storm; 5 = Tornado F1-3; 6 = Tornado F4
+PlanetaryConditionsWind=4
+# Wind Direction: Default = Random; 0 = N; 1 = NE; 2 = SE; 3 = S; 4 = SW; 5 = NW
+PlanetaryConditionsWindDir=2
+# Atmospheric Pressure: Default = Standard; 0 = Vacuum; 1 = Trace; 2 = Thin; 4 = High; 5 = Very High
+PlanetaryConditionsAtmosphere=2
+# Fog: Default = No Fog; 1 = Light Fog; 2 = Heavy Fog
+PlanetaryConditionsFog=1
+
+# Faction (= Player) list ---------------------------------------
+# A scenario can be set to single player style. In this case the first player is
+# the human player and all other players are Princess bots. This will skip the 
+# Player/Camo assignment dialog and the "Host game" dialog and directly connect
+# to a localhost Server and use the correct player name. 
+SinglePlayer=1
 # The player name used to log into the server MUST match this name to play as
 # that faction.  Player names can *not* include spaces.
-#
 Factions=PlayerA,PlayerB,PlayerC
 
 # Faction location
@@ -53,7 +86,13 @@ Team_PlayerC=2
 Minefields_PlayerA=2,0,2
 Minefields_PlayerB=1,0,3
 
-# Mechlist for each faction
+# Player Camos
+# Assigns a camo to a player; advisable in single player scenarios where the player can't do this
+# The directory and filename must be separated by a comma and the directory must end in a /
+Camo_PlayerA=Clans/Wolf/,Alpha Galaxy.jpg
+Camo_PlayerB=Clans/Burrock/,Alpha.jpg
+
+# Mechlist for each faction -------------------------------------------------
 #
 # Units are constructed as Unit_<faction name>_<#>, where the faction name 
 # matches the one listed in the Faction property and the # is a sequential 
@@ -87,6 +126,11 @@ Unit_PlayerB_2_AutoEject=true
 Unit_PlayerA_1_Commander=true
 Unit_PlayerB_1_Commander=true
 Unit_PlayerC_1_Commander=true
+
+# Unit Camos
+# Assigns a camo to a unit, overriding any player camo
+# The directory and filename must be separated by a comma and the directory must end in a /
+Unit_PlayerA_1_Camo=Clans/Wolf/,Alpha Galaxy.jpg
 
 # To initially damage units, you can use a unit armor property, which specifies
 # armor and internal values.  Values above the unit's nominal value for that
@@ -198,9 +242,3 @@ Unit_PlayerA_2_SetAmmoType=3:1-ISAC20 Flak Ammo
 #
 # Unit_Kurita_666_Altitude=3
 
-# Set game options file
-# This is an xml file which can be created by copying your
-# mmconf/gameoptions.xml
-# path is specified relative to the scenario file
-# This is one way to set victory conditions
-GameOptionsFile=Example_options.xml

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
@@ -675,54 +676,82 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         }
 
         // popup options dialog
-        GameOptionsDialog god = new GameOptionsDialog(frame, g.getOptions(), false);
-        god.update(g.getOptions());
-        god.setEditable(true);
-        god.setVisible(true);
-        for (IBasicOption opt : god.getOptions()) {
-            IOption orig = g.getOptions().getOption(opt.getName());
-            orig.setValue(opt.getValue());
+        if (!sl.hasFixedGameOptions()) {
+            GameOptionsDialog god = new GameOptionsDialog(frame, g.getOptions(), false);
+            god.update(g.getOptions());
+            god.setEditable(true);
+            god.setVisible(true);
+            for (IBasicOption opt : god.getOptions()) {
+                IOption orig = g.getOptions().getOption(opt.getName());
+                orig.setValue(opt.getValue());
+            }
         }
 
         // popup planetary conditions dialog
-        PlanetaryConditionsDialog pcd = new PlanetaryConditionsDialog(frame, g.getPlanetaryConditions());
-        pcd.update(g.getPlanetaryConditions());
-        pcd.setVisible(true);
-        g.setPlanetaryConditions(pcd.getConditions());
+        if (!sl.hasFixedPlanetCond()) {
+            PlanetaryConditionsDialog pcd = new PlanetaryConditionsDialog(frame, g.getPlanetaryConditions());
+            pcd.update(g.getPlanetaryConditions());
+            pcd.setVisible(true);
+            g.setPlanetaryConditions(pcd.getConditions());
+        }
+        
+        String playerName;
+        int port;
+        String serverPW;
+        String localName;
+        Player[] pa = new Player[g.getPlayersVector().size()];
+        int[] playerTypes = new int[pa.length];
+        g.getPlayersVector().copyInto(pa);
+        boolean hasSlot = false;
 
         // get player types and colors set
-        Player[] pa = new Player[g.getPlayersVector().size()];
-        g.getPlayersVector().copyInto(pa);
-        ScenarioDialog sd = new ScenarioDialog(frame, pa);
-        sd.setVisible(true);
-        if (!sd.bSet) {
-            return;
-        }
+        if (!sl.isSinglePlayer()) {
+            ScenarioDialog sd = new ScenarioDialog(frame, pa);
+            sd.setVisible(true);
+            if (!sd.bSet) {
+                return;
+            }
 
-        HostDialog hd = new HostDialog(frame);
-        boolean hasSlot = false;
-        if (!("".equals(sd.localName))) {
+            HostDialog hd = new HostDialog(frame);
+            if (!("".equals(sd.localName))) {
+                hasSlot = true;
+            }
+            hd.setPlayerName(sd.localName);
+            hd.setVisible(true);
+
+            if (!hd.dataValidation("MegaMek.HostScenarioAlert.title")) {
+                return;
+            }
+
+            sd.localName = hd.getPlayerName();
+            localName = hd.getPlayerName();
+            playerName = hd.getPlayerName();
+            port = hd.getPort();
+            serverPW = hd.getServerPass();
+            playerTypes = Arrays.copyOf(sd.playerTypes, playerTypes.length);
+
+        } else {
             hasSlot = true;
+            playerName = pa[0].getName();
+            localName = playerName;
+            port = 2346;
+            serverPW = "";
+            playerTypes[0] = 0;
+            for (int i = 1; i < playerTypes.length; i++) {
+                playerTypes[i] = ScenarioDialog.T_BOT;
+            }
         }
-        hd.setPlayerName(sd.localName);
-        hd.setVisible(true);
-
-        if (!hd.dataValidation("MegaMek.HostScenarioAlert.title")) {
-            return;
-        }
-
-        sd.localName = hd.getPlayerName();
 
         // kick off a RNG check
         Compute.d6();
 
         // start server
         try {
-            server = new Server(hd.getServerPass(), hd.getPort());
+            server = new Server(serverPW, port);
         } catch (Exception ex) {
-            MegaMek.getLogger().error("Could not create server socket on port " + hd.getPort(), ex);
+            MegaMek.getLogger().error("Could not create server socket on port " + port, ex);
             JOptionPane.showMessageDialog(frame,
-                    Messages.getFormattedString("MegaMek.StartServerError", hd.getPort(), ex.getMessage()),
+                    Messages.getFormattedString("MegaMek.StartServerError", port, ex.getMessage()),
                     Messages.getString("MegaMek.HostScenarioAlert.title"), JOptionPane.ERROR_MESSAGE);
             return;
         }
@@ -731,15 +760,15 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         // apply any scenario damage
         sl.applyDamage(server);
         ClientGUI gui = null;
-        if (!"".equals(sd.localName)) {
+        if (!"".equals(localName)) {
             // initialize game
-            client = new Client(hd.getPlayerName(), "localhost", hd.getPort());
+            client = new Client(playerName, "localhost", port);
             gui = new ClientGUI(client, controller);
             controller.clientgui = gui;
             gui.initialize();
             if (!client.connect()) {
                 JOptionPane.showMessageDialog(frame,
-                        Messages.getFormattedString("MegaMek.ServerConnectionError", "localhost", hd.getPort()),
+                        Messages.getFormattedString("MegaMek.ServerConnectionError", "localhost", port),
                         Messages.getString("MegaMek.HostScenarioAlert.title"), JOptionPane.ERROR_MESSAGE);
                 frame.setVisible(false);
                 client.die();
@@ -752,14 +781,14 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         
         // setup any bots
         for (int x = 0; x < pa.length; x++) {
-            if (sd.playerTypes[x] == ScenarioDialog.T_BOT) {
+            if (playerTypes[x] == ScenarioDialog.T_BOT) {
                 MegaMek.getLogger().info("Adding bot "  + pa[x].getName() + " as Princess");
-                BotClient c = new Princess(pa[x].getName(), "localhost", hd.getPort(), LogLevel.ERROR);
+                BotClient c = new Princess(pa[x].getName(), "localhost", port, LogLevel.ERROR);
                 c.getGame().addGameListener(new BotGUI(c));
                 c.connect();                
-            } else if (sd.playerTypes[x] == ScenarioDialog.T_OBOT) {
+            } else if (playerTypes[x] == ScenarioDialog.T_OBOT) {
                 MegaMek.getLogger().info("Adding bot "  + pa[x].getName() + " as TestBot");
-                BotClient c = new TestBot(pa[x].getName(), "localhost", hd.getPort());
+                BotClient c = new TestBot(pa[x].getName(), "localhost", port);
                 c.getGame().addGameListener(new BotGUI(c));
                 c.connect();
             }
@@ -771,7 +800,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
             Enumeration<IPlayer> pE = server.getGame().getPlayers();
             while (pE.hasMoreElements()) {
                 IPlayer tmpP = pE.nextElement();
-                if (tmpP.getName().equals(sd.localName)) {
+                if (tmpP.getName().equals(localName)) {
                     tmpP.setObserver(true);
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -756,7 +756,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
             return;
         }
         server.setGame(g);
-
+        
         // apply any scenario damage
         sl.applyDamage(server);
         ClientGUI gui = null;

--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -89,8 +89,20 @@ public class ScenarioLoader {
 
     private static final String PARAM_MMSVERSION = "MMSVersion";
     private static final String PARAM_GAME_OPTIONS_FILE = "GameOptionsFile";
+    private static final String PARAM_GAME_OPTIONS_FIXED = "FixedGameOptions";
     private static final String PARAM_GAME_EXTERNAL_ID = "ExternalId";
     private static final String PARAM_FACTIONS = "Factions";
+    private static final String PARAM_SINGLEPLAYER = "SinglePlayer";
+    
+    private static final String PARAM_PLANETCOND_FIXED = "FixedPlanetaryConditions";
+    private static final String PARAM_PLANETCOND_TEMP = "PlanetaryConditionsTemperature";
+    private static final String PARAM_PLANETCOND_GRAV = "PlanetaryConditionsGravity";
+    private static final String PARAM_PLANETCOND_LIGHT = "PlanetaryConditionsLight";
+    private static final String PARAM_PLANETCOND_WEATHER = "PlanetaryConditionsWeather";
+    private static final String PARAM_PLANETCOND_WIND = "PlanetaryConditionsWind";
+    private static final String PARAM_PLANETCOND_WINDDIR = "PlanetaryConditionsWindDir";
+    private static final String PARAM_PLANETCOND_ATMOS = "PlanetaryConditionsAtmosphere";
+    private static final String PARAM_PLANETCOND_FOG = "PlanetaryConditionsFog";
 
     private static final String PARAM_MAP_WIDTH = "MapWidth";
     private static final String PARAM_MAP_HEIGHT = "MapHeight";
@@ -126,6 +138,19 @@ public class ScenarioLoader {
     private final List<CritHitPlan> critHitPlans = new ArrayList<>();
     // Used to set ammo Spec Ammounts
     private final List<SetAmmoPlan> ammoPlans = new ArrayList<>();
+
+    /** When true, the Game Options Dialog is skipped. */
+    private boolean fixedGameOptions = false;
+    
+    /** When true, the Planetary Conditions Dialog is skipped. */
+    private boolean fixedPlanetCond;
+    
+    /** 
+     * When true, the Player assignment/camo Dialog and the host dialog are skipped. 
+     * The first faction (player) is assumed to be the local player and the rest
+     * are assumed to be Princess.  
+     */
+    private boolean singlePlayer;
 
     public ScenarioLoader(File f) {
         scenarioFile = f;
@@ -389,9 +414,19 @@ public class ScenarioLoader {
         } else {
             g.getOptions().loadOptions(new MegaMekFile(scenarioFile.getParentFile(), optionFile).getFile(), true);
         }
+        if (p.containsKey(PARAM_GAME_OPTIONS_FIXED)) {
+            fixedGameOptions = true;
+        }
 
         // set wind
         g.getPlanetaryConditions().determineWind();
+        if (p.containsKey(PARAM_PLANETCOND_FIXED)) {
+            fixedPlanetCond = true;
+        }
+        
+        if (p.containsKey(PARAM_SINGLEPLAYER)) {
+            singlePlayer = true;
+        }
 
         // Set up the teams (for initiative)
         g.setupTeams();
@@ -1098,5 +1133,17 @@ public class ScenarioLoader {
             Collection<String> values = get(key);
             return (values == null) ? 0 : values.size();
         }
+    }
+    
+    public boolean hasFixedGameOptions() {
+        return fixedGameOptions;
+    }
+    
+    public boolean hasFixedPlanetCond() {
+        return fixedPlanetCond;
+    }
+    
+    public boolean isSinglePlayer() {
+        return singlePlayer;
     }
 }

--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -419,6 +419,7 @@ public class ScenarioLoader {
         }
 
         // set wind
+        buildPlanetaryConditions(g, p);
         g.getPlanetaryConditions().determineWind();
         if (p.containsKey(PARAM_PLANETCOND_FIXED)) {
             fixedPlanetCond = true;
@@ -442,6 +443,41 @@ public class ScenarioLoader {
         g.createVictoryConditions();
 
         return g;
+    }
+
+    private void buildPlanetaryConditions(Game g, StringMultiMap p) {
+        if (p.containsKey(PARAM_PLANETCOND_TEMP)) {
+            int temp = Integer.parseInt(p.getString(PARAM_PLANETCOND_TEMP));
+            g.getPlanetaryConditions().setTemperature(temp);
+        }
+        if (p.containsKey(PARAM_PLANETCOND_GRAV)) {
+            float grav = Float.parseFloat(p.getString(PARAM_PLANETCOND_GRAV));
+            g.getPlanetaryConditions().setGravity(grav);
+        }
+        if (p.containsKey(PARAM_PLANETCOND_FOG)) {
+            int fog = Integer.parseInt(p.getString(PARAM_PLANETCOND_FOG));
+            g.getPlanetaryConditions().setFog(fog);
+        }
+        if (p.containsKey(PARAM_PLANETCOND_ATMOS)) {
+            int atmo = Integer.parseInt(p.getString(PARAM_PLANETCOND_ATMOS));
+            g.getPlanetaryConditions().setAtmosphere(atmo);
+        }
+        if (p.containsKey(PARAM_PLANETCOND_LIGHT)) {
+            int light = Integer.parseInt(p.getString(PARAM_PLANETCOND_LIGHT));
+            g.getPlanetaryConditions().setLight(light);
+        }
+        if (p.containsKey(PARAM_PLANETCOND_WEATHER)) {
+            int weather = Integer.parseInt(p.getString(PARAM_PLANETCOND_WEATHER));
+            g.getPlanetaryConditions().setWeather(weather);
+        }
+        if (p.containsKey(PARAM_PLANETCOND_WIND)) {
+            int wind = Integer.parseInt(p.getString(PARAM_PLANETCOND_WIND));
+            g.getPlanetaryConditions().setWindStrength(wind);
+        }
+        if (p.containsKey(PARAM_PLANETCOND_WINDDIR)) {
+            int dir = Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDDIR));
+            g.getPlanetaryConditions().setWindDirection(dir);
+        }
     }
 
     private Collection<Entity> buildFactionEntities(StringMultiMap p, IPlayer player) throws ScenarioLoaderException {

--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -448,64 +448,49 @@ public class ScenarioLoader {
 
     private void parsePlanetaryConditions(Game g, StringMultiMap p) {
         if (p.containsKey(PARAM_PLANETCOND_TEMP)) {
-            int temp = Integer.parseInt(p.getString(PARAM_PLANETCOND_TEMP));
-            g.getPlanetaryConditions().setTemperature(temp);
+            g.getPlanetaryConditions().setTemperature(Integer.parseInt(p.getString(PARAM_PLANETCOND_TEMP)));
         }
         if (p.containsKey(PARAM_PLANETCOND_GRAV)) {
-            float grav = Float.parseFloat(p.getString(PARAM_PLANETCOND_GRAV));
-            g.getPlanetaryConditions().setGravity(grav);
+            g.getPlanetaryConditions().setGravity(Float.parseFloat(p.getString(PARAM_PLANETCOND_GRAV)));
         }
         if (p.containsKey(PARAM_PLANETCOND_FOG)) {
-            int fog = Integer.parseInt(p.getString(PARAM_PLANETCOND_FOG));
-            g.getPlanetaryConditions().setFog(fog);
+            g.getPlanetaryConditions().setFog(Integer.parseInt(p.getString(PARAM_PLANETCOND_FOG)));
         }
         if (p.containsKey(PARAM_PLANETCOND_ATMOS)) {
-            int atmo = Integer.parseInt(p.getString(PARAM_PLANETCOND_ATMOS));
-            g.getPlanetaryConditions().setAtmosphere(atmo);
+            g.getPlanetaryConditions().setAtmosphere(Integer.parseInt(p.getString(PARAM_PLANETCOND_ATMOS)));
         }
         if (p.containsKey(PARAM_PLANETCOND_LIGHT)) {
-            int light = Integer.parseInt(p.getString(PARAM_PLANETCOND_LIGHT));
-            g.getPlanetaryConditions().setLight(light);
+            g.getPlanetaryConditions().setLight(Integer.parseInt(p.getString(PARAM_PLANETCOND_LIGHT)));
         }
         if (p.containsKey(PARAM_PLANETCOND_WEATHER)) {
-            int weather = Integer.parseInt(p.getString(PARAM_PLANETCOND_WEATHER));
-            g.getPlanetaryConditions().setWeather(weather);
+            g.getPlanetaryConditions().setWeather(Integer.parseInt(p.getString(PARAM_PLANETCOND_WEATHER)));
         }
         if (p.containsKey(PARAM_PLANETCOND_WIND)) {
-            int wind = Integer.parseInt(p.getString(PARAM_PLANETCOND_WIND));
-            g.getPlanetaryConditions().setWindStrength(wind);
+            g.getPlanetaryConditions().setWindStrength(Integer.parseInt(p.getString(PARAM_PLANETCOND_WIND)));
         }
         if (p.containsKey(PARAM_PLANETCOND_WINDDIR)) {
-            int dir = Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDDIR));
-            g.getPlanetaryConditions().setWindDirection(dir);
+            g.getPlanetaryConditions().setWindDirection(Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDDIR)));
         }
         if (p.containsKey(PARAM_PLANETCOND_WINDSHIFTINGDIR)) {
-            var shift = parseBoolean(p, PARAM_PLANETCOND_WINDSHIFTINGDIR, false);
-            g.getPlanetaryConditions().setShiftingWindDirection(shift);
+            g.getPlanetaryConditions().setShiftingWindDirection(parseBoolean(p, PARAM_PLANETCOND_WINDSHIFTINGDIR, false));
         }
         if (p.containsKey(PARAM_PLANETCOND_WINDSHIFTINGSTR)) {
-            var shift = parseBoolean(p, PARAM_PLANETCOND_WINDSHIFTINGSTR, false);
-            g.getPlanetaryConditions().setShiftingWindStrength(shift);
+            g.getPlanetaryConditions().setShiftingWindStrength(parseBoolean(p, PARAM_PLANETCOND_WINDSHIFTINGSTR, false));
         }
         if (p.containsKey(PARAM_PLANETCOND_WINDMIN)) {
-            int min = Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDMIN));
-            g.getPlanetaryConditions().setMinWindStrength(min);
+            g.getPlanetaryConditions().setMinWindStrength(Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDMIN)));
         }
         if (p.containsKey(PARAM_PLANETCOND_WINDMAX)) {
-            int max = Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDMAX));
-            g.getPlanetaryConditions().setMaxWindStrength(max);
+            g.getPlanetaryConditions().setMaxWindStrength(Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDMAX)));
         }
         if (p.containsKey(PARAM_PLANETCOND_EMI)) {
-            var emi = parseBoolean(p, PARAM_PLANETCOND_EMI, false);
-            g.getPlanetaryConditions().setEMI(emi);
+            g.getPlanetaryConditions().setEMI(parseBoolean(p, PARAM_PLANETCOND_EMI, false));
         }
         if (p.containsKey(PARAM_PLANETCOND_TERRAINCHANGES)) {
-            var terr = parseBoolean(p, PARAM_PLANETCOND_TERRAINCHANGES, true);
-            g.getPlanetaryConditions().setTerrainAffected(terr);
+            g.getPlanetaryConditions().setTerrainAffected(parseBoolean(p, PARAM_PLANETCOND_TERRAINCHANGES, true));
         }
         if (p.containsKey(PARAM_PLANETCOND_BLOWINGSAND)) {
-            var sand = parseBoolean(p, PARAM_PLANETCOND_BLOWINGSAND, false);
-            g.getPlanetaryConditions().setBlowingSand(sand);
+            g.getPlanetaryConditions().setBlowingSand(parseBoolean(p, PARAM_PLANETCOND_BLOWINGSAND, false));
         }
     }
 

--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -450,45 +450,59 @@ public class ScenarioLoader {
         if (p.containsKey(PARAM_PLANETCOND_TEMP)) {
             g.getPlanetaryConditions().setTemperature(Integer.parseInt(p.getString(PARAM_PLANETCOND_TEMP)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_GRAV)) {
             g.getPlanetaryConditions().setGravity(Float.parseFloat(p.getString(PARAM_PLANETCOND_GRAV)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_FOG)) {
             g.getPlanetaryConditions().setFog(Integer.parseInt(p.getString(PARAM_PLANETCOND_FOG)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_ATMOS)) {
             g.getPlanetaryConditions().setAtmosphere(Integer.parseInt(p.getString(PARAM_PLANETCOND_ATMOS)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_LIGHT)) {
             g.getPlanetaryConditions().setLight(Integer.parseInt(p.getString(PARAM_PLANETCOND_LIGHT)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_WEATHER)) {
             g.getPlanetaryConditions().setWeather(Integer.parseInt(p.getString(PARAM_PLANETCOND_WEATHER)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_WIND)) {
             g.getPlanetaryConditions().setWindStrength(Integer.parseInt(p.getString(PARAM_PLANETCOND_WIND)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_WINDDIR)) {
             g.getPlanetaryConditions().setWindDirection(Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDDIR)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_WINDSHIFTINGDIR)) {
             g.getPlanetaryConditions().setShiftingWindDirection(parseBoolean(p, PARAM_PLANETCOND_WINDSHIFTINGDIR, false));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_WINDSHIFTINGSTR)) {
             g.getPlanetaryConditions().setShiftingWindStrength(parseBoolean(p, PARAM_PLANETCOND_WINDSHIFTINGSTR, false));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_WINDMIN)) {
             g.getPlanetaryConditions().setMinWindStrength(Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDMIN)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_WINDMAX)) {
             g.getPlanetaryConditions().setMaxWindStrength(Integer.parseInt(p.getString(PARAM_PLANETCOND_WINDMAX)));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_EMI)) {
             g.getPlanetaryConditions().setEMI(parseBoolean(p, PARAM_PLANETCOND_EMI, false));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_TERRAINCHANGES)) {
             g.getPlanetaryConditions().setTerrainAffected(parseBoolean(p, PARAM_PLANETCOND_TERRAINCHANGES, true));
         }
+        
         if (p.containsKey(PARAM_PLANETCOND_BLOWINGSAND)) {
             g.getPlanetaryConditions().setBlowingSand(parseBoolean(p, PARAM_PLANETCOND_BLOWINGSAND, false));
         }


### PR DESCRIPTION
- Adds complete planetary conditions settings to .mms scenarios
- Allows settings planetary conditions as fixed, skipping the respective dialog when the scenario starts
- Also allows setting the game options as fixed, skipping that dialog
- Also allows setting player assignment as fixed ("SinglePlayer"), skipping the player assignment/camo dialog and the host game dialog. In this case the first player of the scenario is the local player and the others are connected as Princess. When all is fixed, the game proceeds directly from scenario selection to in-game deployment/first round.
- Updated the example.mms with the new settings and missing settings (camo examples)

Resolves #2133 


