### PR TITLE
prevent prone mechs on top of short buildings from gaining partial cover

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4582,8 +4582,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         return targetHex.containsTerrain(Terrains.BUILDING) &&
-                ((Entity) target).getHeight() > 0 &&
-                ((Entity) target).relHeight() == targetHex.ceiling();
+                (((Entity) target).getHeight() > 0) &&
+                (((Entity) target).relHeight() == targetHex.ceiling());
     }
     
     /**

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4582,6 +4582,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         return targetHex.containsTerrain(Terrains.BUILDING) &&
+                ((Entity) target).getHeight() > 0 &&
                 ((Entity) target).relHeight() == targetHex.ceiling();
     }
     

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1540,7 +1540,6 @@ public class WeaponHandler implements AttackHandler, Serializable {
         // if the target was in partial cover, then we already handled
         // damage absorption by the partial cover, if it would have happened
         boolean targetStickingOutOfBuilding = unitStickingOutOfBuilding(targetHex, entityTarget);
-        Compute.isInBuilding(game, entityTarget);
                 
         nDamage = absorbBuildingDamage(nDamage, entityTarget, bldgAbsorbs, 
                 vPhaseReport, bldg, targetStickingOutOfBuilding);
@@ -1611,7 +1610,12 @@ public class WeaponHandler implements AttackHandler, Serializable {
      * but part sticking out?
      */
     protected boolean unitStickingOutOfBuilding(IHex targetHex, Entity entityTarget) {
+        // target needs to be on the board,
+        // be tall enough for it to make a difference,
+        // target "feet" are below the "ceiling"
+        // target "head" is above the "ceiling"
         return (targetHex != null) &&
+                (entityTarget.getHeight() > 0) &&
                 (entityTarget.getElevation() < targetHex.ceiling()) &&
                 (entityTarget.relHeight() >= targetHex.ceiling());
     }


### PR DESCRIPTION
Partial cover only applies to units that are currently tall enough to benefit from it. Also removed an extraneous call to Compute.inBuilding().