### PR TITLE
Board Editor Layout

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -198,7 +198,7 @@ public class BoardEditor extends JPanel
  
     private static final long serialVersionUID = 4689863639249616192L;
     
-    GUIPreferences guip = GUIPreferences.getInstance();
+    private GUIPreferences guip = GUIPreferences.getInstance();
 
     //region action commands
     private static final String FILE_BOARD_EDITOR_EXPAND = "fileBoardExpand";
@@ -235,7 +235,7 @@ public class BoardEditor extends JPanel
     private IHex curHex = new Hex();
     
     // Easy terrain access buttons
-    private ArrayList<ScalingIconButton> terrainButtons = new ArrayList<>();
+    private List<ScalingIconButton> terrainButtons = new ArrayList<>();
     private ScalingIconButton buttonLW, buttonLJ;
     private ScalingIconButton buttonOW, buttonOJ;
     private ScalingIconButton buttonWa, buttonSw, buttonRo;
@@ -243,7 +243,7 @@ public class BoardEditor extends JPanel
     private ScalingIconButton buttonMd, buttonPv, buttonSn;
     private ScalingIconButton buttonIc, buttonTu, buttonMg;
     private ScalingIconButton buttonBr, buttonFT;
-    private ArrayList<ScalingIconToggleButton> brushButtons = new ArrayList<>();
+    private List<ScalingIconToggleButton> brushButtons = new ArrayList<>();
     private ScalingIconToggleButton buttonBrush1, buttonBrush2, buttonBrush3;
     private ScalingIconToggleButton buttonUpDn, buttonOOC;
 
@@ -286,11 +286,11 @@ public class BoardEditor extends JPanel
     private FixedYPanel panelBoardSettings = new FixedYPanel();
     
     // Help Texts
-    JLabel labHelp1 = new JLabel(Messages.getString("BoardEditor.helpText"),SwingConstants.LEFT);
-    JLabel labHelp2 = new JLabel(Messages.getString("BoardEditor.helpText2"),SwingConstants.LEFT);
+    private JLabel labHelp1 = new JLabel(Messages.getString("BoardEditor.helpText"),SwingConstants.LEFT);
+    private JLabel labHelp2 = new JLabel(Messages.getString("BoardEditor.helpText2"),SwingConstants.LEFT);
     
     // Undo / Redo
-    ArrayList<ScalingIconButton> undoButtons = new ArrayList<>();
+    private List<ScalingIconButton> undoButtons = new ArrayList<>();
     private ScalingIconButton buttonUndo, buttonRedo;
     private Stack<HashSet<IHex>> undoStack = new Stack<>();
     private Stack<HashSet<IHex>> redoStack = new Stack<>();
@@ -542,12 +542,12 @@ public class BoardEditor extends JPanel
      * Sets up Scaling Icon Buttons
      */
     private ScalingIconButton prepareButton(String iconName, String buttonName, 
-            ArrayList<ScalingIconButton> bList, int width) {
+            List<ScalingIconButton> bList, int width) {
         // Get the normal icon
         File file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile();
         Image imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton == null) {
-            return null;
+            imageButton = ImageUtil.failStandardImage();
         }
         ScalingIconButton button = new ScalingIconButton(imageButton, width);
 
@@ -577,12 +577,12 @@ public class BoardEditor extends JPanel
      * Sets up Scaling Icon ToggleButtons
      */
     private ScalingIconToggleButton prepareToggleButton(String iconName, String buttonName, 
-            ArrayList<ScalingIconToggleButton> bList, int width) {
+            List<ScalingIconToggleButton> bList, int width) {
         // Get the normal icon
         File file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile();
         Image imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton == null) {
-            return null;
+            imageButton = ImageUtil.failStandardImage();
         }
         ScalingIconToggleButton button = new ScalingIconToggleButton(imageButton, width);
         
@@ -2068,9 +2068,9 @@ public class BoardEditor extends JPanel
         labHelp2.setFont(scaledFont);
         labTheme.setFont(scaledFont);
         
-        ((TitledBorder)panelBoardSettings.getBorder()).setTitleFont(scaledFont);
-        ((TitledBorder)panelHexSettings.getBorder()).setTitleFont(scaledFont);
-        ((TitledBorder)panelTerrSettings.getBorder()).setTitleFont(scaledFont);
+        ((TitledBorder) panelBoardSettings.getBorder()).setTitleFont(scaledFont);
+        ((TitledBorder) panelHexSettings.getBorder()).setTitleFont(scaledFont);
+        ((TitledBorder) panelTerrSettings.getBorder()).setTitleFont(scaledFont);
         
         terrainButtons.stream().forEach(ScalingIconButton::rescale);
         undoButtons.stream().forEach(ScalingIconButton::rescale);
@@ -2301,7 +2301,6 @@ public class BoardEditor extends JPanel
         }
     }
     
-    
     /** 
      * A specialized JButton that only shows an icon but scales that icon according
      * to the current GUI scaling when its rescale() method is called.
@@ -2322,6 +2321,7 @@ public class BoardEditor extends JPanel
             rescale();
         }
         
+        /** Adapts all images of this button to the current gui scale. */
         void rescale() {
             int realWidth = UIUtil.scaleForGUI(baseWidth);
             int realHeight = baseImage.getHeight(null) * realWidth / baseImage.getWidth(null);
@@ -2330,18 +2330,31 @@ public class BoardEditor extends JPanel
             if (baseRolloverImage != null) {
                 realHeight = baseRolloverImage.getHeight(null) * realWidth / baseRolloverImage.getWidth(null);
                 setRolloverIcon(new ImageIcon(ImageUtil.getScaledImage(baseRolloverImage, realWidth, realHeight)));
+            } else {
+                setRolloverIcon(null);
             }
+                
             
             if (baseDisabledImage != null) {
                 realHeight = baseDisabledImage.getHeight(null) * realWidth / baseDisabledImage.getWidth(null);
                 setDisabledIcon(new ImageIcon(ImageUtil.getScaledImage(baseDisabledImage, realWidth, realHeight)));
+            } else {
+                setDisabledIcon(null);
             }
         }
         
+        /** 
+         * Sets the unscaled base image to use as a mouse hover image for the button. 
+         * image may be null. Passing null disables the hover image. 
+         */
         void setRolloverImage(Image image) {
             baseRolloverImage = image;
         }
         
+        /** 
+         * Sets the unscaled base image to use as a button disabled image for the button. 
+         * image may be null. Passing null disables the button disabled image. 
+         */
         void setDisabledImage(Image image) {
             baseDisabledImage = image;
         }
@@ -2367,6 +2380,7 @@ public class BoardEditor extends JPanel
             rescale();
         }
         
+        /** Adapts all images of this button to the current gui scale. */ 
         void rescale() {
             int realWidth = UIUtil.scaleForGUI(baseWidth);
             int realHeight = baseImage.getHeight(null) * realWidth / baseImage.getWidth(null);
@@ -2375,18 +2389,30 @@ public class BoardEditor extends JPanel
             if (baseRolloverImage != null) {
                 realHeight = baseRolloverImage.getHeight(null) * realWidth / baseRolloverImage.getWidth(null);
                 setRolloverIcon(new ImageIcon(ImageUtil.getScaledImage(baseRolloverImage, realWidth, realHeight)));
+            } else {
+                setRolloverIcon(null);
             }
             
             if (baseSelectedImage != null) {
                 realHeight = baseSelectedImage.getHeight(null) * realWidth / baseSelectedImage.getWidth(null);
                 setSelectedIcon(new ImageIcon(ImageUtil.getScaledImage(baseSelectedImage, realWidth, realHeight)));
+            } else {
+                setSelectedIcon(null);
             }
         }
         
+        /** 
+         * Sets the unscaled base image to use as a mouse hover image for the button. 
+         * image may be null. Passing null disables the hover image. 
+         */
         void setRolloverImage(Image image) {
             baseRolloverImage = image;
         }
         
+        /** 
+         * Sets the unscaled base image to use as a "toggle button is selected" image for the button. 
+         * image may be null. Passing null disables the "is selected" image. 
+         */
         void setSelectedImage(Image image) {
             baseSelectedImage = image;
         }

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -60,6 +60,7 @@ import megamek.client.ui.swing.util.MegaMekController;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.util.UIUtil.FixedYPanel;
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.util.BoardUtilities;
@@ -2347,7 +2348,7 @@ public class BoardEditor extends JPanel
          * Sets the unscaled base image to use as a mouse hover image for the button. 
          * image may be null. Passing null disables the hover image. 
          */
-        void setRolloverImage(Image image) {
+        void setRolloverImage(@Nullable Image image) {
             baseRolloverImage = image;
         }
         
@@ -2355,7 +2356,7 @@ public class BoardEditor extends JPanel
          * Sets the unscaled base image to use as a button disabled image for the button. 
          * image may be null. Passing null disables the button disabled image. 
          */
-        void setDisabledImage(Image image) {
+        void setDisabledImage(@Nullable Image image) {
             baseDisabledImage = image;
         }
     }
@@ -2405,7 +2406,7 @@ public class BoardEditor extends JPanel
          * Sets the unscaled base image to use as a mouse hover image for the button. 
          * image may be null. Passing null disables the hover image. 
          */
-        void setRolloverImage(Image image) {
+        void setRolloverImage(@Nullable Image image) {
             baseRolloverImage = image;
         }
         
@@ -2413,7 +2414,7 @@ public class BoardEditor extends JPanel
          * Sets the unscaled base image to use as a "toggle button is selected" image for the button. 
          * image may be null. Passing null disables the "is selected" image. 
          */
-        void setSelectedImage(Image image) {
+        void setSelectedImage(@Nullable Image image) {
             baseSelectedImage = image;
         }
     }

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -287,8 +287,8 @@ public class BoardEditor extends JPanel
     private FixedYPanel panelBoardSettings = new FixedYPanel();
     
     // Help Texts
-    private JLabel labHelp1 = new JLabel(Messages.getString("BoardEditor.helpText"),SwingConstants.LEFT);
-    private JLabel labHelp2 = new JLabel(Messages.getString("BoardEditor.helpText2"),SwingConstants.LEFT);
+    private JLabel labHelp1 = new JLabel(Messages.getString("BoardEditor.helpText"), SwingConstants.LEFT);
+    private JLabel labHelp2 = new JLabel(Messages.getString("BoardEditor.helpText2"), SwingConstants.LEFT);
     
     // Undo / Redo
     private List<ScalingIconButton> undoButtons = new ArrayList<>();

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -808,18 +808,6 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
             case VIEW_ACCESSIBILITY_WINDOW:
                 toggleAccessibilityWindow();
                 break;
-            case VIEW_INCGUISCALE:
-                float guiScale = GUIPreferences.getInstance().getGUIScale();
-                if (guiScale < MAX_GUISCALE) {
-                    GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, guiScale + 0.1);
-                }
-                break;
-            case VIEW_DECGUISCALE:
-                guiScale = GUIPreferences.getInstance().getGUIScale();
-                if (guiScale > MIN_GUISCALE) {
-                    GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, guiScale - 0.1);
-                }
-                break;
             case VIEW_KEYBINDS_OVERLAY:
                 bv.toggleKeybindsOverlay();
                 break;

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -826,6 +826,20 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
      * @param event - the <code>ActionEvent</code> that spawned this call.
      */
     public void actionPerformed(ActionEvent event) {
+        
+        // Changes that are independent of the current state of MM
+        if (event.getActionCommand().equals(ClientGUI.VIEW_INCGUISCALE)) {
+            float guiScale = GUIPreferences.getInstance().getGUIScale();
+            if (guiScale < ClientGUI.MAX_GUISCALE) {
+                GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, guiScale + 0.1);
+            }
+        } else if (event.getActionCommand().equals(ClientGUI.VIEW_DECGUISCALE)) {
+            float guiScale = GUIPreferences.getInstance().getGUIScale();
+            if (guiScale > ClientGUI.MIN_GUISCALE) {
+                GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, guiScale - 0.1);
+            }
+        }
+        
         // Pass the action on to each of our listeners.
         Enumeration<ActionListener> iter = actionListeners.elements();
         while (iter.hasMoreElements()) {


### PR DESCRIPTION
Makes the BoardEditor adapt to the gui scaling. Also some code cleanup.
Also moves the reaction to gui scale changes (writing them to the GUI Prefs and creating a Prefchange event) via menu or keyboard shortcut from the ClientGUI (which only operates in lobby and game) to the commonmenubar itself which operates everywhere.