### PR TITLE
Improved unit image scaling in the lobby

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/MekForceTreeRenderer.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekForceTreeRenderer.java
@@ -35,6 +35,7 @@ import megamek.common.*;
 import megamek.common.force.*;
 import megamek.common.icons.Camouflage;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 
 /** A specialized renderer for the Mek Force tree. */
@@ -124,8 +125,9 @@ public class MekForceTreeRenderer extends DefaultTreeCellRenderer {
         return null;
     }
 
-    private void setIcon(Image image, int size) {
-        setIcon(new ImageIcon(image.getScaledInstance(-1, size, Image.SCALE_SMOOTH)));
+    private void setIcon(Image image, int height) {
+        int width = height * image.getWidth(null) / image.getHeight(null);
+        setIcon(new ImageIcon(ImageUtil.getScaledImage(image, width, height)));
     }
 
     MekForceTreeRenderer(ChatLounge cl) {

--- a/megamek/src/megamek/client/ui/swing/lobby/MekForceTreeRenderer.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekForceTreeRenderer.java
@@ -29,6 +29,8 @@ import javax.swing.ImageIcon;
 import javax.swing.JTree;
 import javax.swing.UIManager;
 import javax.swing.tree.DefaultTreeCellRenderer;
+
+import megamek.MegaMek;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
@@ -126,8 +128,13 @@ public class MekForceTreeRenderer extends DefaultTreeCellRenderer {
     }
 
     private void setIcon(Image image, int height) {
-        int width = height * image.getWidth(null) / image.getHeight(null);
-        setIcon(new ImageIcon(ImageUtil.getScaledImage(image, width, height)));
+        if ((image.getHeight(null) > 0) && (image.getWidth(null) > 0)) {
+            int width = height * image.getWidth(null) / image.getHeight(null);
+            setIcon(new ImageIcon(ImageUtil.getScaledImage(image, width, height)));
+        } else {
+            MegaMek.getLogger().error("Trying to resize a unit icon of height or width 0!");
+            setIcon(null);
+        }
     }
 
     MekForceTreeRenderer(ChatLounge cl) {

--- a/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
@@ -38,6 +38,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
 import megamek.common.icons.Portrait;
 import megamek.common.options.*;
+import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 
 import static megamek.client.ui.swing.util.UIUtil.*;
@@ -317,25 +318,23 @@ public class MekTableModel extends AbstractTableModel {
                 setToolTipText(null);
                 if (column == COLS.UNIT.ordinal()) {
                     if (!compact) {
-                        Image image = getToolkit().getImage(UNKNOWN_UNIT);
-                        setIcon(new ImageIcon(image.getScaledInstance(-1, size, Image.SCALE_SMOOTH)));
+                        setIcon(getToolkit().getImage(UNKNOWN_UNIT), size);
                     }
                 } else if (column == COLS.PILOT.ordinal()) {
                     if (!compact) {
-                        Image image = getToolkit().getImage(DEF_PORTRAIT);
-                        setIcon(new ImageIcon(image.getScaledInstance(-1, size, Image.SCALE_SMOOTH)));
+                        setIcon(getToolkit().getImage(DEF_PORTRAIT), size);
                     }
                 } 
             } else {
                 if (column == COLS.UNIT.ordinal()) {
                     setToolTipText(unitTooltips.get(row));
                     final Camouflage camouflage = entity.getCamouflageOrElse(entity.getOwner().getCamouflage());
-                    final Image icon = clientGui.bv.getTilesetManager().loadPreviewImage(entity, camouflage, this);
+                    Image icon = clientGui.bv.getTilesetManager().loadPreviewImage(entity, camouflage, this);
                     if (!compact) {
-                        setIcon(new ImageIcon(icon.getScaledInstance(-1, size, Image.SCALE_SMOOTH)));
+                        setIcon(icon, size);
                         setIconTextGap(UIUtil.scaleForGUI(10));
                     } else {
-                        setIcon(new ImageIcon(icon.getScaledInstance(-1, size/3, Image.SCALE_SMOOTH)));
+                        setIcon(icon, size / 3);
                         setIconTextGap(UIUtil.scaleForGUI(5));
                     }
                 } else if (column == COLS.PILOT.ordinal()) {
@@ -357,7 +356,12 @@ public class MekTableModel extends AbstractTableModel {
             return this;
         }
         
+        private void setIcon(Image image, int height) {
+            int width = height * image.getWidth(null) / image.getHeight(null);
+            setIcon(new ImageIcon(ImageUtil.getScaledImage(image, width, height)));
+        }
     }
+    
     
     @Override
     public int getColumnCount() {

--- a/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
@@ -329,7 +329,7 @@ public class MekTableModel extends AbstractTableModel {
                 if (column == COLS.UNIT.ordinal()) {
                     setToolTipText(unitTooltips.get(row));
                     final Camouflage camouflage = entity.getCamouflageOrElse(entity.getOwner().getCamouflage());
-                    Image icon = clientGui.bv.getTilesetManager().loadPreviewImage(entity, camouflage, this);
+                    final Image icon = clientGui.bv.getTilesetManager().loadPreviewImage(entity, camouflage, this);
                     if (!compact) {
                         setIcon(icon, size);
                         setIconTextGap(UIUtil.scaleForGUI(10));

--- a/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
@@ -28,6 +28,7 @@ import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.table.*;
 
+import megamek.MegaMek;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.tooltip.PilotToolTip;
@@ -357,8 +358,13 @@ public class MekTableModel extends AbstractTableModel {
         }
         
         private void setIcon(Image image, int height) {
-            int width = height * image.getWidth(null) / image.getHeight(null);
-            setIcon(new ImageIcon(ImageUtil.getScaledImage(image, width, height)));
+            if ((image.getHeight(null) > 0) && (image.getWidth(null) > 0)) {
+                int width = height * image.getWidth(null) / image.getHeight(null);
+                setIcon(new ImageIcon(ImageUtil.getScaledImage(image, width, height)));
+            } else {
+                MegaMek.getLogger().error("Trying to resize a unit icon of height or width 0!");
+                setIcon(null);
+            }
         }
     }
     


### PR DESCRIPTION
In the lobby, scaling gave some unit icons (especially those without a drop shadow, as e.g. the new Warhammers) ugly whitish border pixels. We already have a better scaling filter, so I made use of that.