### PR TITLE
Artemis/Apollo validation

### DIFF
--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -355,18 +355,8 @@ public class MechFileParser {
 
                 // link up to a weapon in the same location
                 for (Mounted mWeapon : ent.getTotalWeaponList()) {
-                    WeaponType wtype = (WeaponType) mWeapon.getType();
 
-                    // only srm, lrm and mml are valid for artemis
-                    if ((wtype.getAmmoType() != AmmoType.T_LRM)
-                            && (wtype.getAmmoType() != AmmoType.T_LRM_IMP)
-                            && (wtype.getAmmoType() != AmmoType.T_MML)
-                            && (wtype.getAmmoType() != AmmoType.T_SRM)
-                            && (wtype.getAmmoType() != AmmoType.T_SRM_IMP)
-                            && (wtype.getAmmoType() != AmmoType.T_NLRM)
-                            && (wtype.getAmmoType() != AmmoType.T_LRM_TORPEDO)
-                            && (wtype.getAmmoType() != AmmoType.T_SRM_TORPEDO)
-                            && (wtype.getAmmoType() != AmmoType.T_LRM_TORPEDO_COMBO)) {
+                    if (!mWeapon.getType().hasFlag(WeaponType.F_ARTEMIS_COMPATIBLE)) {
                         continue;
                     }
 

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -607,7 +607,9 @@ public class WeaponType extends EquipmentType {
     public static final BigInteger F_DOUBLE_ONESHOT = BigInteger.valueOf(1).shiftLeft(68);
     // ER flamers do half damage in heat mode
     public static final BigInteger F_ER_FLAMER = BigInteger.valueOf(1).shiftLeft(69);
-    
+    /** Missile weapon that can be linked to an Artemis fire control system */
+    public static final BigInteger F_ARTEMIS_COMPATIBLE = BigInteger.valueOf(1).shiftLeft(70);
+
     // add maximum range for AT2
     public static final int RANGE_SHORT = RangeType.RANGE_SHORT;
     public static final int RANGE_MED = RangeType.RANGE_MEDIUM;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -21,6 +21,7 @@ package megamek.common.verifier;
 
 import java.text.DecimalFormat;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import megamek.common.*;
@@ -1329,6 +1330,10 @@ public abstract class TestEntity implements TestEntityOption {
         int robotics = 0;
         boolean hasExternalFuelTank = false;
         int liftHoists = 0;
+        int artemisIV = 0;
+        int artemisV = 0;
+        int artemisP = 0;
+        int apollo = 0;
         Map<Integer, Integer> bridgeLayersByLocation = new HashMap<>();
         Map<Integer, List<EquipmentType>> physicalWeaponsByLocation = new HashMap<>();
 
@@ -1390,6 +1395,16 @@ public abstract class TestEntity implements TestEntityOption {
                     || m.getType().hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
                     || m.getType().hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)) {
                 bridgeLayersByLocation.merge(m.getLocation(), 1, Integer::sum);
+            }
+
+            if (m.getType().hasFlag(MiscType.F_ARTEMIS)) {
+                artemisIV++;
+            } else if (m.getType().hasFlag(MiscType.F_ARTEMIS_V)) {
+                artemisV++;
+            } else if (m.getType().hasFlag(MiscType.F_ARTEMIS_PROTO)) {
+                artemisP++;
+            } else if (m.getType().hasFlag(MiscType.F_APOLLO)) {
+                apollo++;
             }
         }
         if ((networks > 0) && !countedC3) {
@@ -1503,7 +1518,50 @@ public abstract class TestEntity implements TestEntityOption {
                 illegal |= !isValidLocation(getEntity(), mounted.getType(), mounted.getLocation(), buff);
             }
         }
+
+        if (artemisIV + artemisV + artemisP > 0) {
+            if (((artemisIV > 0) && (artemisV + artemisP > 0))
+                    || ((artemisV > 0) && (artemisP > 0))) {
+                buff.append("All Artemis systems must be of the same type.\n");
+                illegal = true;
+            }
+            illegal |= checkIllegalArtemisApolloLinks(buff, artemisIV + artemisV + artemisP,
+                    "Artemis", w -> w.hasFlag(WeaponType.F_ARTEMIS_COMPATIBLE));
+        }
+        if (apollo > 0) {
+            illegal |= checkIllegalArtemisApolloLinks(buff, apollo, "Apollo",
+                    w -> w.getAmmoType() == AmmoType.T_MRM);
+        }
+
         return illegal;
+    }
+
+    private boolean checkIllegalArtemisApolloLinks(StringBuffer buffer, int expected,
+                                                   String testingEquipment,
+                                                   Predicate<WeaponType> compatibility) {
+        int linkedCount = 0;
+        /*
+         * Besides tracking the number required we also want to check that they are all linked.
+         * This will find situations where the number matches but they're not in the same
+         * locations as the launcher.
+         */
+        boolean hasUnlinked = false;
+        for (Mounted mount : getEntity().getTotalWeaponList()) {
+            if (compatibility.test((WeaponType) mount.getType())) {
+                linkedCount++;
+                if (mount.getLinkedBy() == null) {
+                    hasUnlinked = true;
+                }
+            }
+        }
+        if (linkedCount != expected) {
+            buffer.append("There must be one ").append(testingEquipment).append(" for each compatible weapon.\n");
+            return true;
+        } else if (hasUnlinked) {
+            buffer.append(testingEquipment).append(" must be in the same location as the weapon.\n");
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/megamek/src/megamek/common/weapons/battlearmor/AdvancedSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/AdvancedSRMWeapon.java
@@ -40,6 +40,7 @@ public abstract class AdvancedSRMWeapon extends SRMWeapon {
     public AdvancedSRMWeapon() {
         super();
         this.ammoType = AmmoType.T_SRM_ADVANCED;
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
     }
 
     /*

--- a/megamek/src/megamek/common/weapons/lrms/ExtendedLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/ExtendedLRMWeapon.java
@@ -31,6 +31,7 @@ public abstract class ExtendedLRMWeapon extends LRMWeapon {
     public ExtendedLRMWeapon() {
         super();
         ammoType = AmmoType.T_EXLRM;
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         minimumRange = 10;
         shortRange = 12;
         mediumRange = 22;

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -52,7 +52,7 @@ public abstract class LRMWeapon extends MissileWeapon {
         longRange = 21;
         extremeRange = 28;
         atClass = CLASS_LRM;
-        flags = flags.or(F_PROTO_WEAPON);
+        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE);
     }
 
     

--- a/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
@@ -38,7 +38,7 @@ public abstract class LRTWeapon extends MissileWeapon {
     public LRTWeapon() {
         super();
         ammoType = AmmoType.T_LRM_TORPEDO;
-        flags = flags.or(F_PROTO_WEAPON).andNot(F_AERO_WEAPON);
+        flags = flags.or(F_PROTO_WEAPON).andNot(F_AERO_WEAPON).or(F_ARTEMIS_COMPATIBLE);
 
     }
     

--- a/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
@@ -37,7 +37,7 @@ public abstract class StreakLRMWeapon extends LRMWeapon {
     public StreakLRMWeapon() {
         super();
         this.ammoType = AmmoType.T_LRM_STREAK;
-        flags = flags.or(F_PROTO_WEAPON);
+        flags = flags.or(F_PROTO_WEAPON).andNot(F_ARTEMIS_COMPATIBLE);
         clearModes();
     }
     

--- a/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
@@ -57,6 +57,7 @@ public abstract class MMLWeapon extends MissileWeapon {
         super();
         this.ammoType = AmmoType.T_MML;
         this.atClass = CLASS_MML;
+        flags = flags.or(F_ARTEMIS_COMPATIBLE);
     }
 
     /*

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM10Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM10Primitive.java
@@ -42,6 +42,7 @@ public class ISLRM10Primitive extends LRMWeapon {
         addLookupName("ISLRM10p");
         addLookupName("IS LRM 10 Primitive");
         this.shortName = "LRM/10 p";
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         heat = 4;
         rackSize = 10;
         minimumRange = 6;

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM15Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM15Primitive.java
@@ -42,6 +42,7 @@ public class ISLRM15Primitive extends LRMWeapon {
         addLookupName("ISLRM15p");
         addLookupName("IS LRM 15 Primitive");
         this.shortName = "LRM/15 p";
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         heat = 5;
         rackSize = 15;
         minimumRange = 6;

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM20Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM20Primitive.java
@@ -42,6 +42,7 @@ public class ISLRM20Primitive extends LRMWeapon {
         addLookupName("ISLRM20p");
         addLookupName("IS LRM 20 Primitive");
         this.shortName = "LRM/20 p";
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         heat = 6;
         rackSize = 20;
         minimumRange = 6;

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM5Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM5Primitive.java
@@ -42,6 +42,7 @@ public class ISLRM5Primitive extends LRMWeapon {
         addLookupName("ISLRM5p");
         addLookupName("IS LRM 5 Primitive");
         this.shortName = "LRM/5 p";
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         heat = 2;
         rackSize = 5;
         minimumRange = 6;

--- a/megamek/src/megamek/common/weapons/primitive/ISSRM2Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISSRM2Primitive.java
@@ -42,6 +42,7 @@ public class ISSRM2Primitive extends SRMWeapon {
         addLookupName("ISSRM2p");
         addLookupName("IS SRM 2 Primitive");
         this.shortName = "SRM/2p";
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         heat = 2;
         rackSize = 2;
         shortRange = 3;

--- a/megamek/src/megamek/common/weapons/primitive/ISSRM4Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISSRM4Primitive.java
@@ -42,6 +42,7 @@ public class ISSRM4Primitive extends SRMWeapon {
         this.addLookupName("ISSRM4p");
         this.addLookupName("IS SRM 4 Primitive");
         this.shortName = "SRM/4p";
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         this.heat = 3;
         this.rackSize = 4;
         this.shortRange = 3;

--- a/megamek/src/megamek/common/weapons/primitive/ISSRM6Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISSRM6Primitive.java
@@ -42,6 +42,7 @@ public class ISSRM6Primitive extends SRMWeapon {
         this.addLookupName("ISSRM6p");
         this.addLookupName("IS SRM 6 Primitive");
         this.shortName = "SRM/6p";
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
         this.heat = 4;
         this.rackSize = 6;
         this.shortRange = 3;

--- a/megamek/src/megamek/common/weapons/prototypes/CLPrototypeStreakSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/prototypes/CLPrototypeStreakSRMWeapon.java
@@ -37,6 +37,7 @@ public abstract class CLPrototypeStreakSRMWeapon extends SRMWeapon {
         super();
         ammoType = AmmoType.T_SRM_STREAK;
         toHitModifier = -1;
+        flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
     }
 
     /*

--- a/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
@@ -49,7 +49,7 @@ public abstract class SRMWeapon extends MissileWeapon {
         super();
         ammoType = AmmoType.T_SRM;
         atClass = CLASS_SRM;
-        flags = flags.or(F_PROTO_WEAPON);
+        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE);
     }
 
     

--- a/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
@@ -39,7 +39,7 @@ public abstract class SRTWeapon extends MissileWeapon {
     public SRTWeapon() {
         super();
         ammoType = AmmoType.T_SRM_TORPEDO;
-        flags = flags.or(F_PROTO_WEAPON).andNot(F_AERO_WEAPON);
+        flags = flags.or(F_PROTO_WEAPON).andNot(F_AERO_WEAPON).or(F_ARTEMIS_COMPATIBLE);
     }
     
     @Override

--- a/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
@@ -36,7 +36,7 @@ public abstract class StreakSRMWeapon extends SRMWeapon {
     public StreakSRMWeapon() {
         super();
         this.ammoType = AmmoType.T_SRM_STREAK;
-        flags = flags.or(F_PROTO_WEAPON);
+        flags = flags.or(F_PROTO_WEAPON).andNot(F_ARTEMIS_COMPATIBLE);
     }
     
     @Override

--- a/megamek/unittests/megamek/common/WeaponTypeTest.java
+++ b/megamek/unittests/megamek/common/WeaponTypeTest.java
@@ -1,0 +1,44 @@
+/*
+ * MegaMek
+ * Copyright (C) 2021 - The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+package megamek.common;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class WeaponTypeTest {
+    @Test
+    public void testArtemisCompatibleFlag() {
+        for (Enumeration<EquipmentType> e = EquipmentType.getAllTypes(); e.hasMoreElements(); ) {
+            EquipmentType etype = e.nextElement();
+            if (etype instanceof WeaponType) {
+                int atype = ((WeaponType) etype).getAmmoType();
+
+                assertEquals(etype.hasFlag(WeaponType.F_ARTEMIS_COMPATIBLE),
+                        (atype == AmmoType.T_LRM)
+                        || (atype == AmmoType.T_LRM_IMP)
+                        || (atype == AmmoType.T_MML)
+                        || (atype == AmmoType.T_SRM)
+                        || (atype == AmmoType.T_SRM_IMP)
+                        || (atype == AmmoType.T_NLRM)
+                        || (atype == AmmoType.T_LRM_TORPEDO)
+                        || (atype == AmmoType.T_SRM_TORPEDO)
+                        || (atype == AmmoType.T_LRM_TORPEDO_COMBO));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds checks for rules surrounding Artemis and Apollo fire control systems to entity validation:

- No mixing of Artemis types (IV, V, prototype)
- If any compatible launcher has it, they all have to have it
- The Artemis/Apollo system must be in the same location as the weapon.

In the process I added a F_ARTEMIS_COMPATIBLE flag to WeaponType to make simplify the code to check for compatibility. I added a unit test that checks to make sure the new test has the same results as the old and guard against changes breaking the test. The form of the test is a bit unorthodox but I wrote it to produce meaningful messages on failure.

Fixes MegaMek/megameklab#888