### PR TITLE
potato computer error cleanup

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -783,47 +783,6 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         return minimum;
     }
 
-    /**
-     * Returns distance to the unit's home edge.
-     * Gives the distance to the closest edge
-     *
-     * @param position Final coordinates of the proposed move.
-     * @param homeEdge Unit's home edge.
-     * @param game     The {@link IGame} currently in play.
-     * @return The distance to the unit's home edge.
-     */
-    @Override
-    public int distanceToHomeEdge(Coords position, CardinalEdge homeEdge, IGame game) {
-        int width = game.getBoard().getWidth();
-        int height = game.getBoard().getHeight();
-
-        int distance;
-        switch (homeEdge) {
-            case NORTH: {
-                distance = position.getY();
-                break;
-            }
-            case SOUTH: {
-                distance = height - position.getY() - 1;
-                break;
-            }
-            case WEST: {
-                distance = position.getX();
-                break;
-            }
-            case EAST: {
-                distance = width - position.getX() - 1;
-                break;
-            }
-            default: {
-                getOwner().getLogger().warning("Invalid home edge.  Defaulting to NORTH.");
-                distance = position.getY();
-            }
-        }
-
-        return distance;
-    }
-
     double checkPathForHazards(MovePath path, Entity movingUnit, IGame game) {
         StringBuilder logMsg = new StringBuilder("Checking Path (")
                 .append(path.toString()).append(") for hazards.");

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -521,7 +521,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
      */
     @Override
     protected RankedPath rankPath(MovePath path, IGame game, int maxRange,
-                               double fallTolerance, int distanceHome,
+                               double fallTolerance,
                                List<Entity> enemies, Coords friendsCoords) {
         Entity movingUnit = path.getEntity();
         StringBuilder formula = new StringBuilder("Calculation: {");

--- a/megamek/src/megamek/client/bot/princess/IPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/IPathRanker.java
@@ -12,7 +12,7 @@ import megamek.common.Targetable;
 public interface IPathRanker {
 
     ArrayList<RankedPath> rankPaths(List<MovePath> movePaths, IGame game, int maxRange, double fallTolerance,
-            int startingHomeDistance, List<Entity> enemies, List<Entity> friends);
+            List<Entity> enemies, List<Entity> friends);
 
     /**
      * Performs initialization to help speed later calls of rankPath for this

--- a/megamek/src/megamek/client/bot/princess/InfantryPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryPathRanker.java
@@ -19,7 +19,7 @@ public class InfantryPathRanker extends BasicPathRanker implements IPathRanker {
     }
 
     @Override
-    protected RankedPath rankPath(MovePath path, IGame game, int maxRange, double fallTolerance, int distanceHome,
+    protected RankedPath rankPath(MovePath path, IGame game, int maxRange, double fallTolerance,
             List<Entity> enemies, Coords friendsCoords) {
         Entity movingUnit = path.getEntity();
         StringBuilder formula = new StringBuilder("Calculation: {");

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -356,34 +356,43 @@ public abstract class PathRanker implements IPathRanker {
         return SharedUtility.getPSRList(path);
     }
 
+    /**
+     * Returns distance to the unit's home edge.
+     * Gives the distance to the closest edge
+     *
+     * @param position Final coordinates of the proposed move.
+     * @param homeEdge Unit's home edge.
+     * @param game     The {@link IGame} currently in play.
+     * @return The distance to the unit's home edge.
+     */
     public int distanceToHomeEdge(Coords position, CardinalEdge homeEdge, IGame game) {
-        Coords edgeCoords;
-        int boardHeight = game.getBoard().getHeight();
-        int boardWidth = game.getBoard().getWidth();
-        StringBuilder msg = new StringBuilder("Getting distance to home edge: ");
-        if (CardinalEdge.NORTH.equals(homeEdge)) {
-            msg.append("North");
-            edgeCoords = new Coords(position.getX(), 0);
-        } else if (CardinalEdge.SOUTH.equals(homeEdge)) {
-            msg.append("South");
-            edgeCoords = new Coords(position.getX(), boardHeight);
-        } else if (CardinalEdge.WEST.equals(homeEdge)) {
-            msg.append("West");
-            edgeCoords = new Coords(0, position.getY());
-        } else if (CardinalEdge.EAST.equals(homeEdge)) {
-            msg.append("East");
-            edgeCoords = new Coords(boardWidth, position.getY());
-        } else {
-            msg.append("Default");
-            getOwner().getLogger().warning("Invalid home edge. Defaulting to NORTH.");
-            edgeCoords = new Coords(boardWidth / 2, 0);
+        int width = game.getBoard().getWidth();
+        int height = game.getBoard().getHeight();
+
+        int distance;
+        switch (homeEdge) {
+            case NORTH: {
+                distance = position.getY();
+                break;
+            }
+            case SOUTH: {
+                distance = height - position.getY() - 1;
+                break;
+            }
+            case WEST: {
+                distance = position.getX();
+                break;
+            }
+            case EAST: {
+                distance = width - position.getX() - 1;
+                break;
+            }
+            default: {
+                getOwner().getLogger().warning("Invalid home edge.  Defaulting to NORTH.");
+                distance = position.getY();
+            }
         }
-        msg.append(edgeCoords.toFriendlyString());
 
-        int distance = edgeCoords.distance(position);
-        msg.append(" dist = ").append(NumberFormat.getInstance().format(distance));
-
-        getOwner().getLogger().debug(msg.toString());
         return distance;
     }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1340,16 +1340,11 @@ public class Princess extends BotClient {
             getPathRanker(entity).initUnitTurn(entity, getGame());
             final double fallTolerance =
                     getBehaviorSettings().getFallShameIndex() / 10d;
-            final int startingHomeDistance = getPathRanker(entity).distanceToHomeEdge(
-                    entity.getPosition(),
-                    getBehaviorSettings().getDestinationEdge(),
-                    getGame());
                        
             final List<RankedPath> rankedpaths = getPathRanker(entity).rankPaths(paths,
                                                     getGame(),
                                                     getMaxWeaponRange(entity),
                                                     fallTolerance,
-                                                    startingHomeDistance,
                                                     getEnemyEntities(),
                                                     getFriendEntities());
             

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1846,7 +1846,11 @@ public class Princess extends BotClient {
     protected void processChat(final GamePlayerChatEvent ge) {
         chatProcessor.processChat(ge, this);
     }
-
+    
+    /**
+     * Given an entity and the current behavior settings, get the "home" edge to which the entity should attempt to retreat
+     * Guaranteed to return a cardinal edge or NONE.
+     */
     CardinalEdge getHomeEdge(Entity entity) {
         // if I am crippled and using forced withdrawal rules, my home edge is the "retreat" edge        
         if(entity.isCrippled(true) && getBehaviorSettings().isForcedWithdrawal()) {
@@ -1858,7 +1862,11 @@ public class Princess extends BotClient {
         }
         
         // otherwise, return the destination edge
-        return getBehaviorSettings().getDestinationEdge();
+        if (getBehaviorSettings().getDestinationEdge() == CardinalEdge.NEAREST) {
+            return BoardUtilities.getClosestEdge(entity);                
+        } else {
+            return getBehaviorSettings().getDestinationEdge();
+        }
     }
 
     public int calculateAdjustment(final String ticks) {

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -29,6 +29,7 @@ import java.util.List;
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.PlayerColour;
 import megamek.common.Aero;
 import megamek.common.Board;
 import megamek.common.Crew;
@@ -722,11 +723,14 @@ class LobbyMekCellFormatter {
             result.append(" [").append(force.getId()).append("]</FONT>");
         }
         
-        // Owner
-        if (game.getForces().getOwnerId(force) != client.getLocalPlayerNumber()) {
+        // Display force owner
+        if ((ownerId != client.getLocalPlayerNumber()) && (owner != null)) {
             result.append(guiScaledFontHTML(size));
             result.append(DOT_SPACER).append("</FONT>");
-            result.append(guiScaledFontHTML(owner.getColour().getColour(), size));
+            
+            PlayerColour ownerColour = owner.getColour() == null ?
+                    PlayerColour.FIRE_BRICK : owner.getColour();
+            result.append(guiScaledFontHTML(ownerColour.getColour(), size));
             result.append("\u2691 ");
             result.append(owner.getName()).append("</FONT>");
         }

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -728,7 +728,8 @@ class LobbyMekCellFormatter {
             result.append(guiScaledFontHTML(size));
             result.append(DOT_SPACER).append("</FONT>");
             
-            PlayerColour ownerColour = owner.getColour() == null ?
+            PlayerColour ownerColour = (owner.getColour() == null) ?
+
                     PlayerColour.FIRE_BRICK : owner.getColour();
             result.append(guiScaledFontHTML(ownerColour.getColour(), size));
             result.append("\u2691 ");

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -652,7 +652,7 @@ public final class UnitToolTip {
         }
 
         // Spotting
-        if (entity.isSpotting()) {
+        if (entity.isSpotting() && game.hasEntity(entity.getSpotTargetId())) {
             result.append(addToTT("Spotting", BR, game.getEntity(entity.getSpotTargetId()).getDisplayName()));
         }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -6174,7 +6174,7 @@ public class Compute {
      */
     public static Coords getFinalPosition(Coords curpos, int[] v) {
 
-        if ((v == null) || (v.length != 6)) {
+        if ((v == null) || (v.length != 6) || (curpos == null)) {
             return curpos;
         }
 

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1234,7 +1234,11 @@ public class Game implements Serializable, IGame {
                 case Targetable.TYPE_BUILDING:
                 case Targetable.TYPE_BLDG_IGNITE:
                 case Targetable.TYPE_BLDG_TAG:
-                    return new BuildingTarget(BuildingTarget.idToCoords(nID), board, nType);
+                    if (getBoard().getBuildingAt(BuildingTarget.idToCoords(nID)) != null) {
+                        return new BuildingTarget(BuildingTarget.idToCoords(nID), board, nType);
+                    } else {
+                        return null;
+                    }
                 case Targetable.TYPE_MINEFIELD_CLEAR:
                     return new MinefieldTarget(MinefieldTarget.idToCoords(nID), board);
                 case Targetable.TYPE_INARC_POD:

--- a/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
@@ -204,15 +204,14 @@ public class NewtonianAerospacePathFinder {
         boolean maxMPExceeded = path.getMpUsed() > path.getEntity().getRunMP();
         
         // having generated the child, we add it and (recursively) any of its children to the list of children to be returned            
-        // unless it is illegal or exceeds max MP, in which case we discard it
-        // (max mp is maybe redundant)?
-        if(!path.isMoveLegal() || maxMPExceeded) {
+        // unless it exceeds max MP, in which case we discard it
+        if (maxMPExceeded) {
             return true;
         }
         
         // terminator conditions:
         // we've visited this hex already and the path we are considering is longer than the previous path that visited this hex
-        if(visitedCoords.containsKey(pathDestination) && visitedCoords.get(pathDestination).intValue() < path.getMpUsed()) {
+        if (visitedCoords.containsKey(pathDestination) && visitedCoords.get(pathDestination).intValue() < path.getMpUsed()) {
             return true;
         }
         

--- a/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
@@ -211,7 +211,7 @@ public class NewtonianAerospacePathFinder {
         
         // terminator conditions:
         // we've visited this hex already and the path we are considering is longer than the previous path that visited this hex
-        if (visitedCoords.containsKey(pathDestination) && visitedCoords.get(pathDestination).intValue() < path.getMpUsed()) {
+        if (visitedCoords.containsKey(pathDestination) && (visitedCoords.get(pathDestination).intValue() < path.getMpUsed())) {
             return true;
         }
         

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 
+import megamek.MegaMek;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.IAero;
@@ -373,12 +374,12 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
      */
     public static int getLevelDiff(final MovePath mp, Coords dest, IBoard board, boolean ignore) {
         // Ignore level differences if we're not on the ground
-        if (ignore || (mp.getFinalElevation() != 0)) {
+        if (ignore || !board.onGround() || (mp.getFinalElevation() != 0)) {
             return 0;
         }
         IHex currHex = board.getHex(mp.getFinalCoords());
         if (currHex == null) {
-            System.out.println("getLevelDiff: currHex was null!" +
+            MegaMek.getLogger().debug("getLevelDiff: currHex was null!" +
                                "\nStart: " + mp.getStartCoords() +
                                "\ncurrHex:  " + mp.getFinalCoords() +
                                "\nPath: " + mp.toString());
@@ -386,7 +387,7 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
         }
         IHex destHex = board.getHex(dest);
         if (destHex == null) {
-            System.out.println("getLevelDiff: destHex was null!" +
+            MegaMek.getLogger().debug("getLevelDiff: destHex was null!" +
                                "\nStart: " + mp.getStartCoords() +
                                "\ndestHex: " + dest +
                                "\nPath: " + mp.toString());

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -4880,6 +4880,7 @@ public class Server implements Runnable {
         // An entity that is not vulnerable to anti-TSM green smoke that has stayed in a smoke-filled
         // hex takes damage.
         if ((md.getHexesMoved() == 0)
+                && game.getBoard().contains(md.getFinalCoords())
                 && (game.getBoard().getHex(md.getFinalCoords()).terrainLevel(Terrains.SMOKE) == SmokeCloud.SMOKE_GREEN)
                 && entity.antiTSMVulnerable()) {
             addReport(doGreenSmokeDamage(entity));

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -489,7 +489,7 @@ public class BasicPathRankerTest {
                                                                  LOG_INT.format(0) + ", " +
                                                                  "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0)
                                                                  + " - " + LOG_INT.format(1) + "})]");
-        RankedPath actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        RankedPath actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
 
         // Change the move path success probability.
@@ -514,7 +514,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                      "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                      LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank < actual.getRank()) {
             Assert.fail("Higher chance to fall should mean lower rank.");
@@ -539,7 +539,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                       "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                       LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank < actual.getRank()) {
             Assert.fail("Higher chance to fall should mean lower rank.");
@@ -575,7 +575,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank > actual.getRank()) {
             Assert.fail("The more damage I do, the higher the path rank should be.");
@@ -606,7 +606,7 @@ public class BasicPathRankerTest {
                 (0) + ", " +
                                                    "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                    LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank < actual.getRank()) {
             Assert.fail("The less damage I do, the lower the path rank should be.");
@@ -647,7 +647,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         if (baseRank < actual.getRank()) {
             Assert.fail("The more damage they do, the lower the path rank should be.");
         }
@@ -678,7 +678,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank > actual.getRank()) {
             Assert.fail("The less damage they do, the higher the path rank should be.");
@@ -714,7 +714,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank > actual.getRank()) {
             Assert.fail("The closer I am to the enemy, the higher the path rank should be.");
@@ -740,7 +740,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank < actual.getRank()) {
             Assert.fail("The further I am from the enemy, the lower the path rank should be.");
@@ -769,7 +769,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank > actual.getRank()) {
             Assert.fail("The closer I am to my friends, the higher the path rank should be.");
@@ -793,7 +793,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank < actual.getRank()) {
             Assert.fail("The further I am from my friends, the lower the path rank should be.");
@@ -814,7 +814,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, null);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, null);
         assertRankedPathEquals(expected, actual);
         friendsCoords = new Coords(10, 10);
 
@@ -838,7 +838,7 @@ public class BasicPathRankerTest {
                                                              LOG_INT.format(0) + ", " +
                                                              "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + "" +
                                                              " - " + LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         Mockito.doReturn(10)
                .when(testRanker)
@@ -861,7 +861,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                      "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                      LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseFleeingRank > actual.getRank()) {
             Assert.fail("The closer I am to my home edge when fleeing, the higher the path rank should be.");
@@ -887,7 +887,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                      "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                      LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseFleeingRank < actual.getRank()) {
             Assert.fail("The further I am from my home edge when fleeing, the lower the path rank should be.");
@@ -917,7 +917,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                       "" + LOG_INT.format(50) + " * {" + LOG_INT.format(1) + " - " +
                                                       LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank != actual.getRank()) {
             Assert.fail("Being 1 hex off facing should make no difference in rank.");
@@ -941,7 +941,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                      "" + LOG_INT.format(50) + " * {" + LOG_INT.format(2) + " - " +
                                                      LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank < actual.getRank()) {
             Assert.fail("Being 2 or more hexes off facing should lower the path rank.");
@@ -965,7 +965,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                      "" + LOG_INT.format(50) + " * {" + LOG_INT.format(3) + " - " +
                                                      LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         if (baseRank < actual.getRank()) {
             Assert.fail("Being 2 or more hexes off facing should lower the path rank.");
@@ -994,7 +994,7 @@ public class BasicPathRankerTest {
                 .format(0) + ", " +
                                                     "" + LOG_INT.format(50) + " * {" + LOG_INT.format(0) + " - " +
                                                     LOG_INT.format(1) + "})]");
-        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, 20, testEnemies, friendsCoords);
+        actual = testRanker.rankPath(mockPath, mockGame, 18, 0.5, testEnemies, friendsCoords);
         assertRankedPathEquals(expected, actual);
         Mockito.doReturn(mockEnemyMech1)
                .when(testRanker)


### PR DESCRIPTION
Fixes a bunch of errors logged while playing the game on a potato-grade computer. Didn't feel like spamming twenty separate pull requests.

In no particular order:
- the "distance to home edge" was being called unnecessarily and resulted in some logging. Removed it from where appropriate.
- unified the "distance to home edge" function as it was functionally identical across both implementations, but much simpler in BasicPathRanker
- Some times, search light attacks would try to register against non-existent buildings.
- fix an issue where the bot wouldn't respect the "nearest" setting for the destination edge
- ejected aerospace pilots flying off the board in the newtonian model would crash the server
- fix a long-standing bug where the bot was unable to avoid flying off board at all in the newtonian model
- fix a unit tool tip exception related to spotting non-entity targets
- fix a lobby error rendering forces when color data hasn't come across