### PR TITLE
prevent TAG designating targets for hostile homing munitions

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -331,8 +331,16 @@ public class ArtilleryWeaponIndirectHomingHandler extends
 
         Vector<TagInfo> v = game.getTagInfo();
         Vector<TagInfo> allowed = new Vector<TagInfo>();
+        Entity attacker = game.getEntityFromAllSources(getAttackerId());
+        
         // get only TagInfo on the same side
         for (TagInfo ti : v) {
+            // let's don't allow 
+            Entity tagger = game.getEntityFromAllSources(ti.attackerId);
+            if (attacker.getOwner().isEnemyOf(tagger.getOwner())) {
+                continue;
+            }
+            
             switch (ti.targetType){
             case Targetable.TYPE_BLDG_TAG:
             case Targetable.TYPE_HEX_TAG:

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -334,8 +334,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends
         Entity attacker = game.getEntityFromAllSources(getAttackerId());
         
         // get only TagInfo on the same side
-        for (TagInfo ti : v) {
-            // let's don't allow 
+        for (TagInfo ti : v) { 
             Entity tagger = game.getEntityFromAllSources(ti.attackerId);
             if (attacker.getOwner().isEnemyOf(tagger.getOwner())) {
                 continue;


### PR DESCRIPTION
Pretty straightforward - apparently, you could use TAG to designate targets for hostile Arrow IVs and such. Didn't seem correct, so.