### PR TITLE
Prototype TSM

### DIFF
--- a/megamek/src/megamek/client/bot/CEntity.java
+++ b/megamek/src/megamek/client/bot/CEntity.java
@@ -301,7 +301,7 @@ public class CEntity {
 
                 // If this is a Mech equipped with TSM, push for the sweet
                 // spot at 9 heat
-                if (((Mech) entity).hasTSM()) {
+                if (((Mech) entity).hasTSM(false)) {
                     tsm_offset = true;
                 }
 

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -588,7 +588,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
 
             boolean hasTSM = false;
             boolean mtHeat = false;
-            if (((Mech) en).hasTSM()) {
+            if (((Mech) en).hasTSM(false)) {
                 hasTSM = true;
             }
 

--- a/megamek/src/megamek/common/BipedMech.java
+++ b/megamek/src/megamek/common/BipedMech.java
@@ -164,7 +164,7 @@ public class BipedMech extends Mech {
                 wmp -= (heat / 5);
             }
             // TSM negates some heat, but provides no benefit when using tracks.
-            if ((heat >= 9) && hasTSM() && legsDestroyed == 0 && movementMode != EntityMovementMode.TRACKED) {
+            if ((heat >= 9) && hasTSM(false) && legsDestroyed == 0 && movementMode != EntityMovementMode.TRACKED) {
                 wmp += 2;
             }
         }

--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -116,6 +116,8 @@ public class EquipmentTypeLookup {
     @EquipmentName
     public static final String ITSM = "Industrial Triple Strength Myomer";
     @EquipmentName
+    public static final String P_TSM = "Prototype TSM";
+    @EquipmentName
     public static final String IS_MASC = "ISMASC";
     @EquipmentName
     public static final String CLAN_MASC = "CLMASC";

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -880,13 +880,56 @@ public abstract class Mech extends Entity {
     }
 
     /**
-     * does this mech have TSM?
+     * Check for whether the mech has triple strength myomer
+     * @param includePrototype Whether to include prototype TSM in the check.
+     *                         Prototype TSM does not have a movement bonus or
+     *                         a required heat level.
+     * @return Whether the mech has TSM
      */
-    public boolean hasTSM() {
-        for (Mounted m : getEquipment()) {
-            if ((m.getType() instanceof MiscType)
-                    && m.getType().hasFlag(MiscType.F_TSM)) {
+    public boolean hasTSM(boolean includePrototype) {
+        for (Mounted m : getMisc()) {
+            if (m.getType().hasFlag(MiscType.F_TSM)
+                    && (includePrototype || !m.getType().hasFlag(MiscType.F_PROTOTYPE))) {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check for vulnerability to anti-TSM munitions. ATSM affects prototype TSM and
+     * any industrial TSM created before 3050. I don't see any alternative to using the
+     * construction year here.
+     *
+     * @return Whether the mech TSM that is affected by ATSM munitions
+     */
+    public boolean antiTSMVulnerable() {
+        for (Mounted m : getMisc()) {
+            if ((m.getType().hasFlag(MiscType.F_TSM) && m.getType().hasFlag(MiscType.F_PROTOTYPE))
+                    || (m.getType().hasFlag(MiscType.F_INDUSTRIAL_TSM) && (getYear() <= 3050))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean hasActiveTSM() {
+        return hasActiveTSM(true);
+    }
+
+    /**
+     * Checks whether any type of TSM is active. Industrial and prototype
+     * are always on. Standard is on when heat level is >= 9.
+     *
+     * @param includeIndustrial Whether to include industrial TSM in the check
+     * @return Whether the mech has some form of TSM and it's active
+     */
+    public boolean hasActiveTSM(boolean includeIndustrial) {
+        for (Mounted m : getMisc()) {
+            if (includeIndustrial && m.getType().hasFlag(MiscType.F_INDUSTRIAL_TSM)) {
+                return true;
+            } else if (m.getType().hasFlag(MiscType.F_TSM)) {
+                return (heat >=9) || m.getType().hasFlag(MiscType.F_PROTOTYPE);
             }
         }
         return false;
@@ -3895,7 +3938,7 @@ public abstract class Mech extends Entity {
             bvWalk = Math.max(0, walkMP);
         }
         int runMP;
-        if (hasTSM()) {
+        if (hasTSM(false)) {
             bvWalk++;
         }
         if (hasMASCAndSuperCharger()) {
@@ -5107,7 +5150,7 @@ public abstract class Mech extends Entity {
             bvText.append(endRow);
         }
         // add tonnage, adjusted for TSM
-        if (hasTSM()) {
+        if (hasTSM(true)) {
             weaponBV += weight * 1.5;
             bvText.append(startRow);
             bvText.append(startColumn);
@@ -5377,7 +5420,8 @@ public abstract class Mech extends Entity {
         costs[i++] = cockpitCost;
         costs[i++] = 50000;// life support
         costs[i++] = weight * 2000;// sensors
-        int muscCost = hasSCM() ? 10000 : hasTSM() ? 16000 : hasIndustrialTSM() ? 12000 : 2000;
+        int muscCost = hasSCM() ? 10000 : hasTSM(false) ? 16000 :
+                        hasTSM(true) ? 32000 : hasIndustrialTSM() ? 12000 : 2000;
         costs[i++] = muscCost * weight;// musculature
         double structureCost = EquipmentType.getStructureCost(structureType) * weight;// IS
         costs[i++] = structureCost;
@@ -6671,8 +6715,10 @@ public abstract class Mech extends Entity {
         sb.append(newLine);
 
         sb.append(MtfFile.MYOMER);
-        if (hasTSM()) {
+        if (hasTSM(false)) {
             sb.append("Triple-Strength");
+        } else if (hasTSM(true)) {
+            sb.append("Prototype Triple-Strength");
         } else if (hasIndustrialTSM()) {
             sb.append("Industrial Triple-Strength");
         } else if (hasSCM()) {

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -553,7 +553,7 @@ public class MechFileParser {
                             MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
 
                 if (ent.hasTargComp()
-                        || ((Mech) ent).hasTSM()
+                        || ((Mech) ent).hasTSM(true)
                         || (((Mech) ent).hasMASC() && !ent.hasWorkingMisc(
                                 MiscType.F_MASC, MiscType.S_SUPERCHARGER))) {
                     throw new EntityLoadingException(

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -517,8 +517,10 @@ public class MechSummaryCache {
         }
 
         if (e instanceof Mech){
-            if (((Mech)e).hasTSM()) {
+            if (((Mech) e).hasTSM(false)) {
                 ms.setMyomerName("Triple-Strength");
+            } else if (((Mech) e).hasTSM(true)) {
+                    ms.setMyomerName("Prototype Triple-Strength");
             } else if (((Mech)e).hasIndustrialTSM()) {
                 ms.setMyomerName("Industrial Triple-Strength");
             } else {

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -9051,27 +9051,6 @@ public class MiscType extends EquipmentType {
         misc.addLookupName("IS Industrial TSM");
         misc.addLookupName("Industrial TSM");
         misc.tonnage = 0;
-        misc.criticals = 6;
-        misc.hittable = false;
-        misc.spreadable = true;
-        misc.flags = misc.flags.or(F_TSM).or(F_PROTOTYPE).or(F_MECH_EQUIPMENT);
-        misc.omniFixedOnly = true;
-        misc.bv = 0;
-        misc.rulesRefs = "103,IO";
-        misc.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_E)
-                .setAvailability(RATING_X, RATING_F, RATING_X, RATING_X)
-                .setISAdvancement(3028, DATE_NONE, DATE_NONE, 3050).setPrototypeFactions(F_CC)
-                .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
-        return misc;
-    }
-
-    public static MiscType createPrototypeTSM() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Prototype Triple Strength Myomer";
-        misc.setInternalName("Prototype TSM");
-        misc.shortName = misc.internalName;
-        misc.tonnage = 0;
         misc.criticals = 12;
         misc.hittable = false;
         misc.spreadable = true;
@@ -9085,6 +9064,28 @@ public class MiscType extends EquipmentType {
                 .setISAdvancement(3035, 3045, 3055, DATE_NONE, DATE_NONE)
                 .setISApproximate(true, false, false, false, false).setPrototypeFactions(F_FS)
                 .setProductionFactions(F_FS);
+        return misc;
+    }
+
+    public static MiscType createPrototypeTSM() {
+        MiscType misc = new MiscType();
+
+        misc.name = "Prototype Triple Strength Myomer";
+        misc.setInternalName(EquipmentTypeLookup.P_TSM);
+        misc.shortName = "Prototype TSM";
+        misc.tonnage = 0;
+        misc.criticals = 6;
+        misc.hittable = false;
+        misc.spreadable = true;
+        misc.flags = misc.flags.or(F_TSM).or(F_PROTOTYPE).or(F_MECH_EQUIPMENT);
+        misc.omniFixedOnly = true;
+        misc.bv = 0;
+        misc.rulesRefs = "103,IO";
+        misc.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_E)
+                .setAvailability(RATING_X, RATING_F, RATING_X, RATING_X)
+                .setISAdvancement(3028, DATE_NONE, DATE_NONE, 3050)
+                .setISApproximate(true, false, false, false)
+                .setPrototypeFactions(F_CC).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return misc;
     }
 

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -285,6 +285,7 @@ public class MiscType extends EquipmentType {
     public static final BigInteger F_PROTOMECH_MELEE = BigInteger.valueOf(1).shiftLeft(222);
     public static final BigInteger F_EXTERNAL_POWER_PICKUP = BigInteger.valueOf(1).shiftLeft(223);
     public static final BigInteger F_RAM_PLATE = BigInteger.valueOf(1).shiftLeft(224);
+    public static final BigInteger F_PROTOTYPE = BigInteger.valueOf(1).shiftLeft(225);
 
     // Secondary Flags for Physical Weapons
     public static final long S_CLUB = 1L << 0; // BMR
@@ -1502,6 +1503,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createISMASC());
         EquipmentType.addType(MiscType.createCLMASC());
         EquipmentType.addType(MiscType.createTSM());
+        EquipmentType.addType(MiscType.createPrototypeTSM());
         EquipmentType.addType(MiscType.createC3S());
         EquipmentType.addType(MiscType.createC3SBS());
         EquipmentType.addType(MiscType.createC3I());
@@ -9048,6 +9050,27 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(EquipmentTypeLookup.ITSM);
         misc.addLookupName("IS Industrial TSM");
         misc.addLookupName("Industrial TSM");
+        misc.tonnage = 0;
+        misc.criticals = 6;
+        misc.hittable = false;
+        misc.spreadable = true;
+        misc.flags = misc.flags.or(F_TSM).or(F_PROTOTYPE).or(F_MECH_EQUIPMENT);
+        misc.omniFixedOnly = true;
+        misc.bv = 0;
+        misc.rulesRefs = "103,IO";
+        misc.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_E)
+                .setAvailability(RATING_X, RATING_F, RATING_X, RATING_X)
+                .setISAdvancement(3028, DATE_NONE, DATE_NONE, 3050).setPrototypeFactions(F_CC)
+                .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+        return misc;
+    }
+
+    public static MiscType createPrototypeTSM() {
+        MiscType misc = new MiscType();
+
+        misc.name = "Prototype Triple Strength Myomer";
+        misc.setInternalName("Prototype TSM");
+        misc.shortName = misc.internalName;
         misc.tonnage = 0;
         misc.criticals = 12;
         misc.hittable = false;

--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -162,7 +162,7 @@ public class QuadMech extends Mech {
                 wmp -= (heat / 5);
             }
             // TSM negates some heat but has no benefit for 'Mechs using tracks or QuadVees in vehicle mode.
-            if ((heat >= 9) && hasTSM() && legsDestroyed < 2
+            if ((heat >= 9) && hasTSM(false) && legsDestroyed < 2
                     && movementMode != EntityMovementMode.TRACKED
                     && movementMode != EntityMovementMode.WHEELED) {
                 wmp += 2;

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -204,7 +204,7 @@ public class TripodMech extends Mech {
                 wmp -= (heat / 5);
             }
             // TSM negates some heat
-            if ((heat >= 9) && hasTSM() && legsDestroyed == 0 && movementMode != EntityMovementMode.TRACKED) {
+            if ((heat >= 9) && hasTSM(false) && legsDestroyed == 0 && movementMode != EntityMovementMode.TRACKED) {
                 wmp += 2;
             }
         }

--- a/megamek/src/megamek/common/actions/ClubAttackAction.java
+++ b/megamek/src/megamek/common/actions/ClubAttackAction.java
@@ -166,7 +166,7 @@ public class ClubAttackAction extends PhysicalAttackAction {
         }
 
         // TSM doesn't apply to some weapons, including Saws.
-        if (entity instanceof Mech && ((((entity.heat >= 9) && ((Mech) entity).hasTSM()) || ((Mech) entity).hasIndustrialTSM())
+        if ((entity instanceof Mech) && ((Mech) entity).hasActiveTSM()
             && !(mType.hasSubType(MiscType.S_DUAL_SAW)
                  || mType.hasSubType(MiscType.S_CHAINSAW)
                  || mType.hasSubType(MiscType.S_PILE_DRIVER)
@@ -181,7 +181,7 @@ public class ClubAttackAction extends PhysicalAttackAction {
                  || mType.hasSubType(MiscType.S_SPOT_WELDER)
                  || mType.hasSubType(MiscType.S_CHAIN_WHIP) || mType
                 .hasSubType(MiscType.S_COMBINE))
-            )) {
+            ) {
             nDamage *= 2;
         }
         int clubLocation = club.getLocation();

--- a/megamek/src/megamek/common/actions/GrappleAttackAction.java
+++ b/megamek/src/megamek/common/actions/GrappleAttackAction.java
@@ -153,9 +153,9 @@ public class GrappleAttackAction extends PhysicalAttackAction {
         if ((grappleSide != Entity.GRAPPLE_BOTH) && (ae instanceof Mech)) {
             Mech attacker = (Mech) ae;
             Mech teMech = (te instanceof Mech) ? (Mech)te : null;
-            if (attacker.hasTSM() && (attacker.heat >= 9)
-                    && ((teMech == null) || !teMech.hasTSM() 
-                            || (teMech.hasTSM() && (te.heat < 9)))) {
+            if (attacker.hasActiveTSM(false)
+                    && ((teMech == null) || !teMech.hasActiveTSM(false)
+                            || teMech.hasActiveTSM(false))) {
                 toHit.addModifier(-2, "TSM Active Bonus");
             }
         }

--- a/megamek/src/megamek/common/actions/KickAttackAction.java
+++ b/megamek/src/megamek/common/actions/KickAttackAction.java
@@ -97,8 +97,7 @@ public class KickAttackAction extends PhysicalAttackAction {
         if (!entity.hasWorkingSystem(Mech.ACTUATOR_HIP, legLoc)) {
             damage = 0;
         }
-        if (((entity.heat >= 9) && ((Mech) entity).hasTSM()) ||
-                ((Mech) entity).hasIndustrialTSM()) {
+        if (((Mech) entity).hasActiveTSM()) {
             multiplier *= 2.0f;
         }
 

--- a/megamek/src/megamek/common/actions/PunchAttackAction.java
+++ b/megamek/src/megamek/common/actions/PunchAttackAction.java
@@ -371,8 +371,7 @@ public class PunchAttackAction extends PhysicalAttackAction {
         if (!entity.hasWorkingSystem(Mech.ACTUATOR_SHOULDER, armLoc)) {
             damage = 0;
         }
-        if (((entity.heat >= 9) && ((Mech) entity).hasTSM())
-                || ((Mech) entity).hasIndustrialTSM()) {
+        if (((Mech) entity).hasActiveTSM()) {
             multiplier *= 2.0f;
         }
         int toReturn = (int) Math.floor(damage * multiplier)

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -17018,8 +17018,7 @@ public class Server implements Runnable {
                 roll = Compute.d6(2);
                 int toHitValue = toHit.getValue();
                 String toHitDesc = toHit.getDesc();
-                if ((ae instanceof Mech) && (((Mech) ae).hasTSM() && (ae.heat >= 9))
-                        && (!((Mech) te).hasTSM() || ((((Mech) te).hasTSM()) && (te.heat < 9)))) {
+                if ((ae instanceof Mech) && ((Mech) ae).hasActiveTSM(false)) {
                     toHitValue -= 2;
                     toHitDesc += " -2 (TSM Active Bonus)";
                 }
@@ -24655,11 +24654,10 @@ public class Server implements Runnable {
         } else if (CriticalSlot.TYPE_EQUIPMENT == cs.getType()) {
             vDesc.addAll(applyEquipmentCritical(en, loc, cs, secondaryEffects));
         } // End crit-on-equipment-slot
-        // mechs with TSM hit by anti-tsm missiles this round get another
+        // mechs with prototype TSM hit by anti-tsm missiles this round get another
         // crit
         if ((en instanceof Mech) && en.hitThisRoundByAntiTSM) {
-            Mech mech = (Mech) en;
-            if (mech.hasTSM()) {
+            if (((Mech) en).antiTSMVulnerable()) {
                 r = new Report(6430);
                 r.subject = en.getId();
                 r.indent(2);


### PR DESCRIPTION
Implementation of prototype TSM as requested by MegaMek/megameklab#886.
Rules are found in IO, p. 103 and the table on 218-9.
Summary: prototype TSM works like standard except that it is always on regardless of heat (like industrial) but does not provide any movement boost. Most of the details have to do with making maintenance and repair more difficult, and are found in a companion MekHQ PR.

I've attempted to make the methods in `Mech` that check for the presence of TSM more useful in exchange for making the range of possibilities more complex. The F_PROTOTYPE flag I added to MiscType is something I plan on using to filter prototype equipment but that's for a different update. There is also more work to be done on anti-TSM munitions, which are only partially implemented. At this point I fixed the existing implementation to apply an additional critical only to prototype and early industrial TSM, per the rules.