### PR TITLE
set access level for property needed by MekHQ

### DIFF
--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -148,7 +148,7 @@ public class MULParser {
     private static final String DEPLOYMENT_ZONE = "deploymentZone";
     private static final String NEVER_DEPLOYED = "neverDeployed";
     private static final String VELOCITY = "velocity";
-    private static final String ALTITUDE = "altitude";
+    public static final String ALTITUDE = "altitude";
     private static final String AUTOEJECT = "autoeject";
     private static final String CONDEJECTAMMO = "condejectammo";
     private static final String CONDEJECTENGINE = "condejectengine";


### PR DESCRIPTION
In the future, I'd like to replace MekHQXmlUtil.writeEntityToXmlString with a call to its MegaMek counterpart so we don't have to maintain two separate implementations of the same method, but for now, this will have to do.