### PR TITLE
Fix for #2776 MM Scenario with bot starts inconsistently.

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -924,7 +924,8 @@ public class Server implements Runnable {
             if (game.phaseHasTurns(game.getPhase()) && game.hasMoreTurns()) {
                 send(connId, createTurnVectorPacket());
                 send(connId, createTurnIndexPacket(connId));
-            } else if (game.getPhase() != IGame.Phase.PHASE_LOUNGE) {
+            } else if ((game.getPhase() != IGame.Phase.PHASE_LOUNGE) 
+                    && (game.getPhase() != IGame.Phase.PHASE_STARTING_SCENARIO)) {
                 endCurrentPhase();
             }
 


### PR DESCRIPTION
When attempting to load a game from a MegaMek Scenario (.mss), MegaMek would often get stuck on the phase report prior to going to the 'Deployment' phase.  Tracing into this I found a race condition going on when client threads would execute the `Server::receivePlayerName()` method which calls `Server::sendCurrentInfo()`.  'sendCurrentInfo' would attempt to call `endCurrentPhase()`.  Actually all the configured players/bots would try to do this simultaneously.  When doing so, the game state gets trampled all over before the clients are initialized properly.  

The solution here is to not call `endCurrentPhase()` in the `sendCurrentInfo()` method when starting in the STARTING_SCENARIO phase much the same way as we don't if we are in the 'LOUNGE' phase.  Once all players / bots are initialized and "done" the "Packet Pump" takes over as normal advancing the phases in a single thread as it was intended.

With this small fix, launching MegaMek from .mms files works as intended and starts the player in the Initiative Phase report where they can observe the phase 1 initiative order, BV values and click 'done' before going to the deployment phase.

This PR fixes #2776 