### PR TITLE
fix save quirk command

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekPopup.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekPopup.java
@@ -600,8 +600,8 @@ class LobbyMekPopup {
 
         JMenu menu = new JMenu(Messages.getString("ChatLounge.popup.quirks"));
         menu.setEnabled(enabled);
-        menu.add(menuItem("Save Quirks for Chassis", LMP_SAVE_QUIRKS_ALL + eIds, enabled, listener));
-        menu.add(menuItem("Save Quirks for Chassis/Model", LMP_SAVE_QUIRKS_MODEL + eIds, enabled, listener));
+        menu.add(menuItem("Save Quirks for Chassis", LMP_SAVE_QUIRKS_ALL + NOINFO + eIds, enabled, listener));
+        menu.add(menuItem("Save Quirks for Chassis/Model", LMP_SAVE_QUIRKS_MODEL + NOINFO + eIds, enabled, listener));
         return menu;
     }
 


### PR DESCRIPTION
Apparently, the menu commands need a "NOINFO" between the command and unit IDs.