### PR TITLE
Show all locations for spreadable equipment in summary view

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3168,6 +3168,24 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
+     * Joins the abbreviations for the locations into a String with / as the separator.
+     * If the number of locations exceeds the provided limit, the result is
+     * abbreviated. By default the abbreviation is simply an asterisk, but Mechs have
+     * specific abbreviations locations that include all torso or leg positions.
+     *
+     * @param locations A list of location indices
+     * @param limit     The maximum number of locations to show in full
+     * @return          A string formatted for display that shows the locations
+     */
+    public String joinLocationAbbr(List<Integer> locations, int limit) {
+        if (locations.size() > limit) {
+            return "*";
+        } else {
+            return locations.stream().map(l -> getLocationAbbr(l)).collect(Collectors.joining("/"));
+        }
+    }
+
+    /**
      * Rolls the to-hit number
      */
     public abstract HitData rollHitLocation(int table, int side,

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -20,6 +20,7 @@ import java.io.PrintWriter;
 import java.math.BigInteger;
 import java.text.NumberFormat;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import megamek.MegaMek;
 import megamek.common.loaders.MtfFile;
@@ -2096,6 +2097,18 @@ public abstract class Mech extends Entity {
         }
         // other weapons into the secondary
         return true;
+    }
+
+    @Override
+    public String joinLocationAbbr(List<Integer> locations, int limit) {
+        // If all locations are torso, strip the T from all but the last location.
+        // e.g. R/L/CT
+        if ((locations.size() > limit) && locations.stream().allMatch(this::locationIsTorso)) {
+            return locations.stream().map(l -> getLocationAbbr(l).replace("T", ""))
+                    .collect(Collectors.joining("/")) + "T";
+        } else {
+            return super.joinLocationAbbr(locations, limit);
+        }
     }
 
     /*

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -777,8 +777,9 @@ public class MechView {
         wpnTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_CENTER,
                 TableElement.JUSTIFIED_CENTER, TableElement.JUSTIFIED_LEFT);
         for (Mounted mounted : entity.getWeaponList()) {
-            String[] row = new String[] { mounted.getDesc(),
-                    entity.getLocationAbbr(mounted.getLocation()), "", "" };
+            String[] row = { mounted.getDesc(),
+                    mounted.allLocations().stream().map(l -> entity.getLocationAbbr(l))
+                            .collect(Collectors.joining("/")), "", "" };
             WeaponType wtype = (WeaponType) mounted.getType();
 
             if (entity.isClan()
@@ -795,11 +796,6 @@ public class MechView {
              * //$NON-NLS-1$ .append(mounted.getLinked().getDesc()).append("]");
              * //$NON-NLS-1$ }
              */
-
-            if (mounted.isSplit()) {
-                row[1] += "/" + entity.getLocationAbbr(mounted // $NON-NLS-1$
-                                .getSecondLocation());
-            }
 
             int heat = wtype.getHeat();
             int bWeapDamaged = 0;
@@ -912,7 +908,7 @@ public class MechView {
             if (mounted.getLocation() == Entity.LOC_NONE) {
                 continue;
             }
-            
+
             String[] row = { mounted.getName(), entity.getLocationAbbr(mounted.getLocation()),
                     String.valueOf(mounted.getBaseShotsLeft()), "" };
             if (entity.isOmni()) {
@@ -997,7 +993,9 @@ public class MechView {
             }
             nEquip++;
             
-            String[] row = { mounted.getDesc(), entity.getLocationAbbr(mounted.getLocation()), "" };
+            String[] row = { mounted.getDesc(),
+                    mounted.allLocations().stream()
+                            .map(l -> entity.getLocationAbbr(l)).collect(Collectors.joining("/")), "" };
             if (entity.isClan()
                     && (mounted.getType().getTechBase() == ITechnology.TECH_BASE_IS)) {
                 row[0] += Messages.getString("MechView.IS"); //$NON-NLS-1$

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -777,9 +777,7 @@ public class MechView {
         wpnTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_CENTER,
                 TableElement.JUSTIFIED_CENTER, TableElement.JUSTIFIED_LEFT);
         for (Mounted mounted : entity.getWeaponList()) {
-            String[] row = { mounted.getDesc(),
-                    mounted.allLocations().stream().map(l -> entity.getLocationAbbr(l))
-                            .collect(Collectors.joining("/")), "", "" };
+            String[] row = { mounted.getDesc(), entity.joinLocationAbbr(mounted.allLocations(), 3), "", "" };
             WeaponType wtype = (WeaponType) mounted.getType();
 
             if (entity.isClan()
@@ -993,9 +991,7 @@ public class MechView {
             }
             nEquip++;
             
-            String[] row = { mounted.getDesc(),
-                    mounted.allLocations().stream()
-                            .map(l -> entity.getLocationAbbr(l)).collect(Collectors.joining("/")), "" };
+            String[] row = { mounted.getDesc(), entity.joinLocationAbbr(mounted.allLocations(), 3), "" };
             if (entity.isClan()
                     && (mounted.getType().getTechBase() == ITechnology.TECH_BASE_IS)) {
                 row[0] += Messages.getString("MechView.IS"); //$NON-NLS-1$

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -22,10 +22,7 @@
 package megamek.common;
 
 import java.io.Serializable;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import megamek.MegaMek;
 import megamek.common.actions.WeaponAttackAction;
@@ -1064,6 +1061,41 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     public void setSecondLocation(int location, boolean rearMounted) {
         secondLocation = location;
         this.rearMounted = rearMounted;
+    }
+
+    /**
+     * Fetches all locations that contain this equipment. This is primarily for
+     * spreadable equipment, can be placed in locations other than the primary or secondary,
+     * but will also work for non-spreadable equipment.
+     *
+     * @return A list of indices for all locations that contain this equipment.
+     * @see #getLocation()
+     * @see #getSecondLocation()
+     */
+    public List<Integer> allLocations() {
+        List<Integer> locations = new ArrayList<>();
+        if (getType().isSpreadable()) {
+            for (int loc = 0; loc < getEntity().locations(); loc++) {
+                if (getEntity().isFighter() && (loc == Aero.LOC_WINGS)) {
+                    continue;
+                }
+                for (int slot = 0; slot < getEntity().getNumberOfCriticals(loc); slot++) {
+                    final CriticalSlot crit = getEntity().getCritical(loc, slot);
+                    if ((crit != null) && ((crit.getMount() == this) || (crit.getMount2() == this))) {
+                        locations.add(loc);
+                        break;
+                    }
+                }
+            }
+        } else {
+            if (getLocation() >= 0) {
+                locations.add(getLocation());
+            }
+            if (getSecondLocation() >= 0) {
+                locations.add(getSecondLocation());
+            }
+        }
+        return locations;
     }
 
     public Mounted getLinked() {

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1076,9 +1076,6 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         List<Integer> locations = new ArrayList<>();
         if (getType().isSpreadable()) {
             for (int loc = 0; loc < getEntity().locations(); loc++) {
-                if (getEntity().isFighter() && (loc == Aero.LOC_WINGS)) {
-                    continue;
-                }
                 for (int slot = 0; slot < getEntity().getNumberOfCriticals(loc); slot++) {
                     final CriticalSlot crit = getEntity().getCritical(loc, slot);
                     if ((crit != null) && ((crit.getMount() == this) || (crit.getMount2() == this))) {

--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -17,6 +17,7 @@
 package megamek.common;
 
 import java.io.PrintWriter;
+import java.util.List;
 
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
@@ -421,6 +422,16 @@ public class QuadMech extends Mech {
     @Override
     protected double getLegActuatorCost() {
         return (weight * 150 * 4) + (weight * 80 * 4) + (weight * 120 * 4);
+    }
+
+    @Override
+    public String joinLocationAbbr(List<Integer> locations, int limit) {
+        // If we need to abbreviate something that occupies all leg locations, simply return "Legs"
+        if ((locations.size() > limit) && (locations.size() == 4) && locations.stream().allMatch(this::locationIsLeg)) {
+            return "Legs";
+        } else {
+            return super.joinLocationAbbr(locations, limit);
+        }
     }
 
     @Override

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -16,6 +16,7 @@
 package megamek.common;
 
 import java.io.PrintWriter;
+import java.util.List;
 
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
@@ -977,6 +978,16 @@ public class TripodMech extends Mech {
     @Override
     public int locations() {
         return 9;
+    }
+
+    @Override
+    public String joinLocationAbbr(List<Integer> locations, int limit) {
+        // If we need to abbreviate something that occupies all leg locations, simply return "Legs"
+        if ((locations.size() > limit) && (locations.size() == 3) && locations.stream().allMatch(this::locationIsLeg)) {
+            return "Legs";
+        } else {
+            return super.joinLocationAbbr(locations, limit);
+        }
     }
 
     /*


### PR DESCRIPTION
1. Adds a method to `Mounted` that returns all locations where the equipment is located. For most equipment, including weapons that are split between two adjacent locations, this is fairly simple. For spreadable equipment, which includes myomer and bulky armor/structure, but also equipment with multiple fixed locations like the partial wing, it's necessary to check all the critical slots.
2. Adds a method to Entity that formats the location(s) into a string for display. A second argument permits setting a limit to the number of slots that should be displayed without abbreviation. There are some special abbreviations for all-torso or all-leg equipment on Mechs.
3. Uses the new methods to show all locations instead of the single one returned by `Mounted#getLocation` in the `MechView` summary.

The fix for MegaMek/megameklab#869 is based on this.