### PR TITLE
Small AbstractDialog rearrangement

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
@@ -75,6 +75,21 @@ public abstract class AbstractDialog extends JDialog implements WindowListener {
         setName(name);
         setFrame(frame);
         this.resources = resources;
+        // Escape keypress
+        final KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+        getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, CLOSE_ACTION);
+        getRootPane().getInputMap(JComponent.WHEN_FOCUSED).put(escape, CLOSE_ACTION);
+        getRootPane().getActionMap().put(CLOSE_ACTION, new AbstractAction() {
+            private static final long serialVersionUID = 95171770700983453L;
+
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                cancelActionPerformed(evt);
+            }
+        });
+
+        addWindowListener(this);
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     }
     //endregion Constructors
 
@@ -96,7 +111,6 @@ public abstract class AbstractDialog extends JDialog implements WindowListener {
      * Anything that overrides this method MUST end by calling {@link AbstractDialog#finalizeInitialization()}
      */
     protected void initialize() {
-        setLayout(new BorderLayout());
         add(createCenterPane(), BorderLayout.CENTER);
         finalizeInitialization();
     }
@@ -113,22 +127,6 @@ public abstract class AbstractDialog extends JDialog implements WindowListener {
      */
     protected void finalizeInitialization() {
         pack();
-
-        // Escape keypress
-        final KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
-        getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, CLOSE_ACTION);
-        getRootPane().getInputMap(JComponent.WHEN_FOCUSED).put(escape, CLOSE_ACTION);
-        getRootPane().getActionMap().put(CLOSE_ACTION, new AbstractAction() {
-            private static final long serialVersionUID = 95171770700983453L;
-
-            @Override
-            public void actionPerformed(ActionEvent evt) {
-                cancelActionPerformed(evt);
-            }
-        });
-
-        addWindowListener(this);
-        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         setPreferences();
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/BVDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BVDisplayDialog.java
@@ -42,16 +42,10 @@ public class BVDisplayDialog extends AbstractDialog {
     }
     //endregion Constructors
 
-    //region Getters
-    public Entity getEntity() {
-        return entity;
-    }
-    //endregion Getters
-
     //region Initialization
     @Override
     protected Container createCenterPane() {
-        final JEditorPane editorPane = new JEditorPane("text/html", getEntity().getBVText());
+        final JEditorPane editorPane = new JEditorPane("text/html", entity.getBVText());
         editorPane.setEditable(false);
         editorPane.setCaretPosition(0);
 


### PR DESCRIPTION
Small suggestions for AbstractDialog (since I have now been looking at it for quite a bit): 
- Most of the initialization bit can be moved up to the constructor as it needs no dialog content, so that's where I would put it.
- BorderLayout is the default layout of JDialog, so setting it isn't necessary.
- The entity getter seems overkill in the subclassed BVDialog.

