### PR TITLE
Lobby PlayerTable oddity

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1182,6 +1182,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
                 tablePlayers.addRowSelectionInterval(row, row);
             }
         }
+        // If no one is selected now (and the table isn't empty), select the first player
         if (tablePlayers.getSelectedRowCount() == 0 && tablePlayers.getRowCount() > 0) {
             tablePlayers.addRowSelectionInterval(0, 0);
         }

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1183,7 +1183,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             }
         }
         // If no one is selected now (and the table isn't empty), select the first player
-        if (tablePlayers.getSelectedRowCount() == 0 && tablePlayers.getRowCount() > 0) {
+        if ((tablePlayers.getSelectedRowCount() == 0) && (tablePlayers.getRowCount() > 0)) {
             tablePlayers.addRowSelectionInterval(0, 0);
         }
     }

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1182,6 +1182,9 @@ public class ChatLounge extends AbstractPhaseDisplay implements
                 tablePlayers.addRowSelectionInterval(row, row);
             }
         }
+        if (tablePlayers.getSelectedRowCount() == 0 && tablePlayers.getRowCount() > 0) {
+            tablePlayers.addRowSelectionInterval(0, 0);
+        }
     }
 
     /** Updates the camo button to displays the camo of the currently selected player. */ 


### PR DESCRIPTION
With the new lobby, the player table remembers now what players were previously selected when the client receives any changes from the server (instead of reverting to having the first player selected as before 0.49). This had the effect that when starting a new game, no player was selected. This PR changes this to select the first player (=self) when no player would otherwise be selected. 