### PR TITLE
KeyCommandBinds maintenance and defaults correction

### DIFF
--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -61,28 +61,28 @@
     <KeyBind>
         <command>turnLeft</command> <!-- Shift-A -->
         <keyCode>65</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>turnRight</command> <!-- Shift-D -->
         <keyCode>68</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>twistLeft</command> <!-- Shift-A -->
         <keyCode>65</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>twistRight</command> <!-- Shift-D -->
         <keyCode>68</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
@@ -110,14 +110,14 @@
     <KeyBind>
         <command>nextUnit</command> <!-- Ctrl-N -->
         <keyCode>78</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>prevUnit</command> <!-- Shift-Q -->
         <keyCode>81</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
@@ -138,42 +138,42 @@
     <KeyBind>
         <command>nextTargetValid</command> <!-- Shift-C -->
         <keyCode>67</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>prevTargetValid</command> <!-- Shift-Z -->
         <keyCode>90</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>nextTargetNoAllies</command> <!-- Ctrl-C -->
         <keyCode>67</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>prevTargetNoAllies</command> <!-- Ctrl-Z -->
         <keyCode>90</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>nextTargetValidNoAllies</command> <!-- Ctrl+Shift-C -->
         <keyCode>67</keyCode>
-        <modifier>3</modifier>
+        <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>prevTargetValidNoAllies</command> <!-- Ctrl+Shift-Z -->
         <keyCode>90</keyCode>
-        <modifier>3</modifier>
+        <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
@@ -187,7 +187,7 @@
     <KeyBind>
         <command>movementEnvelope</command> <!-- Ctrl-Q -->
         <keyCode>81</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
@@ -201,7 +201,7 @@
     <KeyBind>
         <command>autoArtyDeployZone</command> <!-- Shift-Space -->
         <keyCode>32</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
@@ -222,7 +222,7 @@
     <KeyBind>
         <command>done</command> <!-- Ctrl-Enter -->
         <keyCode>10</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
@@ -285,7 +285,7 @@
     <KeyBind>
         <command>prevMode</command> <!-- Shift-Tab -->
         <keyCode>9</keyCode>
-        <modifier>1</modifier>
+        <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
@@ -299,21 +299,21 @@
     <KeyBind>
         <command>toggleDrawLabels</command> <!-- Ctrl-Y -->
         <keyCode>89</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>toggleKeyBindDisplay</command> <!-- Ctrl-K -->
         <keyCode>75</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
         <command>toggleHexCoords</command> <!-- Ctrl-G -->
         <keyCode>71</keyCode>
-        <modifier>2</modifier>
+        <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -1,126 +1,121 @@
 /*
- * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
- * Copyright © 2013 Nicholas Walczak (walczak@cs.umn.edu)
+ * Copyright (c) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2013 Nicholas Walczak (walczak@cs.umn.edu)
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This file is part of MegaMek.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package megamek.client.ui.swing.util;
 
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
-import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This enum is a collection of commands that can be bound to a particular key.
- * 
  * @author arlith
- *
  */
 public enum KeyCommandBind {
-    SCROLL_NORTH("scrollN",true, KeyEvent.VK_W, 0), // Default: W
-    SCROLL_SOUTH("scrollS",true, KeyEvent.VK_S, 0), // Default: S
-    SCROLL_EAST("scrollE",true, KeyEvent.VK_D, 0),  // Default: D
-    SCROLL_WEST("scrollW",true, KeyEvent.VK_A, 0),  // Default: A
+    SCROLL_NORTH("scrollN", true, KeyEvent.VK_W), 
+    SCROLL_SOUTH("scrollS", true, KeyEvent.VK_S), 
+    SCROLL_EAST("scrollE", true, KeyEvent.VK_D),  
+    SCROLL_WEST("scrollW", true, KeyEvent.VK_A),  
     // Toggles isometric view on/off
-    TOGGLE_ISO("toggleIso",false, KeyEvent.VK_T, 0),// Default: T
+    TOGGLE_ISO("toggleIso", false, KeyEvent.VK_T),
     // Activates chat box
-    TOGGLE_CHAT("toggleChat",false, KeyEvent.VK_BACK_QUOTE, 0), // Default: ` (back quote/grave)
+    TOGGLE_CHAT("toggleChat", false, KeyEvent.VK_BACK_QUOTE), // Default: ` (back quote/grave)
     // Activates chat box and adds the command character (/)
-    TOGGLE_CHAT_CMD("toggleChatCmd", false, KeyEvent.VK_SLASH, 0), // Default: /
+    TOGGLE_CHAT_CMD("toggleChatCmd", false, KeyEvent.VK_SLASH),
     // Change facing one hexside to the left
-    TURN_LEFT("turnLeft",false, KeyEvent.VK_A, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-A
+    TURN_LEFT("turnLeft", false, KeyEvent.VK_A, InputEvent.SHIFT_DOWN_MASK),
     // Change facing one hexside to the right
-    TURN_RIGHT("turnRight",false, KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-D
+    TURN_RIGHT("turnRight", false, KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK),
     // Change facing one hexside to the left
-    TWIST_LEFT("twistLeft",false, KeyEvent.VK_A, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-A
+    TWIST_LEFT("twistLeft", false, KeyEvent.VK_A, InputEvent.SHIFT_DOWN_MASK),
     // Change facing one hexside to the right
-    TWIST_RIGHT("twistRight",false, KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-D
+    TWIST_RIGHT("twistRight", false, KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK),
     // Fire the currently selected weapon
-    FIRE("fire", false, KeyEvent.VK_F, 0), // Default: F
-    NEXT_WEAPON("nextWeapon", false, KeyEvent.VK_E, 0), // Default: E
-    PREV_WEAPON("prevWeapon", false, KeyEvent.VK_Q, 0), // Default: Q
-    NEXT_UNIT("nextUnit", false, KeyEvent.VK_E, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-E
-    PREV_UNIT("prevUnit", false, KeyEvent.VK_Q, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-Q
-    NEXT_TARGET("nextTarget", false, KeyEvent.VK_C, 0), // Default: C
-    PREV_TARGET("prevTarget", false, KeyEvent.VK_Z, 0), // Default: Z
-    NEXT_TARGET_VALID("nextTargetValid", false, KeyEvent.VK_C, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-C
-    PREV_TARGET_VALID("prevTargetValid", false, KeyEvent.VK_Z, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-Z
-    NEXT_TARGET_NOALLIES("nextTargetNoAllies", false, KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK), // Default: Ctrl-C
-    PREV_TARGET_NOALLIES("prevTargetNoAllies", false, KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK), // Default: Ctrl-Z
-    NEXT_TARGET_VALID_NO_ALLIES("nextTargetValidNoAllies", false, KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK & InputEvent.SHIFT_DOWN_MASK), // Default: Ctrl-Shift-C
-    PREV_TARGET_VALID_NO_ALLIES("prevTargetValidNoAllies", false, KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK & InputEvent.SHIFT_DOWN_MASK), // Default: Ctrl-Shift-Z
+    FIRE("fire", false, KeyEvent.VK_F),
+    NEXT_WEAPON("nextWeapon", false, KeyEvent.VK_E),
+    PREV_WEAPON("prevWeapon", false, KeyEvent.VK_Q),
+    NEXT_UNIT("nextUnit", false, KeyEvent.VK_E, InputEvent.SHIFT_DOWN_MASK),
+    PREV_UNIT("prevUnit", false, KeyEvent.VK_Q, InputEvent.SHIFT_DOWN_MASK),
+    NEXT_TARGET("nextTarget", false, KeyEvent.VK_C),
+    PREV_TARGET("prevTarget", false, KeyEvent.VK_Z),
+    NEXT_TARGET_VALID("nextTargetValid", false, KeyEvent.VK_C, InputEvent.SHIFT_DOWN_MASK),
+    PREV_TARGET_VALID("prevTargetValid", false, KeyEvent.VK_Z, InputEvent.SHIFT_DOWN_MASK),
+    NEXT_TARGET_NOALLIES("nextTargetNoAllies", false, KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK),
+    PREV_TARGET_NOALLIES("prevTargetNoAllies", false, KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK),
+    NEXT_TARGET_VALID_NO_ALLIES("nextTargetValidNoAllies", false, KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK & InputEvent.SHIFT_DOWN_MASK),
+    PREV_TARGET_VALID_NO_ALLIES("prevTargetValidNoAllies", false, KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK & InputEvent.SHIFT_DOWN_MASK),
     // Undo an action, such as a move step in the movement phase
-    UNDO("undo",false, KeyEvent.VK_BACK_SPACE, 0), // Default: Backspace
-    MOVE_ENVELOPE("movementEnvelope",false, KeyEvent.VK_R, 0), // Default: R
-    CENTER_ON_SELECTED("centerOnSelected",false, KeyEvent.VK_SPACE, 0), // Default: Space
-    AUTO_ARTY_DEPLOYMENT_ZONE("autoArtyDeployZone",false, KeyEvent.VK_Z, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-Z
-    FIELD_FIRE("fieldOfFire",false, KeyEvent.VK_R, InputEvent.SHIFT_DOWN_MASK), // Default: Shift-R
+    UNDO("undo", false, KeyEvent.VK_BACK_SPACE),
+    MOVE_ENVELOPE("movementEnvelope", false, KeyEvent.VK_R),
+    CENTER_ON_SELECTED("centerOnSelected", false, KeyEvent.VK_SPACE),
+    AUTO_ARTY_DEPLOYMENT_ZONE("autoArtyDeployZone", false, KeyEvent.VK_Z, InputEvent.SHIFT_DOWN_MASK),
+    FIELD_FIRE("fieldOfFire", false, KeyEvent.VK_R, InputEvent.SHIFT_DOWN_MASK),
     // Used to cancel moves/fires/chatterbox
-    CANCEL("cancel", false, KeyEvent.VK_ESCAPE, 0, true), // Default: Escape
-    DONE("done", false, KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK, true), // Default: Ctrl-Enter
+    CANCEL("cancel", false, KeyEvent.VK_ESCAPE, 0, true),
+    DONE("done", false, KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK, true),
     // Used to select the tab in the unit display
-    UD_GENERAL("udGeneral", false, KeyEvent.VK_F1, 0), // Default: F1
-    UD_PILOT("udPilot", false, KeyEvent.VK_F2, 0), // Default: F2
-    UD_ARMOR("udArmor", false, KeyEvent.VK_F3, 0), // Default: F3
-    UD_SYSTEMS("udSystems", false, KeyEvent.VK_F4, 0), // Default: F4
-    UD_WEAPONS("udWeapons", false, KeyEvent.VK_F5, 0), // Default: F5
-    UD_EXTRAS("udExtras", false, KeyEvent.VK_F6, 0), // Default: F6
+    UD_GENERAL("udGeneral", false, KeyEvent.VK_F1),
+    UD_PILOT("udPilot", false, KeyEvent.VK_F2),
+    UD_ARMOR("udArmor", false, KeyEvent.VK_F3),
+    UD_SYSTEMS("udSystems", false, KeyEvent.VK_F4),
+    UD_WEAPONS("udWeapons", false, KeyEvent.VK_F5),
+    UD_EXTRAS("udExtras", false, KeyEvent.VK_F6),
     /** Toggles between Jumping and Walk/Run, also acts as a reset when a unit cannot jump */
-    TOGGLE_MOVEMODE("toggleJump", false, KeyEvent.VK_J, 0), // Default: J
-    TOGGLE_CONVERSIONMODE("toggleConversion", false, KeyEvent.VK_M, 0), // Default: M
-    PREV_MODE("prevMode", false, KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK), // Default: Tab
-    NEXT_MODE("nextMode", false, KeyEvent.VK_TAB, 0), // Default: Tab
-    TOGGLE_DRAW_LABELS("toggleDrawLabels", false, KeyEvent.VK_Y, 0), // Default: Y
-    TOGGLE_KEYBIND_DISPLAY("toggleKeyBindDisplay", false, KeyEvent.VK_K, InputEvent.CTRL_DOWN_MASK), // Default: Ctrl-K
-    TOGGLE_HEX_COORDS("toggleHexCoords", false, KeyEvent.VK_G, InputEvent.CTRL_DOWN_MASK); // Default: Ctrl-G
+    TOGGLE_MOVEMODE("toggleJump", false, KeyEvent.VK_J),
+    TOGGLE_CONVERSIONMODE("toggleConversion", false, KeyEvent.VK_M),
+    PREV_MODE("prevMode", false, KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK),
+    NEXT_MODE("nextMode", false, KeyEvent.VK_TAB),
+    TOGGLE_DRAW_LABELS("toggleDrawLabels", false, KeyEvent.VK_Y),
+    TOGGLE_KEYBIND_DISPLAY("toggleKeyBindDisplay", false, KeyEvent.VK_K, InputEvent.CTRL_DOWN_MASK),
+    TOGGLE_HEX_COORDS("toggleHexCoords", false, KeyEvent.VK_G, InputEvent.CTRL_DOWN_MASK);
 
-
-    /**
-     * The command associated with this binding.
-     */
+    /** The command associated with this binding. */
     public String cmd;
     
-    /**
-     * Defines the keycode for the command. This should correspond to defines in
-     * <code>KeyEvent</code>.
-     */
+    /** Defines the keycode for the command, e.g. KeyEvent.VK_X. */
     public int key;
     
-    /**
-     * Defines any modifiers to the key code, such as whether control or alt 
-     * are pressed.  This should correspond to the modifiers defined in 
-     * <code>KeyEvent</code>.
-     */
+    /** Modifiers to the key code, such as InputEvent.CTRL_DOWN_MASK. */ 
     public int modifiers;
     
     /**
      * Defines if an action is exclusive, which means that only one
-     * CommandAction will be performed for each key press.  The CommandAction
+     * CommandAction will be performed for each key press. The CommandAction
      * that is performed will be the first one encountered.
      */
     public boolean isExclusive = false;
 
     /**
-     * A flag that determines whether this binding is repeatable.  If a bind is
-     * repeatable then when the key is pressed the action will be added to a 
-     * timer and will be repeated until the key is released.
+     * For a repeatable bind, when the key is pressed the action will be added to a 
+     * timer and repeated until the key is released.
      */
     public boolean isRepeatable;
     
+    private KeyCommandBind(String c, boolean r, int k){
+        this(c, r, k, 0, false);
+    }
+    
     private KeyCommandBind(String c, boolean r, int k, int m){
-        cmd = c;
-        key = k;
-        modifiers = m;
-        isRepeatable = r;
+        this(c, r, k, m, false);
     }
     
     private KeyCommandBind(String c, boolean r, int k, int m, boolean e){
@@ -131,23 +126,17 @@ public enum KeyCommandBind {
         isExclusive = e;
     }
 
-    public static ArrayList<KeyCommandBind> getBindByKey(int keycode, int modifiers){
-        ArrayList<KeyCommandBind> binds = new ArrayList<KeyCommandBind>();
-        for (KeyCommandBind bind : values()){
-            if (bind.key == keycode && bind.modifiers == modifiers){
-                binds.add(bind);
-            }
-        }
-        return binds;
+    /** Returns a list of binds using the given keycode and modifier. */
+    public static List<KeyCommandBind> getBindByKey(int keycode, int modifiers) {
+        return Stream.of(values())
+                .filter(bind -> bind.key == keycode)
+                .filter(bind -> bind.modifiers == modifiers)
+                .collect(Collectors.toList());
     }
     
-    public static KeyCommandBind getBindByCmd(String cmd){
-        for (KeyCommandBind bind : values()){
-            if (bind.cmd.equals(cmd)){
-                return bind;
-            }
-        }
-        return null;
+    /** Returns the bind identified by the given cmd or null if there is no such bind. */
+    public static KeyCommandBind getBindByCmd(String cmd) {
+        return Stream.of(values()).filter(bind -> bind.cmd.equals(cmd)).findAny().orElse(null);
     }
     
 }


### PR DESCRIPTION
I think that keycommands using modifiers all stopped working with the recent replacement of deprecated modifier constants as the new modifier constants use different values. These were not updated in the defaultkeybinds.xml. Correcting this.
Also some code maintenance on the KeyCommandBinds and MegaMekController.
