### PR TITLE
Fix failure to apply single critical

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -27050,13 +27050,13 @@ public class Server implements Runnable {
                 r = new Report(6005);
                 r.subject = en.getId();
                 vDesc.addElement(r);
+                return vDesc;
             } else if ((!advancedCrit && (roll >= 8) && (roll <= 9))
                     || (advancedCrit && (roll >= 9) && (roll <= 10))) {
                 hits = 1;
                 r = new Report(6315);
                 r.subject = en.getId();
                 vDesc.addElement(r);
-                return vDesc;
             } else if ((!advancedCrit && (roll >= 10) && (roll <= 11))
                     || (advancedCrit && (roll >= 11) && (roll <= 12))) {
                 hits = 2;


### PR DESCRIPTION
It looks like I introduced this when I reworked this method to implement anti-TSM warheads. If the critical roll results in no criticals, the method exits early instead of adding an additional critical for ATSM susceptible units and skips some other irrelevant calculations as well. At least that seems to have been the intent. But the return is in the wrong block and exits when the critical roll results in one crit.

Fixes #2995 