### PR TITLE
CommonMenuBar maintenance (checkbox items)

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -1040,6 +1040,7 @@ public class BoardEditor extends JPanel
         // Set up the minimap 
         minimapW = new JDialog(frame, Messages.getString("BoardEditor.minimapW"), false);
         minimapW.setLocation(guip.getMinimapPosX(), guip.getMinimapPosY());
+        minimapW.setAutoRequestFocus(false);
         try {
             minimap = new MiniMap(minimapW, game, bv);
         } catch (IOException e) {
@@ -1049,7 +1050,7 @@ public class BoardEditor extends JPanel
             frame.dispose();
         }
         minimapW.add(minimap);
-        minimapW.setVisible(true);
+        minimapW.setVisible(guip.getMinimapEnabled());
     }
     
     /**
@@ -1864,7 +1865,7 @@ public class BoardEditor extends JPanel
             cheTerrExitSpecified.setSelected(texTerrExits.getNumber() != 0);
             updateWhenSelected();
         } else if (ae.getActionCommand().equals(ClientGUI.VIEW_MINI_MAP)) {
-            minimapW.setVisible(!minimapW.isVisible());
+            minimapW.setVisible(guip.getMinimapEnabled());
         } else if (ae.getActionCommand().equals(ClientGUI.HELP_ABOUT)) {
             showAbout();
         } else if (ae.getActionCommand().equals(ClientGUI.HELP_CONTENTS)) {

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1082,9 +1082,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
             case PHASE_OFFBOARD:
             case PHASE_FIRING:
             case PHASE_PHYSICAL:
-//                if (GUIPreferences.getInstance().getMinimapEnabled() && !minimapW.isVisible()) {
-                    setMapVisible(GUIPreferences.getInstance().getMinimapEnabled());
-//                }
+                setMapVisible(GUIPreferences.getInstance().getMinimapEnabled());
                 break;
             case PHASE_INITIATIVE_REPORT:
             case PHASE_TARGETING_REPORT:

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -545,7 +545,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
                 }
             }
         };
-
+        minimapW.setAutoRequestFocus(false);
         x = GUIPreferences.getInstance().getMinimapPosX();
         y = GUIPreferences.getInstance().getMinimapPosY();
         try {
@@ -1082,9 +1082,9 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
             case PHASE_OFFBOARD:
             case PHASE_FIRING:
             case PHASE_PHYSICAL:
-                if (GUIPreferences.getInstance().getMinimapEnabled() && !minimapW.isVisible()) {
-                    setMapVisible(true);
-                }
+//                if (GUIPreferences.getInstance().getMinimapEnabled() && !minimapW.isVisible()) {
+                    setMapVisible(GUIPreferences.getInstance().getMinimapEnabled());
+//                }
                 break;
             case PHASE_INITIATIVE_REPORT:
             case PHASE_TARGETING_REPORT:
@@ -1309,18 +1309,16 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         }
     }
 
-    /** Switches the Minimap and the MechDisplay an and off together.
-     *  If the MechDisplay is active, both will be hidden, else
-     *  both will be shown.
+    /** 
+     * Switches the Minimap and the MechDisplay an and off together.
+     * If the MechDisplay is active, both will be hidden, else
+     * both will be shown.
      */
     public void toggleMMUDDisplays() {
-        if (mechW.isVisible()) {
-            setDisplayVisible(false);
-            setMapVisible(false);
-        } else {
-            setDisplayVisible(true);
-            setMapVisible(true);
-        }
+        boolean wasVisible = mechW.isVisible();
+        setDisplayVisible(!wasVisible);
+        GUIPreferences.getInstance().setMinimapEnabled(!wasVisible);
+        toggleMap();
     }
 
     /**
@@ -1373,25 +1371,19 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         bv.refreshDisplayables();
     }
 
-    /**
-     * Toggles the minimap window Also, toggles the minimap enabled setting
-     */
+    /** Shows or hides the minimap based on the current menu setting. */
     private void toggleMap() {
-        minimapW.setVisible(!minimapW.isVisible());
-        GUIPreferences.getInstance().setMinimapEnabled(minimapW.isVisible());
-        if (minimapW.isVisible()) {
-            frame.requestFocus();
-        }
+        setMapVisible(GUIPreferences.getInstance().getMinimapEnabled());
     }
 
-    /**
-     * Sets the visibility of the minimap window
+    /** 
+     * Shows or hides the minimap based on the given visible. This works independently 
+     * of the current menu setting, so it should be used only when the minimap is to 
+     * be shown or hidden without regard for the user setting, e.g. hiding it in the lobby. 
+     * Does not change the menu bar setting. 
      */
     void setMapVisible(boolean visible) {
         minimapW.setVisible(visible);
-        if (visible) {
-            frame.requestFocus();
-        }
     }
 
     private boolean fillPopup(Coords coords) {

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -85,7 +85,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
     private IGame.Phase phase = IGame.Phase.PHASE_UNKNOWN;
 
     // The View menu
-    private JMenuItem viewMiniMap;
+    private JCheckBoxMenuItem viewMiniMap;
     private JMenuItem viewMekDisplay;
     private JMenuItem viewAccessibilityWindow;
     private JCheckBoxMenuItem viewKeybindsOverlay;
@@ -101,7 +101,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
     private JMenuItem viewMovModEnvelope;
     private JMenuItem viewChangeTheme;
     private JMenuItem viewLOSSetting;
-    private JMenuItem viewUnitOverview;
+    private JCheckBoxMenuItem viewUnitOverview;
     private JMenuItem viewRoundReport;
     private JMenuItem viewGameOptions;
     private JMenuItem viewClientSettings;
@@ -195,10 +195,10 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
         viewKeybindsOverlay = createCbxMenuItem(menu, getString("CommonMenuBar.viewKeyboardShortcuts"), VIEW_KEYBINDS_OVERLAY);
         viewKeybindsOverlay.setState(GUIPreferences.getInstance().getBoolean(GUIPreferences.SHOW_KEYBINDS_OVERLAY));
         viewResetWindowPositions = createMenuItem(menu, getString("CommonMenuBar.viewResetWindowPos"), VIEW_RESET_WINDOW_POSITIONS);
-        //TODO: show minimap should be a checkbox
-        viewMiniMap = createMenuItem(menu, getString("CommonMenuBar.viewMiniMap"), VIEW_MINI_MAP, KeyEvent.VK_M);
-        //TODO: show unit overview should be a checkbox
-        viewUnitOverview = createMenuItem(menu, getString("CommonMenuBar.viewUnitOverview"), VIEW_UNIT_OVERVIEW, KeyEvent.VK_U);
+        viewMiniMap = createCbxMenuItem(menu, getString("CommonMenuBar.viewMiniMap"), VIEW_MINI_MAP, KeyEvent.VK_M);
+        viewMiniMap.setState(GUIPreferences.getInstance().getMinimapEnabled());
+        viewUnitOverview = createCbxMenuItem(menu, getString("CommonMenuBar.viewUnitOverview"), VIEW_UNIT_OVERVIEW, KeyEvent.VK_U);
+        viewUnitOverview.setState(GUIPreferences.getInstance().getShowUnitOverview());
         viewZoomIn = createMenuItem(menu, getString("CommonMenuBar.viewZoomIn"), VIEW_ZOOM_IN);
         viewZoomOut = createMenuItem(menu, getString("CommonMenuBar.viewZoomOut"), VIEW_ZOOM_OUT);
         menu.addSeparator();
@@ -434,17 +434,23 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
      */
     public void actionPerformed(ActionEvent event) {
         
+        GUIPreferences guip = GUIPreferences.getInstance();
+        
         // Changes that are independent of the current state of MM
         if (event.getActionCommand().equals(ClientGUI.VIEW_INCGUISCALE)) {
             float guiScale = GUIPreferences.getInstance().getGUIScale();
             if (guiScale < ClientGUI.MAX_GUISCALE) {
-                GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, guiScale + 0.1);
+                guip.setValue(GUIPreferences.GUI_SCALE, guiScale + 0.1);
             }
         } else if (event.getActionCommand().equals(ClientGUI.VIEW_DECGUISCALE)) {
             float guiScale = GUIPreferences.getInstance().getGUIScale();
             if (guiScale > ClientGUI.MIN_GUISCALE) {
-                GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, guiScale - 0.1);
+                guip.setValue(GUIPreferences.GUI_SCALE, guiScale - 0.1);
             }
+        } else if (event.getActionCommand().equals(ClientGUI.VIEW_MINI_MAP)) {
+            // Only here the actual user preference is changed. The listeners should
+            // just set thew visibility of the map based on guip.getMinimapEnabled()
+            guip.setMinimapEnabled(!guip.getMinimapEnabled());
         }
         
         // Pass the action on to each of our listeners.
@@ -803,6 +809,10 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             toggleFieldOfFire.setSelected((Boolean)e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.SHOW_KEYBINDS_OVERLAY)) {
             viewKeybindsOverlay.setSelected((Boolean)e.getNewValue());
+        } else if (e.getName().equals(GUIPreferences.SHOW_UNIT_OVERVIEW)) {
+            viewUnitOverview.setSelected((Boolean)e.getNewValue());
+        } else if (e.getName().equals(GUIPreferences.MINIMAP_ENABLED)) {
+            viewMiniMap.setSelected((Boolean)e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
             adaptToGUIScale();
         } 

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -449,8 +449,10 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             }
         } else if (event.getActionCommand().equals(ClientGUI.VIEW_MINI_MAP)) {
             // Only here the actual user preference is changed. The listeners should
-            // just set thew visibility of the map based on guip.getMinimapEnabled()
-            guip.setMinimapEnabled(!guip.getMinimapEnabled());
+            // just adjust the visibility of the map dialog based on guip.getMinimapEnabled()
+            boolean newSetting = !guip.getMinimapEnabled();
+            guip.setMinimapEnabled(newSetting);
+            viewMiniMap.setSelected(newSetting);
         }
         
         // Pass the action on to each of our listeners.
@@ -811,8 +813,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
             viewKeybindsOverlay.setSelected((Boolean)e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.SHOW_UNIT_OVERVIEW)) {
             viewUnitOverview.setSelected((Boolean)e.getNewValue());
-        } else if (e.getName().equals(GUIPreferences.MINIMAP_ENABLED)) {
-            viewMiniMap.setSelected((Boolean)e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
             adaptToGUIScale();
         } 


### PR DESCRIPTION
Converts the unit overview and the minimap items of the menu bar to checkbox items as they always should have been and adapts the way the minimap is toggled where necessary.

![image](https://user-images.githubusercontent.com/17069663/120916835-24dbef00-c6ac-11eb-8358-bebcf32f3697.png)
