### PR TITLE
no torso twist for artillery and TAG per errata

### DIFF
--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -249,16 +249,6 @@ public class ArtilleryTargetingControl {
     public FiringPlan calculateIndirectArtilleryPlan(Entity shooter, IGame game, Princess owner) {
         FiringPlan bestPlan = calculateIndirectArtilleryPlan(shooter, game, owner, 0);
         
-        // simply loop through all possible facings and see if any of those is better than the no-turning plan
-        if (!shooter.isOffBoard()) {
-            for (int facingChange : FireControl.getValidFacingChanges(shooter)) {
-                FiringPlan twistPlan = calculateIndirectArtilleryPlan(shooter, game, owner, facingChange);
-                if (twistPlan.getUtility() > bestPlan.getUtility()) {
-                    bestPlan = twistPlan;
-                }
-            }
-        }
-        
         return bestPlan;
     }
     

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -155,25 +155,6 @@ public class MapMenu extends JPopupMenu {
                     itemCount++;
                 }
 
-            } else if (currentPanel instanceof TargetingPhaseDisplay) {
-                
-                if (itemCount > 0) {
-                    addSeparator();
-                    itemCount++;
-                }
-                    
-                menu = createTorsoTwistMenu();
-                if (menu.getItemCount() > 0) {
-                    this.add(menu);
-                    itemCount++;
-                }
-
-                menu = createRotateTurretMenu();
-                if (menu.getItemCount() > 0) {
-                    this.add(menu);
-                    itemCount++;
-                }
-                
             } else if ((currentPanel instanceof FiringDisplay)) {
 
                 if (itemCount > 0) {
@@ -1448,9 +1429,6 @@ public class MapMenu extends JPopupMenu {
                     int twistDir = Integer.parseInt(e.getActionCommand());
                     if (currentPanel instanceof FiringDisplay) {
                         ((FiringDisplay) currentPanel).torsoTwist(twistDir);
-                    } else if (currentPanel instanceof TargetingPhaseDisplay) {
-                        ((TargetingPhaseDisplay) currentPanel)
-                                .torsoTwist(twistDir);
                     }
                 } catch (Exception ex) {
                     ex.printStackTrace();
@@ -1474,9 +1452,6 @@ public class MapMenu extends JPopupMenu {
                                                                        .nextToken()), Integer.parseInt(result.nextToken()));
                     if (currentPanel instanceof FiringDisplay) {
                         ((FiringDisplay) currentPanel).torsoTwist(coord);
-                    } else if (currentPanel instanceof TargetingPhaseDisplay) {
-                        ((TargetingPhaseDisplay) currentPanel)
-                                .torsoTwist(coord);
                     }
                 } catch (Exception ex) {
                     ex.printStackTrace();

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -81,7 +81,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
      */
     public static enum TargetingCommand implements PhaseCommand {
         FIRE_NEXT("fireNext"),
-        FIRE_TWIST("fireTwist"),
         FIRE_FIRE("fireFire"),
         FIRE_SKIP("fireSkip"),
         FIRE_NEXT_TARG("fireNextTarg"),
@@ -132,8 +131,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
 
     // is the shift key held?
     private boolean shiftheld;
-
-    private boolean twisting;
 
     private final IGame.Phase phase;
 
@@ -206,51 +203,7 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
                         removeLastFiring();
                     }
                 });
-        // Register the action for TWIST_LEFT
-        controller.registerCommandAction(KeyCommandBind.TWIST_LEFT.cmd,
-                new CommandAction() {
 
-                    @Override
-                    public boolean shouldPerformAction() {
-                        if (!clientgui.getClient().isMyTurn()
-                                || clientgui.bv.getChatterBoxActive()
-                                || !display.isVisible()
-                                || display.isIgnoringEvents()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
-                    }
-
-                    @Override
-                    public void performAction() {
-                        updateFlipArms(false);
-                        torsoTwist(0);
-                    }
-                });
-
-        // Register the action for TWIST_RIGHT
-        controller.registerCommandAction(KeyCommandBind.TWIST_RIGHT.cmd,
-                new CommandAction() {
-
-                    @Override
-                    public boolean shouldPerformAction() {
-                        if (!clientgui.getClient().isMyTurn()
-                                || clientgui.bv.getChatterBoxActive()
-                                || !display.isVisible()
-                                || display.isIgnoringEvents()) {
-                            return false;
-                        } else {
-                            return true;
-                        }
-                    }
-
-                    @Override
-                    public void performAction() {
-                        updateFlipArms(false);
-                        torsoTwist(1);
-                    }
-                });
      // Register the action for FIRE
         controller.registerCommandAction(KeyCommandBind.FIRE.cmd,
                 new CommandAction() {
@@ -575,10 +528,7 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
             // Update the menu bar.
             clientgui.getMenuBar().setEntity(ce());
 
-            // 2003-12-29, nemchenk -- only twist if crew conscious
-            setTwistEnabled(ce().canChangeSecondaryFacing()
-                            && ce().getCrew().isActive());
-            setFlipArmsEnabled(ce().canFlipArms());
+            setFlipArmsEnabled(ce().canFlipArms() && ce().getCrew().isActive());
             updateSearchlight();
 
             setFireModeEnabled(true);
@@ -712,7 +662,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
     private void disableButtons() {
         setFireEnabled(false);
         setSkipEnabled(false);
-        setTwistEnabled(false);
         setNextEnabled(false);
         butDone.setEnabled(false);
         setFlipArmsEnabled(false);
@@ -1120,49 +1069,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
     }
 
     /**
-     * Torso twist in the proper direction.
-     */
-    void torsoTwist(Coords cTarget) {
-        int direction = ce().getFacing();
-
-        if (null != cTarget) {
-            direction = ce().clipSecondaryFacing(
-                    ce().getPosition().direction(cTarget));
-        }
-
-        if (direction != ce().getSecondaryFacing()) {
-            clearAttacks();
-            attacks.addElement(new TorsoTwistAction(cen, direction));
-            ce().setSecondaryFacing(direction);
-            refreshAll();
-        }
-    }
-
-    /**
-     * Torso twist to the left or right
-     *
-     * @param twistDirection An <code>int</code> specifying wether we're twisting left or
-     *                       right, 0 if we're twisting to the left, 1 if to the right.
-     */
-
-    void torsoTwist(int twistDirection) {
-        int direction = ce().getSecondaryFacing();
-        if (twistDirection == 0) {
-            clearAttacks();
-            direction = ce().clipSecondaryFacing((direction + 5) % 6);
-            attacks.addElement(new TorsoTwistAction(cen, direction));
-            ce().setSecondaryFacing(direction);
-            refreshAll();
-        } else if (twistDirection == 1) {
-            clearAttacks();
-            direction = ce().clipSecondaryFacing((direction + 7) % 6);
-            attacks.addElement(new TorsoTwistAction(cen, direction));
-            ce().setSecondaryFacing(direction);
-            refreshAll();
-        }
-    }
-
-    /**
      * Cache the list of visible targets. This is used for the 'next target'
      * button.
      * <p/>
@@ -1309,13 +1215,11 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
         }
 
         if (b.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
-            if (shiftheld || twisting) {
+            if (shiftheld) {
                 updateFlipArms(false);
-                torsoTwist(b.getCoords());
             }
             clientgui.getBoardView().cursor(b.getCoords());
         } else if (b.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
-            twisting = false;
             clientgui.getBoardView().select(b.getCoords());
         }
     }
@@ -1333,7 +1237,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
                 && (ce() != null) && !b.getCoords().equals(ce().getPosition())) {
             if (shiftheld) {
                 updateFlipArms(false);
-                torsoTwist(b.getCoords());
             } else if (phase == IGame.Phase.PHASE_TARGETING) {
                 target(new HexTarget(b.getCoords(), Targetable.TYPE_HEX_ARTILLERY));
             } else {
@@ -1499,8 +1402,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
             fire();
         } else if (ev.getActionCommand().equals(TargetingCommand.FIRE_SKIP.getCmd())) {
             nextWeapon();
-        } else if (ev.getActionCommand().equals(TargetingCommand.FIRE_TWIST.getCmd())) {
-            twisting = true;
         } else if (ev.getActionCommand().equals(TargetingCommand.FIRE_NEXT.getCmd())) {
             selectEntity(clientgui.getClient().getNextEntityNum(cen));
         } else if (ev.getActionCommand().equals(TargetingCommand.FIRE_NEXT_TARG.getCmd())) {
@@ -1527,10 +1428,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
             return;
         }
 
-        twisting = false;
-
-        torsoTwist(null);
-
         clearAttacks();
         ce().setArmsFlipped(armsFlipped);
         attacks.addElement(new FlipArmsAction(cen, armsFlipped));
@@ -1550,11 +1447,6 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
     private void setFireEnabled(boolean enabled) {
         buttons.get(TargetingCommand.FIRE_FIRE).setEnabled(enabled);
         clientgui.getMenuBar().setEnabled(FiringCommand.FIRE_FIRE.getCmd(), enabled);
-    }
-
-    private void setTwistEnabled(boolean enabled) {
-        buttons.get(TargetingCommand.FIRE_TWIST).setEnabled(enabled);
-        clientgui.getMenuBar().setEnabled(FiringCommand.FIRE_TWIST.getCmd(), enabled);
     }
 
     private void setSkipEnabled(boolean enabled) {


### PR DESCRIPTION
Fixes #3002 by disallowing torso-twisting during the artillery and TAG targeting phases, as those occur before firing, which is when torso-twisting happens. Also, prevents the bot from doing so.