### PR TITLE
prevent NPE when resolving homing arty attacks vs hex

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -427,7 +427,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends
      */
     protected boolean checkPDConditions() {
         advancedPD = game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADV_POINTDEF);
-        if ((target == null) || !advancedPD) {
+        if ((target == null) || !advancedPD || (target.getTargetType() != Targetable.TYPE_ENTITY)) {
             return false;
         }
         return true;


### PR DESCRIPTION
Fixes #2920, as non-entities can't use point defenses anyway.