### PR TITLE
Fix aerospace TRO fluff header

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/fluff.ftl
+++ b/megamek/resources/megamek/common/templates/tro/fluff.ftl
@@ -9,8 +9,12 @@ Movement Type: ${moveType}
 Frame: ${frameDesc}
 </#if>
 Power Plant: ${engineDesc}
+<#if cruisingSpeed??>
 Cruising Speed: ${cruisingSpeed} kph
+</#if>
+<#if maxSpeed??>
 Maximum Speed: ${maxSpeed} kph
+</#if>
 <#if jumpMP?? && jjDesc??>
 Jump Jets: ${jjDesc}
      Jump Capacity: ${jumpCapacity} meters

--- a/megamek/resources/megamek/common/templates/tro/fluff.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/fluff.ftlh
@@ -4,8 +4,8 @@
 <#if moveType??><b>Movement Type: </b>${moveType}<br/></#if>
 <#if frameDesc??><b>Chassis: </b>${frameDesc}<br/></#if>
 <b>Power Plant: </b>${engineDesc}<br/>
-<b>Cruising Speed: </b>${cruisingSpeed} kph<br/>
-<b>Maximum Speed: </b>${maxSpeed} kph<br/>
+<#if cruisingSpeed??><b>Cruising Speed: </b>${cruisingSpeed} kph<br/></#if>
+<#if cruisingSpeed??><b>Maximum Speed: </b>${maxSpeed} kph<br/></#if>
 <#if jumpDesc??>
 <b>Jump Jets: </b>${jjDesc}<br/>
 <b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jump Capacity: </b>${jumpCapacity} meters<br/>

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -604,7 +604,7 @@ public class TROView {
                 bayRow.put("doors", bay.getDoors());
                 bays.add(bayRow);
             } else {
-                MegaMek.getLogger().warning("Could not determine bay type for " + bay.toString());
+                MegaMek.getLogger().warning("Could not determine bay type for " + bay);
             }
         }
         setModelData("bays", bays);

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -233,8 +233,10 @@ public class TROView {
                 + Messages.getString(entity.getWeight() == 1.0 ? "TROView.ton" : "TROView.tons"));
         model.put("engineDesc", formatSystemFluff(EntityFluff.System.ENGINE, entity.getFluff(),
                 () -> stripNotes(entity.getEngine().getEngineName())));
-        model.put("cruisingSpeed", entity.getWalkMP() * 10.8);
-        model.put("maxSpeed", entity.getRunMP() * 10.8);
+        if (!entity.isAero()) {
+            model.put("cruisingSpeed", entity.getWalkMP() * 10.8);
+            model.put("maxSpeed", entity.getRunMP() * 10.8);
+        }
         model.put("armorDesc",
                 formatSystemFluff(EntityFluff.System.ARMOR, entity.getFluff(), () -> formatArmorType(entity, false)));
         final Map<String, Integer> weaponCount = new HashMap<>();


### PR DESCRIPTION
The fluff header on the TRO summary includes lines for cruising and maximum ground speed, which are being filled in for aerospace units using thrust as if they are ground MP. While thrust in Gs would be appropriate, the official TRO books simply omit any speed entry, so that's what I've done.

Fixes MegaMek/megameklab#870