### PR TITLE
disable pointless error logging

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1262,7 +1262,7 @@ public class Client implements IClientCommandHandler {
     /**
      * Hashtable for storing <img> tags containing base64Text src.
      */
-    private void cacheImgTag(Entity entity) {
+    protected void cacheImgTag(Entity entity) {
         if(entity == null) {
             return;
         }

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1262,10 +1262,8 @@ public class Client implements IClientCommandHandler {
     /**
      * Hashtable for storing <img> tags containing base64Text src.
      */
-    private void cacheImgTag(Entity entity){
-
+    private void cacheImgTag(Entity entity) {
         if(entity == null) {
-            MegaMek.getLogger().error("Null entity reference");
             return;
         }
 

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -61,6 +61,7 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.MovePath;
 import megamek.common.Protomech;
+import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.Terrains;
 import megamek.common.ToHitData;
@@ -1215,6 +1216,24 @@ public abstract class BotClient extends Client {
     @SuppressWarnings("unchecked")
     protected void receiveBuildingCollapse(Packet packet) {
         game.getBoard().collapseBuilding((Vector<Coords>) packet.getObject(0));
+    }
+    
+    /**
+     * The bot client doesn't really need a text report
+     * Let's save ourselves a little processing time and not deal with any of it
+     */
+    @Override
+    public String receiveReport(Vector<Report> v) {
+        return "";
+    }
+    
+    /**
+     * The bot client has no need of image tag caching
+     * Let's save ourselves some CPU and memory and not deal with it
+     */
+    @Override
+    protected void cacheImgTag(Entity entity) {
+        
     }
 
     public BoardClusterTracker getClusterTracker() {


### PR DESCRIPTION
The cacheImgTag operation is meaningless with a null entity, but is not a fatal error. 

Additionally, the bot has no need of unit images in its human-readable round reports (or human-readable round reports at all), so that functionality has been overridden in the BotClient class for a probably very minor performance improvement.