### PR TITLE
Issue #2543 Board images save at current zoom, game summary at zoom 1

### DIFF
--- a/megamek/src/megamek/client/ui/IBoardView.java
+++ b/megamek/src/megamek/client/ui/IBoardView.java
@@ -161,9 +161,11 @@ public interface IBoardView extends MechDisplayListener {
      * mapsheets), draws the hexes onto it, and returns that image.
      *
      * @param ignoreUnits If true, no units are drawn, only the board
+     * @param useBaseZoom If true, save the image at zoom = 1, otherwise at the
+     * current board zoom.
      * @return
      */
-    public abstract BufferedImage getEntireBoardImage(boolean ignoreUnits);
+    public abstract BufferedImage getEntireBoardImage(boolean ignoreUnits, boolean useBaseZoom);
 
     /**
      * Sets the BoardView's currently selected entity.

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -1518,7 +1518,7 @@ public class BoardEditor extends JPanel
         waitD.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         // save!
         try {
-            ImageIO.write(bv.getEntireBoardImage(ignoreUnits), "png", curfileImage);
+            ImageIO.write(bv.getEntireBoardImage(ignoreUnits, false), "png", curfileImage);
         } catch (IOException e) {
             MegaMek.getLogger().error(e);
         }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -2297,7 +2297,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         waitD.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         // save!
         try {
-            ImageIO.write(bv.getEntireBoardImage(ignoreUnits), "png", curfileBoardImage);
+            ImageIO.write(bv.getEntireBoardImage(ignoreUnits, false), "png", curfileBoardImage);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -2332,16 +2332,14 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         graph.drawString(string, x, y);
     }
 
-    /**
-     * This method creates an image the size of the entire board (all
-     * mapsheets), draws the hexes onto it, and returns that image.
-     */
-    public BufferedImage getEntireBoardImage(boolean ignoreUnits) {
+    public BufferedImage getEntireBoardImage(boolean ignoreUnits, boolean useBaseZoom) {
         // Set zoom to base, so we get a consist board image
 
         int oldZoom = zoomIndex;
-        zoomIndex = BASE_ZOOM_INDEX;
-        zoom();
+        if (useBaseZoom && zoomIndex != BASE_ZOOM_INDEX) {
+            zoomIndex = BASE_ZOOM_INDEX;
+            zoom();
+        }
 
         Image entireBoard = createImage(boardSize.width, boardSize.height);
         Graphics2D boardGraph = (Graphics2D) entireBoard.getGraphics();
@@ -5336,7 +5334,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 File imgFile = new File(dir, "round_" + game.getRoundCount() + "_" + e.getOldPhase().ordinal() + "_"
                         + IGame.Phase.getDisplayableName(e.getOldPhase()) + ".png");
                 try {
-                    ImageIO.write(getEntireBoardImage(false), "png", imgFile);
+                    ImageIO.write(getEntireBoardImage(false, true), "png", imgFile);
                 } catch (Exception ex) {
                     MegaMek.getLogger().error(ex);
                 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -2336,7 +2336,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         // Set zoom to base, so we get a consist board image
 
         int oldZoom = zoomIndex;
-        if (useBaseZoom && zoomIndex != BASE_ZOOM_INDEX) {
+        if (useBaseZoom) {
             zoomIndex = BASE_ZOOM_INDEX;
             zoom();
         }


### PR DESCRIPTION
Arlith changed the board image save method to always use zoom 1 (not only for the game summary). Reverting this for manual saves.

Resolves #2543 