### PR TITLE
Root fix for Left click issues including movement and LOS issues. #2819, #2800

### DIFF
--- a/megamek/src/megamek/client/event/BoardViewEvent.java
+++ b/megamek/src/megamek/client/event/BoardViewEvent.java
@@ -47,6 +47,7 @@ public class BoardViewEvent extends java.util.EventObject {
     private int type;
     private int modifiers;
     private int entityId;
+    private int mouseButton = 0;
 
     public BoardViewEvent(Object source, Coords c, Entity entity, int type,
             int modifiers) {
@@ -67,6 +68,12 @@ public class BoardViewEvent extends java.util.EventObject {
         super(source);
         this.type = type;
         this.entityId = entityId;
+    }
+    
+    public BoardViewEvent(Object source, Coords c, Entity entity, int type, 
+            int modifiers, int mouseButton) {
+        this(source, c, entity, type, modifiers);
+        this.mouseButton = mouseButton;
     }
 
     /**
@@ -105,5 +112,22 @@ public class BoardViewEvent extends java.util.EventObject {
      */
     public int getEntityId() {
         return entityId;
+    }
+
+    /**
+     * @return the id of the mouse button associated with this event if any.
+     * <ul>
+     * <li> 0 no button
+     * <li> 1 Button 1
+     * <li> 2 Button 2
+     * <li> 3 Button 3
+     * <li> 4 Button greater than 3
+     * <li> 5 Button greater than 3
+     * </ul>
+     * <p>
+     * 
+     */
+    public int getButton() {
+        return mouseButton ;
     }
 }

--- a/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
+++ b/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
@@ -31,6 +31,7 @@ import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyListener;
+import java.awt.event.MouseEvent;
 import java.util.LinkedList;
 
 public class AccessibilityWindow extends JDialog implements KeyListener {
@@ -178,9 +179,9 @@ public class AccessibilityWindow extends JDialog implements KeyListener {
                     Integer.parseInt(args[2]) - 1);
             // Why don't constants work here?
             // Cursor over the hex.
-            gui.bv.mouseAction(selectedTarget, 3, InputEvent.BUTTON1_DOWN_MASK);
+            gui.bv.mouseAction(selectedTarget, 3, InputEvent.BUTTON1_DOWN_MASK, MouseEvent.BUTTON1);
             // Click.
-            ((BoardView1) gui.getBoardView()).mouseAction(selectedTarget, 1, InputEvent.BUTTON1_DOWN_MASK);
+            ((BoardView1) gui.getBoardView()).mouseAction(selectedTarget, 1, InputEvent.BUTTON1_DOWN_MASK, MouseEvent.BUTTON1);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/DeployMinefieldDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeployMinefieldDisplay.java
@@ -15,7 +15,7 @@
 package megamek.client.ui.swing;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -362,7 +362,7 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
 
         // ignore buttons other than 1
         if (!clientgui.getClient().isMyTurn()
-                || ((b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) == 0)) {
+                || ((b.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
 

--- a/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
@@ -15,6 +15,7 @@ package megamek.client.ui.swing;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -494,7 +495,7 @@ public class DeploymentDisplay extends StatusBarPhaseDisplay {
 
         // ignore buttons other than 1
         if (!clientgui.getClient().isMyTurn() || (ce() == null)
-                || ((b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) == 0)) {
+                || ((b.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
 

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -41,6 +41,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
 import java.util.*;
 
 public class FiringDisplay extends StatusBarPhaseDisplay implements
@@ -2031,7 +2032,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
 
         // ignore buttons other than 1
         if (!clientgui.getClient().isMyTurn()
-            || ((b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) == 0)) {
+            || ((b.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
         // control pressed means a line of sight check.

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -18,6 +18,7 @@ import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1376,9 +1377,9 @@ public class MapMenu extends JPopupMenu {
         ((MovementDisplay) currentPanel).actionPerformed(e);
 
         // Cursor over the hex.
-        ((BoardView1) gui.bv).mouseAction(coords, BoardViewEvent.BOARD_HEX_CURSOR, InputEvent.BUTTON1_DOWN_MASK);
+        ((BoardView1) gui.bv).mouseAction(coords, BoardViewEvent.BOARD_HEX_CURSOR, InputEvent.BUTTON1_DOWN_MASK, MouseEvent.BUTTON1);
         // Click
-        ((BoardView1) gui.bv).mouseAction(coords, BoardViewEvent.BOARD_HEX_CLICKED, InputEvent.BUTTON1_DOWN_MASK);
+        ((BoardView1) gui.bv).mouseAction(coords, BoardViewEvent.BOARD_HEX_CLICKED, InputEvent.BUTTON1_DOWN_MASK, MouseEvent.BUTTON1);
     }
 
     Targetable decodeTargetInfo(String info) {

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -17,6 +17,7 @@ package megamek.client.ui.swing;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1741,7 +1742,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
 
         // ignore buttons other than 1
         if (!clientgui.getClient().isMyTurn()
-            || ((b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) == 0)) {
+            || ((b.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
         // control pressed means a line of sight check.

--- a/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
@@ -19,6 +19,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -921,7 +922,7 @@ public class PointblankShotDisplay extends FiringDisplay implements
 
         // ignore buttons other than 1
         if (!clientgui.isProcessingPointblankShot()
-            || ((b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) == 0)) {
+            || ((b.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
         // control pressed means a line of sight check.

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -19,6 +19,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.KeyListener;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -1293,7 +1294,7 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
 
         // ignore buttons other than 1
         if (!clientgui.getClient().isMyTurn()
-            || ((b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) == 0)) {
+            || ((b.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
         // control pressed means a line of sight check.

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -673,7 +673,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 // only scroll when we should
                 if (!shouldScroll) {
                     mouseAction(getCoordsAt(point), BOARD_HEX_DRAG,
-                                e.getModifiersEx());
+                                e.getModifiersEx(), e.getButton());
                     return;
                 }
                 // if we have not yet been dragging, set the var so popups don't
@@ -4836,7 +4836,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
 
         if (me.isPopupTrigger() && !dragging) {
-            mouseAction(getCoordsAt(point), BOARD_HEX_POPUP, me.getModifiersEx());
+            mouseAction(getCoordsAt(point), BOARD_HEX_POPUP, me.getModifiersEx(), me.getButton());
             return;
         }
         for (int i = 0; i < displayables.size(); i++) {
@@ -4856,14 +4856,14 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 return;
             }
         }
-        mouseAction(getCoordsAt(point), BOARD_HEX_DRAG, me.getModifiersEx());
+        mouseAction(getCoordsAt(point), BOARD_HEX_DRAG, me.getModifiersEx(), me.getButton());
     }
 
     public void mouseReleased(MouseEvent me) {
         // don't show the popup if we are drag-scrolling
         if (me.isPopupTrigger() && !dragging) {
             mouseAction(getCoordsAt(me.getPoint()), BOARD_HEX_POPUP,
-                        me.getModifiersEx());
+                        me.getModifiersEx(), me.getButton());
             // stop scrolling
             shouldScroll = false;
             return;
@@ -4887,10 +4887,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
         if (me.getClickCount() == 1) {
             mouseAction(getCoordsAt(me.getPoint()), BOARD_HEX_CLICK,
-                        me.getModifiersEx());
+                        me.getModifiersEx(), me.getButton());
         } else {
             mouseAction(getCoordsAt(me.getPoint()), BOARD_HEX_DOUBLECLICK,
-                        me.getModifiersEx());
+                        me.getModifiersEx(), me.getButton());
         }
     }
 
@@ -5122,7 +5122,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
      * Determines if this Board contains the (x, y) Coords, and if so, notifies
      * listeners about the specified mouse action.
      */
-    public void mouseAction(int x, int y, int mtype, int modifiers) {
+    public void mouseAction(int x, int y, int mtype, int modifiers, int mouseButton) {
         if (game.getBoard().contains(x, y)) {
             Coords c = new Coords(x, y);
             switch (mtype) {
@@ -5131,20 +5131,20 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         checkLOS(c);
                     } else {
                         processBoardViewEvent(new BoardViewEvent(this, c, null,
-                                BoardViewEvent.BOARD_HEX_CLICKED, modifiers));
+                                BoardViewEvent.BOARD_HEX_CLICKED, modifiers, mouseButton));
                     }
                     break;
                 case BOARD_HEX_DOUBLECLICK:
                     processBoardViewEvent(new BoardViewEvent(this, c, null,
-                            BoardViewEvent.BOARD_HEX_DOUBLECLICKED, modifiers));
+                            BoardViewEvent.BOARD_HEX_DOUBLECLICKED, modifiers, mouseButton));
                     break;
                 case BOARD_HEX_DRAG:
                     processBoardViewEvent(new BoardViewEvent(this, c, null,
-                            BoardViewEvent.BOARD_HEX_DRAGGED, modifiers));
+                            BoardViewEvent.BOARD_HEX_DRAGGED, modifiers, mouseButton));
                     break;
                 case BOARD_HEX_POPUP:
                     processBoardViewEvent(new BoardViewEvent(this, c, null,
-                            BoardViewEvent.BOARD_HEX_POPUP, modifiers));
+                            BoardViewEvent.BOARD_HEX_POPUP, modifiers, mouseButton));
                     break;
             }
         }
@@ -5152,11 +5152,17 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
     /**
      * Notifies listeners about the specified mouse action.
-     *
-     * @param coords the Coords.
+     * 
+     * @param coords     - coords the Coords.
+     * @param mtype      - Board view event type
+     * @param modifiers  - mouse event modifiers usch as CTRL, ALT, and SHIFT
+     * @param button     - button associated with this board event 
+     *                      0 = no button
+     *                      1 = Button 1
+     *                      2 = Button 2
      */
-    public void mouseAction(Coords coords, int mtype, int modifiers) {
-        mouseAction(coords.getX(), coords.getY(), mtype, modifiers);
+    public void mouseAction(Coords coords, int mtype, int modifiers, int mouseButton) {
+        mouseAction(coords.getX(), coords.getY(), mtype, modifiers, mouseButton);
     }
 
     /*

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -5153,13 +5153,13 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     /**
      * Notifies listeners about the specified mouse action.
      * 
-     * @param coords     - coords the Coords.
-     * @param mtype      - Board view event type
-     * @param modifiers  - mouse event modifiers usch as CTRL, ALT, and SHIFT
-     * @param button     - button associated with this board event 
-     *                      0 = no button
-     *                      1 = Button 1
-     *                      2 = Button 2
+     * @param coords          - coords the Coords.
+     * @param mtype           - Board view event type
+     * @param modifiers       - mouse event modifiers mask such as SHIFT_DOWN_MASK etc.
+     * @param mouseButton     - mouse button associated with this event 
+     *                           0 = no button
+     *                           1 = Button 1
+     *                           2 = Button 2
      */
     public void mouseAction(Coords coords, int mtype, int modifiers, int mouseButton) {
         mouseAction(coords.getX(), coords.getY(), mtype, modifiers, mouseButton);


### PR DESCRIPTION
# Proposed fix for several left-click issues introduced with the upgrade to Java 11 Key events
This pull request fixes several left-click issues including movement, and LOS not updating during the movement phase.

One of they key differences between `getModifiersEx()` and the legacy `getModifiers()` is that the button modifiers are not carried with the mouseRelease event as they previously were.  The code here relied on the mouse modifiers to detect if button 1 was pressed on mouse up (BOARD_HEX_CLICK) events.  

The solution here passes a separate value carrying the mouse button that was associated to the event.

With this change it would be possible to restore the torso twist/flip code that was removed in #2819 if desired to cover those cases as they worked before.  The fix previously implemented in #2819 works but is not a full fix because it forces the click and drag functionality together (i.e. the code that used to run only on mouse up now runs on mouse up and mouse down etc)  It also didn't handle cases for movement, deployment, accessibility, etc.

Please consider this set of changes as a more complete fix for the mouse issues.

I've manually tested impacted areas to the best of my app knowledge with the exception of mine deployment.
I am unsure how to test these changes with MekHQ but am open to suggestions.

## Fixes issues during movement phase including updating line of sight during movement.