### PR TITLE
Kinder matching of lasers and insulators on load

### DIFF
--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -289,7 +289,7 @@ public class MechFileParser {
                             && mount.getType().hasFlag(WeaponType.F_LASER);
                 // The laser pulse module is also restricted to non-pulse lasers, IS only
                 if (m.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                    linkable = linkable.or(mount -> !mount.getType().hasFlag(WeaponType.F_LASER)
+                    linkable = linkable.and(mount -> !mount.getType().hasFlag(WeaponType.F_LASER)
                             && !mount.getType().isClan());
                 }
 

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -279,32 +279,16 @@ public class MechFileParser {
 
             // link laser insulators
             if ((m.getType().hasFlag(MiscType.F_LASER_INSULATOR))) {
-                // get the mount directly before the insulator, this is the
-                // weapon
-                Mounted weapon = ent.getEquipment().get(
-                        ent.getEquipment().indexOf(m) - 1);
-                // already linked?
-                if (weapon.getLinkedBy() != null) {
-                    continue;
-                }
-                if (!(weapon.getType() instanceof WeaponType)
-                        && !(weapon.getType().hasFlag(WeaponType.F_LASER))) {
-                    continue;
-                }
-                // check location
-                if (weapon.getLocation() == m.getLocation()) {
+                // get the mount directly before the insulator; this is the weapon
+                Mounted weapon = ent.getEquipment().get(ent.getEquipment().indexOf(m) - 1);
+                if ((weapon.getLinkedBy() == null) && (weapon.getLocation() == m.getLocation())
+                        && weapon.getType().hasFlag(WeaponType.F_LASER)) {
                     m.setLinked(weapon);
-                    continue;
+                } else {
+                    throw new EntityLoadingException("Unable to match laser insulator to laser for "
+                            + ent.getShortName());
                 }
-                if (m.getLinked() == null) {
-                    // huh. this shouldn't happen
-                    throw new EntityLoadingException(
-                            "Unable to match laser insulator to laser for "+ent.getShortName());
-                }
-            }
-
-            // link DWPs to their weapons
-            if ((m.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK))) {
+            } else if ((m.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK))) {
                 for (Mounted mWeapon : ent.getTotalWeaponList()) {
                     if (!mWeapon.isDWPMounted()) {
                         continue;
@@ -322,14 +306,9 @@ public class MechFileParser {
                 }
                 if (m.getLinked() == null) {
                     // huh. this shouldn't happen
-                    throw new EntityLoadingException(
-                            "Unable to match DWP to weapon for "
-                                    + ent.getShortName());
+                    throw new EntityLoadingException("Unable to match DWP to weapon for " + ent.getShortName());
                 }
-            }
-
-            // Link AP weapons to their AP Mount, when applicable
-            if ((m.getType().hasFlag(MiscType.F_AP_MOUNT))) {
+            } else if ((m.getType().hasFlag(MiscType.F_AP_MOUNT))) {
                 for (Mounted mWeapon : ent.getTotalWeaponList()) {
                     // Can only link APM mounted weapons that aren't linked
                     if (!mWeapon.isAPMMounted()
@@ -343,10 +322,7 @@ public class MechFileParser {
                         break;
                     }
                 }
-            }
-
-            // Link Artemis IV fire-control systems to their missle racks.
-            if ((m.getType().hasFlag(MiscType.F_ARTEMIS) 
+            } else if ((m.getType().hasFlag(MiscType.F_ARTEMIS)
                     || (m.getType().hasFlag(MiscType.F_ARTEMIS_V))
                     || (m.getType().hasFlag(MiscType.F_ARTEMIS_PROTO)))
                     && (m.getLinked() == null)) {
@@ -382,38 +358,17 @@ public class MechFileParser {
 
                 if (m.getLinked() == null) {
                     // huh. this shouldn't happen
-                    throw new EntityLoadingException(
-                            "Unable to match Artemis to launcher for "+ent.getShortName());
+                    throw new EntityLoadingException("Unable to match Artemis to launcher for " + ent.getShortName());
                 }
-            } // End link-Artemis
-            // Link RISC Laser Pulse Module to their lasers
-            else if ((m.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE) && (m.getLinked() == null))) {
-
-                // link up to a weapon in the same location
-                for (Mounted mWeapon : ent.getTotalWeaponList()) {
-                    WeaponType wtype = (WeaponType) mWeapon.getType();
-
-                    // only IS lasers that are not pulse are allows
-                    if (wtype.hasFlag(WeaponType.F_PULSE) || TechConstants.isClan(wtype.getTechLevel(ent.getYear()))) {
-                        continue;
-                    }
-
-                    // already linked?
-                    if (mWeapon.getLinkedBy() != null) {
-                        continue;
-                    }
-
-                    // check location
-                    if (mWeapon.getLocation() == m.getLocation()) {
-                        m.setLinked(mWeapon);
-                        break;
-                    }
-                }
-
-                if (m.getLinked() == null) {
-                    // huh. this shouldn't happen
-                    throw new EntityLoadingException(
-                            "Unable to match RISC Laser Pulse Model to laser for "+ent.getShortName());
+            } else if ((m.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE) && (m.getLinked() == null))) {
+                // get the mount directly before the module; this is the weapon
+                Mounted weapon = ent.getEquipment().get(ent.getEquipment().indexOf(m) - 1);
+                if ((weapon.getLinkedBy() == null) && (weapon.getLocation() == m.getLocation())
+                        && !weapon.getType().hasFlag(WeaponType.F_PULSE) && !weapon.getType().isClan()) {
+                    m.setLinked(weapon);
+                } else {
+                    throw new EntityLoadingException("Unable to match RISC Laser Pulse Model to laser for "
+                            + ent.getShortName());
                 }
             } // End link-RISC laser pulse module
             else if ((m.getType().hasFlag(MiscType.F_STEALTH) || m.getType()


### PR DESCRIPTION
The post load initialization expects a laser insulator to be immediately after the laser in the equipment list, and if not it may throw an exception or fail silently depending on the reason the preceding equipment is ineligible. This constraint is not particularly obvious to a user designing a unit in MML, and modifying a unit to add an insulator would require removing the laser then adding it back followed immediately by the insulator. On the other hand, ignoring the positioning makes it impossible to place an insulator on specific lasers in a location unless they are the first ones listed.

My solution is to prefer the positioning of laser followed directly by insulator, but if the insulator is not directly preceded by an eligible laser, apply it to the first one in the location. That way as long as there is at least one laser per insulator in a location it will work, and if the user wants to match the insulators with specific lasers that is also possible.

Everything that applies to laser insulators also applies to RISC laser pulse modules, so I combined the logic. Currently it matches the first non-pulse non-Clan weapon in the location, and fails to check whether it's a laser. As much as I'd like to see pulse ACs and missiles, I fixed that. I also changed the remaining if blocks to else if, since no more than one of them can apply and there's no reason to check the remaining conditions.

Fixes MegaMek/megameklab#885

P.S. This also fixes a potential IndexOutOfRangeException when a laser insulator is the first mount in the equipment list.