### PR TITLE
Issue 2886 Wreck Sprites

### DIFF
--- a/megamek/i18n/megamek/client/messages_en.properties
+++ b/megamek/i18n/megamek/client/messages_en.properties
@@ -411,6 +411,7 @@ BoardView1.Tooltip.TurretLocked=<I><FONT COLOR=RED>Turret locked!</FONT></I>
 BoardView1.Tooltip.ChassisPlayer=<B>{0} ({1})</B>
 BoardView1.Tooltip.Weapon=&nbsp;{1}{2}
 BoardView1.Tooltip.WeaponN=&nbsp;<B>{0} x</B>  {1}{2}
+BoardView1.Tooltip.Wreckof=Wreck of 
 
 #Buildings and Bridges
 BoardView1.Tooltip.Hex=Hex: {0} - Level: {1}

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -15,6 +15,8 @@
 */
 package megamek.client.ui.swing.boardview;
 
+import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
+
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -5972,6 +5974,17 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             if (aSprite.isInside(point)) {
                 txt.append("<TABLE BORDER=0 BGCOLOR=#FFDDDD width=100%><TR><TD><FONT color=\"black\">"); //$NON-NLS-1$
                 txt.append(aSprite.getTooltip().toString());
+                txt.append("</FONT></TD></TR></TABLE>"); //$NON-NLS-1$
+            }
+        }
+        
+        // Add wreck info
+        var wreckList = useIsometric() ? isometricWreckSprites : wreckSprites;
+        for (var wSprite : wreckList) {
+            if (wSprite.getPosition().equals(mcoords)) {
+                txt.append("<TABLE BORDER=0 width=100%><TR><TD>"); //$NON-NLS-1$
+                txt.append(guiScaledFontHTML());
+                txt.append(wSprite.getTooltip());
                 txt.append("</FONT></TD></TR></TABLE>"); //$NON-NLS-1$
             }
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/IsometricWreckSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/IsometricWreckSprite.java
@@ -21,7 +21,6 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.ImageObserver;
 
-import megamek.common.Coords;
 import megamek.common.Entity;
 
 /**
@@ -73,11 +72,4 @@ class IsometricWreckSprite extends AbstractWreckSprite {
         return entity;
     }
     
-    public Coords getPosition() {
-        if (secondaryPos < 0 || secondaryPos >= entity.getSecondaryPositions().size()) {
-            return entity.getPosition();
-        } else {
-            return entity.getSecondaryPositions().get(secondaryPos);
-        }
-    }
 }


### PR DESCRIPTION
Corrects wreck sprite scaling (the size of the sprite image was scaled twice)
Also removes the label from wrecks as I've seen some screenshots in issues of players where the wreck labels make for quite a clutter and IMO they shouldn't interfere with live units; additionally the labels tended to get cut off.
When hovering a wreck, the hex tooltip will show what wreck is present. The unit ID is shown when the user pref setting is active.

![image](https://user-images.githubusercontent.com/17069663/120066944-466c2380-c079-11eb-89e3-fe24bd698649.png)
![image](https://user-images.githubusercontent.com/17069663/120066958-5b48b700-c079-11eb-805b-e3d6ccdc5d2b.png)
![image](https://user-images.githubusercontent.com/17069663/120066963-656ab580-c079-11eb-90d3-c04cb5329784.png)


Resolves #2886 