### PR TITLE
safety check for WeaponAttackAction.toHit() method

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -334,6 +334,11 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             MegaMek.getLogger().error("Trying to make a weapon attack with " + weapon.getName() + " which has type " + type.getName());
             return new ToHitData(TargetRoll.AUTOMATIC_FAIL, Messages.getString("WeaponAttackAction.NotAWeapon"));
         }
+        
+        if (target == null) {
+            MegaMek.getLogger().error(attackerId + "Attempting to attack null target");
+            return new ToHitData(TargetRoll.AUTOMATIC_FAIL, Messages.getString("MovementDisplay.NoTarget"));
+        }
 
         final WeaponType wtype = (WeaponType) type;
 


### PR DESCRIPTION
Addresses, in a "prevent the bot from crashing" manner, one of the exceptions reported in #2859, although not the blank phase report issue itself.