### PR TITLE
Standard Components: Creating EntityViewPane and EntityImagePanel

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -7,12 +7,23 @@ Cancel.toolTipText=Cancel out of the dialog. No changes made will be saved.
 Ok.text=Ok
 Ok.toolTipText=Confirm the changes and close the dialog.
 
+
+
 ##### client/ui Resources
-#### client/ui/dialogs Resources
-# AbstractHelpDialog Class
+#### Dialogs
+### AbstractHelpDialog Class
 AbstractHelpDialog.errorReading=Error reading help file:\u0020
 AbstractHelpDialog.helpFile=Help File:\u0020
 AbstractHelpDialog.noHelp.title=No Help Available
+
+
+
+#### Panes
+### EntityViewPane Class
+Summary.title=Summary
+TRO.title=TRO
+
+
 
 ##### Unsorted Resources
 # Generic Resources

--- a/megamek/src/megamek/client/ui/panels/EntityImagePanel.java
+++ b/megamek/src/megamek/client/ui/panels/EntityImagePanel.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.panels;
+
+import megamek.client.ui.swing.tileset.EntityImage;
+import megamek.client.ui.swing.tileset.MMStaticDirectoryManager;
+import megamek.common.Entity;
+import megamek.common.annotations.Nullable;
+import megamek.common.icons.AbstractIcon;
+import megamek.common.icons.Camouflage;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * The EntityImagePanel displays the Entity's Image using the provided camouflage.
+ */
+public class EntityImagePanel extends JPanel {
+    //region Variable Declarations
+    private JLabel imageLabel;
+    //endregion Variable Declarations
+
+    //region Constructors
+    public EntityImagePanel(final @Nullable Entity entity, final AbstractIcon camouflage) {
+        super();
+        initialize();
+        updateDisplayedEntity(entity, camouflage);
+    }
+    //endregion Constructors
+
+    //region Getters/Setters
+    public JLabel getImageLabel() {
+        return imageLabel;
+    }
+
+    public void setImageLabel(final JLabel imageLabel) {
+        this.imageLabel = imageLabel;
+    }
+    //endregion Getters/Setters
+
+    //region Initialization
+    private void initialize() {
+        // Create Panel Components
+        setImageLabel(new JLabel());
+
+        // Layout the UI
+        setName("entityImagePanel");
+        GroupLayout layout = new GroupLayout(this);
+        setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
+                        .addComponent(getImageLabel())
+        );
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addComponent(getImageLabel())
+        );
+    }
+    //endregion Initialization
+
+    /**
+     * This updates the panel's currently displayed entity
+     *
+     * @param entity     the entity to update to, or null if the label is to be reset.
+     * @param camouflage the camouflage to display
+     */
+    public void updateDisplayedEntity(final @Nullable Entity entity, final AbstractIcon camouflage) {
+        if ((entity == null) || (MMStaticDirectoryManager.getMechTileset() == null)
+                || !(camouflage instanceof Camouflage)) {
+            getImageLabel().setIcon(null);
+            return;
+        }
+
+        final Image base = MMStaticDirectoryManager.getMechTileset().imageFor(entity);
+        getImageLabel().setIcon(new ImageIcon(new EntityImage(base, (Camouflage) camouflage, this, entity)
+                .loadPreviewImage()));
+    }
+}

--- a/megamek/src/megamek/client/ui/panels/EntityImagePanel.java
+++ b/megamek/src/megamek/client/ui/panels/EntityImagePanel.java
@@ -61,9 +61,8 @@ public class EntityImagePanel extends JPanel {
 
         // Layout the UI
         setName("entityImagePanel");
-        GroupLayout layout = new GroupLayout(this);
+        final GroupLayout layout = new GroupLayout(this);
         setLayout(layout);
-
         layout.setAutoCreateGaps(true);
         layout.setAutoCreateContainerGaps(true);
 

--- a/megamek/src/megamek/client/ui/panes/EntityViewPane.java
+++ b/megamek/src/megamek/client/ui/panes/EntityViewPane.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.panes;
+
+import megamek.client.ui.baseComponents.AbstractTabbedPane;
+import megamek.client.ui.swing.MechViewPanel;
+import megamek.common.Entity;
+import megamek.common.annotations.Nullable;
+import megamek.common.templates.TROView;
+
+import javax.swing.*;
+
+/**
+ * The EntityViewPane displays the Entity Summary and the TRO panels within a Tabbed Pane.
+ */
+public class EntityViewPane extends AbstractTabbedPane {
+    //region Variable Declarations
+    private MechViewPanel entityPanel;
+    private MechViewPanel troPanel;
+    //endregion Variable Declarations
+
+    //region Constructors
+    public EntityViewPane(final JFrame frame, final @Nullable Entity entity) {
+        super(frame, "EntityViewPane");
+        initialize();
+        updateDisplayedEntity(entity);
+    }
+    //endregion Constructors
+
+    //region Getters/Setters
+    public MechViewPanel getEntityPanel() {
+        return entityPanel;
+    }
+
+    public void setEntityPanel(final MechViewPanel entityPanel) {
+        this.entityPanel = entityPanel;
+    }
+
+    public MechViewPanel getTROPanel() {
+        return troPanel;
+    }
+
+    public void setTROPanel(final MechViewPanel troPanel) {
+        this.troPanel = troPanel;
+    }
+    //endregion Getters/Setters
+
+    //region Initialization
+    /**
+     * This purposefully does not set preferences, as it may be used on differing panes for
+     * differing uses and thus you don't want to remember the selected tab between the different
+     * locations.
+     */
+    @Override
+    protected void initialize() {
+        setEntityPanel(new MechViewPanel());
+        getEntityPanel().setName("entityPanel");
+        addTab(resources.getString("Summary.title"), getEntityPanel());
+
+        setTROPanel(new MechViewPanel());
+        getTROPanel().setName("troPanel");
+        addTab(resources.getString("TRO.title"), getTROPanel());
+    }
+    //endregion Initialization
+
+    /**
+     * This updates the pane's currently displayed entity
+     * @param entity the entity to update to, or null if the panels are to be reset.
+     */
+    public void updateDisplayedEntity(final @Nullable Entity entity) {
+        // Null entity, which means to reset the panels
+        if (entity == null) {
+            getEntityPanel().reset();
+            getTROPanel().reset();
+        } else {
+            getEntityPanel().setMech(entity, true);
+            getTROPanel().setMech(entity, TROView.createView(entity, true));
+        }
+    }
+}


### PR DESCRIPTION
This backports two unmerged components made to standardize GUI functionality within the suite.

https://github.com/MegaMek/mekhq/pull/2478 implements both in MekHQ, although the two PRs do not rely on each other.