### PR TITLE
first crack at bot minefield avoidance

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -540,6 +540,9 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         double expectedDamageTaken = checkPathForHazards(pathCopy,
                                                          movingUnit,
                                                          game);
+        
+        expectedDamageTaken += MinefieldUtil.checkPathForMinefieldHazards(pathCopy);
+        
         boolean extremeRange = game.getOptions()
                                    .booleanOption(
                                            OptionsConstants.ADVCOMBAT_TACOPS_RANGE);
@@ -931,12 +934,13 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                     break;
             }
         }
+        
         logMsg.append("\n\tTotal Hazard = ")
               .append(LOG_DECIMAL.format(hazardValue));
 
         return hazardValue;
     }
-
+    
     // Building collapse and basements are handled in PathRanker.validatePaths.
     private double calcBuildingHazard(MoveStep step, Entity movingUnit,
                                       boolean jumpLanding, IBoard board,

--- a/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
+++ b/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
@@ -22,6 +22,7 @@ import megamek.common.Mech;
 import megamek.common.Minefield;
 import megamek.common.MovePath;
 import megamek.common.MoveStep;
+import megamek.common.annotations.Nullable;
 
 /**
  * This class contains logic to evaluate the damage a unit could sustain from
@@ -30,7 +31,7 @@ import megamek.common.MoveStep;
  */
 public class MinefieldUtil {
     /**
-     * Calculate how much damage we'll take from stepping on mines over  a particular path
+     * Calculate how much damage we'll take from stepping on mines over a particular path
      */
     public static double checkPathForMinefieldHazards(MovePath path) {
         double hazardAccumulator = 0;
@@ -48,7 +49,7 @@ public class MinefieldUtil {
     /**
      * Calculate how much damage we'll take from stepping on mines in a particular hex
      */
-    public static double calcMinefieldHazardForHex(MoveStep step, Entity movingUnit, 
+    public static double calcMinefieldHazardForHex(@Nullable MoveStep step, Entity movingUnit, 
             boolean isJumping, boolean lastStep) {
         // if we're not actually taking a step, no minefield hazard
         if ((step == null) || !step.getType().entersNewHex()) {
@@ -63,7 +64,7 @@ public class MinefieldUtil {
         double hazardAccumulator = 0;
         // hovercraft and WIGEs grinding along the ground detonate minefields on a 12
         boolean hoverMovement = movingUnit.getMovementMode() == EntityMovementMode.HOVER ||
-                (movingUnit.getMovementMode() == EntityMovementMode.WIGE && movingUnit.getElevation() == 0);
+                ((movingUnit.getMovementMode() == EntityMovementMode.WIGE) && (movingUnit.getElevation() == 0));
         double hoverMovementMultiplier = hoverMovement ?
                 Compute.oddsAbove(Minefield.HOVER_WIGE_DETONATION_TARGET) : 1;
         

--- a/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
+++ b/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
@@ -1,0 +1,100 @@
+/*
+* MegaMek -
+* Copyright (C) 2021 The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
+*/
+
+package megamek.client.bot.princess;
+
+import megamek.common.Compute;
+import megamek.common.Entity;
+import megamek.common.EntityMovementMode;
+import megamek.common.Mech;
+import megamek.common.Minefield;
+import megamek.common.MovePath;
+import megamek.common.MovePath.MoveStepType;
+import megamek.common.MoveStep;
+
+/**
+ * This class contains logic to evaluate the damage a unit could sustain from
+ * moving a long a move path containing minefields
+ * @author NickAragua
+ */
+public class MinefieldUtil {
+    /**
+     * Calculate how much damage we'll take from stepping on mines over  a particular path
+     */
+    public static double checkPathForMinefieldHazards(MovePath path) {
+        double hazardAccumulator = 0;
+                
+        for (MoveStep step : path.getStepVector()) {
+            hazardAccumulator += calcMinefieldHazardForHex(step, path.getEntity(),
+                    path.isJumping(), step.equals(path.getLastStep())); 
+        }
+        
+        //TODO: Teach bot to activate minesweepers
+        
+        return hazardAccumulator;
+    }
+    
+    /**
+     * Calculate how much damage we'll take from stepping on mines in a particular hex
+     */
+    public static double calcMinefieldHazardForHex(MoveStep step, Entity movingUnit, 
+            boolean isJumping, boolean lastStep) {
+        // if we're not actually taking a step, no minefield hazard
+        if ((step == null) || !step.getType().entersNewHex()) {
+            return 0;
+        }
+        
+        // if our movement mode does not result in minefield detonation, no minefield hazard
+        if (!movingUnit.getMovementMode().detonatesGroundMinefields()) {
+            return 0;
+        }
+        
+        double hazardAccumulator = 0;
+        // hovercraft and WIGEs grinding along the ground detonate minefields on a 12
+        boolean hoverMovement = movingUnit.getMovementMode() == EntityMovementMode.HOVER ||
+                (movingUnit.getMovementMode() == EntityMovementMode.WIGE && movingUnit.getElevation() == 0);
+        double hoverMovementMultiplier = hoverMovement ?
+                Compute.oddsAbove(Minefield.HOVER_WIGE_DETONATION_TARGET) : 1;
+        
+        // only mechs interact with vibrabombs
+        boolean unitIsMech = movingUnit instanceof Mech;
+        
+        for (Minefield minefield : movingUnit.getGame().getMinefields(step.getPosition())) {
+            switch (minefield.getType()) {
+                case Minefield.TYPE_CONVENTIONAL:
+                case Minefield.TYPE_INFERNO:
+                    // if we're either not jumping
+                    if (!isJumping || lastStep) {
+                        hazardAccumulator += minefield.getDensity() * hoverMovementMultiplier;
+                    }
+                    break;
+                case Minefield.TYPE_ACTIVE:
+                    hazardAccumulator += minefield.getDensity() * hoverMovementMultiplier;
+                    break;
+                case Minefield.TYPE_VIBRABOMB:
+                    // mechs >10 tons the "setting" will set off vibrabombs before they 
+                    // get to them so we don't particularly care 
+                    if (unitIsMech && (!isJumping || lastStep) &&
+                            (movingUnit.getWeight() >= minefield.getSetting()) &&
+                            (movingUnit.getWeight() <= minefield.getSetting() + 10)) {
+                        hazardAccumulator += minefield.getDensity();
+                    }
+                    break;
+            }
+        }
+        
+        return hazardAccumulator;
+    }
+}

--- a/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
+++ b/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
@@ -63,7 +63,7 @@ public class MinefieldUtil {
         
         double hazardAccumulator = 0;
         // hovercraft and WIGEs grinding along the ground detonate minefields on a 12
-        boolean hoverMovement = movingUnit.getMovementMode() == EntityMovementMode.HOVER ||
+        boolean hoverMovement = (movingUnit.getMovementMode() == EntityMovementMode.HOVER) ||
                 ((movingUnit.getMovementMode() == EntityMovementMode.WIGE) && (movingUnit.getElevation() == 0));
         double hoverMovementMultiplier = hoverMovement ?
                 Compute.oddsAbove(Minefield.HOVER_WIGE_DETONATION_TARGET) : 1;

--- a/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
+++ b/megamek/src/megamek/client/bot/princess/MinefieldUtil.java
@@ -21,7 +21,6 @@ import megamek.common.EntityMovementMode;
 import megamek.common.Mech;
 import megamek.common.Minefield;
 import megamek.common.MovePath;
-import megamek.common.MovePath.MoveStepType;
 import megamek.common.MoveStep;
 
 /**
@@ -75,7 +74,7 @@ public class MinefieldUtil {
             switch (minefield.getType()) {
                 case Minefield.TYPE_CONVENTIONAL:
                 case Minefield.TYPE_INFERNO:
-                    // if we're either not jumping
+                    // if we're either not jumping or it's the last step
                     if (!isJumping || lastStep) {
                         hazardAccumulator += minefield.getDensity() * hoverMovementMultiplier;
                     }

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -42,6 +42,7 @@ import megamek.common.Terrains;
 import megamek.common.pathfinder.AbstractPathFinder.Filter;
 import megamek.common.pathfinder.AeroGroundPathFinder;
 import megamek.common.pathfinder.AeroGroundPathFinder.AeroGroundOffBoardFilter;
+import megamek.common.pathfinder.LongestPathFinder.MovePathMinefieldAvoidanceMinMPMaxDistanceComparator;
 import megamek.common.util.BoardUtilities;
 import megamek.common.pathfinder.AeroLowAltitudePathFinder;
 import megamek.common.pathfinder.AeroSpacePathFinder;
@@ -269,12 +270,14 @@ public class PathEnumerator {
                 LongestPathFinder lpf = LongestPathFinder
                         .newInstanceOfLongestPath(mover.getRunMPwithoutMASC(),
                                 MoveStepType.FORWARDS, getGame());
+                lpf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
                 lpf.run(new MovePath(game, mover));
                 paths.addAll(lpf.getLongestComputedPaths());
 
                 //add walking moves
                 lpf = LongestPathFinder.newInstanceOfLongestPath(
                         mover.getWalkMP(), MoveStepType.BACKWARDS, getGame());
+                lpf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
                 lpf.run(new MovePath(getGame(), mover));
                 paths.addAll(lpf.getLongestComputedPaths());
 
@@ -288,6 +291,7 @@ public class PathEnumerator {
                 	ShortestPathFinder spf = ShortestPathFinder
                             .newInstanceOfOneToAll(mover.getJumpMP(),
                                     MoveStepType.FORWARDS, getGame());
+                	spf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
                     spf.run((new MovePath(game, mover))
                             .addStep(MoveStepType.START_JUMP));
                     paths.addAll(spf.getAllComputedPathsUncategorized());

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -288,10 +288,10 @@ public class PathEnumerator {
                 
                 //add jumping moves
                 if (mover.getJumpMP() > 0) {
-                	ShortestPathFinder spf = ShortestPathFinder
+                    ShortestPathFinder spf = ShortestPathFinder
                             .newInstanceOfOneToAll(mover.getJumpMP(),
                                     MoveStepType.FORWARDS, getGame());
-                	spf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
+                    spf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
                     spf.run((new MovePath(game, mover))
                             .addStep(MoveStepType.START_JUMP));
                     paths.addAll(spf.getAllComputedPathsUncategorized());

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import megamek.client.bot.princess.FireControl;
+import megamek.client.bot.princess.MinefieldUtil;
 import megamek.common.pathfinder.BoardClusterTracker.MovementType;
 
 /**
@@ -116,6 +117,14 @@ public class BulldozerMovePath extends MovePath {
                     additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP());
                 }
             }
+        }
+        
+        // we want to discourage running over minefields
+        double minefieldFactor = MinefieldUtil.calcMinefieldHazardForHex(mp.getLastStep(), mp.getEntity(), 
+                mp.isJumping(), false);
+        
+        if (minefieldFactor > 0) {
+            additionalCosts.put(mp.getFinalCoords(), (int) Math.ceil(minefieldFactor));
         }
 
         return mp;

--- a/megamek/src/megamek/common/EntityMovementMode.java
+++ b/megamek/src/megamek/common/EntityMovementMode.java
@@ -77,4 +77,21 @@ public enum EntityMovementMode {
     {
         return t.name();
     }
+    
+    /**
+     * Whether this movement mode is capable of detonating minefields.
+     */
+    public boolean detonatesGroundMinefields() {
+        return (this == BIPED) ||
+                (this == TRIPOD) ||
+                (this == QUAD) ||
+                (this == TRACKED) ||
+                (this == WHEELED) ||
+                (this == HOVER) || // a lot less likely, but...
+                (this == INF_LEG) ||
+                (this == INF_MOTORIZED) ||
+                (this == INF_JUMP) ||
+                (this == RAIL) ||
+                (this == MAGLEV);
+    }
 }

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -44,6 +44,8 @@ public class Minefield implements Serializable, Cloneable {
 
     public static final int TO_HIT_SIDE = ToHitData.SIDE_FRONT;
     public static final int TO_HIT_TABLE = ToHitData.HIT_KICK;
+    
+    public static final int HOVER_WIGE_DETONATION_TARGET = 12;
 
     public static final int MAX_DAMAGE = 30;
 

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -70,6 +70,18 @@ public class MovePath implements Cloneable, Serializable {
         SHUTDOWN, STARTUP, SELF_DESTRUCT, ACCN, DECN, ROLL, OFF, RETURN, LAUNCH, THRUST, YAW, CRASH, RECOVER,
         RAM, HOVER, MANEUVER, LOOP, CAREFUL_STAND, JOIN, DROP, VLAND, MOUNT, UNDOCK, TAKE_COVER,
         CONVERT_MODE, BOOTLEGGER, TOW, DISCONNECT;
+        
+        /**
+         * Whether this move step type will result in the unit entering a new hex
+         */
+        public boolean entersNewHex() {
+            return this == FORWARDS || 
+                    this == BACKWARDS ||
+                    this == LATERAL_LEFT ||
+                    this == LATERAL_RIGHT ||
+                    this == LATERAL_LEFT_BACKWARDS ||
+                    this == LATERAL_RIGHT_BACKWARDS;
+        }
     }
 
     public static class Key {

--- a/megamek/src/megamek/common/pathfinder/LongestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/LongestPathFinder.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 
+import megamek.client.bot.princess.MinefieldUtil;
 import megamek.common.Coords;
 import megamek.common.IGame;
 import megamek.common.Infantry;
@@ -105,6 +106,29 @@ public class LongestPathFinder extends MovePathFinder<Deque<MovePath>> {
                 return s;
             } else {
                 return second.getHexesMoved() - first.getHexesMoved();
+            }
+        }
+    }
+    
+    /**
+     * Comparator that sorts MovePaths based on, in order, the following criteria:
+     * Minefield hazard (less is better)
+     *
+     */
+    public static class MovePathMinefieldAvoidanceMinMPMaxDistanceComparator extends MovePathMinMPMaxDistanceComparator {
+        @Override
+        public int compare(MovePath first, MovePath second) {
+            Double firstMinefieldScore = MinefieldUtil.calcMinefieldHazardForHex(first.getLastStep(), 
+                    first.getEntity(), first.isJumping(), false);
+            Double secondMinefieldScore = MinefieldUtil.calcMinefieldHazardForHex(second.getLastStep(), 
+                    second.getEntity(), second.isJumping(), false);
+               
+            int s = secondMinefieldScore.compareTo(firstMinefieldScore);
+            
+            if (s == 0) {
+                return super.compare(first, second);
+            } else {
+                return s;
             }
         }
     }

--- a/megamek/src/megamek/common/pathfinder/LongestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/LongestPathFinder.java
@@ -112,8 +112,9 @@ public class LongestPathFinder extends MovePathFinder<Deque<MovePath>> {
     
     /**
      * Comparator that sorts MovePaths based on, in order, the following criteria:
-     * Minefield hazard (less is better)
-     *
+     * Minefield hazard (stepping on less mines is better)
+     * Least MP used
+     * Most distance moved
      */
     public static class MovePathMinefieldAvoidanceMinMPMaxDistanceComparator extends MovePathMinMPMaxDistanceComparator {
         @Override

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -27,6 +27,7 @@ import megamek.common.IHex;
 import megamek.common.MovePath;
 import megamek.common.Terrains;
 import megamek.common.MovePath.MoveStepType;
+import megamek.common.pathfinder.LongestPathFinder.MovePathMinefieldAvoidanceMinMPMaxDistanceComparator;
 
 /**
  * This class contains functionality that takes a given path
@@ -155,6 +156,7 @@ public class PathDecorator {
         LongestPathFinder lpf = LongestPathFinder
                 .newInstanceOfLongestPath(desiredMP,
                         MoveStepType.FORWARDS, source.getGame());
+        lpf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
         lpf.run(source);
         turnPaths.addAll(lpf.getLongestComputedPaths());
         

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11135,7 +11135,7 @@ public class Server implements Runnable {
                 }
                 if ((entity.getMovementMode() == EntityMovementMode.HOVER)
                         || (entity.getMovementMode() == EntityMovementMode.WIGE)) {
-                    target = 12;
+                    target = Minefield.HOVER_WIGE_DETONATION_TARGET;
                 }
             }
 

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -406,6 +406,7 @@ public class BasicPathRankerTest {
         Mockito.when(mockPath.toString()).thenReturn("F F F");
         Mockito.when(mockPath.clone()).thenReturn(mockPath);
         Mockito.when(mockPath.getLastStep()).thenReturn(mockLastStep);
+        Mockito.when(mockPath.getStepVector()).thenReturn(new Vector<MoveStep>());
 
         final IBoard mockBoard = Mockito.mock(IBoard.class);
         Mockito.when(mockBoard.contains(Mockito.any(Coords.class))).thenReturn(true);


### PR DESCRIPTION
This is the first attempt at having the bot try to avoid minefields. The basic gist is that the bot will generally prefer not to step on mines if she thinks she will detonate them. The bot client only has access to minefields it knows about.

More detailed breakdown:
- when generating ground paths for mechs, due to the specialized nature of the routine, strongly prefer to retain paths that do not go over known minefields.
- when generating long range movement paths, strongly prefer to avoid paths that do not go over known minefields.
- when evaluating generated paths, prefer to avoid paths that go over minefields