### PR TITLE
don't process assault drops if the unit isn't deployed

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -34842,7 +34842,7 @@ public class Server implements Runnable {
      *
      * @param entity the <code>Entity</code> for which to resolve it
      */
-    public void doAssaultDrop(Entity entity) {
+    public void doAssaultDrop(Entity entity) {       
         //resolve according to SO p.22
 
         Report r = new Report(2380);
@@ -34979,7 +34979,7 @@ public class Server implements Runnable {
      */
     void doAllAssaultDrops() {
         for (Entity e : game.getEntitiesVector()) {
-            if (e.isAssaultDropInProgress()) {
+            if (e.isAssaultDropInProgress() && e.isDeployed()) {
                 doAssaultDrop(e);
                 e.setLandedAssaultDrop();
             }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -34842,7 +34842,7 @@ public class Server implements Runnable {
      *
      * @param entity the <code>Entity</code> for which to resolve it
      */
-    public void doAssaultDrop(Entity entity) {       
+    public void doAssaultDrop(Entity entity) {
         //resolve according to SO p.22
 
         Report r = new Report(2380);


### PR DESCRIPTION
You can't do it through the UI, but if you wind up in a situation where you've got a delayed deployment of a unit in mid-air, it immediately scatters off board on the first round. This fixes that behavior by delaying assault drop processing until a unit actually gets deployed. 