### PR TITLE
Do not use GUIPreferences from Board

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1110,7 +1110,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             repaint();
         }
         if (e.getName().equals(GUIPreferences.INCLINES)) {
-            game.getBoard().initializeAllAutomaticTerrain();
+            game.getBoard().initializeAllAutomaticTerrain((boolean) e.getNewValue());
             clearHexImageCache();
             repaint();
         }

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -46,7 +46,6 @@ import java.util.Set;
 import java.util.Vector;
 
 import megamek.MegaMek;
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.Building.BasementType;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.BoardEvent;
@@ -477,7 +476,7 @@ public class Board implements Serializable, IBoard {
         }
         
         // Internally handled terrain (inclines, cliff-bottoms)
-        initializeAutomaticTerrain(x, y);
+        initializeAutomaticTerrain(x, y, /* useInclines: */ true);
         
         // Add woods/jungle elevation where none was saved
         initializeFoliageElev(x, y);
@@ -511,9 +510,12 @@ public class Board implements Serializable, IBoard {
     
     /** 
      * Checks all hex edges of the hex at (x,y) if automatically handled 
-     * terrains such as inclines must be placed or removed. 
+     * terrains such as inclines must be placed or removed.
+     * @param x The hex X-coord.
+     * @param y The hex Y-coord.
+     * @param useInclines Indicates whether or not to include inclines at hex exits.
      */
-    private void initializeAutomaticTerrain(int x, int y) {
+    private void initializeAutomaticTerrain(int x, int y, boolean useInclines) {
         IHex hex = getHex(x, y);
         int origCliffTopExits = 0;
         int correctedCliffTopExits = 0;
@@ -590,7 +592,7 @@ public class Board implements Serializable, IBoard {
         }
         addOrRemoveAutoTerrain(hex, Terrains.CLIFF_TOP, correctedCliffTopExits);
         addOrRemoveAutoTerrain(hex, Terrains.CLIFF_BOTTOM, cliffBotExits);
-        if (GUIPreferences.getInstance().getHexInclines()) {
+        if (useInclines) {
             addOrRemoveAutoTerrain(hex, Terrains.INCLINE_TOP, inclineTopExits);
             addOrRemoveAutoTerrain(hex, Terrains.INCLINE_BOTTOM, inclineBotExits);
             addOrRemoveAutoTerrain(hex, Terrains.INCLINE_HIGH_TOP, highInclineTopExits);
@@ -616,11 +618,13 @@ public class Board implements Serializable, IBoard {
         }
     }
     
-    /** Rebuilds automatic terrains for the whole board. */
-    public void initializeAllAutomaticTerrain() {
+    /** Rebuilds automatic terrains for the whole board.
+     * @param useInclines Indicates whether or not to use inclines on hex exits.
+     */
+    public void initializeAllAutomaticTerrain(boolean useInclines) {
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                initializeAutomaticTerrain(x, y);
+                initializeAutomaticTerrain(x, y, useInclines);
             }
         }
         processBoardEvent(new BoardEvent(this, null, BoardEvent.BOARD_CHANGED_ALL_HEXES));

--- a/megamek/src/megamek/common/Building.java
+++ b/megamek/src/megamek/common/Building.java
@@ -238,14 +238,14 @@ public class Building implements Serializable {
      * Basement handlers
      */
     public enum BasementType {
-        UNKNOWN(0,0, Messages.getString("Building.BasementUnknown")),
-        NONE(1,0, Messages.getString("Building.BasementNone")),
-        TWO_DEEP_FEET(2,2,Messages.getString("Building.BasementTwoDeepFeet")),
-        ONE_DEEP_FEET(3,1,Messages.getString("Building.BasementOneDeepFeet")),
-        ONE_DEEP_NORMAL(4,1,Messages.getString("Building.BasementOneDeepNormal")),
-        ONE_DEEP_NORMALINFONLY(5,1,Messages.getString("Building.BasementOneDeepNormalInfOnly")),
-        ONE_DEEP_HEAD(6,1,Messages.getString("Building.BasementOneDeepHead")),
-        TWO_DEEP_HEAD(7,2,Messages.getString("Building.BasementTwoDeepHead"));
+        UNKNOWN(0, 0, "Building.BasementUnknown"),
+        NONE(1, 0, "Building.BasementNone"),
+        TWO_DEEP_FEET(2, 2, "Building.BasementTwoDeepFeet"),
+        ONE_DEEP_FEET(3, 1, "Building.BasementOneDeepFeet"),
+        ONE_DEEP_NORMAL(4, 1, "Building.BasementOneDeepNormal"),
+        ONE_DEEP_NORMALINFONLY(5, 1, "Building.BasementOneDeepNormalInfOnly"),
+        ONE_DEEP_HEAD(6, 1, "Building.BasementOneDeepHead"),
+        TWO_DEEP_HEAD(7, 2, "Building.BasementTwoDeepHead");
 
         private int value;
         private int depth;
@@ -266,7 +266,7 @@ public class Building implements Serializable {
         }
 
         public String getDesc() {
-            return desc;
+            return Messages.getString(desc);
         }
 
         public static BasementType getType(int value) {

--- a/megamek/src/megamek/common/IBoard.java
+++ b/megamek/src/megamek/common/IBoard.java
@@ -589,7 +589,7 @@ public interface IBoard {
     public void setTheme(String newTheme);
     
     /** Rebuilds automatic terrains for the whole board. */
-    public void initializeAllAutomaticTerrain();
+    public void initializeAllAutomaticTerrain(boolean useInclines);
     
     /** Returns true when the given Coord c is on the edge of the board. */
     public boolean isOnBoardEdge(Coords c);


### PR DESCRIPTION
Removes coupling of the `Board` with anything GUI related. This likely needs some work on the `BoardView` side to ensure we toggle that value at the correct points. Fixes the issue with the Boards Validator no longer working.