### PR TITLE
fighter squadron refactor

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1430,7 +1430,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
             }
         }
 
-        int numFighters = ce().getActiveSubEntities().orElse(Collections.emptyList()).size();
+        int numFighters = ce().getActiveSubEntities().size();
         BombPayloadDialog bombsDialog = new BombPayloadDialog(
                 clientgui.frame,
                 Messages.getString("FiringDisplay.BombNumberDialog" + ".title"), //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -25,7 +25,6 @@ import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -4208,7 +4207,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         // bring up dialog to dump bombs, then make a control roll and report
         // success or failure
         // should update mp available
-        int numFighters = ce().getActiveSubEntities().orElse(Collections.emptyList()).size();
+        int numFighters = ce().getActiveSubEntities().size();
         BombPayloadDialog dumpBombsDialog = new BombPayloadDialog(
                 clientgui.frame,
                 Messages.getString("MovementDisplay.BombDumpDialog.title"), //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -318,7 +318,7 @@ public class LobbyActions {
 
                 // Customizations to a Squadron can effect the fighters
                 if (entity instanceof FighterSquadron) {
-                    entity.getSubEntities().ifPresent(ents -> ents.forEach(client::sendUpdateEntity));
+                    entity.getSubEntities().forEach(client::sendUpdateEntity);
                 }
             }
         }
@@ -398,7 +398,7 @@ public class LobbyActions {
 
                 // Customizations to a Squadron can effect the fighters
                 if (entity instanceof FighterSquadron) {
-                    entity.getSubEntities().ifPresent(ents -> updateCandidates.addAll(ents));
+                    updateCandidates.addAll(entity.getSubEntities());
                 }
 
                 // Do we need to update the members of our C3 network?

--- a/megamek/src/megamek/client/ui/swing/widget/SquadronMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SquadronMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
-import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
@@ -129,7 +128,7 @@ public class SquadronMapSet implements DisplayMapSet {
     }
 
     public void setEntity(Entity e) {
-        List<Entity> fighters = e.getSubEntities().orElse(Collections.emptyList());
+        List<Entity> fighters = e.getSubEntities();
         for(int i = 0; i < max_size; ++ i) {
             if(i < fighters.size()) {
                 final Entity fighter = fighters.get(i);

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -28,7 +28,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Vector;
@@ -15500,21 +15499,18 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      *
      * @return an optional collection of sub-entities, if this entity is considered a grouping of them.
      */
-    public Optional<List<Entity>> getSubEntities() {
-        return Optional.empty();
+    public List<Entity> getSubEntities() {
+        return Collections.emptyList();
     }
 
     /**
-     * The default implementation calls getSubEntities(), then filters them. This might not be
-     * the optimal code for many applications, so feel free to override both if needed.
+     * A list of all active sub-entities. In most cases, this is simply an empty list.
      *
      * @return an optional collection of sub-entities, if this entity is considered a grouping of them,
      *         pre-filtered to only contain active (non-destroyed and non-doomed) entities.
      */
-    public Optional<List<Entity>> getActiveSubEntities() {
-        return getSubEntities().map(
-            ents -> ents.stream().filter(
-                ent -> !(ent.isDestroyed() || ent.isDoomed())).collect(Collectors.toList()));
+    public List<Entity> getActiveSubEntities() {
+        return Collections.emptyList();
     }
 
     /**

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -144,12 +144,12 @@ public class FighterSquadron extends Aero {
 
     @Override
     public int getFuel() {
-        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getFuel()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero) ent).getFuel()).min().orElse(0);
     }
     
     @Override
     public int getCurrentFuel() {
-        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getCurrentFuel()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero) ent).getCurrentFuel()).min().orElse(0);
     }
 
     /*
@@ -241,8 +241,8 @@ public class FighterSquadron extends Aero {
     @Override
     public int getClusterMods() {
         return getActiveSubEntities().stream()
-                .filter(ent -> (((IAero)ent).getFCSHits() <= 2))
-                .mapToInt(ent -> ((IAero)ent).getClusterMods()).sum();
+                .filter(ent -> (((IAero) ent).getFCSHits() <= 2))
+                .mapToInt(ent -> ((IAero) ent).getClusterMods()).sum();
     }
 
     @Override
@@ -276,7 +276,7 @@ public class FighterSquadron extends Aero {
 
     @Override
     public int getHeatSinks() {
-        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getHeatSinks()).sum();
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero) ent).getHeatSinks()).sum();
     }
     
     @Override
@@ -323,7 +323,7 @@ public class FighterSquadron extends Aero {
         List<Entity> activeFighters = getActiveSubEntities();
         
         // If this squadron is doomed or is of size 1 then just return the first one
-        if (isDoomed() || activeFighters.size() <= 1) {
+        if (isDoomed() || (activeFighters.size() <= 1)) {
             return new HitData(0);
         }
 

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -84,12 +84,12 @@ public class FighterSquadron extends Aero {
 
     @Override
     public int get0SI() {
-        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).get0SI()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero) ent).get0SI()).min().orElse(0);
     }
 
     @Override
     public int getSI() {
-        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getSI()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero) ent).getSI()).min().orElse(0);
     }
 
     @Override

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -12,17 +12,16 @@
 package megamek.common;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.Vector;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import megamek.MegaMek;
 import megamek.common.IGame.Phase;
 import megamek.common.options.OptionsConstants;
 
@@ -70,8 +69,8 @@ public class FighterSquadron extends Aero {
      */
     @Override
     public double getCost(boolean ignoreAmmo) {
-        return fighters.stream()
-                .mapToDouble(fid -> game.getEntity(fid).getCost(ignoreAmmo))
+        return getSubEntities().stream()
+                .mapToDouble(entity -> entity.getCost(ignoreAmmo))
                 .sum();
     }
 
@@ -85,27 +84,25 @@ public class FighterSquadron extends Aero {
 
     @Override
     public int get0SI() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK).mapToInt(ent -> ((IAero)ent).get0SI()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).get0SI()).min().orElse(0);
     }
 
     @Override
     public int getSI() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK).mapToInt(ent -> ((IAero)ent).getSI()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getSI()).min().orElse(0);
     }
 
     @Override
     public int getTotalArmor() {
-        return fighters.stream()
-                .mapToInt(fid -> ((IAero)game.getEntity(fid)).getCapArmor())
+        return getSubEntities().stream()
+                .mapToInt(entity -> ((IAero) entity).getCapArmor())
                 .sum();
     }
 
     @Override
     public int getTotalOArmor() {
-        return fighters.stream()
-                .mapToInt(fid -> ((IAero) game.getEntity(fid)).getCap0Armor())
+        return getSubEntities().stream()
+                .mapToInt(entity -> ((IAero) entity).getCap0Armor())
                 .sum();
     }
     
@@ -133,30 +130,26 @@ public class FighterSquadron extends Aero {
     @Override
     public int getWalkMP(boolean gravity, boolean ignoreheat,
             boolean ignoremodulararmor) {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-                .filter(ACTIVE_CHECK)
+        return getActiveSubEntities().stream()
                 .mapToInt(ent -> ent.getWalkMP(gravity, ignoreheat)).min()
                 .orElse(0);
     }
     
     @Override
     public int getCurrentThrust() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-                .filter(ACTIVE_CHECK)
+        return getActiveSubEntities().stream()
                 .mapToInt(ent -> ((IAero) ent).getCurrentThrust()).min()
                 .orElse(0);
     }
 
     @Override
     public int getFuel() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK).mapToInt(ent -> ((IAero)ent).getFuel()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getFuel()).min().orElse(0);
     }
     
     @Override
     public int getCurrentFuel() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK).mapToInt(ent -> ((IAero)ent).getCurrentFuel()).min().orElse(0);
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getCurrentFuel()).min().orElse(0);
     }
 
     /*
@@ -169,8 +162,7 @@ public class FighterSquadron extends Aero {
 
     @Override
     public boolean hasTargComp() {
-        List<Entity> activeFighters = getActiveSubEntities()
-                .orElse(Collections.emptyList());
+        List<Entity> activeFighters = getActiveSubEntities();
         if (activeFighters.isEmpty()) {
             return false;
         }
@@ -186,8 +178,7 @@ public class FighterSquadron extends Aero {
                 || !game.getBoard().inSpace()) {
             return super.hasActiveECM();
         }
-        return fighters.stream().map(fid -> game.getEntity(fid))
-                .filter(ACTIVE_CHECK).anyMatch(Entity::hasActiveECM);
+        return getActiveSubEntities().stream().anyMatch(Entity::hasActiveECM);
     }
 
     /**
@@ -249,9 +240,9 @@ public class FighterSquadron extends Aero {
 
     @Override
     public int getClusterMods() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK).filter(ent -> (((IAero)ent).getFCSHits() <= 2))
-            .mapToInt(ent -> ((IAero)ent).getClusterMods()).sum();
+        return getActiveSubEntities().stream()
+                .filter(ent -> (((IAero)ent).getFCSHits() <= 2))
+                .mapToInt(ent -> ((IAero)ent).getClusterMods()).sum();
     }
 
     @Override
@@ -263,11 +254,8 @@ public class FighterSquadron extends Aero {
         int bv = 0;
         
         // We'll just add up the BV of all non-destroyed fighters in the squadron.
-        for (Integer fid : fighters) {
-            final Entity fighter = game.getEntity(fid);
-            if ((null != fighter) && !fighter.isDoomed() && !fighter.isDestroyed()) {
-                bv += fighter.calculateBattleValue(ignoreC3, ignorePilot);
-            }
+        for (Entity fighter : getActiveSubEntities()) {
+            bv += fighter.calculateBattleValue(ignoreC3, ignorePilot);
         }
 
         return bv;
@@ -288,8 +276,7 @@ public class FighterSquadron extends Aero {
 
     @Override
     public int getHeatSinks() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK).mapToInt(ent -> ((IAero)ent).getHeatSinks()).sum();
+        return getActiveSubEntities().stream().mapToInt(ent -> ((IAero)ent).getHeatSinks()).sum();
     }
     
     @Override
@@ -302,9 +289,7 @@ public class FighterSquadron extends Aero {
     }
 
     public void resetHeatCapacity() {
-        List<Entity> activeFighters = fighters.stream()
-                .map(fid -> game.getEntity(fid)).filter(ACTIVE_CHECK)
-                .collect(Collectors.toList());
+        List<Entity> activeFighters = getActiveSubEntities();
         heatcap = activeFighters.stream()
                 .mapToInt(ent -> ent.getHeatCapacity(true)).sum();
         heatcapNoRHS = activeFighters.stream()
@@ -313,13 +298,11 @@ public class FighterSquadron extends Aero {
 
     @Override
     public double getWeight() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK).mapToDouble(ent -> ent.getWeight()).sum();
+        return getActiveSubEntities().stream().mapToDouble(ent -> ent.getWeight()).sum();
     }
 
     public double getAveWeight() {
-        List<Entity> activeFighters = getActiveSubEntities()
-                .orElse(Collections.emptyList());
+        List<Entity> activeFighters = getActiveSubEntities();
         return activeFighters.isEmpty() ? Double.NaN
                 : (getWeight() / activeFighters.size());
     }
@@ -337,22 +320,15 @@ public class FighterSquadron extends Aero {
      */
     @Override
     public HitData rollHitLocation(int table, int side, int aimedLocation, int aimingMode, int cover) {
-        // Create a list of the indices of all the active fighters, which serves as the list of valid hit locations
-        List<Integer> indices = new ArrayList<>();
-        for (int i = 0; i < fighters.size(); i++) {
-            if (ACTIVE_CHECK.test(game.getEntity(fighters.get(i)))) {
-                indices.add(i);
-            }
-        }
-        // If this squadron is doomed or is of size 1 then just return the first
-        // one
-        if (isDoomed() || indices.isEmpty()) {
+        List<Entity> activeFighters = getActiveSubEntities();
+        
+        // If this squadron is doomed or is of size 1 then just return the first one
+        if (isDoomed() || activeFighters.size() <= 1) {
             return new HitData(0);
         }
 
-        // Pick a random number between 0 and the number of fighters in the
-        // squadron.
-        int hit = indices.get(Compute.randomInt(indices.size()));
+        // Pick a random number between 0 and the number of fighters in the squadron.        
+        int hit = Compute.randomInt(activeFighters.size());
         return new HitData(hit);
     }
 
@@ -377,8 +353,7 @@ public class FighterSquadron extends Aero {
      */
     public void updateSensors() {
         if (getActiveSensor() == null) {
-            for (Integer fId : fighters) {
-                Entity entity = game.getEntity(fId);
+            for (Entity entity : getActiveSubEntities()) {
                 Aero fighter = (Aero) entity;
                 if (fighter.getSensorHits() > 2) {
                     // Sensors destroyed. Check the next fighter
@@ -411,12 +386,11 @@ public class FighterSquadron extends Aero {
         Iterator<String> iter = set.iterator();
         while (iter.hasNext()) {
             String key = iter.next();
-            this.getEquipment(weaponGroups.get(key)).setNWeapons(0);
+            getEquipment(weaponGroups.get(key)).setNWeapons(0);
         }
         // now collect a hash of all the same weapons in each location by id
         Map<String, Integer> groups = new HashMap<String, Integer>();
-        for (Integer fId : fighters) {
-            Entity entity = game.getEntity(fId);
+        for (Entity entity : getActiveSubEntities()) {
             IAero fighter = (IAero) entity;
             if (fighter.getFCSHits() > 2) {
                 // can't fire with no more FCS
@@ -460,8 +434,7 @@ public class FighterSquadron extends Aero {
                         newmount.setNWeapons(groups.get(key));
                         weaponGroups.put(key, getEquipmentNum(newmount));
                     } catch (LocationFullException ex) {
-                        System.out.println("Unable to compile weapon groups"); //$NON-NLS-1$
-                        ex.printStackTrace();
+                        MegaMek.getLogger().error("Unable to compile weapon groups.", ex);
                         return;
                     }
                 } else if (name != "0") {
@@ -493,7 +466,7 @@ public class FighterSquadron extends Aero {
      * update the skills for this squadron
      */
     public void updateSkills() {
-        List<Entity> activeFighters = getActiveSubEntities().orElse(Collections.emptyList());
+        List<Entity> activeFighters = getActiveSubEntities();
         if(activeFighters.isEmpty()) {
             return;
         }
@@ -525,8 +498,7 @@ public class FighterSquadron extends Aero {
     @Override
     public ArrayList<Mounted> getAmmo() {
         ArrayList<Mounted> allAmmo = new ArrayList<Mounted>();
-        for (Integer fId : fighters) {
-            Entity fighter = game.getEntity(fId);
+        for (Entity fighter : getActiveSubEntities()) {
             allAmmo.addAll(fighter.getAmmo());
         }
         return allAmmo;
@@ -534,17 +506,15 @@ public class FighterSquadron extends Aero {
 
     @Override
     public void useFuel(int fuel) {
-        for (Integer fId : fighters) {
-            IAero fighter = (IAero) game.getEntity(fId);
-            fighter.useFuel(fuel);
+        for (Entity fighter : getActiveSubEntities()) {
+            ((IAero) fighter).useFuel(fuel);
         }
     }
 
     @Override
     public void autoSetMaxBombPoints() {
         maxBombPoints = Integer.MAX_VALUE;
-        for (Integer fId : fighters) {
-            Entity fighter = game.getEntity(fId);
+        for (Entity fighter : getSubEntities()) {
             int currBombPoints = (int) Math.round(fighter.getWeight() / 5);
             maxBombPoints = Math.min(maxBombPoints, currBombPoints);
         }
@@ -557,9 +527,8 @@ public class FighterSquadron extends Aero {
             bombChoices = bc;
         }
         // Update each fighter in the squadron
-        for (Integer fId : fighters) {
-            IBomber fighter = (IBomber) game.getEntity(fId);
-            fighter.setBombChoices(bc);
+        for (Entity bomber : getSubEntities()) {
+            ((IBomber) bomber).setBombChoices(bc);
         }
     }
 
@@ -569,14 +538,11 @@ public class FighterSquadron extends Aero {
      * represent the number of bombs in a salvo. That is, it is a count of the
      * number of fighters in the squadron that have a bomb of the particular
      * type mounted.
-     *
-     * @return
      */
     @Override
     public int[] getBombLoadout() {
         int[] loadout = new int[BombType.B_NUM];
-        for (Integer fId : fighters) {
-            Entity fighter = (Entity) game.getEntity(fId);
+        for (Entity fighter : getSubEntities()) {
             for (Mounted m : fighter.getBombs()) {
                 loadout[((BombType) m.getType()).getBombType()]++;
             }
@@ -590,9 +556,8 @@ public class FighterSquadron extends Aero {
         // problems
         // once the bombs are applied, the choices are cleared, so it's not an
         // issue if the bombs are applied twice for an Aero
-        for (Integer fId : fighters) {
-            IBomber fighter = (IBomber) game.getEntity(fId);
-            fighter.applyBombs();
+        for (Entity fighter : getSubEntities()) {
+            ((IBomber) fighter).applyBombs();
         }
         computeSquadronBombLoadout();
     }
@@ -615,9 +580,8 @@ public class FighterSquadron extends Aero {
         for (int btype = 0; btype < BombType.B_NUM; btype++) {
             // This is smallest number of such a bomb
             int maxBombCount = 0;
-            for (Integer fId : fighters) {
+            for (Entity fighter : getSubEntities()) {
                 int bombCount = 0;
-                Entity fighter = game.getEntity(fId);
                 for (Mounted m : fighter.getBombs()) {
                     if (((BombType) m.getType()).getBombType() == btype) {
                         bombCount++;
@@ -815,7 +779,7 @@ public class FighterSquadron extends Aero {
      */
     @Override
     public Vector<Entity> getLoadedUnits() {
-        return fighters.stream().map(fid -> game.getEntity(fid))
+        return getSubEntities().stream()
             .collect(Collectors.toCollection(Vector::new));
     }
 
@@ -919,14 +883,16 @@ public class FighterSquadron extends Aero {
      */
     @Override
     public EntityMovementMode getMovementMode() {
-        if (fighters.size() < 1) {
+        List<Entity> entities = getSubEntities();
+        
+        if (entities.size() < 1) {
             return EntityMovementMode.NONE;
         }
-        EntityMovementMode moveMode = game.getEntity(fighters.get(0)).getMovementMode();
-        for (Integer fId : fighters) {
-            Entity fighter = game.getEntity(fId);
+        
+        EntityMovementMode moveMode = entities.get(0).getMovementMode();
+        for (Entity fighter : entities) {
             if (moveMode != fighter.getMovementMode()) {
-                System.out.println("Error: Fighter squadron movement mode " + "doesn't agree!");
+                MegaMek.getLogger().error("Error: Fighter squadron movement mode doesn't agree!");
                 return EntityMovementMode.NONE;
             }
         }
@@ -934,16 +900,18 @@ public class FighterSquadron extends Aero {
     }
     
     @Override
-    public Optional<List<Entity>> getSubEntities() {
-        return Optional.of(fighters.stream().map(fid -> game.getEntity(fid))
-            .collect(Collectors.toList()));
+    public List<Entity> getSubEntities() {
+        return fighters.stream().map(fid -> game.getEntity(fid))
+                .filter(entity -> entity != null)
+                .collect(Collectors.toList());
     }
     
     @Override
-    public Optional<List<Entity>> getActiveSubEntities() {
-        return Optional.of(fighters.stream().map(fid -> game.getEntity(fid))
-            .filter(ACTIVE_CHECK)
-            .collect(Collectors.toList()));
+    public List<Entity> getActiveSubEntities() {
+        return fighters.stream().map(fid -> game.getEntity(fid))
+                .filter(entity -> entity != null)
+                .filter(ACTIVE_CHECK)
+                .collect(Collectors.toList());
     }
 
 }

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -24,7 +24,6 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -745,7 +744,7 @@ public class MechView {
                 String.valueOf(fs.getTotalArmor())));
 
         retVal.add(new LabeledElement(Messages.getString("MechView.ActiveFighters"), //$NON-NLS-1$
-                String.valueOf(fs.getActiveSubEntities().orElse(Collections.emptyList()).size())));
+                String.valueOf(fs.getActiveSubEntities().size())));
 
         return retVal;
     }

--- a/megamek/src/megamek/common/weapons/ScreenLauncherBayHandler.java
+++ b/megamek/src/megamek/common/weapons/ScreenLauncherBayHandler.java
@@ -104,7 +104,7 @@ public class ScreenLauncherBayHandler extends AmmoBayWeaponHandler {
             for (Entity entity : game.getEntitiesVector(coords)) {
                 // if fighter squadron all fighters are damaged
                 if (entity instanceof FighterSquadron) {
-                    entity.getSubEntities().ifPresent(ents -> ents.forEach(
+                    entity.getSubEntities().forEach(
                     ent -> {
                         ToHitData squadronToHit = new ToHitData();
                         squadronToHit.setHitTable(ToHitData.HIT_NORMAL);
@@ -112,7 +112,7 @@ public class ScreenLauncherBayHandler extends AmmoBayWeaponHandler {
                         hit.setCapital(false);
                         vPhaseReport.addAll(server.damageEntity(ent, hit, attackValue));
                         server.creditKill(ent, ae);
-                    }));
+                    });
                 } else {
                     ToHitData hexToHit = new ToHitData();
                     hexToHit.setHitTable(ToHitData.HIT_NORMAL);

--- a/megamek/src/megamek/common/weapons/ScreenLauncherHandler.java
+++ b/megamek/src/megamek/common/weapons/ScreenLauncherHandler.java
@@ -98,7 +98,7 @@ public class ScreenLauncherHandler extends AmmoWeaponHandler {
         for (Entity entity :  game.getEntitiesVector(coords)) {
             // if fighter squadron all fighters are damaged
             if (entity instanceof FighterSquadron) {
-                entity.getSubEntities().ifPresent(ents -> ents.forEach(
+                entity.getSubEntities().forEach(
                     ent -> {
                         ToHitData squadronToHit = new ToHitData();
                         squadronToHit.setHitTable(ToHitData.HIT_NORMAL);
@@ -106,7 +106,7 @@ public class ScreenLauncherHandler extends AmmoWeaponHandler {
                         hit.setCapital(false);
                         vPhaseReport.addAll(server.damageEntity(ent, hit, attackValue));
                         server.creditKill(ent, ae);
-                    }));
+                    });
             } else {
                 ToHitData hexToHit = new ToHitData();
                 hexToHit.setHitTable(ToHitData.HIT_NORMAL);

--- a/megamek/src/megamek/common/weapons/SpaceBombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/SpaceBombAttackHandler.java
@@ -17,7 +17,6 @@
  */
 package megamek.common.weapons;
 
-import java.util.Collections;
 import java.util.List;
 
 import megamek.common.Aero;
@@ -100,7 +99,7 @@ public class SpaceBombAttackHandler extends WeaponHandler {
             //  The salvo consists of one bomb from each fighter equipped with
             //  a bomb of the proper type.  
             for (int type = 0; type < payload.length; type++) {
-                List<Entity> activeFighters = ae.getActiveSubEntities().orElse(Collections.emptyList());
+                List<Entity> activeFighters = ae.getActiveSubEntities();
                 if(activeFighters.isEmpty()) {
                     break;
                 }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -21799,7 +21799,7 @@ public class Server implements Runnable {
         if (te instanceof FighterSquadron) {
             List<Entity> fighters = te.getActiveSubEntities();
             
-            if(fighters.isEmpty()) {
+            if (fighters.isEmpty()) {
                 return vDesc;
             }
             Entity fighter = fighters.get(hit.getLocation());

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -21797,10 +21797,11 @@ public class Server implements Runnable {
         // if this is a fighter squadron then pick an active fighter and pass on
         // the damage
         if (te instanceof FighterSquadron) {
-            if(te.getActiveSubEntities().orElse(Collections.emptyList()).isEmpty()) {
+            List<Entity> fighters = te.getActiveSubEntities();
+            
+            if(fighters.isEmpty()) {
                 return vDesc;
             }
-            List<Entity> fighters = te.getSubEntities().orElse(Collections.emptyList());
             Entity fighter = fighters.get(hit.getLocation());
             HitData new_hit = fighter.rollHitLocation(ToHitData.HIT_NORMAL, ToHitData.SIDE_FRONT);
             new_hit.setBoxCars(hit.rolledBoxCars());
@@ -27800,12 +27801,9 @@ public class Server implements Runnable {
                 // if this is the last fighter in a fighter squadron then remove
                 // the squadron
                 if ((transport instanceof FighterSquadron)
-                        && transport.getSubEntities().orElse(Collections.emptyList()).isEmpty()) {
+                        && transport.getSubEntities().isEmpty()) {
                     transport.setDestroyed(true);
-                    // Can't remove this here, otherwise later attacks will fail
-                    //game.moveToGraveyard(transport.getId());
-                    //entityUpdate(transport.getId());
-                    //send(createRemoveEntityPacket(transport.getId(), condition));
+                    
                     r = new Report(6365);
                     r.subject = transport.getId();
                     r.addDesc(transport);


### PR DESCRIPTION
There are two components to this set of changes. One is the removal of the unnecessary and burdensome "Optional" in Entity.getSubEntities(). I like syntactic sugar as much as the next guy, but only if it actually reduces code volume or provides some other return on investment.

The second component is that all interactions within FighterSquadron that used the "fighters" list directly now use the getSubEntities() or getActiveSubEntities() methods instead, guaranteeing that the entities in question are never null, which is what caused #2988, #2989.