### PR TITLE
Fixed Board Editor Level Up/Dn and left click dragging to work like .48  #2856

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -446,7 +446,10 @@ public class BoardEditor extends JComponent
                         }
                     }
                     // ------- End Raise/Lower Terrain
-                } else if (isLMB) {
+                } else if (isLMB || (b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) != 0) {
+                    // 'isLMB' is true if a button 1 is associated to a click or release but not while dragging.
+                    // The left button down mask is checked because we could be dragging.
+                    
                     // Normal texture paint
                     if (isALT) { // ALT-Click
                         setCurrentHex(board.getHex(b.getCoords()));

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -409,10 +409,10 @@ public class BoardEditor extends JComponent
                 }
                 lastClicked = c;
                 bv.cursor(c);
-                boolean isALT = (b.getModifiers() & ActionEvent.ALT_MASK) != 0;
-                boolean isSHIFT = (b.getModifiers() & ActionEvent.SHIFT_MASK) != 0;
-                boolean isCTRL = (b.getModifiers() & ActionEvent.CTRL_MASK) != 0;
-                boolean isLMB = (b.getModifiers() & InputEvent.BUTTON1_DOWN_MASK) != 0;
+                boolean isALT = (b.getModifiers() & InputEvent.ALT_DOWN_MASK) != 0;
+                boolean isSHIFT = (b.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0;
+                boolean isCTRL = (b.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0;
+                boolean isLMB = (b.getButton() == MouseEvent.BUTTON1);
 
                 // Raise/Lower Terrain is selected
                 if (buttonUpDn.isSelected()) {


### PR DESCRIPTION
The Board Editor was using ActionEvent Ctrl/Alt/Shift detection but was comparing to the board event modifiers now supplied by the Java 11 Key events.  This PR compares against the correct masks since #2800.  

Also, since the left mouse event `getButton()` doesn't apply now to interim 'drag' events, we also have to check the if the button down mask is applied while dragging in addition to the `getButton()` in case it's a mouse-up/click event.

This PR restores the left mouse click/drag functionality while editing a board to work the same way as 0.48.0

This fixes issue: #2856 