### PR TITLE
UnitReadoutDialog based on AbstractDlg

### DIFF
--- a/megamek/i18n/megamek/client/messages_en.properties
+++ b/megamek/i18n/megamek/client/messages_en.properties
@@ -23,6 +23,9 @@ AbstractHelpDialog.noHelp.title=No Help Available
 ### BVDisplayDialog Class
 BVDisplayDialog.title=BV Calculation Display
 
+### EntityReadoutDialog
+EntityReadoutDialog.title=Unit Readout: 
+
 
 
 #### Panes

--- a/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
@@ -30,6 +30,7 @@ public class EntityReadoutDialog extends AbstractDialog {
 
     private final JFrame parent;
     private final Entity entity;
+    private EntityViewPane entityView;
 
     /** Constructs a non-modal dialog showing the readout (TRO) of the given entity. */ 
     public EntityReadoutDialog(final JFrame frame, final Entity entity) {
@@ -47,7 +48,8 @@ public class EntityReadoutDialog extends AbstractDialog {
 
     @Override
     protected Container createCenterPane() {
-        return new EntityViewPane(parent, entity);
+        entityView = new EntityViewPane(parent, entity);
+        return entityView;
     }
-
+    
 }

--- a/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
@@ -23,12 +23,13 @@ import java.util.Objects;
 import javax.swing.*;
 import megamek.client.ui.baseComponents.AbstractDialog;
 import megamek.client.ui.panes.EntityViewPane;
+import megamek.client.ui.preferences.JTabbedPanePreference;
+import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.*;
 
 /** A dialog showing the unit readout for a given unit. */
 public class EntityReadoutDialog extends AbstractDialog {
 
-    private final JFrame parent;
     private final Entity entity;
     private EntityViewPane entityView;
 
@@ -42,14 +43,19 @@ public class EntityReadoutDialog extends AbstractDialog {
         super(frame, modal, "EntityReadoutDialog", "EntityReadoutDialog.title");
         setTitle(getTitle() + entity.getShortNameRaw());
         this.entity = Objects.requireNonNull(entity);
-        parent = frame;
         initialize();
     }
 
     @Override
     protected Container createCenterPane() {
-        entityView = new EntityViewPane(parent, entity);
+        entityView = new EntityViewPane(getFrame(), entity);
         return entityView;
+    }
+    
+    @Override
+    protected void setCustomPreferences(final PreferencesNode preferences) {
+        super.setCustomPreferences(preferences);
+        preferences.manage(new JTabbedPanePreference(entityView));
     }
     
 }

--- a/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
@@ -22,40 +22,32 @@ import java.awt.Container;
 import java.util.Objects;
 import javax.swing.*;
 import megamek.client.ui.baseComponents.AbstractDialog;
-import megamek.client.ui.swing.util.UIUtil;
+import megamek.client.ui.panes.EntityViewPane;
 import megamek.common.*;
 
 /** A dialog showing the unit readout for a given unit. */
-public class UnitReadoutDialog extends AbstractDialog {
+public class EntityReadoutDialog extends AbstractDialog {
 
+    private final JFrame parent;
     private final Entity entity;
 
     /** Constructs a non-modal dialog showing the readout (TRO) of the given entity. */ 
-    public UnitReadoutDialog(final JFrame frame, final Entity entity) {
+    public EntityReadoutDialog(final JFrame frame, final Entity entity) {
         this(frame, false, entity);
     }
 
     /** Constructs a dialog showing the readout (TRO) of the given entity with the given modality. */
-    public UnitReadoutDialog(final JFrame frame, final boolean modal, final Entity entity) {
-        super(frame, modal, "BVDisplayDialog", "BVDisplayDialog.title");
+    public EntityReadoutDialog(final JFrame frame, final boolean modal, final Entity entity) {
+        super(frame, modal, "EntityReadoutDialog", "EntityReadoutDialog.title");
+        setTitle(getTitle() + entity.getShortNameRaw());
         this.entity = Objects.requireNonNull(entity);
+        parent = frame;
         initialize();
     }
 
     @Override
     protected Container createCenterPane() {
-        MechView mv = new MechView(entity, false);
-        // The label must want a fixed width to enforce linebreaks on fluff text
-        JLabel mechSummary = new JLabel("<HTML>" + mv.getMechReadoutHead() + mv.getMechReadoutBasic()
-                + mv.getMechReadoutLoadout() + mv.getMechReadoutFluff());
-        mechSummary.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-
-        JScrollPane tScroll = new JScrollPane(mechSummary,
-                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-                JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-        tScroll.getVerticalScrollBar().setUnitIncrement(16);
-        mechSummary.setFont(UIUtil.getScaledFont());
-        return tScroll;
+        return new EntityViewPane(parent, entity);
     }
 
 }

--- a/megamek/src/megamek/client/ui/dialogs/UnitReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/UnitReadoutDialog.java
@@ -19,7 +19,6 @@
 package megamek.client.ui.dialogs;
 
 import java.awt.Container;
-import java.awt.Dimension;
 import java.util.Objects;
 import javax.swing.*;
 import megamek.client.ui.baseComponents.AbstractDialog;
@@ -28,7 +27,7 @@ import megamek.common.*;
 
 /** A dialog showing the unit readout for a given unit. */
 public class UnitReadoutDialog extends AbstractDialog {
-    
+
     private final Entity entity;
 
     /** Constructs a non-modal dialog showing the readout (TRO) of the given entity. */ 
@@ -47,21 +46,15 @@ public class UnitReadoutDialog extends AbstractDialog {
     protected Container createCenterPane() {
         MechView mv = new MechView(entity, false);
         // The label must want a fixed width to enforce linebreaks on fluff text
-        JLabel mechSummary = new JLabel("<HTML>" + mv.getMechReadoutHead()
-        + mv.getMechReadoutBasic() + mv.getMechReadoutLoadout()
-        + mv.getMechReadoutFluff()) {
-            @Override
-            public Dimension getPreferredSize() {
-                return new Dimension(500, super.getPreferredSize().height);
-            }
-        };
+        JLabel mechSummary = new JLabel("<HTML>" + mv.getMechReadoutHead() + mv.getMechReadoutBasic()
+                + mv.getMechReadoutLoadout() + mv.getMechReadoutFluff());
         mechSummary.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
         JScrollPane tScroll = new JScrollPane(mechSummary,
                 JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
                 JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         tScroll.getVerticalScrollBar().setUnitIncrement(16);
-//        mechSummary.setFont(UIUtil.);
+        mechSummary.setFont(UIUtil.getScaledFont());
         return tScroll;
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/UnitReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/UnitReadoutDialog.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.dialogs;
+
+import java.awt.Container;
+import java.awt.Dimension;
+import java.util.Objects;
+import javax.swing.*;
+import megamek.client.ui.baseComponents.AbstractDialog;
+import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.*;
+
+/** A dialog showing the unit readout for a given unit. */
+public class UnitReadoutDialog extends AbstractDialog {
+    
+    private final Entity entity;
+
+    /** Constructs a non-modal dialog showing the readout (TRO) of the given entity. */ 
+    public UnitReadoutDialog(final JFrame frame, final Entity entity) {
+        this(frame, false, entity);
+    }
+
+    /** Constructs a dialog showing the readout (TRO) of the given entity with the given modality. */
+    public UnitReadoutDialog(final JFrame frame, final boolean modal, final Entity entity) {
+        super(frame, modal, "BVDisplayDialog", "BVDisplayDialog.title");
+        this.entity = Objects.requireNonNull(entity);
+        initialize();
+    }
+
+    @Override
+    protected Container createCenterPane() {
+        MechView mv = new MechView(entity, false);
+        // The label must want a fixed width to enforce linebreaks on fluff text
+        JLabel mechSummary = new JLabel("<HTML>" + mv.getMechReadoutHead()
+        + mv.getMechReadoutBasic() + mv.getMechReadoutLoadout()
+        + mv.getMechReadoutFluff()) {
+            @Override
+            public Dimension getPreferredSize() {
+                return new Dimension(500, super.getPreferredSize().height);
+            }
+        };
+        mechSummary.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+        JScrollPane tScroll = new JScrollPane(mechSummary,
+                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        tScroll.getVerticalScrollBar().setUnitIncrement(16);
+//        mechSummary.setFont(UIUtil.);
+        return tScroll;
+    }
+
+}

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -17,45 +17,25 @@ package megamek.client.ui.swing.dialog;
 import megamek.MegaMek;
 import megamek.client.ui.Messages;
 import megamek.client.ui.dialogs.BVDisplayDialog;
-import megamek.client.ui.swing.AdvancedSearchDialog;
-import megamek.client.ui.swing.GUIPreferences;
-import megamek.client.ui.swing.MechViewPanel;
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.MechFileParser;
-import megamek.common.MechSearchFilter;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.MechView;
-import megamek.common.TechConstants;
-import megamek.common.UnitType;
+import megamek.client.ui.panes.EntityViewPane;
+import megamek.client.ui.swing.*;
+import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
-import megamek.common.options.GameOptions;
-import megamek.common.options.OptionsConstants;
-import megamek.common.templates.TROView;
+import megamek.common.options.*;
 import megamek.common.util.sorter.NaturalOrderComparator;
 
 import javax.swing.*;
 import javax.swing.RowSorter.SortKey;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.awt.event.WindowEvent;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import javax.swing.event.*;
+import javax.swing.table.*;
+
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.*;
+import java.util.*;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -96,8 +76,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
     protected JLabel labelImage = new JLabel(""); //inline to avoid potential null pointer issues
     protected JTable tableUnits;
     protected JTextField textFilter;
-    private MechViewPanel panelMechView;
-    private MechViewPanel panelTROView;
+    protected EntityViewPane panePreview;
     private JSplitPane splitPane;
 
     private StringBuffer searchBuffer = new StringBuffer();
@@ -188,15 +167,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         getContentPane().setLayout(new GridBagLayout());
 
         //region Unit Preview Pane
-        JTabbedPane panePreview = new JTabbedPane();
-
-        panelMechView = new MechViewPanel();
-        panelMechView.setMinimumSize(new Dimension(300, 500));
-        panelMechView.setPreferredSize(new Dimension(300, 600));
-        panePreview.addTab("Summary", panelMechView);
-
-        panelTROView = new MechViewPanel();
-        panePreview.addTab("TRO", panelTROView);
+        panePreview = new EntityViewPane(frame, null);
         //endregion Unit Preview Pane
 
         //region Selection Panel
@@ -587,34 +558,12 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
      * @return the selected entity (required for MekHQ/MegaMek overrides)
      */
     protected Entity refreshUnitView() {
-        boolean populateTextFields = true;
-
         Entity selectedEntity = getSelectedEntity();
-        // null entity, so load a default unit.
+        panePreview.updateDisplayedEntity(selectedEntity);
+        // Empty the unit preview icon if there's no entity selected
         if (selectedEntity == null) {
-            panelMechView.reset();
             labelImage.setIcon(null);
-            return null;
         }
-
-        MechView mechView = null;
-        TROView troView = null;
-        try {
-            mechView = new MechView(selectedEntity, false);
-            troView = TROView.createView(selectedEntity, true);
-        } catch (Exception e) {
-            MegaMek.getLogger().error(e);
-            // error: unit didn't load right. this is bad news.
-            populateTextFields = false;
-        }
-        if (populateTextFields) {
-            panelMechView.setMech(selectedEntity, mechView);
-            panelTROView.setMech(selectedEntity, troView);
-        } else {
-            panelMechView.reset();
-            panelTROView.reset();
-        }
-
         return selectedEntity;
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -74,6 +74,7 @@ import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.ui.Messages;
 import megamek.client.ui.dialogs.BVDisplayDialog;
 import megamek.client.ui.dialogs.CamoChooserDialog;
+import megamek.client.ui.dialogs.UnitReadoutDialog;
 import megamek.client.ui.swing.*;
 import megamek.client.ui.swing.boardview.BoardView1;
 import megamek.client.ui.swing.dialog.DialogButton;
@@ -1482,40 +1483,9 @@ public class ChatLounge extends AbstractPhaseDisplay implements
      * so that multiple dialogs dont appear exactly on top of each other. 
      */
     private void mechReadout(Entity entity, int index) {
-        final ClientDialog dialog = new ClientDialog(clientgui.frame, Messages.getString("ChatLounge.quickView"), false, true);
-        final int height = 600;
-        final int width = 500;
-
-        MechView mv = new MechView(entity, false);
-        // The label must want a fixed width to enforce linebreaks on fluff text
-        JLabel mechSummary = new JLabel("<HTML>" + mv.getMechReadoutHead()
-        + mv.getMechReadoutBasic() + mv.getMechReadoutLoadout()
-        + mv.getMechReadoutFluff()) {
-            private static final long serialVersionUID = 2989361635430008853L;
-            @Override
-            public Dimension getPreferredSize() {
-                return new Dimension(width - 10, super.getPreferredSize().height);
-            }
-        };
-        mechSummary.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-
-        JScrollPane tScroll = new JScrollPane(mechSummary,
-                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-                JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-        tScroll.getVerticalScrollBar().setUnitIncrement(16);
-        dialog.add(tScroll, BorderLayout.CENTER);
-
-        JButton button = new DialogButton(Messages.getString("Okay"));
-        button.addActionListener(e -> dialog.setVisible(false));
-        JPanel okayPanel = new JPanel(new FlowLayout());
-        okayPanel.add(button);
-        dialog.add(okayPanel, BorderLayout.PAGE_END);
-
-        Dimension sz = new Dimension(scaleForGUI(width), scaleForGUI(height));
-        dialog.setPreferredSize(sz);
-        dialog.center();
+        final UnitReadoutDialog dialog = new UnitReadoutDialog(clientgui.frame, entity);
         dialog.setVisible(true);
-        dialog.setLocation(dialog.getLocation().x + index * 10, dialog.getLocation().y + index * 10);
+//        dialog.setLocation(dialog.getLocation().x + index * 10, dialog.getLocation().y + index * 10);
     }
 
     /** 

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1485,7 +1485,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
     private void mechReadout(Entity entity, int index) {
         final UnitReadoutDialog dialog = new UnitReadoutDialog(clientgui.frame, entity);
         dialog.setVisible(true);
-//        dialog.setLocation(dialog.getLocation().x + index * 10, dialog.getLocation().y + index * 10);
+        dialog.setLocation(dialog.getLocation().x + index * 10, dialog.getLocation().y + index * 10);
     }
 
     /** 

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -74,7 +74,7 @@ import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.ui.Messages;
 import megamek.client.ui.dialogs.BVDisplayDialog;
 import megamek.client.ui.dialogs.CamoChooserDialog;
-import megamek.client.ui.dialogs.UnitReadoutDialog;
+import megamek.client.ui.dialogs.EntityReadoutDialog;
 import megamek.client.ui.swing.*;
 import megamek.client.ui.swing.boardview.BoardView1;
 import megamek.client.ui.swing.dialog.DialogButton;
@@ -1483,7 +1483,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
      * so that multiple dialogs dont appear exactly on top of each other. 
      */
     private void mechReadout(Entity entity, int index) {
-        final UnitReadoutDialog dialog = new UnitReadoutDialog(clientgui.frame, entity);
+        final EntityReadoutDialog dialog = new EntityReadoutDialog(clientgui.frame, entity);
         dialog.setVisible(true);
         dialog.setLocation(dialog.getLocation().x + index * 10, dialog.getLocation().y + index * 10);
     }


### PR DESCRIPTION
As the title says. No functional change. Separates out the readout dialog from the lobby's "View" menu option into its own class based on AbstractDialog. 
I'll say this was effortless.