### PR TITLE
Issue #2820 Game Options

### DIFF
--- a/megamek/src/megamek/client/ui/swing/DialogOptionComponent.java
+++ b/megamek/src/megamek/client/ui/swing/DialogOptionComponent.java
@@ -1,49 +1,38 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This file is part of MegaMek.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
- */
-
-/**
- * DialogOptionComponent.java
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * @author Cord Awtry
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package megamek.client.ui.swing;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
+import java.awt.FlowLayout;
+import java.awt.event.*;
 import java.util.StringTokenizer;
 
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
+import javax.swing.*;
+import megamek.client.ui.swing.util.UIUtil.FixedYPanel;
+import megamek.common.options.*;
 
-import megamek.common.options.BasicOption;
-import megamek.common.options.IBasicOption;
-import megamek.common.options.IOption;
+/**
+ * @author Cord Awtry
+ */
+public class DialogOptionComponent extends FixedYPanel implements ItemListener, Comparable<DialogOptionComponent> {
 
-public class DialogOptionComponent extends JPanel implements
-        ItemListener, Comparable<DialogOptionComponent> {
-    /**
-     *
-     */
     private static final long serialVersionUID = -4190538980884459746L;
 
     IOption option;
@@ -54,9 +43,7 @@ public class DialogOptionComponent extends JPanel implements
     private JLabel label;
     private DialogOptionListener dialogOptionListener;
     
-    /**
-     * Value used to force a change
-     */
+    /** Value used to force a change */
     private boolean hasOptionChanged = false;
 
     public DialogOptionComponent(DialogOptionListener parent, IOption option) {
@@ -73,103 +60,65 @@ public class DialogOptionComponent extends JPanel implements
         dialogOptionListener = parent;
         this.option = option;
 
-        setLayout(new GridBagLayout());
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.anchor = GridBagConstraints.WEST;
+        setLayout(new FlowLayout(FlowLayout.LEFT, 5, 2));
         switch (option.getType()) {
             case IOption.BOOLEAN:
                 checkbox = new JCheckBox("", option.booleanValue());
                 checkbox.addItemListener(this);
                 checkbox.setToolTipText(convertToHtml(option.getDescription()));
-                if (!editable) {
-                    checkbox.setEnabled(false);
-                }
+                checkbox.setEnabled(editable);
                 label = new JLabel(option.getDisplayableName());
-		label.setLabelFor(checkbox);
+                label.setLabelFor(checkbox);
                 label.setToolTipText(convertToHtml(option.getDescription()));
-                label.addMouseListener(new MouseListener(){
+                label.addMouseListener(new MouseAdapter() {
+                    @Override
                     public void mouseClicked(MouseEvent evt) {
                         if (checkbox.isEnabled()) {
                             checkbox.setSelected(!checkbox.isSelected());
                         }
                     }
-                    public void mouseEntered(MouseEvent evt) {}
-                    public void mouseExited(MouseEvent evt) {}
-                    public void mousePressed(MouseEvent evt) {}
-                    public void mouseReleased(MouseEvent evt) {}                    
                 });
-                
-                gbc.gridx = gbc.gridy = 0;
-                gbc.anchor = GridBagConstraints.CENTER;
-                gbc.insets = new Insets(0,10,0,10);
-                add(checkbox, gbc);
-                gbc.gridx++;
-                gbc.weightx = 1.0;
-                gbc.anchor = GridBagConstraints.WEST;
-                gbc.insets = new Insets(0,0,0,0);
-                add(label, gbc);
+                add(Box.createHorizontalStrut(10));
+                add(checkbox);
+                add(label);
                 break;
             case IOption.CHOICE:
                 choice = new JComboBox<String>();
                 label = new JLabel(option.getDisplayableName());
-		label.setLabelFor(choice);
+                label.setLabelFor(choice);
                 label.setToolTipText(convertToHtml(option.getDescription()));
-                if (!editable) {
-                    choice.setEnabled(false);
-                }
-
+                choice.setEnabled(editable);
                 if (choiceLabelFirst) {
-                    gbc.gridx = gbc.gridy = 0;
-                    add(choice, gbc);
-                    gbc.gridx++;
-                    gbc.weightx = 1.0;
-                    add(label, gbc);
+                    add(choice);
+                    add(label);
                 } else {
-                    gbc.gridx = gbc.gridy = 0;
-                    add(label, gbc);
-                    gbc.gridx++;
-                    gbc.weightx = 1.0;
-                    add(choice, gbc);
+                    add(label);
+                    add(choice);
                 }
                 break;
             default:
-                textField = new JTextField(option.stringValue(), option
-                        .getTextFieldLength());
+                textField = new JTextField(option.stringValue(), option.getTextFieldLength());
                 textField.setHorizontalAlignment(JTextField.CENTER);
                 label = new JLabel(option.getDisplayableName());
                 label.setToolTipText(convertToHtml(option.getDescription()));
-		label.setLabelFor(textField);
-                label.addMouseListener(new MouseListener(){
+                label.setLabelFor(textField);
+                label.addMouseListener(new MouseAdapter() {
+                    @Override
                     public void mouseClicked(MouseEvent evt) {
                         if (textField.isEnabled()) {
                             textField.requestFocus();
                             textField.selectAll();
                         }
                     }
-                    public void mouseEntered(MouseEvent evt) {}
-                    public void mouseExited(MouseEvent evt) {}
-                    public void mousePressed(MouseEvent evt) {}
-                    public void mouseReleased(MouseEvent evt) {}                    
                 });
-                
-                if (!editable) {
-                    textField.setEnabled(false);
-                }
-                
+                textField.setEnabled(editable);
                 if (option.isLabelBeforeTextField()) {
-                    gbc.gridx = gbc.gridy = 0;
-                    add(label, gbc);
-                    gbc.gridx++;
-                    gbc.weightx = 1.0;
-                    add(textField, gbc);
+                    add(textField);
+                    add(label);
                 } else {
-                    gbc.gridx = gbc.gridy = 0;
-                    gbc.insets = new Insets(0,2,0,2);
-                    add(textField, gbc);
-                    gbc.gridx++;
-                    gbc.insets = new Insets(0,0,0,0);
-                    gbc.weightx = 1.0;
-                    add(label, gbc);
+                    add(Box.createHorizontalStrut(2));
+                    add(textField);
+                    add(label);
                 }
                 break;
         }
@@ -178,8 +127,8 @@ public class DialogOptionComponent extends JPanel implements
     public static String convertToHtml(String source) {
         StringBuffer sb = new StringBuffer();
         sb.append("<html>");
-        StringTokenizer tok =new StringTokenizer(source,"\n");
-        while ( tok.hasMoreTokens() ) {
+        StringTokenizer tok = new StringTokenizer(source, "\n");
+        while (tok.hasMoreTokens()) {
             sb.append(tok.nextToken());
             sb.append("<br>");
         }
@@ -289,8 +238,7 @@ public class DialogOptionComponent extends JPanel implements
     public boolean isDefaultValue() {
         switch (option.getType()) {
             case IOption.BOOLEAN:
-                return checkbox.isSelected() == ((Boolean) option.getDefault())
-                        .booleanValue();
+                return checkbox.isSelected() == ((Boolean) option.getDefault()).booleanValue();
             case IOption.CHOICE:
                 // Assume first choice is always default
                 return choice.getSelectedIndex() == 0;
@@ -302,12 +250,10 @@ public class DialogOptionComponent extends JPanel implements
     public void resetToDefault() {
         switch (option.getType()) {
             case IOption.BOOLEAN:
-                checkbox.setSelected(((Boolean) option.getDefault())
-                        .booleanValue());
+                checkbox.setSelected(((Boolean) option.getDefault()).booleanValue());
                 break;
             case IOption.CHOICE:
-                choice.setSelectedIndex(0); // Assume first choice is always
-                                            // default
+                choice.setSelectedIndex(0); // Assume first choice is always default
                 break;
             default:
                 textField.setText(String.valueOf(option.getDefault()));
@@ -315,11 +261,7 @@ public class DialogOptionComponent extends JPanel implements
         }
     }
 
-
-
-    /**
-     * Returns a new option, representing the option in it's changed state.
-     */
+    /** Returns a new option, representing the option in it's changed state. */
     public IBasicOption changedOption() {
         return new BasicOption(option.getName(), getValue());
     }
@@ -336,5 +278,4 @@ public class DialogOptionComponent extends JPanel implements
     public String toString() {
         return option.getDisplayableName();
     }
-
 }

--- a/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
@@ -83,14 +83,14 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
      */
     private JTextField txtSearch = new JTextField("");
     private WrappingButtonPanel panPassword = new WrappingButtonPanel();
-    private JLabel labPass = new JLabel(Messages.getString("GameOptionsDialog.Password")); //$NON-NLS-1$
+    private JLabel labPass = new JLabel(Messages.getString("GameOptionsDialog.Password")); 
     private JTextField texPass = new JTextField(15);
     private WrappingButtonPanel panButtons = new WrappingButtonPanel();
-    private JButton butSave = new JButton(Messages.getString("GameOptionsDialog.Save")); //$NON-NLS-1$
-    private JButton butLoad = new JButton(Messages.getString("GameOptionsDialog.Load")); //$NON-NLS-1$
-    private JButton butDefaults = new JButton(Messages.getString("GameOptionsDialog.Defaults")); //$NON-NLS-1$
-    private JButton butOkay = new JButton(Messages.getString("Okay")); //$NON-NLS-1$
-    private JButton butCancel = new JButton(Messages.getString("Cancel")); //$NON-NLS-1$
+    private JButton butSave = new JButton(Messages.getString("GameOptionsDialog.Save")); 
+    private JButton butLoad = new JButton(Messages.getString("GameOptionsDialog.Load")); 
+    private JButton butDefaults = new JButton(Messages.getString("GameOptionsDialog.Defaults")); 
+    private JButton butOkay = new JButton(Messages.getString("Okay")); 
+    private JButton butCancel = new JButton(Messages.getString("Cancel")); 
     private MMToggleButton butUnofficial = new MMToggleButton("Unofficial Opts");
     private MMToggleButton butLegacy = new MMToggleButton("Legacy Opts");
 
@@ -143,7 +143,7 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
      *            - the <code>ClientGUI</code> parent of this dialog.
      */
     public GameOptionsDialog(ClientGUI cg) {
-        super(cg.frame, Messages.getString("GameOptionsDialog.title"), true); //$NON-NLS-1$
+        super(cg.frame, Messages.getString("GameOptionsDialog.title"), true); 
         clientGui = cg;
         frame = cg.getFrame();
         init(frame, cg.getClient().getGame().getOptions());
@@ -360,77 +360,77 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
         groupPanel.add(optionComp);
         maxOptionWidth = Math.max(maxOptionWidth, optionComp.getPreferredSize().width);
 
-        if (OptionsConstants.INIT_INF_DEPLOY_EVEN.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || !(options.getOption(OptionsConstants.INIT_INF_MOVE_EVEN)).booleanValue() // $NON-NLS-1$
+        if (OptionsConstants.INIT_INF_DEPLOY_EVEN.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || !(options.getOption(OptionsConstants.INIT_INF_MOVE_EVEN)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (OptionsConstants.INIT_INF_MOVE_MULTI.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_EVEN)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_LATER)).booleanValue() // $NON-NLS-1$
+        } else if (OptionsConstants.INIT_INF_MOVE_MULTI.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_EVEN)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_LATER)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (OptionsConstants.INIT_INF_MOVE_EVEN.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_MULTI)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_LATER)).booleanValue() // $NON-NLS-1$
+        } else if (OptionsConstants.INIT_INF_MOVE_EVEN.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_MULTI)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_LATER)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (OptionsConstants.INIT_INF_MOVE_LATER.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_EVEN)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_MULTI)).booleanValue() // $NON-NLS-1$
+        } else if (OptionsConstants.INIT_INF_MOVE_LATER.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_EVEN)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_INF_MOVE_MULTI)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (OptionsConstants.INIT_PROTOS_MOVE_EVEN.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || !(options.getOption(OptionsConstants.INIT_PROTOS_MOVE_EVEN)).booleanValue() // $NON-NLS-1$
+        } else if (OptionsConstants.INIT_PROTOS_MOVE_EVEN.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || !(options.getOption(OptionsConstants.INIT_PROTOS_MOVE_EVEN)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (OptionsConstants.INIT_PROTOS_MOVE_MULTI.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_EVEN)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)).booleanValue() // $NON-NLS-1$
+        } else if (OptionsConstants.INIT_PROTOS_MOVE_MULTI.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_EVEN)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (OptionsConstants.INIT_PROTOS_MOVE_EVEN.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_MULTI)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)).booleanValue() // $NON-NLS-1$
+        } else if (OptionsConstants.INIT_PROTOS_MOVE_EVEN.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_MULTI)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_LATER)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (OptionsConstants.INIT_PROTOS_MOVE_LATER.equals(option.getName())) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_EVEN)).booleanValue() // $NON-NLS-1$
-                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_MULTI)).booleanValue() // $NON-NLS-1$
+        } else if (OptionsConstants.INIT_PROTOS_MOVE_LATER.equals(option.getName())) { 
+            if ((options.getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_EVEN)).booleanValue() 
+                    || (options.getOption(OptionsConstants.INIT_PROTOS_MOVE_MULTI)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (option.getName().equals(OptionsConstants.ADVGRNDMOV_TACOPS_FALLING_EXPANDED)) { // $NON-NLS-1$
-            if (!(options.getOption(OptionsConstants.ADVGRNDMOV_TACOPS_HULL_DOWN)).booleanValue() // $NON-NLS-1$
+        } else if (option.getName().equals(OptionsConstants.ADVGRNDMOV_TACOPS_FALLING_EXPANDED)) { 
+            if (!(options.getOption(OptionsConstants.ADVGRNDMOV_TACOPS_HULL_DOWN)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (option.getName().equals(OptionsConstants.ADVCOMBAT_TACOPS_LOS1)) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES)).booleanValue() // $NON-NLS-1$
+        } else if (option.getName().equals(OptionsConstants.ADVCOMBAT_TACOPS_LOS1)) { 
+            if ((options.getOption(OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (option.getName().equals(OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE)) { // $NON-NLS-1$
-            if (!options.getOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE).booleanValue() // $NON-NLS-1$
+        } else if (option.getName().equals(OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE)) { 
+            if (!options.getOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
-        } else if (option.getName().equals(OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES)) { // $NON-NLS-1$
-            if ((options.getOption(OptionsConstants.ADVCOMBAT_TACOPS_LOS1)).booleanValue() // $NON-NLS-1$
+        } else if (option.getName().equals(OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES)) { 
+            if ((options.getOption(OptionsConstants.ADVCOMBAT_TACOPS_LOS1)).booleanValue() 
                     || !editable) {
                 optionComp.setEditable(false);
             }
@@ -525,113 +525,113 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
             }
         }
 
-        if (OptionsConstants.INIT_INF_MOVE_EVEN.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.INIT_INF_DEPLOY_EVEN); // $NON-NLS-1$
+        if (OptionsConstants.INIT_INF_MOVE_EVEN.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.INIT_INF_DEPLOY_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_MULTI); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_MULTI); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_LATER); // $NON-NLS-1$
-            for (DialogOptionComponent comp_i : comps) {
-                comp_i.setEditable(!state);
-            }
-        }
-        if (OptionsConstants.INIT_INF_MOVE_MULTI.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_EVEN); // $NON-NLS-1$
-            for (DialogOptionComponent comp_i : comps) {
-                comp_i.setEditable(!state);
-            }
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_LATER); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_LATER); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
         }
-        if (OptionsConstants.INIT_INF_MOVE_LATER.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_EVEN); // $NON-NLS-1$
+        if (OptionsConstants.INIT_INF_MOVE_MULTI.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_MULTI); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_LATER); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
         }
-        if (OptionsConstants.INIT_PROTOS_MOVE_EVEN.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); // $NON-NLS-1$
+        if (OptionsConstants.INIT_INF_MOVE_LATER.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_EVEN); 
+            for (DialogOptionComponent comp_i : comps) {
+                comp_i.setEditable(!state);
+            }
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_MULTI); 
+            for (DialogOptionComponent comp_i : comps) {
+                comp_i.setEditable(!state);
+            }
+        }
+        if (OptionsConstants.INIT_PROTOS_MOVE_EVEN.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_MULTI); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_MULTI); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_LATER); // $NON-NLS-1$
-            for (DialogOptionComponent comp_i : comps) {
-                comp_i.setEditable(!state);
-            }
-        }
-        if (OptionsConstants.INIT_PROTOS_MOVE_MULTI.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); // $NON-NLS-1$
-            for (DialogOptionComponent comp_i : comps) {
-                comp_i.setEditable(!state);
-            }
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_LATER); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_LATER); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
         }
-        if (OptionsConstants.INIT_PROTOS_MOVE_LATER.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); // $NON-NLS-1$
+        if (OptionsConstants.INIT_PROTOS_MOVE_MULTI.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_MULTI); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_LATER); 
+            for (DialogOptionComponent comp_i : comps) {
+                comp_i.setEditable(!state);
+            }
+        }
+        if (OptionsConstants.INIT_PROTOS_MOVE_LATER.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); 
+            for (DialogOptionComponent comp_i : comps) {
+                comp_i.setEditable(!state);
+            }
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_MULTI); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
             }
         }
         if (option.getName().equals(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)) {
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(false);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_MULTI); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_MULTI); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_LATER); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_PROTOS_MOVE_LATER); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_INF_DEPLOY_EVEN); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_INF_DEPLOY_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(false);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_EVEN); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_EVEN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_MULTI); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_MULTI); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_LATER); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.INIT_INF_MOVE_LATER); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
@@ -655,22 +655,22 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
                 comp_i.setSelected(false);
             }
         }
-        if ("vacuum".equals(option.getName())) { //$NON-NLS-1$
-            comps = optionComps.get("fire"); //$NON-NLS-1$
+        if ("vacuum".equals(option.getName())) { 
+            comps = optionComps.get("fire"); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
             }
         }
-        if (OptionsConstants.ADVGRNDMOV_TACOPS_HULL_DOWN.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.ADVGRNDMOV_TACOPS_FALLING_EXPANDED); // $NON-NLS-1$
+        if (OptionsConstants.ADVGRNDMOV_TACOPS_HULL_DOWN.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.ADVGRNDMOV_TACOPS_FALLING_EXPANDED); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.setSelected(false);
             }
         }
-        if (OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.ADVCOMBAT_TACOPS_LOS1); // $NON-NLS-1$
+        if (OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.ADVCOMBAT_TACOPS_LOS1); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
@@ -683,41 +683,41 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
                 comp_i.setSelected(false);
             }
         }
-        if (OptionsConstants.ADVCOMBAT_TACOPS_LOS1.equals(option.getName())) { // $NON-NLS-1$
-            comps = optionComps.get(OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES); // $NON-NLS-1$
+        if (OptionsConstants.ADVCOMBAT_TACOPS_LOS1.equals(option.getName())) { 
+            comps = optionComps.get(OptionsConstants.ADVCOMBAT_TACOPS_DEAD_ZONES); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(!state);
                 comp_i.setSelected(false);
             }
         }
         if (option.getName().equals(OptionsConstants.ADVCOMBAT_TACOPS_RAPID_AC)) {
-            comps = optionComps.get(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.setSelected(false);
             }
         }
         if (option.getName().equals(OptionsConstants.ADVCOMBAT_VEHICLES_THRESHOLD)) {
-            comps = optionComps.get(OptionsConstants.ADVCOMBAT_VEHICLES_THRESHOLD_VARIABLE); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.ADVCOMBAT_VEHICLES_THRESHOLD_VARIABLE); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.setSelected(false);
             }
-            comps = optionComps.get(OptionsConstants.ADVCOMBAT_VEHICLES_THRESHOLD_DIVISOR); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.ADVCOMBAT_VEHICLES_THRESHOLD_DIVISOR); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.resetToDefault();
             }
         }
         if (option.getName().equals(OptionsConstants.RPG_MANUAL_SHUTDOWN)) {
-            comps = optionComps.get(OptionsConstants.RPG_BEGIN_SHUTDOWN); //$NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.RPG_BEGIN_SHUTDOWN); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.setSelected(false);
             }
         }
         if (option.getName().equals(OptionsConstants.ADVANCED_ALTERNATE_MASC)) {
-            comps = optionComps.get(OptionsConstants.ADVANCED_ALTERNATE_MASC_ENHANCED); // $NON-NLS-1$
+            comps = optionComps.get(OptionsConstants.ADVANCED_ALTERNATE_MASC_ENHANCED); 
             for (DialogOptionComponent comp_i : comps) {
                 comp_i.setEditable(state);
                 comp_i.setSelected(false);
@@ -842,10 +842,8 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
     }
 
     private File selectGameOptionsFile(boolean saveDialog) {
-        JFileChooser fc = new JFileChooser("mmconf"); //$NON-NLS-1$
+        JFileChooser fc = new JFileChooser("mmconf"); 
         fc.setLocation(getLocation().x + 150, getLocation().y + 100);
-        // fc.setDialogTitle(Messages.getString(
-        // "GameOptionsDialog.FileChooser.title")); //$NON-NLS-1$
         fc.setFileFilter(new FileFilter() {
             @Override
             public boolean accept(File dir) {
@@ -856,11 +854,7 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
                         DocumentBuilder builder = MegaMekXmlUtil.newSafeDocumentBuilder();
                         Document doc = builder.parse(dir);
                         NodeList listOfComponents = doc.getElementsByTagName("options");
-                        if (listOfComponents.getLength() > 0) {
-                            return true;
-                        } else {
-                            return false;
-                        }
+                        return listOfComponents.getLength() > 0;
                     } catch (Exception e) {
                         return false;
                     }
@@ -871,15 +865,11 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
 
             @Override
             public String getDescription() {
-                return "GameOptions"; //$NON-NLS-1$
+                return "GameOptions"; 
             }
         });
         int returnVal;
-        if (saveDialog) {
-            returnVal = fc.showSaveDialog(this);
-        } else {
-            returnVal = fc.showOpenDialog(this);
-        }
+        returnVal = saveDialog ? fc.showSaveDialog(this) : fc.showOpenDialog(this);
         if ((returnVal != JFileChooser.APPROVE_OPTION) || (fc.getSelectedFile() == null)) {
             return null;
         }

--- a/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
@@ -17,23 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package megamek.client.ui.swing;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
 import java.io.File;
 import java.util.*;
 
 import javax.swing.*;
-import javax.swing.ScrollPaneConstants;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.filechooser.FileFilter;
@@ -42,13 +32,13 @@ import javax.xml.parsers.DocumentBuilder;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
-import megamek.client.ui.GBC;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.dialog.MMConfirmDialog;
 import megamek.common.*;
 import megamek.common.options.*;
 import megamek.common.weapons.bayweapons.CapitalMissileBayWeapon;
 import megamek.utils.MegaMekXmlUtil;
+import static megamek.client.ui.swing.util.UIUtil.*;
 import static megamek.client.ui.Messages.*;
 
 /**
@@ -87,15 +77,15 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
     /**
      * Panel that holds all of the options found via search
      */
-    private JPanel panSearchOptions;
+    private JPanel panSearchOptions = new JPanel();
     /**
      * Text field that contains text to search on
      */
-    private JTextField txtSearch;
-    private JPanel panPassword = new JPanel();
+    private JTextField txtSearch = new JTextField("");
+    private WrappingButtonPanel panPassword = new WrappingButtonPanel();
     private JLabel labPass = new JLabel(Messages.getString("GameOptionsDialog.Password")); //$NON-NLS-1$
     private JTextField texPass = new JTextField(15);
-    private JPanel panButtons = new JPanel();
+    private WrappingButtonPanel panButtons = new WrappingButtonPanel();
     private JButton butSave = new JButton(Messages.getString("GameOptionsDialog.Save")); //$NON-NLS-1$
     private JButton butLoad = new JButton(Messages.getString("GameOptionsDialog.Load")); //$NON-NLS-1$
     private JButton butDefaults = new JButton(Messages.getString("GameOptionsDialog.Defaults")); //$NON-NLS-1$
@@ -124,24 +114,18 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
      */
     private void init(JFrame frame, GameOptions options) {
         this.options = options;
-
+        
         setupButtons();
         setupPassword();
-        JPanel mainPanel = new JPanel(new GridBagLayout());
 
-        // layout
-        mainPanel.add(panOptions, GBC.eol().fill(GridBagConstraints.BOTH).insets(5, 5, 5, 5));
-        mainPanel.add(panPassword, GBC.eol().fill(GridBagConstraints.HORIZONTAL).insets(5, 5, 5, 5));
-        mainPanel.add(panButtons, GBC.eol().anchor(GridBagConstraints.CENTER));
-
-        getContentPane().add(mainPanel);
-
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                setVisible(false);
-            }
-        });
+        var mainPanel = new JPanel();
+        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.PAGE_AXIS));
+        mainPanel.add(panOptions);
+        mainPanel.add(Box.createVerticalStrut(5));
+        mainPanel.add(panPassword);
+        mainPanel.add(Box.createVerticalStrut(5));
+        mainPanel.add(panButtons);
+        add(mainPanel);
 
         pack();
         GUIPreferences guip = GUIPreferences.getInstance();
@@ -150,11 +134,6 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
         setSize(width, height);
         setResizable(true);
         setLocationRelativeTo(frame);
-        Dimension size = new Dimension((getSize().width * 40) / 100, (getSize().height * 59) / 100);
-        panOptions.setPreferredSize(size);
-        panOptions.setMinimumSize(size);
-        panOptions.setMaximumSize(size);
-
     }
 
     /**
@@ -172,7 +151,6 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
 
     public GameOptionsDialog(JFrame jf, GameOptions options, boolean shouldSave) {
         super(jf, Messages.getString("GameOptionsDialog.title"), true);
-        // $NON-NLS-1$
         performSave = shouldSave;
         frame = jf;
         init(frame, options);
@@ -252,11 +230,6 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
         }
 
         addSearchPanel();
-
-        // Make the width accomadate the longest game option label
-        // without needing to scroll horizontally.
-        setSize(Math.max(getSize().width, maxOptionWidth + 30), Math.max(getSize().height, 400));
-
         validate();
     }
     
@@ -331,6 +304,7 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
     private JPanel addGroup(IOptionGroup group) {
         JPanel groupPanel = new JPanel();
         JScrollPane scrOptions = new JScrollPane(groupPanel);
+        scrOptions.getVerticalScrollBar().setUnitIncrement(16);
         groupPanel.setLayout(new BoxLayout(groupPanel, BoxLayout.Y_AXIS));
         scrOptions.setAutoscrolls(true);
         scrOptions.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
@@ -343,15 +317,16 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
     private void addSearchPanel() {
         JPanel panSearch = new JPanel();
         JScrollPane scrOptions = new JScrollPane(panSearch);
+        scrOptions.getVerticalScrollBar().setUnitIncrement(16);
+        panSearch.setLayout(new BoxLayout(panSearch, BoxLayout.PAGE_AXIS));
         scrOptions.setAutoscrolls(true);
         scrOptions.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
         scrOptions.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
         // Panel for holding the label and text field for searching
-        JPanel panText = new JPanel();
+        var panSearchBar = new FixedYPanel();
         JLabel lblSearch = new JLabel(Messages.getString("GameOptionsDialog.Search") + ":");
-        txtSearch = new JTextField("");
-	lblSearch.setLabelFor(txtSearch);
+        lblSearch.setLabelFor(txtSearch);
         lblSearch.setToolTipText(Messages.getString("GameOptionsDialog.SearchToolTip"));
         txtSearch.setToolTipText(Messages.getString("GameOptionsDialog.SearchToolTip"));
         txtSearch.getDocument().addDocumentListener(new DocumentListener() {
@@ -368,34 +343,11 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
             }
         });
 
-        panText.setLayout(new GridBagLayout());
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.gridx = gbc.gridy = 0;
-        gbc.insets = new Insets(10, 5, 15, 5);
-        gbc.anchor = GridBagConstraints.NORTHWEST;
-        gbc.fill = GridBagConstraints.NONE;
-        panText.add(lblSearch, gbc);
-        gbc.gridx++;
-        gbc.weightx = 0.7;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        panText.add(txtSearch, gbc);
-
-        panSearchOptions = new JPanel();
-        panSearchOptions.setLayout(new BoxLayout(panSearchOptions, BoxLayout.Y_AXIS));
-
-        panSearch.setLayout(new GridBagLayout());
-        gbc.gridx = gbc.gridy = 0;
-        gbc.insets = new Insets(0, 0, 0, 0);
-        gbc.anchor = GridBagConstraints.NORTHWEST;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        gbc.weightx = 0.7;
-        panSearch.add(panText, gbc);
-        gbc.gridy++;
-        gbc.weighty = 0.7;
-
-        gbc.fill = GridBagConstraints.BOTH;
-        panSearch.add(panSearchOptions, gbc);
-
+        panSearchOptions.setLayout(new BoxLayout(panSearchOptions, BoxLayout.PAGE_AXIS));
+        panSearchBar.add(lblSearch);
+        panSearchBar.add(txtSearch);
+        panSearch.add(panSearchBar);
+        panSearch.add(panSearchOptions);
         panOptions.addTab(Messages.getString("GameOptionsDialog.Search"), scrOptions);
     }
 
@@ -805,10 +757,9 @@ public class GameOptionsDialog extends JDialog implements ActionListener, Dialog
     }
 
     private void setupPassword() {
-        panPassword.setLayout(new BorderLayout());
         labPass.setLabelFor(texPass);
-        panPassword.add(labPass, BorderLayout.WEST);
-        panPassword.add(texPass, BorderLayout.CENTER);
+        panPassword.add(labPass);
+        panPassword.add(texPass);
     }
 
     public void actionPerformed(ActionEvent e) {

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -632,6 +632,39 @@ public final class UIUtil {
     }
     
     /**
+     * This is a specialized JPanel for use with a button bar at the bottom
+     * of a dialog for when it's possible that the button bar has to wrap (is
+     * wider than the dialog and needs to use two or more rows for the buttons).
+     * With a normal JPanel the wrapped buttons just disappear. 
+     * This Panel tries to detect when wrapping occurs and then extends vertically.
+     * Note that it will only extend to two rows, not more. But if three rows of 
+     * buttons are used, this will be very obvious.
+     * The native FlowLayout should be kept for the buttons. 
+     */
+    public static class WrappingButtonPanel extends JPanel {
+        private static final long serialVersionUID = -6966176665047676553L;
+
+        @Override
+        public Dimension getPreferredSize() {
+            int height = super.getPreferredSize().height; 
+            if (getSize().width < super.getPreferredSize().width) {
+                height = height * 2;
+            }
+            return new Dimension(super.getPreferredSize().width, height);
+        }
+        
+        @Override
+        public Dimension getMinimumSize() {
+            return new Dimension(super.getMinimumSize().width, getPreferredSize().height);
+        }
+        
+        @Override
+        public Dimension getMaximumSize() {
+            return new Dimension(super.getMaximumSize().width, getPreferredSize().height);
+        }
+    };
+    
+    /**
      * Returns a single menu item with the given text, the given command string
      * cmd, the given enabled state, and assigned the given listener.
      */


### PR DESCRIPTION
Updates the layouting in the GameOptions Dialog so that the buttons don't just disappear when the dialog is too small. Also some other updates, mostly code-side, no functional changes. Also makes the game options not stretch in the dialog but stay at the top.
The second commit only contains //NON_NLS removal and two ternary operators.

Resolves #2820 

![image](https://user-images.githubusercontent.com/17069663/117323010-ca722780-ae8e-11eb-9c92-36aca75384f0.png)
