### PR TITLE
second pass through mounted components

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11566,6 +11566,21 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             }
         }
         
+        // some equipment is not present in critical slots
+        // but is present in the location, so we'll need to look at it as well
+        for (Mounted mounted : getEquipment()) {
+            if (((mounted.getLocation() == loc) && mounted.getType().isHittable())
+                || (mounted.isSplit() && (mounted.getSecondLocation() == loc))) {
+                if (blownOff) {
+                    mounted.setMissing(true);
+                // we don't want to hit something twice here to avoid triggering
+                // things that fire off when a mounted is hit
+                } else if (!mounted.isHit()) {
+                    mounted.setHit(true);
+                }
+            }
+        }
+        
         // dependent locations destroyed, unless they are already destroyed
         if ((getDependentLocation(loc) != Entity.LOC_NONE)
             && !(getInternal(getDependentLocation(loc)) < 0)) {


### PR DESCRIPTION
Fixes #2745  - it turns out that some equipment may be present in a location but not in a critical slot. In addition to it being possible that a piece of equipment is present in a critical slot but spread across multiple locations (e.g. chameleon).

So, now we go both through all critical slots in the location to mark them and contents as hit, *and* all equipment and mark all equipment with that location as hit.