### PR TITLE
Unit Label display settings

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -94,7 +94,7 @@ public class MegaMek {
                 }
             }
 
-//            configureLogging(logFileName);
+            configureLogging(logFileName);
 
             MegaMek.showInfo();
 

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -94,7 +94,7 @@ public class MegaMek {
                 }
             }
 
-            configureLogging(logFileName);
+//            configureLogging(logFileName);
 
             MegaMek.showInfo();
 

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -19,6 +19,7 @@ import java.awt.*;
 import javax.swing.*;
 
 import megamek.client.ui.swing.boardview.BoardView1;
+import megamek.client.ui.swing.boardview.LabelDisplayStyle;
 import megamek.client.ui.swing.util.PlayerColour;
 import megamek.common.Entity;
 import megamek.common.preference.PreferenceManager;
@@ -239,6 +240,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String SHOW_KEYBINDS_OVERLAY = "ShowKeybindsOverlay";
     public static final String OPTIONS_SHOW_UNOFFICIAL = "OptionsShowUnofficial";
     public static final String OPTIONS_SHOW_LEGACY = "OptionsShowLegacy";
+    public static final String UNIT_LABEL_STYLE = "UnitLabelStyle";
     
     // RAT dialog preferences
     public static String RAT_TECH_LEVEL = "RATTechLevel";
@@ -347,6 +349,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(GAME_SUMMARY_MINI_MAP, false);
         store.setDefault(ENTITY_OWNER_LABEL_COLOR, true);
         store.setDefault(UNIT_LABEL_BORDER, true);
+        store.setDefault(UNIT_LABEL_STYLE, "NICKNAME");
         store.setDefault(GAME_OPTIONS_SIZE_HEIGHT, 400);
         store.setDefault(GAME_OPTIONS_SIZE_WIDTH, 400);
         store.setDefault(FIRING_SOLUTIONS,true);
@@ -1558,6 +1561,20 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setWarningColor(Color color) {
         store.setValue(WARNING_COLOR, getColorString(color));
     }
+    
+    public LabelDisplayStyle getUnitLabelStyle() {
+        try {
+            return LabelDisplayStyle.valueOf(store.getString(UNIT_LABEL_STYLE));
+        } catch (Exception e) {
+            return LabelDisplayStyle.FULL;
+        }
+    }
+
+    public void setUnitLabelStyle(LabelDisplayStyle style) {
+        store.setValue(UNIT_LABEL_STYLE, style.name());
+    }
+    
+    
 
     public Color getColor(String name) {
         final String text = store.getString(name);

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -349,7 +349,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(GAME_SUMMARY_MINI_MAP, false);
         store.setDefault(ENTITY_OWNER_LABEL_COLOR, true);
         store.setDefault(UNIT_LABEL_BORDER, true);
-        store.setDefault(UNIT_LABEL_STYLE, "NICKNAME");
+        store.setDefault(UNIT_LABEL_STYLE, LabelDisplayStyle.NICKNAME.name());
         store.setDefault(GAME_OPTIONS_SIZE_HEIGHT, 400);
         store.setDefault(GAME_OPTIONS_SIZE_WIDTH, 400);
         store.setDefault(FIRING_SOLUTIONS,true);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -982,17 +982,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     @Override
                     public void performAction() {
                         GUIPreferences guip = GUIPreferences.getInstance();
-                        boolean drawLabels = guip.getBoolean(
-                                GUIPreferences.ADVANCED_DRAW_ENTITY_LABEL);
-                        guip.setValue(GUIPreferences.ADVANCED_DRAW_ENTITY_LABEL,
-                                !drawLabels);
+                        guip.setUnitLabelStyle(guip.getUnitLabelStyle().next());
                         updateEntityLabels();
-                        for (Sprite s: wreckSprites) {
-                            s.prepare();
-                        }
-                        for (Sprite s: isometricWreckSprites) {
-                            s.prepare();
-                        }
                     }
 
                 });

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -982,7 +982,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     @Override
                     public void performAction() {
                         GUIPreferences guip = GUIPreferences.getInstance();
-                        guip.setUnitLabelStyle(guip.getUnitLabelStyle().next());
+                        LabelDisplayStyle style = guip.getUnitLabelStyle().next();
+                        guip.setUnitLabelStyle(style);
+                        clientgui.systemMessage("Changed unit label display style to: " + style.description);
                         updateEntityLabels();
                     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -31,6 +31,9 @@ import java.awt.Rectangle;
 import java.awt.Stroke;
 import java.awt.Transparency;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.EntityWreckHelper;
@@ -71,7 +74,14 @@ class EntitySprite extends Sprite {
     
     // Keep track of ECM state, as it's too expensive to compute on the fly.
     private boolean isAffectedByECM = false;
-
+    
+    private static final Set<String> removableNameStrings = new HashSet<String>( 
+            Arrays.asList("Defense", "Platoon", "Heavy", "Medium", "Light", "Artillery", "Tank", 
+                    "Wheeled", "Command", "Standard", "Hover", "Hovercraft", "Mechanized", 
+                    "(Standard)", "Platoon", "Defense", "Transport", "Vehicle", "Air", 
+                    "Assault", "Mobile", "Platform", "Battle Armor", "Vessel", "Infantry",
+                    "Fighting", "Fire", "Suport", "Reconnaissance", "Fast"));
+    
     public EntitySprite(BoardView1 boardView1, final Entity entity,
             int secondaryPos, Image radarBlipImage) {
         super(boardView1);
@@ -88,18 +98,95 @@ class EntitySprite extends Sprite {
     
     private String getAdjShortName() {
         if (onlyDetectedBySensors()) {
-            return Messages.getString("BoardView1.sensorReturn"); //$NON-NLS-1$
+            return Messages.getString("BoardView1.sensorReturn");
         } else {
-            String name = entity.getShortName();
-            int firstApo = name.indexOf('\'');
-            int secondApo = name.indexOf('\'', name.indexOf('\'')+1);
-            if ((firstApo >= 0) && (secondApo >= 0)) {
-                name = name
-                        .substring(firstApo+1, secondApo)
-                        .toUpperCase();
+            switch (GUIPreferences.getInstance().getUnitLabelStyle()) {
+            case FULL:
+                return standardLabelName();
+            case ABBREV:
+                if (entity instanceof Mech) {
+                    return entity.getModel();
+                } else {
+                    return abbreviateUnitName(standardLabelName());
+                }
+            case CHASSIS:
+                return reduceVehName(entity.getChassis());
+            case NICKNAME:
+                if (!pilotNick().isBlank()) {
+                    return "\"" + pilotNick().toUpperCase() + "\"";
+                } else if (!unitNick().isBlank()) {
+                    return "\'" + unitNick() + "\'";
+                } else {
+                    return reduceVehName(entity.getChassis());
+                }
+            case ONLY_NICKNAME:
+                if (!pilotNick().isBlank()) {
+                    return "\"" + pilotNick().toUpperCase() + "\"";
+                } else if (!unitNick().isBlank()) {
+                    return "\'" + unitNick() + "\'";
+                } else {
+                    return "";
+                }
+            default: // ONLY_STATUS
+                return "";
             }
-            return name;
         }
+    }
+    
+    /** 
+     * Returns a shortened unit name string, mostly for vehicles. Words contained
+     * in the removableNameStrings list are taken away from the end of the name
+     * until something is encountered that is not contained in that list. 
+     * On Mech names this will typically have no effect.
+     */
+    private static String reduceVehName(String unitName) {
+        String[] tokens = unitName.split(" ");
+        int i = tokens.length - 1;
+        for ( ; i > 0; i--) {
+            if (!removableNameStrings.contains(tokens[i])) {
+                break;
+            }
+        }
+        return String.join(" ", Arrays.copyOfRange(tokens, 0, i + 1));
+    }
+    
+    /** Returns the string with some content shortened like Battle Armor -> BA */
+    private static String abbreviateUnitName(String unitName) {
+        return unitName
+                .replace("(Standard)", "").replace("Battle Armor", "BA")
+                .replace("Standard", "Std.").replace("Vehicle", "Veh.")
+                .replace("Medium", "Med.").replace("Support", "Spt.")
+                .replace("Heavy", "Hvy.").replace("Light", "Lgt.")
+                .replace("Assault", "Asslt.").replace("Transport", "Trnsp.")
+                .replace("Command", "Cmd.").replace("Mechanized", "Mechn.")
+                .replace("Wheeled", "Whee.").replace("Platoon", "Plt.")
+                .replace("Artillery", "Arty.").replace("Defense", "Def.")
+                .replace("Hovercraft", "Hov.").replace("Platoon", "Plt.")
+                .replace("Reconnaissance", "Rcn.").replace("Recon", "Rcn.")
+                .replace("Tank", "Tk.").replace("Hover ", "Hov. ");
+    }
+    
+    private String pilotNick() {
+        if ((entity.getCrew().getSize() >= 1) && !entity.getCrew().getNickname().isBlank()) {
+            return entity.getCrew().getNickname();
+        } else {
+            return "";
+        }
+    }
+    
+    private String unitNick() {
+        String name = entity.getShortName();
+        int firstApo = name.indexOf('\'');
+        int secondApo = name.indexOf('\'', name.indexOf('\'') + 1);
+        if ((firstApo >= 0) && (secondApo >= 0)) {
+            return name.substring(firstApo + 1, secondApo);
+        } else {
+            return "";
+        }
+    }
+    
+    private String standardLabelName() {
+        return entity.getShortName();
     }
 
     @Override
@@ -137,8 +224,7 @@ class EntitySprite extends Sprite {
         if (labelRect != null)
             oldRect = new Rectangle(labelRect);
         
-        int face = (entity.isCommander() && !onlyDetectedBySensors()) ? 
-                Font.ITALIC : Font.PLAIN;
+        int face = (entity.isCommander() && !onlyDetectedBySensors()) ? Font.ITALIC : Font.PLAIN;
         labelFont = new Font("SansSerif", face, (int)(10*Math.max(bv.scale,0.9))); //$NON-NLS-1$
         
         // Check the hexes in directions 2,5,1,4 if they are free of entities
@@ -516,7 +602,7 @@ class EntitySprite extends Sprite {
             graph.scale(1/bv.scale, 1/bv.scale);
             
             // Label background
-            if (guip.getBoolean(GUIPreferences.ADVANCED_DRAW_ENTITY_LABEL)) {
+            if (!getAdjShortName().isBlank()) {
                 if (criticalStatus) {
                     graph.setColor(LABEL_CRITICAL_BACK);
                 } else {
@@ -542,7 +628,7 @@ class EntitySprite extends Sprite {
                     }
                     Stroke oldStroke = graph.getStroke();
                     graph.setStroke(new BasicStroke(3));
-                    graph.drawRoundRect(labelRect.x - 1, labelRect.y - 1,
+                    graph.drawRoundRect(labelRect.x - 1, labelRect.y - 1, 
                             labelRect.width + 1, labelRect.height + 1, 5, 10);
                     graph.setStroke(oldStroke);
                 }
@@ -551,12 +637,10 @@ class EntitySprite extends Sprite {
                 graph.setFont(labelFont);
                 Color textColor = LABEL_TEXT_COLOR;
                 if (!entity.isDone() && !onlyDetectedBySensors()) {
-                    textColor = guip.getColor(
-                            GUIPreferences.ADVANCED_UNITOVERVIEW_VALID_COLOR);
+                    textColor = guip.getColor(GUIPreferences.ADVANCED_UNITOVERVIEW_VALID_COLOR);
                 }
                 if (isSelected) {
-                    textColor = guip.getColor(
-                            GUIPreferences.ADVANCED_UNITOVERVIEW_SELECTED_COLOR);
+                    textColor = guip.getColor(GUIPreferences.ADVANCED_UNITOVERVIEW_SELECTED_COLOR);
                 }
                 BoardView1.drawCenteredText(graph, getAdjShortName(),
                         labelRect.x + labelRect.width / 2,

--- a/megamek/src/megamek/client/ui/swing/boardview/LabelDisplayStyle.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/LabelDisplayStyle.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.boardview;
+
+/** The style of unit label display (full, shortened, show the nickname, etc.) */
+public enum LabelDisplayStyle { 
+    FULL, ABBREV, NICKNAME, CHASSIS, ONLY_NICKNAME, ONLY_STATUS;
+    
+    public LabelDisplayStyle next() { 
+        switch (this) {
+            case FULL: return ABBREV;
+            case ABBREV: return CHASSIS;
+            case CHASSIS: return NICKNAME;
+            case NICKNAME: return ONLY_NICKNAME;
+            case ONLY_NICKNAME: return ONLY_STATUS;
+            default: return FULL;
+        }
+    }
+}

--- a/megamek/src/megamek/client/ui/swing/boardview/LabelDisplayStyle.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/LabelDisplayStyle.java
@@ -20,7 +20,18 @@ package megamek.client.ui.swing.boardview;
 
 /** The style of unit label display (full, shortened, show the nickname, etc.) */
 public enum LabelDisplayStyle { 
-    FULL, ABBREV, NICKNAME, CHASSIS, ONLY_NICKNAME, ONLY_STATUS;
+    FULL("Chassis and model"), 
+    ABBREV("Abbreviated chassis and model / Meks only model"), 
+    NICKNAME("Pilot or unit nickname  / chassis"), 
+    CHASSIS("Chassis only"), 
+    ONLY_NICKNAME("Only pilot or unit nickname"), 
+    ONLY_STATUS("No labels");
+    
+    LabelDisplayStyle(String d) {
+        description = d;
+    }
+    
+    public final String description;
     
     public LabelDisplayStyle next() { 
         switch (this) {

--- a/megamek/src/megamek/client/ui/swing/boardview/LabelDisplayStyle.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/LabelDisplayStyle.java
@@ -35,12 +35,18 @@ public enum LabelDisplayStyle {
     
     public LabelDisplayStyle next() { 
         switch (this) {
-            case FULL: return ABBREV;
-            case ABBREV: return CHASSIS;
-            case CHASSIS: return NICKNAME;
-            case NICKNAME: return ONLY_NICKNAME;
-            case ONLY_NICKNAME: return ONLY_STATUS;
-            default: return FULL;
+            case FULL: 
+                return ABBREV;
+            case ABBREV: 
+                return CHASSIS;
+            case CHASSIS: 
+                return NICKNAME;
+            case NICKNAME: 
+                return ONLY_NICKNAME;
+            case ONLY_NICKNAME: 
+                return ONLY_STATUS;
+            default: 
+                return FULL;
         }
     }
 }


### PR DESCRIPTION
Adds some more options to unit label display.

Note that the reduced vehicle chassis names ("Ontos") are created by taking the chassis and removing from the end words from a list of generic words like Heavy, Tank, Defense until something non-generic is found. This works reasonably well for many units and there's no pressure for it to find really short names for all units. The first word of the name is never removed.

The label styles are cycled using the keybind and output a description to the chatbox so players know what the style shows even if they don't have a nicknamed unit at the moment. I intentionally didn't implement some client settings for it as there's too many of those already. Cycling through it is easy.

Other suggestions or combinations of features as below, please tell me.

The current style (still available): 
![image](https://user-images.githubusercontent.com/17069663/126000158-dd7a74f2-cbb1-4fbc-8938-9886834ca623.png)

Abbreviated style: 
![image](https://user-images.githubusercontent.com/17069663/125999921-e7bab64e-5a83-4a36-8edb-9466069cbcef.png)

Chassis only:
![image](https://user-images.githubusercontent.com/17069663/125999980-9d719cbc-b6d1-452a-8b6d-ef8da67cbb58.png)

Nickname and chassis:
![image](https://user-images.githubusercontent.com/17069663/126000029-1146a532-35b7-4e61-8944-1e4edca48791.png)

Only nicknames:
![image](https://user-images.githubusercontent.com/17069663/126000092-8f913f5c-c82b-4df0-906e-3e1e1d213348.png)

and no labels (as before)