### PR TITLE
Lobby tooltip bulletproofing

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BehaviorSettingsFactory.java
+++ b/megamek/src/megamek/client/bot/princess/BehaviorSettingsFactory.java
@@ -302,7 +302,7 @@ public class BehaviorSettingsFactory {
         try {
             BehaviorSettings cowardlyBehavior = new BehaviorSettings();
             cowardlyBehavior.setDescription(COWARDLY_BEHAVIOR_DESCRIPTION);
-            cowardlyBehavior.setDestinationEdge(CardinalEdge.NEAREST);
+            cowardlyBehavior.setDestinationEdge(CardinalEdge.NONE);
             cowardlyBehavior.setRetreatEdge(CardinalEdge.NEAREST);
             cowardlyBehavior.setForcedWithdrawal(true);
             cowardlyBehavior.setAutoFlee(false);

--- a/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
+++ b/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
@@ -79,8 +79,9 @@ public class AccessibilityWindow extends JDialog implements KeyListener {
 
             @Override
             public void gameTurnChange(GameTurnChangeEvent e) {
-                systemEvent("Turn changed it is now " + e.getPlayer().getName() + "'s turn.");
-                //systemEvent(cleanHtml(client.roundReport));
+                if (e.getPlayer() != null) {
+                    systemEvent("Turn changed it is now " + e.getPlayer().getName() + "'s turn.");
+                }
             }
 
             @Override

--- a/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
+++ b/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
@@ -80,7 +80,7 @@ public class AccessibilityWindow extends JDialog implements KeyListener {
             @Override
             public void gameTurnChange(GameTurnChangeEvent e) {
                 if (e.getPlayer() != null) {
-                    systemEvent("Turn changed it is now " + e.getPlayer().getName() + "'s turn.");
+                    systemEvent("Turn changed, it is now " + e.getPlayer().getName() + "'s turn.");
                 }
             }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -378,7 +378,7 @@ class LobbyMekCellFormatter {
                 result.append(aero.getCurrentVelocity());
                 if (mapType != MapSettings.MEDIUM_SPACE) {
                     result.append(", " + Messages.getString("ChatLounge.compact.altitude") + ": ");
-                    result.append(entity.getAltitude());
+                    result.append(aero.getAltitude());
                 } 
                 if (entity.getGame().getOptions().booleanOption(OptionsConstants.ADVAERORULES_FUEL_CONSUMPTION)) {
                     result.append(", " + Messages.getString("ChatLounge.compact.fuel") + ": ");
@@ -633,7 +633,7 @@ class LobbyMekCellFormatter {
         // Starting values for Altitude / Velocity / Elevation
         if (!isCarried) {
             if (entity.isAero()) {
-                Aero aero = (Aero) entity;
+                IAero aero = (IAero) entity;
                 result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>"); 
                 result.append(Messages.getString("ChatLounge.compact.velocity") + ": ");
                 result.append(aero.getCurrentVelocity());

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -35,6 +35,7 @@ import megamek.common.Crew;
 import megamek.common.Entity;
 import megamek.common.FighterSquadron;
 import megamek.common.GunEmplacement;
+import megamek.common.IAero;
 import megamek.common.IGame;
 import megamek.common.IPlayer;
 import megamek.common.IStartingPositions;
@@ -370,14 +371,14 @@ class LobbyMekCellFormatter {
         // Starting values for Altitude / Velocity / Elevation
         if (!isCarried) {
             if (entity.isAero()) {
-                Aero aero = (Aero) entity;
+                IAero aero = (IAero) entity;
                 firstEntry = dotSpacer(result, firstEntry);
                 result.append(guiScaledFontHTML(uiGreen()) + "<I>"); 
                 result.append(Messages.getString("ChatLounge.compact.velocity") + ": ");
                 result.append(aero.getCurrentVelocity());
                 if (mapType != MapSettings.MEDIUM_SPACE) {
                     result.append(", " + Messages.getString("ChatLounge.compact.altitude") + ": ");
-                    result.append(aero.getAltitude());
+                    result.append(entity.getAltitude());
                 } 
                 if (entity.getGame().getOptions().booleanOption(OptionsConstants.ADVAERORULES_FUEL_CONSUMPTION)) {
                     result.append(", " + Messages.getString("ChatLounge.compact.fuel") + ": ");

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -608,8 +608,7 @@ public final class UnitToolTip {
         // Velocity, Altitude, Elevation
         if (entity.isAero()) {
             result.append(guiScaledFontHTML(uiLightViolet()));
-            Aero aero = (Aero) entity;
-            result.append(addToTT("AeroVelAlt", BR, aero.getCurrentVelocity(), aero.getAltitude()));
+            result.append(addToTT("AeroVelAlt", BR, ((IAero) entity).getCurrentVelocity(), entity.getAltitude()));
             result.append("</FONT>");
         } else if (entity.getElevation() != 0) {
             result.append(guiScaledFontHTML(uiLightViolet()));

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -608,7 +608,8 @@ public final class UnitToolTip {
         // Velocity, Altitude, Elevation
         if (entity.isAero()) {
             result.append(guiScaledFontHTML(uiLightViolet()));
-            result.append(addToTT("AeroVelAlt", BR, ((IAero) entity).getCurrentVelocity(), entity.getAltitude()));
+            IAero aero = (IAero) entity;
+            result.append(addToTT("AeroVelAlt", BR, aero.getCurrentVelocity(), aero.getAltitude()));
             result.append("</FONT>");
         } else if (entity.getElevation() != 0) {
             result.append(guiScaledFontHTML(uiLightViolet()));

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -169,6 +169,8 @@ public interface IAero {
     void autoSetCapArmor();
 
     void autoSetFatalThresh();
+    
+    int getAltitude();
 
     /**
      * Iterate through current weapons and count the number in each capital


### PR DESCRIPTION
This resolves "weird rendering artifacts" (class cast exceptions) when loading up a MegaMek lobby using LAM, especially in fighter mode, and a random exception logged for the accessibility window (probably during the minefield deployment phase) when changing phases sometimes.