### PR TITLE
fix NPEs in mek tree sorter

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/sorters/MekTreeTopLevelSorter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/sorters/MekTreeTopLevelSorter.java
@@ -63,11 +63,13 @@ public class MekTreeTopLevelSorter implements Comparator<Object> {
             idB = ((Entity) b).getId();
         }
 
-        boolean isLocalBotA = ownerA != null && client.bots.containsKey(ownerA.getName());
-        boolean isLocalBotB = ownerB != null && client.bots.containsKey(ownerB.getName());
+        boolean isLocalBotA = (ownerA != null) && client.bots.containsKey(ownerA.getName());
+        boolean isLocalBotB = (ownerB != null) && client.bots.containsKey(ownerB.getName());
 
-        boolean isLocalAllyA = ownerA != null && !ownerA.equals(localPlayer) && !ownerA.isEnemyOf(localPlayer);
-        boolean isLocalAllyB = ownerB != null && !ownerB.equals(localPlayer) && !ownerB.isEnemyOf(localPlayer);
+
+        boolean isLocalAllyA = (ownerA) != null && !ownerA.equals(localPlayer) && !ownerA.isEnemyOf(localPlayer);
+        boolean isLocalAllyB = (ownerB) != null && !ownerB.equals(localPlayer) && !ownerB.isEnemyOf(localPlayer);
+
 
         if ((ownerA == localPlayer) && (ownerB != localPlayer)) {
             return -1;

--- a/megamek/src/megamek/client/ui/swing/lobby/sorters/MekTreeTopLevelSorter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/sorters/MekTreeTopLevelSorter.java
@@ -63,11 +63,11 @@ public class MekTreeTopLevelSorter implements Comparator<Object> {
             idB = ((Entity) b).getId();
         }
 
-        boolean isLocalBotA = client.bots.containsKey(ownerA.getName());
-        boolean isLocalBotB = client.bots.containsKey(ownerB.getName());
+        boolean isLocalBotA = ownerA != null && client.bots.containsKey(ownerA.getName());
+        boolean isLocalBotB = ownerB != null && client.bots.containsKey(ownerB.getName());
 
-        boolean isLocalAllyA = !ownerA.equals(localPlayer) && !ownerA.isEnemyOf(localPlayer);
-        boolean isLocalAllyB = !ownerB.equals(localPlayer) && !ownerB.isEnemyOf(localPlayer);
+        boolean isLocalAllyA = ownerA != null && !ownerA.equals(localPlayer) && !ownerA.isEnemyOf(localPlayer);
+        boolean isLocalAllyB = ownerB != null && !ownerB.equals(localPlayer) && !ownerB.isEnemyOf(localPlayer);
 
         if ((ownerA == localPlayer) && (ownerB != localPlayer)) {
             return -1;


### PR DESCRIPTION
In certain situations (such as when the game is ending and MekHQ is doing its final scenario resolution), the various "getOwner()" methods return null for bot-controlled entities (and probably entities belonging to any player that has left the game). This PR makes the sorter code more robust with regard to that condition.