### PR TITLE
don't validate weapon groups for Artemis/Apollo

### DIFF
--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1547,7 +1547,8 @@ public abstract class TestEntity implements TestEntityOption {
          */
         boolean hasUnlinked = false;
         for (Mounted mount : getEntity().getTotalWeaponList()) {
-            if (compatibility.test((WeaponType) mount.getType())) {
+            if (!mount.isWeaponGroup() && 
+                    compatibility.test((WeaponType) mount.getType())) {
                 linkedCount++;
                 if (mount.getLinkedBy() == null) {
                     hasUnlinked = true;


### PR DESCRIPTION
Weapon groups are added to aerospace fighters after loading all the weapons; according to the comments it's for the purposes of allowing an aerospace fighter to operate as a squadron. That's fine, but we probably don't need to count those pseudo-weapons when checking whether a fighter has a legal Artemis IV setup.