### PR TITLE
Fix double MASC listing for Clan mechs in MML

### DIFF
--- a/megamek/src/megamek/common/ITechManager.java
+++ b/megamek/src/megamek/common/ITechManager.java
@@ -107,7 +107,7 @@ public interface ITechManager {
             faction = ITechnology.F_TH;
         } else if (useClanTechBase() && !introducedClan
                 && tech.isAvailableIn(2787, false, ITechnology.F_TH)
-                && !extinctClan && !extinctIS
+                && !extinctClan && (tech.getExtinctionDate(false) > getGameYear())
                 && (tech.getExtinctionDate(false) != ITechnology.DATE_NONE)) {
             // Transitional period: Clans can treat IS tech as Clan if it was available to TH and
             // has an extinction date that it hasn't reached yet (using specific Clan date if given).

--- a/megamek/src/megamek/common/ITechManager.java
+++ b/megamek/src/megamek/common/ITechManager.java
@@ -30,7 +30,7 @@ public interface ITechManager {
     int getTechIntroYear();
     
     /**
-     * @return The date to use in determining the current tech level if {@link variableTechLevel()}
+     * @return The date to use in determining the current tech level if {@link #useVariableTechLevel()}
      *         is true.
      */
     int getGameYear();
@@ -64,7 +64,7 @@ public interface ITechManager {
     SimpleTechLevel getTechLevel();
     
     /**
-     * @return If true and {@link getTechLevel()} is <code>UNOFFICIAL</code>, intro dates are ignored.
+     * @return If true and {@link #getTechLevel()} is <code>UNOFFICIAL</code>, intro dates are ignored.
      */
     boolean unofficialNoYear();
     

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -2132,8 +2132,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createISMASC() {
         MiscType misc = new MiscType();
 
-        misc.name = "MASC (Inner Sphere)";
-        misc.shortName = "MASC";
+        misc.name = "MASC";
         misc.setInternalName(EquipmentTypeLookup.IS_MASC);
         misc.addLookupName("IS MASC");
         misc.tonnage = TONNAGE_VARIABLE;
@@ -2155,8 +2154,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createCLMASC() {
         MiscType misc = new MiscType();
 
-        misc.name = "MASC (Clan)";
-        misc.shortName = "MASC";
+        misc.name = "MASC";
         misc.setInternalName(EquipmentTypeLookup.CLAN_MASC);
         misc.addLookupName("Clan MASC");
         misc.tonnage = TONNAGE_VARIABLE;


### PR DESCRIPTION
This fixes a logic error in the early Clan transition period, which is intended to all Star League tech to be used on Clan units up until it goes extinct in the Inner Sphere. The check for IS extinction fails to take into account that it's no longer extinct after its reintroduction date, which causes (at least) IS MASC to be treated as Clan tech after 3035.

I've also reverted an earlier partial fix which is now rendered moot because it introduces some undesired behavior. See the commit note for details.

Note that the mechanism of treating SL tech as Clan for a limited time is my own hack to make it possible to build the canon early Clan units. Many of them violate the rules as written. As such there is no end date for the transition period, and using the existing extinction date seemed better to me than creating an arbitrary cutoff, as it results in the IS tech being phased out instead of suddenly stopping.