### PR TITLE
LobbyMekCellFormatter NPE

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
 package megamek.client.ui.swing.lobby;
 
 import static megamek.client.ui.Messages.getString;
@@ -6,7 +24,7 @@ import static megamek.client.ui.swing.util.UIUtil.*;
 
 import java.awt.Color;
 import java.text.MessageFormat;
-import java.util.ArrayList;
+import java.util.List;
 
 import megamek.client.Client;
 import megamek.client.ui.Messages;
@@ -685,7 +703,7 @@ class LobbyMekCellFormatter {
         color = addGray(color, 128).brighter();
 
         StringBuilder result = new StringBuilder("<HTML><NOBR>");
-        result.append(guiScaledFontHTML(color, size)).append("");
+        result.append(guiScaledFontHTML(color, size));
         
         // A top-level / subforce special char
         if (force.isTopLevel()) {
@@ -713,10 +731,10 @@ class LobbyMekCellFormatter {
         }
         
         // BV
-        ArrayList<Entity> fullEntities = lobby.game().getForces().getFullEntities(force);
+        List<Entity> fullEntities = lobby.game().getForces().getFullEntities(force);
         result.append(guiScaledFontHTML(color, size));
         result.append(DOT_SPACER);
-        int totalBv = fullEntities.stream().filter(e -> !e.isPartOfFighterSquadron()).mapToInt(e -> e.calculateBattleValue()).sum();
+        int totalBv = fullEntities.stream().filter(e -> !e.isPartOfFighterSquadron()).mapToInt(Entity::calculateBattleValue).sum();
         if (totalBv > 0) {
             result.append("BV ").append(String.format("%,d", totalBv));
             // Unit Type

--- a/megamek/src/megamek/common/force/Forces.java
+++ b/megamek/src/megamek/common/force/Forces.java
@@ -35,6 +35,8 @@ import megamek.MegaMek;
 import megamek.common.Entity;
 import megamek.common.IGame;
 import megamek.common.IPlayer;
+import megamek.common.annotations.Nullable;
+
 import static megamek.common.force.Force.*;
 import static java.util.stream.Collectors.*;
 
@@ -49,7 +51,7 @@ public final class Forces implements Serializable {
 
     private static final long serialVersionUID = -1382468145554363945L;
     
-    private HashMap<Integer, Force> forces = new HashMap<Integer, Force>();
+    private HashMap<Integer, Force> forces = new HashMap<>();
     private transient IGame game;
     
     public Forces(IGame g) {
@@ -723,20 +725,27 @@ public final class Forces implements Serializable {
     
     @Override
     public String toString() {
-        List<String> forceStrings = forces.values().stream().map(f -> f.toString()).collect(toList());
+        List<String> forceStrings = forces.values().stream().map(Force::toString).collect(toList());
         return String.join("\n", forceStrings);
     }
     
     /** 
      * Returns a list of all entities of the given force and all its subforces to any depth. 
      */
-    public ArrayList<Entity> getFullEntities(Force force) {
-        ArrayList<Entity> result = new ArrayList<>();
+    public List<Entity> getFullEntities(final @Nullable Force force) {
+        if (force == null) {
+            return new ArrayList<>();
+        }
+
+        final List<Entity> result = new ArrayList<>();
         if (contains(force)) {
-            for (int entityId: force.getEntities()) {
-                result.add(game.getEntity(entityId));
+            for (int entityId : force.getEntities()) {
+                final Entity entity = game.getEntity(entityId);
+                if (entity != null) {
+                    result.add(entity);
+                }
             }
-            for (int subForceId: force.getSubForces()) {
+            for (int subForceId : force.getSubForces()) {
                 result.addAll(getFullEntities(forces.get(subForceId)));
             }
         }


### PR DESCRIPTION
This prevents the list returned by getFullEntities from containing null entities, and does a few things to simplify the code. Was found in https://github.com/MegaMek/mekhq/issues/2598