### PR TITLE
Kinda urgent: Fixing Base components resources calls (camo chooser and others)

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.baseComponents;
 
 import megamek.client.ui.enums.DialogResult;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 
 import javax.swing.*;
@@ -62,7 +63,8 @@ public abstract class AbstractButtonDialog extends AbstractDialog {
      */
     protected AbstractButtonDialog(final JFrame frame, final boolean modal, final String name,
                                    final String title) {
-        this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", new EncodeControl()), name, title);
+        this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", 
+                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name, title);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.baseComponents;
 
 import megamek.MegaMek;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
@@ -59,7 +60,8 @@ public abstract class AbstractDialog extends JDialog implements WindowListener {
      * modal dialogs.
      */
     protected AbstractDialog(final JFrame frame, final boolean modal, final String name, final String title) {
-        this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", new EncodeControl()), name, title);
+        this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", 
+                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name, title);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractScrollPane.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractScrollPane.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.baseComponents;
 
 import megamek.MegaMek;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 import megamek.client.ui.preferences.PreferencesNode;
 
@@ -54,7 +55,8 @@ public abstract class AbstractScrollPane extends JScrollPane {
      */
     protected AbstractScrollPane(final JFrame frame, final String name,
                                  final int verticalScrollBarPolicy, final int horizontalScrollBarPolicy) {
-        this(frame, ResourceBundle.getBundle("megamek.client.messages", new EncodeControl()),
+        this(frame, ResourceBundle.getBundle("megamek.client.messages", 
+                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()),
                 name, verticalScrollBarPolicy, horizontalScrollBarPolicy);
     }
 

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractSplitPane.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractSplitPane.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.baseComponents;
 
 import megamek.MegaMek;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 import megamek.client.ui.preferences.JSplitPanePreference;
 import megamek.client.ui.preferences.PreferencesNode;
@@ -48,7 +49,8 @@ public abstract class AbstractSplitPane extends JSplitPane {
      * constructor to use for an AbstractSplitPane.
      */
     protected AbstractSplitPane(final JFrame frame, final String name) {
-        this(frame, ResourceBundle.getBundle("megamek.client.messages", new EncodeControl()), name);
+        this(frame, ResourceBundle.getBundle("megamek.client.messages", 
+                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractTabbedPane.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractTabbedPane.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.baseComponents;
 
 import megamek.MegaMek;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 import megamek.client.ui.preferences.JTabbedPanePreference;
 import megamek.client.ui.preferences.PreferencesNode;
@@ -46,7 +47,8 @@ public abstract class AbstractTabbedPane extends JTabbedPane {
      * constructor to use for an AbstractTabbedPane.
      */
     protected AbstractTabbedPane(final JFrame frame, final String name) {
-        this(frame, ResourceBundle.getBundle("megamek.client.messages", new EncodeControl()), name);
+        this(frame, ResourceBundle.getBundle("megamek.client.messages", 
+                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractValidationButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractValidationButtonDialog.java
@@ -21,6 +21,7 @@ package megamek.client.ui.baseComponents;
 import megamek.MegaMek;
 import megamek.client.ui.enums.ValidationState;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 
 import javax.swing.*;
@@ -68,7 +69,8 @@ public abstract class AbstractValidationButtonDialog extends AbstractButtonDialo
      */
     protected AbstractValidationButtonDialog(final JFrame frame, final boolean modal,
                                              final String name, final String title) {
-        this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", new EncodeControl()), name, title);
+        this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", 
+                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name, title);
     }
 
     /**


### PR DESCRIPTION
The base components should respect MM's language setting (for what its worth) and the resource calls didnt work probably because I renamed the messages to messages_en recently to fix it on non-english systems.