### PR TITLE
remove testbot as option from bot config dialog

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -3278,7 +3278,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener, 
                 int row = Integer.parseInt(st.nextToken());
                 IPlayer player = playerModel.getPlayerAt(row);
                 BotClient bot = (BotClient) clientgui.getBots().get(player.getName());
-                BotConfigDialog bcd = new BotConfigDialog(clientgui.frame, bot);
+                BotConfigDialog bcd = new BotConfigDialog(clientgui.frame, bot, false);
                 bcd.setVisible(true);
 
                 if (bcd.dialogAborted) {


### PR DESCRIPTION
This one's pretty straightforward - gets rid of the TestBot option on the add bot dialog, thus addressing #2794. 

Also implements a "better" version of disabling the option to re-name a bot, with an explicit parameter in the constructor. There will be a MekHQ companion for it that *does* allow editing bot names from the briefing screen.