### PR TITLE
Report Messages Cleanup

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -1,23 +1,23 @@
 ###############################################################################
-#This is the English server messages file for MegaMek.  Any line that
-#of the lines is the message index (this must match the index in the
-#code) followed by a double-colon and then the message itself.  The
-#message may contain any of the following tags:
+# This is the English server messages file for MegaMek. Any line that
+# of the lines is the message index (this must match the index in the
+# code) followed by a double-colon and then the message itself. The
+# message may contain any of the following tags:
 #
-#<data> - the code will substitute the relevant info for each of these tags
-#<list> - the code will substitute a list of values for this tag
-#<msg:N1,N2> - the code will substitute either message N1 or N2 for this tag
-#<newline> - the code will substitute a newline character for this tag
+# <data> - the code will substitute the relevant info for each of these tags
+# <list> - the code will substitute a list of values for this tag
+# <msg:N1,N2> - the code will substitute either message N1 or N2 for this tag
+# <newline> - the code will substitute a newline character for this tag
 #
-#At this time, only standalone tags are supported (no <tag>stuff in
-#middle</tag>).  Unrecognized tags (including literal "<" and ">" characters)
-#will be printed as-is.
+# At this time, only standalone tags are supported (no <tag>stuff in
+# middle</tag>). Unrecognized tags (including literal "<" and ">" characters)
+# will be printed as-is.
 ###############################################################################
 
-#0 through 999 -- System messages?  (reserved at the moment)
+# 0 through 999 -- System messages? (reserved at the moment)
 
 
-#1000's -- Initiative phase, Offboard phase, and other assorted stuff.
+# 1000's -- Initiative phase, Offboard phase, and other assorted stuff.
 1000=<B>Initiative Phase for Round #<data></B>
 1005=<B>Initiative Phase for Deployment</B>
 1010=<B>Initiative Phase for Deployment for Round #<data></B>
@@ -79,7 +79,7 @@
 2110=<data>.
 2111=<data> in Hex <data> is entered and has unknown basement, rolls <data>: <data> basement.
 2112=Basement of <data> in Hex <data> collapses.
-2115=<newline><data> (<data>) passes through a fire.  It will generate <data> more heat this round.
+2115=<newline><data> (<data>) passes through a fire. It will generate <data> more heat this round.
 2118=<newline><data> (<data>) breaks through ice on a 6, rolls <data>.
 2119=<newline><data> (<data>) breaks through ice on a 4, rolls <data>.
 2120=<data> discovers a minefield.
@@ -97,7 +97,7 @@
 2145=<newline><data> can't stand the fire's heat and drops off.
 2150=<data> <B>hits</B> a mine in hex <data>.
 2151=A unit enters the <data> minefield in hex <data>, needs <data>+, rolls <data>:
-2152=A minesweeper attempts to clear the <data> minefield in hex <data>, needs 6+, rolls <data>:  
+2152=A minesweeper attempts to clear the <data> minefield in hex <data>, needs 6+, rolls <data>: 
 2155=<newline><data> <B>hits</B> an inferno mine in hex <data>.
 2156=<newline><data> sets off a vibrabomb in hex <data>.
 2157=<data> evades a vibrabomb attack.
@@ -126,7 +126,7 @@
 2210=, causing an accidental fall from above onto <data> (<data>).
 2212=The accidental fall from above is an automatic hit (<data>).
 2213=The accidental fall from above is an automatic miss (<data>).
-2215=Collision occurs on a <data> or greater.  Rolls <data>, 
+2215=Collision occurs on a <data> or greater. Rolls <data>, 
 2216=collides!
 2217=<font color='808080'><B>misses</B></font>.
 2220=<data> (<data>) takes <data> damage from the collision.
@@ -140,7 +140,7 @@
 2251=Minefield in hex <data> has density reduced by <data>!
 2252=Minefield in hex <data> cleared!
 2253=<data> is protected from the Minefield Clearance munitions and takes no damage
-2255=<data> needs <data>, rolls <data>: minefield is accidently detonated!
+2255=<data> needs <data>, rolls <data>: minefield is accidentally detonated!
 2260=<data> needs <data>, rolls <data>: minefield clearance fails.
 2265=<data> is damaged in a minefield accident.
 2270=<font color='008000'><B>hits</B></font>!
@@ -154,7 +154,7 @@
 2302=<B>falls</B>.
 2303=\ Engine stalled!
 2304=\ Engine restarted!
-2305=But, since the 'mech is making a death from above attack, damage will be dealt during the physical phase.
+2305=But, since the 'Mech is making a death from above attack, damage will be dealt during the physical phase.
 2306=); needs <data>, rolls <data> <font color='C00000'>Fumble!</font>: <msg:2301,2302>
 2310=<data> (<data>) falls on its <data>, suffering <data> damage.
 2315=<data> (<data>) falls on its <data>, suffering <data> damage when hitting the water surface and <data> when hitting the ground.
@@ -172,7 +172,7 @@
 2352=<data> (<data>) steps <msg:2354,2353> out of the domino effect, into hex <data>
 2353=forward
 2354=backward
-2355=Collision occurs on a <data> or greater.  Rolls <data>, <msg:2356,2357>
+2355=Collision occurs on a <data> or greater. Rolls <data>, <msg:2356,2357>
 2356=<font color='008000'><B>hits</B></font>!
 2357=<font color='808080'><B>misses</B></font>.
 2358=<data> (<data>) chooses not to step out of the domino effect!
@@ -182,7 +182,7 @@
 2370=Needs <data>, rolls <data> : <msg:2371,2372>
 2371=succeeds.
 2372=fails!
-2373=<data> (<data>) used Protomech myomer booster, must roll 3+ to avoid pilot damage, rolls <data>: <msg:2371,2372>
+2373=<data> (<data>) used ProtoMech myomer booster, must roll 3+ to avoid pilot damage, rolls <data>: <msg:2371,2372>
 2375=<data> collapses due to heavy load.
 2376=Top floor of <data> collapses due to heavy load.
 2378=<data> (<data>) descends one level.
@@ -205,9 +205,9 @@
 2426=<data> (<data>) automatically fails to avoid the skid (<data>).
 2440=The swamp becomes quicksand!
 2445=<data> (<data>) sinks into the quicksand.
-2450=<data> (<data>) converts to mech mode.
+2450=<data> (<data>) converts to 'Mech mode.
 2451=<data> (<data>) converts to vehicle mode.
-2452=<data> (<data>) converts to airmech mode.
+2452=<data> (<data>) converts to AirMech mode.
 2453=<data> (<data>) converts to fighter mode.
 2454=<data> (<data>) failed to convert due to fall.
 2455=<data> (<data>) switches to <msg:2456,2457> movement.
@@ -337,16 +337,16 @@
 3241=The <data> survived the AMS fire (rolled <data>).
 3245=<font color='008000'><B>hits</B></font>, but doesn't do anything.
 3249=<font color='008000'><B>hits</B></font>, but <data> is behind cover.
-3250=<font color='008000'><B>hits</B></font> <data>.  Pod attached to <data>.
-3251=<font color='008000'><B>hits</B></font> <data>.  ECM Pod attached to <data>.
-3252=<font color='008000'><B>hits</B></font> <data>.  Haywire Pod attached to <data>.
-3253=<font color='008000'><B>hits</B></font> <data>.  Nemesis Pod attached to <data>.
-3254=<font color='008000'><B>hits</B></font> <data>.  Homing Pod attached to <data>.
+3250=<font color='008000'><B>hits</B></font> <data>. Pod attached to <data>.
+3251=<font color='008000'><B>hits</B></font> <data>. ECM Pod attached to <data>.
+3252=<font color='008000'><B>hits</B></font> <data>. Haywire Pod attached to <data>.
+3253=<font color='008000'><B>hits</B></font> <data>. Nemesis Pod attached to <data>.
+3254=<font color='008000'><B>hits</B></font> <data>. Homing Pod attached to <data>.
 3255=<font color='008000'><B>hits</B></font> and may clear minefields:
 3260=<newline><font color='008000'><B>hits</B></font>, but fails to clear it.
 3265=succeeds, but the defender is already swarmed by another unit.
 3270=succeeds, but the defender was destroyed by weapons fire.
-3275=succeeds!  Defender swarmed.
+3275=succeeds! Defender swarmed.
 3285=<data> Inferno rounds added to hex <data>.
 3290=<data> Inferno rounds start fire in hex <data>.
 3295=<data><data>hit,<newline>        but 
@@ -377,8 +377,8 @@
 3361=<B>Systems overheating. Point defenses shutting down!</B>
 3362=Point defenses engaging!
 3365=\ Attack deals zero damage.
-3366=Point Defense engaged (Distributing <data> damage as cluster modifier to bay attack)!  
-3367=Point Defense engaged (Distributing <data> damage as cluster modifier to missile attack)!  
+3366=Point Defense engaged (Distributing <data> damage as cluster modifier to bay attack)! 
+3367=Point Defense engaged (Distributing <data> damage as cluster modifier to missile attack)! 
 3370=<font color='008000'><B>hits</B></font> with <data> inferno missile(s).
 3371=<data> (<data>) is hit by incendiary grenades!
 3372=<data> is hit by incendiary grenades!
@@ -494,7 +494,7 @@
 4055=Kick (<data>) at <data>
 4060=, but the kick is impossible (<data>).
 4065=, the kick is an automatic hit (<data>), 
-4070=Protomech frenzy attack at <data>
+4070=ProtoMech frenzy attack at <data>
 4075=, but the attack is impossible (<data>).
 4080=, the attack is an automatic hit (<data>), 
 4085=Brush Off <data> with <data>
@@ -510,14 +510,14 @@
 4135=<newline><font color='008000'><B>hits</B></font> <data>
 4140=<data> (<data>) must make a piloting skill check (thrashing at infantry).
 4145=<data> attack on <data>
-4146=Vibroclaw attack at <data>
-4147=, but the vibroclaw attack is impossible (<data>).
+4146=Vibro-claw attack at <data>
+4147=, but the vibro-claw attack is impossible (<data>).
 4148=\<font color='008000'><B>hits</B></font> and deals <data> points of damage in (<data>) point clusters.
 4149=\<font color='008000'><B>hits</B></font> and deals <data> points of damage.
 4150=<font color='C00000'>The <data> breaks.</font>
 4155=Pushing <data> (<data>)
 4160=, but the push is impossible (<data>).
-4165=succeeds: but <data> (<data>)  pushed back!.<newline><newline>Physical attacks for <data> (<data><newline>    Pushing <data> (<data>); needs <data>, rolls <data> : succeeds: but <data> (<data>)  pushed back!.
+4165=succeeds: but <data> (<data>) pushed back!.<newline><newline>Physical attacks for <data> (<data><newline>    Pushing <data> (<data>); needs <data>, rolls <data> : succeeds: but <data> (<data>) pushed back!.
 4166=succeeds, but <data> (<data>) tried to push back.<newline>    Pushing <data> (<data>); needs <data>, rolls <data> : failed
 4170=succeeds: target is pushed
 4175=\ into hex <data>.
@@ -537,7 +537,7 @@
 4220=, but the charge is impossible (<data>) : 
 4222=, but the ram is impossible (<data>) : 
 4225=, the charge is an automatic hit (<data>),
-4226=The Telemissile attack is an automatic hit (<data>), 
+4226=The tele-operated missile attack is an automatic hit (<data>), 
 4227=, the ram is an automatic hit (<data>), 
 4230=Defender takes <data> damage <data>.
 4235=<data> (<data>) suffers no damage.
@@ -586,7 +586,7 @@
 5015=Adding 10 heat from Stealth Armor...
 5016=Adding 10 heat from Void-Signature System...
 5017=Adding 10 heat from Null-Signature System...
-5018=Adding <data> heat from active vibroblade(s)...
+5018=Adding <data> heat from active vibro-blade(s)...
 5019=Adding <data> heat from Charged Capacitor...
 5020=Adding <data> heat due to extreme temperatures...
 5021=Adding <data> heat due to flawed cooling system...
@@ -613,7 +613,7 @@
 5066=avoids successfully!
 5067=fails to avoid explosion.
 5068=Ammo explosion damages nearby units.
-5070=<data> (<data>) has <data> or higher heat and damaged life support.  Mechwarrior takes <data> damage.
+5070=<data> (<data>) has <data> or higher heat and damaged life support. MechWarrior takes <data> damage.
 5075=<data> (<data>) needs a <data> to avoid pilot damage, rolls a <data>, <msg:5076,5077>
 5076=\ succeeds.
 5077=\ fails and takes a hit!
@@ -715,7 +715,7 @@
 6015=<newline><data> (<data>) is in a <data> and cannot survive there!!!.
 6016=<newline><data> (<data>) is in low atmosphere and cannot fly!! Goodbye!
 6017=<newline><data> (<data>) shouldn't be in space!! Goodbye!
-6020=<newline><data> (<data>) is underwater with damaged life support.  Mechwarrior takes 1 damage.
+6020=<newline><data> (<data>) is underwater with damaged life support. MechWarrior takes 1 damage.
 6021=Pilot of <data> (<data>) "<data>" is already dead, so no damage is dealt!
 6022=Crew of <data> (<data>) "<data>" is already dead, so no damage is dealt!
 6023=Pilot of <data> (<data>) "<data>" has ejected, so no damage is dealt!
@@ -724,32 +724,32 @@
 6026=<data> of <data> (<data>) "<data>" takes <data> damage, killing the pilot (<data> total hits).
 6027=<data> of <data> (<data>) "<data>" is killed.
 6028=Crew of <data> (<data>) takes <data> damage <data> (<data> total hits).
-6029=<newline><data> of <data> (<data>) "<data>" needs a <data> to wake up.  Rolls <data> : <msg:6031,6033>
-6030=<data> of <data> (<data>) "<data>" needs a <data> to stay conscious.  Rolls <data> : <msg:6031,6032>
+6029=<newline><data> of <data> (<data>) "<data>" needs a <data> to wake up. Rolls <data> : <msg:6031,6033>
+6030=<data> of <data> (<data>) "<data>" needs a <data> to stay conscious. Rolls <data> : <msg:6031,6032>
 6031=successful!
 6032=<font color='C00000'>blacks out</font>.
 6033=stays unconscious.
-6035=Near miss! The Protomech is unaffected.
+6035=Near miss! The ProtoMech is unaffected.
 6036=The wing structure is damaged.
 6037=The Battle Armor takes no damage from a near miss (critical roll was <data>).
 6038=The Battle Armor has fire resistant damage and takes half damage.
 6039=Infantry is hit by area-effect artillery!!! Damage doubled.
-6040=Infantry platoon caught in the open!!!  Damage doubled.
+6040=Infantry platoon caught in the open!!! Damage doubled.
 6041=Infantry is in Vacuum!!! Space suits are breached!!! Damage doubled.
 6042=Dermal armor reduces the damage by <data> to <data>.
 6043=Armor reduces the damage to <data>.
 6044=Battle Armor hit by area-effect damage. Each trooper takes damage. 
 6045=Infantry platoon hit by fragmentation missiles!!!
-6050=Hardened unit hit by fragmentation missiles!!!  No damage.
+6050=Hardened unit hit by fragmentation missiles!!! No damage.
 6051=Weapon cannot penetrate armor!!! No damage.
 6055=Infantry platoon hit by flechette ammunition!!!
-6060=Hardened unit hit by flechette ammunition!!!  Damage halved.
-6061=Target hit by acid warhead!  <data> damage.
+6060=Hardened unit hit by flechette ammunition!!! Damage halved.
+6061=Target hit by acid warhead! <data> damage.
 6062=Acid warheads do 50% more damage to infantry.
 6063=Nail/Rivet gun against armor with BAR >= 5! No damage.
 6064=Infantry platoon hit by incendiary ammunition!!! 2 extra damage.
 6065=<data> (<data>) takes <data> damage to <data>.
-6066=\ Reflective armor takes double damage from physical damage:  <data> armor increases <data> damage by <data>, for <data> total damage.
+6066=\ Reflective armor takes double damage from physical damage: <data> armor increases <data> damage by <data>, for <data> total damage.
 6067=\ Reflective armor takes half damage from energy damage: <data> damage.
 6068=\ Reactive armor takes half damage from explosive-type damage: <data> damage.
 6069=\ Hardened armor takes half damage: <data> damage.
@@ -770,7 +770,7 @@
 6084=The passenger, <data> (<data>), avoids damage.
 6085=<data> Armor remaining.
 6086=<data> Armor remaining (damaged).
-6087=\ Reflective armor takes double damage from area effect attack:  <data> armor increases <data> damage by <data>, for <data> total damage.
+6087=\ Reflective armor takes double damage from area effect attack: <data> armor increases <data> damage by <data>, for <data> total damage.
 6088=\ Ballistic-reinforced armor takes reduced damage: <data> damage.
 6089=\ Impact-resistant armor takes reduced damage from physical damage: <data> damage.
 6090=Armor destroyed.
@@ -812,9 +812,9 @@
 6195=\ But the critical is cancelled, because there is no main weapon to jam.
 6200=\ <font color='C00000'><data> jams for 1 turn.</font>
 6205=\ <font color='C00000'><data> jams for 1 more turn (<data> turns total).</font>
-6210=\ <font color='C00000'>Engine destroyed.  Immobile.</font>
+6210=\ <font color='C00000'>Engine destroyed. Immobile.</font>
 6215=\ <font color='C00000'>Fuel Tank Hit (Vehicle Explodes).</font>
-6220=\ <font color='C00000'>Power plant hit.  BOOM!</font>
+6220=\ <font color='C00000'>Power plant hit. BOOM!</font>
 6225=<font color='C00000'>CRITICAL HIT on <data></font>.
 6230=<font color='C00000'>HEAD DESTROYED</font>
 6235=<font color='C00000'>ARM DESTROYED</font>
@@ -826,9 +826,9 @@
 6249=<font color='C00000'>Torso weapon E destroyed.</font>
 6250=<font color='C00000'>Torso weapon F destroyed.</font>
 6252=<font color='C00000'>Magnetic Clamp System destroyed.</font>
-6255=<font color='C00000'><data>  will stop functioning at end of turn.</font>
-6260=<font color='C00000'><data> (<data>) has lost its movement and crashes.  </font>
-6261=<font color='C00000'><data> (<data>) has lost its crew and crashes.  </font>
+6255=<font color='C00000'><data> will stop functioning at end of turn.</font>
+6260=<font color='C00000'><data> (<data>) has lost its movement and crashes.</font>
+6261=<font color='C00000'><data> (<data>) has lost its crew and crashes.</font>
 6265=However, it's already on the ground, so no harm done.
 6270=<font color='C00000'>It plummets <data> levels to the ground.</font>
 6275=<font color='C00000'>It falls into water and is destroyed.</font>
@@ -861,7 +861,7 @@
 6375=<font color='C00000'>*** <data> (<data>) tried to escape the wreckage, but couldn't. ***</font>
 6380=<data> (<data>) ends its swarm attack.
 6385=<data> (<data>) is freed from its swarm attack.
-6390=<font color='C00000'>*** <data> EXPLODES!  <data> DAMAGE! ***</font>
+6390=<font color='C00000'>*** <data> EXPLODES! <data> DAMAGE! ***</font>
 6395=><data> (<data>) suffers catastrophic damage, but the autoeject system was engaged.
 6400=The pilot ejects safely!
 6401=<data> lifeboats/escape pods successfully launched, carrying <data> people to safety.
@@ -999,7 +999,7 @@
 9030=Ramming <data>
 9031=Attacking <data>
 9032=; needs <data> (<data>), rolls <data> : 
-9033=Telemissile attack needs <data> (<data>), rolls <data> : 
+9033=Tele-operated missile attack needs <data> (<data>), rolls <data> : 
 9035=Possible collision between <data> and <data>!
 9040=<data> has no thrust left to spend and cannot avoid collision.
 9045=<data> attempts to avoid the collision. Needs <data>, rolls <data>: <msg:9046,9047>
@@ -1056,7 +1056,7 @@
 9170=\ <font color='C00000'>An <data> bay door is destroyed!</font>
 9171=\ There are no functioning bay doors on this vessel.
 9172=\ Transport bay hit and units would be destroyed, but Edge used to reroll! <data> Edge remaining.
-9175=\ <font color='C00000'>Docking Collar hit. Dropship will be unable to dock.</font>
+9175=\ <font color='C00000'>Docking Collar hit. DropShip will be unable to dock.</font>
 9176=\ <font color='C00000'>Docking Collar hit.</font>
 9177=\ Vessel has no operational docking collars. 
 9180=\ <font color='C00000'>KF Boom hit.</font>
@@ -1164,7 +1164,7 @@
 9707=avoids crash.
 9710=<data> (<data>) cannot stay airborne with destroyed side torso.
 #flawed cooling system related
-9800=<newline><data> [<data>] Checking Flawed Cooling due to <data>.  Rolls <data>.
+9800=<newline><data> [<data>] Checking Flawed Cooling due to <data>. Rolls <data>.
 9805=\ --Adding 5 heat per turn for the remainder of the scenario.
 # HarJel II/III related
 9850=<data> (<data>) repairs <data> armor in <data> due to HarJel II system.

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11009,8 +11009,7 @@ public class Server implements Runnable {
         // Check for Mine sweepers
         Mounted minesweeper = null;
         for (Mounted m : entity.getMisc()) {
-            if (m.getType().hasFlag(MiscType.F_MINESWEEPER) && m.isReady()
-                    && (m.getArmorValue() > 0)) {
+            if (m.getType().hasFlag(MiscType.F_MINESWEEPER) && m.isReady() && (m.getArmorValue() > 0)) {
                 minesweeper = m;
                 break; // Can only have one minesweeper
             }
@@ -11019,7 +11018,6 @@ public class Server implements Runnable {
         Vector<Minefield> fieldsToRemove = new Vector<>();
         // loop through mines in this hex
         for (Minefield mf : game.getMinefields(c)) {
-
             // vibrabombs are handled differently
             if (mf.getType() == Minefield.TYPE_VIBRABOMB) {
                 continue;
@@ -11027,16 +11025,14 @@ public class Server implements Runnable {
 
             // if we are in the water, then the sea mine will only blow up if at
             // the right depth
-            if (game.getBoard().getHex(mf.getCoords())
-                    .containsTerrain(Terrains.WATER)) {
+            if (game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)) {
                 if ((Math.abs(curElev) != mf.getDepth())
-                    && (Math.abs(curElev + entity.getHeight()) != mf
-                        .getDepth())) {
+                        && (Math.abs(curElev + entity.getHeight()) != mf.getDepth())) {
                     continue;
                 }
             }
 
-            // Check for mine-sweeping.  Vibramines handled elsewhere
+            // Check for mine-sweeping. Vibramines handled elsewhere
             if ((minesweeper != null)
                     && ((mf.getType() == Minefield.TYPE_CONVENTIONAL)
                             || (mf.getType() == Minefield.TYPE_ACTIVE)
@@ -11046,19 +11042,19 @@ public class Server implements Runnable {
 
                 // Report minefield roll
                 if (doBlind()) { // only report if DB, otherwise all players see
-                r = new Report(2152);
-                r.player = mf.getPlayerId();
-                r.add(Minefield.getDisplayableName(mf.getType()));
-                r.add(mf.getCoords().getBoardNum());
-                r.add(roll);
-                r.newlines = 0;
-                vMineReport.add(r);
+                    r = new Report(2152, Report.PLAYER);
+                    r.player = mf.getPlayerId();
+                    r.add(Minefield.getDisplayableName(mf.getType()));
+                    r.add(mf.getCoords().getBoardNum());
+                    r.add(roll);
+                    r.newlines = 0;
+                    vMineReport.add(r);
                 }
 
                 if (roll >= 6) {
                     // Report hit
                     if (doBlind()) {
-                        r = new Report(5543);
+                        r = new Report(5543, Report.PLAYER);
                         r.player = mf.getPlayerId();
                         vMineReport.add(r);
                     }
@@ -11111,7 +11107,7 @@ public class Server implements Runnable {
                 } else {
                     // Report miss
                     if (doBlind()) {
-                        r = new Report(5542);
+                        r = new Report(5542, Report.PLAYER);
                         r.player = mf.getPlayerId();
                         vMineReport.add(r);
                     }
@@ -11121,8 +11117,7 @@ public class Server implements Runnable {
             // check whether we have an active mine
             if ((mf.getType() == Minefield.TYPE_ACTIVE) && isOnGround) {
                 continue;
-            }
-            if ((mf.getType() != Minefield.TYPE_ACTIVE) && !isOnGround) {
+            } else if ((mf.getType() != Minefield.TYPE_ACTIVE) && !isOnGround) {
                 continue;
             }
 
@@ -11148,7 +11143,7 @@ public class Server implements Runnable {
 
             // Report minefield roll
             if (doBlind()) { // Only do if DB, otherwise all players will see
-                r = new Report(2151);
+                r = new Report(2151, Report.PLAYER);
                 r.player = mf.getPlayerId();
                 r.add(Minefield.getDisplayableName(mf.getType()));
                 r.add(mf.getCoords().getBoardNum());
@@ -11161,7 +11156,7 @@ public class Server implements Runnable {
             if (roll < target) {
                 // Report miss
                 if (doBlind()) {
-                    r = new Report(2217);
+                    r = new Report(2217, Report.PLAYER);
                     r.player = mf.getPlayerId();
                     vMineReport.add(r);
                 }
@@ -11170,7 +11165,7 @@ public class Server implements Runnable {
 
             // Report hit
             if (doBlind()) {
-                r = new Report(2270);
+                r = new Report(2270, Report.PLAYER);
                 r.player = mf.getPlayerId();
                 vMineReport.add(r);
             }
@@ -11208,6 +11203,7 @@ public class Server implements Runnable {
                     }
                     vMineReport.addAll(damageEntity(entity, hit, cur_damage));
                 }
+
                 if (entity instanceof Tank) {
                     // Tanks check for motive system damage from minefields as
                     // from a side hit even though the damage proper hits the


### PR DESCRIPTION
This:
a) Fixes a bunch of double space text issues
b) Cleans up a bunch of typos and incorrect naming in report messages
c) Adds missing Player specifications for minefield reports