### PR TITLE
Calculate LOS NPEs

### DIFF
--- a/megamek/src/megamek/client/bot/MoveOption.java
+++ b/megamek/src/megamek/client/bot/MoveOption.java
@@ -368,7 +368,7 @@ public class MoveOption extends MovePath {
         }
 
         // calc & add attacker los mods
-        LosEffects los = LosEffects.calculateLos(getGame(), ae.getId(), te);
+        LosEffects los = LosEffects.calculateLOS(getGame(), ae, te);
         toHita.append(los.losModifiers(getGame()));
         // save variables
         pc = los.isTargetCover();

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -249,10 +249,10 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             return 0;
         }
 
-        //  If they don't have LoS, they can't do damage.
-        LosEffects losEffects = 
-                LosEffects.calculateLos(game, enemy.getId(), path.getEntity(), shooterState.getPosition(), targetState.getPosition(), false);
-        
+        // If they don't have LoS, they can't do damage.
+        final LosEffects losEffects = LosEffects.calculateLOS(game, enemy, path.getEntity(),
+                shooterState.getPosition(), targetState.getPosition(), false);
+
         if (!losEffects.canSee()) {
             return 0;
         }
@@ -260,7 +260,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         Targetable actualTarget = path.getEntity();
         
         // if the target is infantry protected by a building, we have to fire at the building instead. 
-        if(losEffects.infantryProtected()) {
+        if (losEffects.infantryProtected()) {
             actualTarget = new BuildingTarget(targetState.getPosition(), game.getBoard(), false);
             targetState = new EntityState(actualTarget);            
         }
@@ -277,9 +277,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         return getFireControl(path.getEntity()).determineBestFiringPlan(guess).getUtility();
     }
 
-    double calculateKickDamagePotential(Entity enemy, MovePath path,
-                                        IGame game) {
-
+    double calculateKickDamagePotential(Entity enemy, MovePath path, IGame game) {
         if (!(enemy instanceof Mech)) {
             return 0.0;
         }
@@ -309,16 +307,15 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         }
 
         // If I don't have LoS, I can't do damage.  ToDo: Account for indirect fire.
-        LosEffects losEffects = 
-                LosEffects.calculateLos(game, me.getId(), enemy, path.getFinalCoords(), enemy.getPosition(), false);
+        LosEffects losEffects = LosEffects.calculateLOS(game, me, enemy, path.getFinalCoords(),
+                enemy.getPosition(), false);
         if (!losEffects.canSee()) {
             return 0;
         }
 
         // If I am an infantry unit that cannot both move and fire, and I am 
         // moving, I can't do damage.
-        boolean isZeroMpInfantry =
-                me instanceof Infantry && (me.getWalkMP() == 0);
+        boolean isZeroMpInfantry = me instanceof Infantry && (me.getWalkMP() == 0);
         if (isZeroMpInfantry && path.getMpUsed() > 0) {
             return 0;
         }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -635,24 +635,22 @@ public class FireControl {
     }
 
     /**
-     * Returns the value of {@link LosEffects#calculateLos(IGame, int, Targetable, Coords, Coords, boolean)}.
+     * Returns the value of {@link LosEffects#calculateLOS(IGame, Entity, Targetable, Coords, Coords, boolean)}.
      *
      * @param game            The {@link IGame} being played.
-     * @param shooterId       The id of the shooting unit.
+     * @param shooter         The shooting unit.
      * @param target          The unit being shot at as a {@link Targetable} object.
      * @param shooterPosition The current {@link Coords} of the shooter.
      * @param targetPosition  The current {@link Coords} of the target.
-     * @param spotting        Set TRUE if the shooter is simply spotting for indrect fire.
+     * @param spotting        Set TRUE if the shooter is simply spotting for indirect fire.
      * @return The resulting {@link LosEffects}.
      */
     @StaticWrapper
-    LosEffects getLosEffects(final IGame game,
-                             final int shooterId,
-                             final Targetable target,
-                             final Coords shooterPosition,
-                             final Coords targetPosition,
-                             final boolean spotting) {
-        return LosEffects.calculateLos(game, shooterId, target, shooterPosition, targetPosition, spotting);
+    LosEffects getLosEffects(final IGame game, final @Nullable Entity shooter,
+                             final @Nullable Targetable target,
+                             final @Nullable Coords shooterPosition,
+                             final @Nullable Coords targetPosition, final boolean spotting) {
+        return LosEffects.calculateLOS(game, shooter, target, shooterPosition, targetPosition, spotting);
     }
 
     /**
@@ -860,8 +858,8 @@ public class FireControl {
 
         // There is kindly already a class that will calculate line of sight for me
         // todo take into account spotting for indirect fire.
-        final LosEffects losEffects = getLosEffects(game, shooter.getId(), target, shooterState.getPosition(),
-                                                    targetState.getPosition(), false);
+        final LosEffects losEffects = getLosEffects(game, shooter, target, shooterState.getPosition(),
+                targetState.getPosition(), false);
 
         // water is a separate los effect
         final IHex targetHex = game.getBoard().getHex(targetState.getPosition());
@@ -2312,7 +2310,7 @@ public class FireControl {
     	// loop through all enemy targets, pick a random one out of the closest.
     	// future revision: pick one that's the least evasive
     	for(Targetable target : enemyTargets) {
-    		LosEffects effects = LosEffects.calculateLos(spotter.getGame(), spotter.getId(), target);
+    		LosEffects effects = LosEffects.calculateLOS(spotter.getGame(), spotter, target);
             
             // if we're in LOS
     		if (effects.canSee()) {
@@ -2356,9 +2354,7 @@ public class FireControl {
 
             // If they are my enemy and we can either see them or have IDF capability
             if (entity.isTargetable()) {
-
-                final LosEffects effects =
-                        LosEffects.calculateLos(game, shooter.getId(), entity);
+                final LosEffects effects = LosEffects.calculateLOS(game, shooter, entity);
                 
                 // if we're in LOS or we have IDF capability
                 if (effects.canSee() || shooterHasIDF) {

--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -79,8 +79,8 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
         }
 
         // If I don't have LoS, I can't do damage. We're on a space map so this probably is unnecessary.
-        LosEffects losEffects =
-        LosEffects.calculateLos(game, me.getId(), enemy, path.getFinalCoords(), enemy.getPosition(), false);
+        LosEffects losEffects = LosEffects.calculateLOS(game, me, enemy, path.getFinalCoords(),
+                enemy.getPosition(), false);
         if (!losEffects.canSee()) {
             return 0;
         }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1514,17 +1514,17 @@ public class Princess extends BotClient {
                 BulldozerMovePath prunedPath = movePath.clone();
                 prunedPath.clipToPossible();
                 
-                if(levelingTarget != null) {
-                    LosEffects los = LosEffects.calculateLos(game, mover.getId(), levelingTarget, 
+                if (levelingTarget != null) {
+                    LosEffects los = LosEffects.calculateLOS(game, mover, levelingTarget,
                             prunedPath.getFinalCoords(), levelingTarget.getPosition(), false);
                     
                     // break out of this loop, we can get to the thing we're trying to level this turn, so let's
                     // use normal movement routines to move into optimal position to blow it up
                     // Also set the behavior to "engaged"
                     // so it doesn't hump walls due to "self preservation mods"
-                    if(los.canSee()) {
+                    if (los.canSee()) {
                         // if we've explicitly forced 'move to contact' behavior, don't flip back to 'engaged'
-                        if(!forceMoveToContact) {
+                        if (!forceMoveToContact) {
                             getUnitBehaviorTracker().overrideBehaviorType(mover, BehaviorType.Engaged);
                         }
                         
@@ -1539,7 +1539,7 @@ public class Princess extends BotClient {
                 
                 // also return some paths that go a little slower than max speed
                 // in case the faster path would force an unwanted PSR or MASC check 
-                for(MovePath childBMP : PathDecorator.decoratePath(prunedPath)) {
+                for (MovePath childBMP : PathDecorator.decoratePath(prunedPath)) {
                     prunedPaths.add(childBMP);
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1829,9 +1829,8 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
         IGame game = clientgui.getClient().getGame();
         // allow spotting
         if ((ce() != null) && !ce().isSpotting() && ce().canSpot() && (target != null)
-                && game.getOptions().booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) { //$NON-NLS-1$)
-            boolean hasLos = LosEffects.calculateLos(game, cen, target)
-                    .canSee();
+                && game.getOptions().booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            boolean hasLos = LosEffects.calculateLOS(game, ce(), target).canSee();
             // In double blind, we need to "spot" the target as well as LoS
             if (hasLos
                     && game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -4620,13 +4620,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                                                                                           .getString("BoardView1.Mech") : Messages.getString("BoardView1.NonMech"), //$NON-NLS-1$ //$NON-NLS-2$
                                                                                   c2.getBoardNum()}));
             } else {
-                le = LosEffects.calculateLos(game, ae.getId(), te);
-                message.append(Messages.getString(
-                        "BoardView1.Attacker", new Object[]{ //$NON-NLS-1$
-                                                             ae.getDisplayName(), c1.getBoardNum()}));
-                message.append(Messages.getString(
-                        "BoardView1.Target", new Object[]{ //$NON-NLS-1$
-                                                           te.getDisplayName(), c2.getBoardNum()}));
+                le = LosEffects.calculateLOS(game, ae, te);
+                message.append(Messages.getString("BoardView1.Attacker", ae.getDisplayName(), c1.getBoardNum()));
+                message.append(Messages.getString("BoardView1.Target", te.getDisplayName(), c2.getBoardNum()));
             }
             // Check to see if LoS is blocked
             if (!le.canSee()) {

--- a/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
@@ -174,7 +174,7 @@ class FovHighlightingAndDarkening {
                 LosEffects los = getCachedLosEffects(src, c);
                 if (null != this.boardView1.selectedEntity) {
                     if (los == null) {
-                        los = LosEffects.calculateLos(boardView1.game, boardView1.selectedEntity.getId(), null);
+                        los = LosEffects.calculateLOS(boardView1.game, boardView1.selectedEntity, null);
                     }
 
                     if (doubleBlindOn) { // Visual Range only matters in DB

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -954,8 +954,7 @@ public class Compute {
                     .getTargetId())) || (taggedBy == other.getId()))
                 && !attacker.isEnemyOf(other)) {
                 // what are this guy's mods to the attack?
-                LosEffects los = LosEffects.calculateLos(game, other.getId(),
-                        target, true);
+                LosEffects los = LosEffects.calculateLOS(game, other, target, true);
                 ToHitData mods = los.losModifiers(game);
                 // If the target isn't spotted, can't target
                 if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
@@ -1357,7 +1356,7 @@ public class Compute {
         if (isIndirect
             && game.getOptions().booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)
             && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_INDIRECT_ALWAYS_POSSIBLE)
-            && LosEffects.calculateLos(game, ae.getId(), target).canSee()
+            && LosEffects.calculateLOS(game, ae, target).canSee()
             && (!game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND) || Compute
                 .canSee(game, ae, target))
             && !(wtype instanceof MekMortarWeapon)) {
@@ -1875,7 +1874,7 @@ public class Compute {
             }
 
             // Must have LoS, Compute.canSee considers sensors and visual range
-            if (!LosEffects.calculateLos(game, friend.getId(), target).canSee()) {
+            if (!LosEffects.calculateLOS(game, friend, target).canSee()) {
                 continue;
             }
 
@@ -4222,7 +4221,7 @@ public class Compute {
 
         // check visual range based on planetary conditions
         if (los == null) {
-            los = LosEffects.calculateLos(game, ae.getId(), target);
+            los = LosEffects.calculateLOS(game, ae, target);
         }
         int visualRange = getVisualRange(game, ae, los, teIlluminated);
 
@@ -4788,10 +4787,9 @@ public class Compute {
         }
 
         if (los == null) {
-            los = LosEffects.calculateLos(game, ae.getId(), target);
+            los = LosEffects.calculateLOS(game, ae, target);
         }
-        boolean isVisible = los.canSee()
-                            && Compute.inVisualRange(game, los, ae, target);
+        boolean isVisible = los.canSee() && Compute.inVisualRange(game, los, ae, target);
         if (useSensors) {
             isVisible = isVisible
                     || Compute.inSensorRange(game, los, ae, target, allECMInfo);
@@ -4878,7 +4876,7 @@ public class Compute {
     public static int getSensorRangeByBracket(IGame game, Entity ae, @Nullable Targetable target,
                                               @Nullable LosEffects los) {
         if (los == null) {
-            los = LosEffects.calculateLos(game, ae.getId(), target);
+            los = LosEffects.calculateLOS(game, ae, target);
         }
 
         Sensor sensor = ae.getActiveSensor();

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Vector;
 
 import megamek.client.ui.Messages;
+import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
 import megamek.server.SmokeCloud;
 
@@ -342,76 +343,82 @@ public class LosEffects {
                         // + heavySmoke) * 2) < 3;
     }
 
+    @Deprecated // Deprecated for nullable passing
+    public static LosEffects calculateLos(final IGame game, final int attackerId,
+                                          final @Nullable Targetable target) {
+        return calculateLOS(game, game.getEntity(attackerId), target, false);
+    }
+
+    public static LosEffects calculateLOS(final IGame game, final @Nullable Entity attacker,
+                                          final @Nullable Targetable target) {
+        return calculateLOS(game, attacker, target, false);
+    }
+
     /**
-     * Returns a LosEffects object representing the LOS effects of interveing
+     * Returns a LosEffects object representing the LOS effects of intervening
      * terrain between the attacker and target. Checks to see if the attacker
      * and target are at an angle where the LOS line will pass between two
      * hexes. If so, calls losDivided, otherwise calls losStraight.
      */
-    public static LosEffects calculateLos(IGame game, int attackerId,
-            Targetable target) {
-        return calculateLos(game, attackerId, target, false);
-    }
+    public static LosEffects calculateLOS(final IGame game, final @Nullable Entity attacker,
+                                          final @Nullable Targetable target, final boolean spotting) {
+        // we need an extra step here, because units with secondary position can calculate LoS
+        // from hexes other than that returned from getPosition()
+        // create a vector of attacker position and a vector of target positions - double loop
+        // through them both and select the best one
+        Vector<Coords> attackerPositions = new Vector<>();
+        attackerPositions.add(attacker.getPosition());
+        // if a grounded DropShip is the attacker, then it gets to choose the best secondary position for LoS
+        if ((attacker instanceof Dropship) && !attacker.getSecondaryPositions().isEmpty()) {
+            attackerPositions = new Vector<>();
+            for (final int key : attacker.getSecondaryPositions().keySet()) {
+                attackerPositions.add(attacker.getSecondaryPositions().get(key));
+            }
+        }
 
-    public static LosEffects calculateLos(IGame game, int attackerId,
-            Targetable target, boolean spotting) {
-        //we need an extra step here, because units with secondary position can calculate LoS
-        //from hexes other than that returned from getPosition()
-        final Entity ae = game.getEntity(attackerId);
-        //create a vector of attacker position and a vector of target positions - double loop through them
-        //both and select the best one
-        Vector<Coords> attackPos = new Vector<Coords>();
-        attackPos.add(ae.getPosition());
-        Vector<Coords> targetPos = new Vector<Coords>();
-        targetPos.add(target.getPosition());
-        //if a grounded dropship is the attacker, then it gets to choose the best secondary position for LoS
-        if(ae instanceof Dropship && !ae.getSecondaryPositions().isEmpty()) {
-            attackPos = new Vector<Coords>();
-            for(int key : ae.getSecondaryPositions().keySet()) {
-                attackPos.add(ae.getSecondaryPositions().get(key));
+        Vector<Coords> targetPositions = new Vector<>();
+        targetPositions.add(target.getPosition());
+        // if a grounded DropShip is the target, then the attacker chooses the best secondary position
+        if ((target instanceof Dropship) && !target.getSecondaryPositions().isEmpty()) {
+            targetPositions = new Vector<>();
+            for (final int key : target.getSecondaryPositions().keySet()) {
+                targetPositions.add(target.getSecondaryPositions().get(key));
             }
         }
-        //if a grounded dropship is the target, then the attacker chooses the best secondary position
-        if(target instanceof Dropship && !((Entity)target).getSecondaryPositions().isEmpty()) {
-            targetPos = new Vector<Coords>();
-            for(int key : ((Entity)target).getSecondaryPositions().keySet()) {
-                targetPos.add(((Entity)target).getSecondaryPositions().get(key));
-            }
-        }
-        LosEffects bestLos = null;  
-        for(Coords apos : attackPos) {
-            for(Coords tpos : targetPos) {         
-                LosEffects newLos = calculateLos(game, attackerId, target, apos, tpos, spotting);
-                //is the new one better?
-                if(null == bestLos 
-                        || bestLos.isBlocked() 
-                        || newLos.losModifiers(game).getValue() < bestLos.losModifiers(game).getValue()) {
-                    bestLos = newLos;
+
+        LosEffects bestLOS = null;
+        for (final Coords attackerPosition : attackerPositions) {
+            for (final Coords targetPosition : targetPositions) {
+                LosEffects newLos = calculateLOS(game, attacker, target, attackerPosition, targetPosition, spotting);
+                // is the new one better?
+                if ((bestLOS == null) || bestLOS.isBlocked()
+                        || (newLos.losModifiers(game).getValue() < bestLOS.losModifiers(game).getValue())) {
+                    bestLOS = newLos;
                 }
             }
         }
-        bestLos.targetLoc = target.getPosition();
-        return bestLos;
+        bestLOS.targetLoc = target.getPosition();
+        return bestLOS;
     }
-    
 
-    public static LosEffects calculateLos(IGame game, int attackerId, Targetable target,
-            Coords attackPos, Coords targetPos, boolean spotting) {
-        final Entity ae = game.getEntity(attackerId);
-
+    public static LosEffects calculateLOS(final IGame game, final @Nullable Entity attacker,
+                                          final @Nullable Targetable target,
+                                          final @Nullable Coords attackerPosition,
+                                          final @Nullable Coords targetPosition,
+                                          final boolean spotting) {
         // LOS fails if one of the entities is not deployed.
-        if ((null == attackPos) || (null == targetPos)
-                || ae.isOffBoard() || target.isOffBoard()) {
+        if ((attacker == null) || (target == null) || (attackerPosition == null)
+                || (targetPosition == null) || attacker.isOffBoard() || target.isOffBoard()) {
             LosEffects los = new LosEffects();
             los.blocked = true; // TODO: come up with a better "impossible"
             los.hasLoS = false;
-            los.targetLoc = target.getPosition();
+            los.targetLoc = (target == null) ? targetPosition : target.getPosition();
             return los;
         }
 
-        IHex attHex = game.getBoard().getHex(attackPos);
-        IHex targetHex = game.getBoard().getHex(targetPos);
-        if ((attHex == null) || (targetHex == null)) {
+        final IHex attackerHex = game.getBoard().getHex(attackerPosition);
+        final IHex targetHex = game.getBoard().getHex(targetPosition);
+        if ((attackerHex == null) || (targetHex == null)) {
             LosEffects los = new LosEffects();
             los.blocked = true; // TODO: come up with a better "impossible"
             los.hasLoS = false;
@@ -420,102 +427,95 @@ public class LosEffects {
         }
 
         // this will adjust the effective height of a building target by 1 if the hex contains a rooftop gun emplacement
-        int targetHeightAdjustment = game.hasRooftopGunEmplacement(targetHex.getCoords()) ? 1 : 0;
+        final int targetHeightAdjustment = game.hasRooftopGunEmplacement(targetHex.getCoords()) ? 1 : 0;
         
         final AttackInfo ai = new AttackInfo();
-        ai.attackerIsMech = ae instanceof Mech;
-        ai.attackPos = attackPos;
-        ai.attackerId = ae.getId();
-        ai.targetPos = targetPos;
+        ai.attackerIsMech = attacker instanceof Mech;
+        ai.attackPos = attackerPosition;
+        ai.attackerId = attacker.getId();
+        ai.targetPos = targetPosition;
         ai.targetEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
-        if(ai.targetEntity) {
-            ai.targetId = ((Entity)target).getId();
+        if (ai.targetEntity) {
+            ai.targetId = ((Entity) target).getId();
             ai.targetIsMech = target instanceof Mech;
-        }else {
+        } else {
             ai.targetIsMech = false;
         }
         
         ai.targetInfantry = target instanceof Infantry;
-        ai.attackHeight = ae.getHeight();
+        ai.attackHeight = attacker.getHeight();
         ai.targetHeight = target.getHeight() + targetHeightAdjustment;
 
-        int attEl = ae.relHeight() + attHex.getLevel();
+        int attackerElevation = attacker.relHeight() + attackerHex.getLevel();
         // for spotting, a mast mount raises our elevation by 1
-        if (spotting && ae.hasWorkingMisc(MiscType.F_MAST_MOUNT, -1)) {
-            attEl += 1;
+        if (spotting && attacker.hasWorkingMisc(MiscType.F_MAST_MOUNT, -1)) {
+            attackerElevation += 1;
         }
-        int targEl = target.relHeight() + targetHex.getLevel() + targetHeightAdjustment;
+        final int targetElevation = target.relHeight() + targetHex.getLevel() + targetHeightAdjustment;
 
-        ai.attackAbsHeight = attEl;
-        ai.targetAbsHeight = targEl;
-        boolean attOffBoard = ae.isOffBoard();
-        boolean attUnderWater;
-        boolean attInWater;
-        boolean attOnLand;
-        if (attOffBoard) {
-            attUnderWater = true;
-            attInWater = false;
-            attOnLand = true;
+        ai.attackAbsHeight = attackerElevation;
+        ai.targetAbsHeight = targetElevation;
+
+        ai.attOffBoard = attacker.isOffBoard();
+        final boolean attackerUnderWater;
+        final boolean attackerInWater;
+        final boolean attackerOnLand;
+        if (ai.attOffBoard) {
+            attackerUnderWater = true;
+            attackerInWater = false;
+            attackerOnLand = true;
         } else {
-            attUnderWater = attHex.containsTerrain(Terrains.WATER)
-                    && (attHex.depth() > 0) && (attEl < attHex.surface());
-            attInWater = attHex.containsTerrain(Terrains.WATER)
-                    && (attHex.depth() > 0) && (attEl == attHex.surface());
-            attOnLand = !(attUnderWater || attInWater);
+            attackerUnderWater = attackerHex.containsTerrain(Terrains.WATER)
+                    && (attackerHex.depth() > 0) && (attackerElevation < attackerHex.surface());
+            attackerInWater = attackerHex.containsTerrain(Terrains.WATER)
+                    && (attackerHex.depth() > 0) && (attackerElevation == attackerHex.surface());
+            attackerOnLand = !(attackerUnderWater || attackerInWater);
         }
 
-        boolean targetOffBoard = !game.getBoard()
-                .contains(targetPos);
-        boolean targetUnderWater;
-        boolean targetInWater;
-        boolean targetOnLand;
-        if (targetOffBoard) {
+        final boolean targetUnderWater;
+        final boolean targetInWater;
+        final boolean targetOnLand;
+        if (game.getBoard().contains(targetPosition)) {
+            targetUnderWater = targetHex.containsTerrain(Terrains.WATER)
+                    && (targetHex.depth() > 0) && (targetElevation < targetHex.surface());
+            targetInWater = targetHex.containsTerrain(Terrains.WATER)
+                    && (targetHex.depth() > 0) && (targetElevation == targetHex.surface());
+            targetOnLand = !(targetUnderWater || targetInWater);
+        } else {
             targetUnderWater = true;
             targetInWater = false;
             targetOnLand = true;
-        } else {
-            targetUnderWater = targetHex.containsTerrain(Terrains.WATER)
-                    && (targetHex.depth() > 0) && (targEl < targetHex.surface());
-            targetInWater = targetHex.containsTerrain(Terrains.WATER)
-                    && (targetHex.depth() > 0) && (targEl == targetHex.surface());
-            targetOnLand = !(targetUnderWater || targetInWater);
         }
 
-        boolean underWaterCombat = targetUnderWater || attUnderWater;
-
-        ai.attUnderWater = attUnderWater;
-        ai.attInWater = attInWater;
-        ai.attOnLand = attOnLand;
+        ai.attUnderWater = attackerUnderWater;
+        ai.attInWater = attackerInWater;
+        ai.attOnLand = attackerOnLand;
         ai.targetUnderWater = targetUnderWater;
         ai.targetInWater = targetInWater;
         ai.targetOnLand = targetOnLand;
-        ai.underWaterCombat = underWaterCombat;
-        ai.attOffBoard = attOffBoard;
+        ai.underWaterCombat = targetUnderWater || attackerUnderWater;
         // Handle minimum water depth.
-        // Applies to Torpedos.
+        // Applies to Torpedoes.
         if (ai.attOnLand || ai.targetOnLand) {
             ai.minimumWaterDepth = 0;
         } else if (ai.attInWater || ai.targetInWater) {
             ai.minimumWaterDepth = 1;
         } else if (ai.attUnderWater || ai.targetUnderWater) {
-            ai.minimumWaterDepth = Math.min(
-                    attHex.terrainLevel(Terrains.WATER), targetHex
-                            .terrainLevel(Terrains.WATER));
+            ai.minimumWaterDepth = Math.min(attackerHex.terrainLevel(Terrains.WATER),
+                    targetHex.terrainLevel(Terrains.WATER));
         }
 
-        //if this is an air to ground or ground to air attack or a ground to air,
-        //treat the attacker's position as the same as the target's
-        if(Compute.isAirToGround(ae, target) || Compute.isGroundToAir(ae, target)) {
+        // if this is an air to ground or ground to air attack or a ground to air, treat the
+        // attacker's position as the same as the target's
+        if (Compute.isAirToGround(attacker, target) || Compute.isGroundToAir(attacker, target)) {
             ai.attackPos = ai.targetPos;
         }
 
-        LosEffects finalLoS = calculateLos(game, ai);
+        final LosEffects finalLoS = calculateLos(game, ai);
         finalLoS.setMinimumWaterDepth(ai.minimumWaterDepth);
-        
         finalLoS.targetLoc = target.getPosition();
-        
-        finalLoS.targetIsOversized = ai.targetEntity && ((Entity) target).hasQuirk(OptionsConstants.QUIRK_NEG_OVERSIZED);
-        
+        finalLoS.targetIsOversized = ai.targetEntity
+                && ((Entity) target).hasQuirk(OptionsConstants.QUIRK_NEG_OVERSIZED);
         return finalLoS;
     }
 

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -355,10 +355,9 @@ public class LosEffects {
     }
 
     /**
-     * Returns a LosEffects object representing the LOS effects of intervening
-     * terrain between the attacker and target. Checks to see if the attacker
-     * and target are at an angle where the LOS line will pass between two
-     * hexes. If so, calls losDivided, otherwise calls losStraight.
+     * Returns a LosEffects object representing the LOS effects of intervening terrain between the
+     * attacker and target. Checks to see if the attacker and target are at an angle where the LOS
+     * line will pass between two hexes. If so, calls losDivided, otherwise calls losStraight.
      *
      * @param game the game to calculate using
      * @param attacker the attacker, which may be null. If it is, the view is blocked.
@@ -377,8 +376,8 @@ public class LosEffects {
         // We need to create Attacker and Target position lists because they might have secondary
         // positions that would be better
         final List<Coords> attackerPositions = new ArrayList<>();
-        // if a grounded DropShip is the attacker, then it gets to choose the best secondary position for LoS
-        if ((attacker instanceof Dropship) && !attacker.getSecondaryPositions().isEmpty()) {
+        // if a multi-hex entity is the attacker, then it gets to choose the best secondary position for LoS
+        if (!attacker.getSecondaryPositions().isEmpty()) {
             for (final int key : attacker.getSecondaryPositions().keySet()) {
                 attackerPositions.add(attacker.getSecondaryPositions().get(key));
             }
@@ -387,8 +386,8 @@ public class LosEffects {
         }
 
         final List<Coords> targetPositions = new ArrayList<>();
-        // if a grounded DropShip is the target, then the attacker chooses the best secondary position
-        if ((target instanceof Dropship) && !target.getSecondaryPositions().isEmpty()) {
+        // if a multi-hex entity is the target, then the attacker chooses the best secondary position
+        if (!target.getSecondaryPositions().isEmpty()) {
             for (final int key : target.getSecondaryPositions().keySet()) {
                 targetPositions.add(target.getSecondaryPositions().get(key));
             }

--- a/megamek/src/megamek/common/actions/SearchlightAttackAction.java
+++ b/megamek/src/megamek/common/actions/SearchlightAttackAction.java
@@ -73,17 +73,14 @@ public class SearchlightAttackAction extends AbstractAttackAction {
         }
         
         // can't light up more than once per round
-        for (Enumeration<EntityAction> actions = game.getActions(); actions
-                .hasMoreElements();) {
+        for (Enumeration<EntityAction> actions = game.getActions(); actions.hasMoreElements();) {
             EntityAction action = actions.nextElement();
             if (action instanceof SearchlightAttackAction) {
                 SearchlightAttackAction act = (SearchlightAttackAction) action;
-                if (act == exempt)
-                 {
+                if (act == exempt) {
                     break; // 1st in list is OK
                 }
-                if (act.getEntityId() == attackerId)
-                 {
+                if (act.getEntityId() == attackerId) {
                     return false; // can only declare searchlight once!
                 }
             }
@@ -96,15 +93,14 @@ public class SearchlightAttackAction extends AbstractAttackAction {
         }
         
         // can't light up if out of LOS. Most expensive calculation, so keep it last        
-        LosEffects los = LosEffects.calculateLos(game, attackerId, target);
-        return los.canSee();
+        return LosEffects.calculateLOS(game, attacker, target).canSee();
     }
 
     /**
      * illuminate an entity and all entities that are between us and the hex
      */
     public Vector<Report> resolveAction(IGame game) {
-        Vector<Report> reports = new Vector<Report>();
+        Vector<Report> reports = new Vector<>();
         Report r;
         if (!isPossible(game)) {
             r = new Report(3445);
@@ -133,8 +129,7 @@ public class SearchlightAttackAction extends AbstractAttackAction {
                                                                 // target
         for (Coords c : in) {
             for (Entity en : game.getEntitiesVector(c)) {
-                LosEffects los = LosEffects.calculateLos(game, getEntityId(),
-                        en);
+                LosEffects los = LosEffects.calculateLOS(game, attacker, en);
                 if (los.canSee()) {
                     en.setIlluminated(true);
                     r = new Report(3455);
@@ -186,8 +181,7 @@ public class SearchlightAttackAction extends AbstractAttackAction {
                                                                 // target
         for (Coords c : in) {
             for (Entity en : game.getEntitiesVector(c)) {
-                LosEffects los = LosEffects.calculateLos(game, getEntityId(),
-                        en);
+                LosEffects los = LosEffects.calculateLOS(game, attacker, en);
                 if (los.canSee() && en.equals(who)) {
                     return true;
                 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -627,8 +627,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     los = LosEffects.calculateLos(game, swarmSecondaryTarget.getTargetId(), swarmPrimaryTarget);
                 }
             } else {
-                //For everything else, set up a plain old LOS
-                los = LosEffects.calculateLos(game, spotter.getId(), target, true);
+                // For everything else, set up a plain old LOS
+                los = LosEffects.calculateLOS(game, spotter, target, true);
             }
 
             // do not count attacker partial cover in indirect fire
@@ -844,7 +844,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         boolean inSameBuilding = Compute.isInSameBuilding(game, ae, te);
 
         // check LOS
-        LosEffects los = LosEffects.calculateLos(game, attackerId, target);
+        LosEffects los = LosEffects.calculateLOS(game, ae, target);
 
         if (ae.hasActiveEiCockpit()) {
             if (los.getLightWoods() > 0) {
@@ -2308,7 +2308,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             // Can't fire Indirect LRM with direct LOS
             if (isIndirect && game.getOptions().booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)
                     && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_INDIRECT_ALWAYS_POSSIBLE)
-                    && LosEffects.calculateLos(game, ae.getId(), target).canSee()
+                    && LosEffects.calculateLOS(game, ae, target).canSee()
                     && (!game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
                             || Compute.canSee(game, ae, target))
                     && !(wtype instanceof ArtilleryCannonWeapon) && !(wtype instanceof MekMortarWeapon)) {
@@ -4829,7 +4829,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         LosEffects swarmlos;
-        // TO makes it seem like the terrain modifers should be between the
+        // TO makes it seem like the terrain modifiers should be between the
         // attacker and the secondary target, but we have received rules
         // clarifications on the old forums indicating that this is correct
         if (swarmPrimaryTarget.getTargetType() != Targetable.TYPE_ENTITY) {

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -193,16 +193,13 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                         public Targetable targ = target;
 
                         public boolean accept(Entity entity) {
-                            Integer id = Integer.valueOf(entity.getId());
+                            Integer id = entity.getId();
                             if ((player == entity.getOwnerId())
                                     && spottersBefore.contains(id)
-                                    && !(LosEffects.calculateLos(game,
-                                            entity.getId(), targ, true))
-                                            .isBlocked()
+                                    && !LosEffects.calculateLOS(game, entity, targ, true).isBlocked()
                                     && entity.isActive()
                                     // airborne aeros can't spot for arty
-                                    && !(entity.isAero() && entity
-                                            .isAirborne())
+                                    && !(entity.isAero() && entity.isAirborne())
                                     && !entity.isINarcedWith(INarcPod.HAYWIRE)) {
                                 return true;
                             }

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -170,16 +170,13 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                         public Targetable targ = target;
 
                         public boolean accept(Entity entity) {
-                            Integer id = Integer.valueOf(entity.getId());
+                            Integer id = entity.getId();
                             if ((player == entity.getOwnerId())
                                     && spottersBefore.contains(id)
-                                    && !(LosEffects.calculateLos(game,
-                                            entity.getId(), targ, true))
-                                            .isBlocked()
+                                    && !LosEffects.calculateLOS(game, entity, targ, true).isBlocked()
                                     && entity.isActive()
                                     // airborne aeros can't spot for arty
-                                    && !((entity.isAero()) && entity
-                                            .isAirborne())
+                                    && !((entity.isAero()) && entity.isAirborne())
                                     && !entity.isINarcedWith(INarcPod.HAYWIRE)) {
                                 return true;
                             }
@@ -544,7 +541,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                 // as observed already by the entity's team
                 if(entity.isEnemyOf(aaa.getEntity(game)) &&
                         !aaa.getEntity(game).isOffBoardObserved(entity.getOwner().getTeam())) {
-                    boolean hasLoS = LosEffects.calculateLos(game, entity.getId(), hexTarget).canSee();
+                    boolean hasLoS = LosEffects.calculateLOS(game, entity, hexTarget).canSee();
                     
                     if(hasLoS) {
                         aaa.getEntity(game).addOffBoardObserver(entity.getOwner().getTeam());

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -4857,7 +4857,7 @@ public class Server implements Runnable {
             Entity tm = game.getEntity(missileId);
             if ((null != tm) && !tm.isDestroyed()
                 && (tm instanceof TeleMissile)) {
-                if (LosEffects.calculateLos(game, entity.getId(), tm).canSee()) {
+                if (LosEffects.calculateLOS(game, entity, tm).canSee()) {
                     ((TeleMissile) tm).setOutContact(false);
                 } else {
                     ((TeleMissile) tm).setOutContact(true);
@@ -10676,7 +10676,7 @@ public class Server implements Runnable {
                 if ((te instanceof Mech) && (!areaEffect)) {
                     // Bug #1585497: Check for partial cover
                     int m = missiles;
-                    LosEffects le = LosEffects.calculateLos(game, attId, t);
+                    LosEffects le = LosEffects.calculateLOS(game, ae, t);
                     int cover = le.getTargetCover();
                     Vector<Report> coverDamageReports = new Vector<>();
                     int heatDamage = 0;
@@ -11640,12 +11640,12 @@ public class Server implements Runnable {
                     if (!team.equals(game.getTeamForPlayer(en.getOwner()))) {
                         continue;
                     }
-                    if (LosEffects.calculateLos(game, en.getId(),
+                    if (LosEffects.calculateLOS(game, en,
                             new HexTarget(mf.getCoords(), Targetable.TYPE_HEX_CLEAR)).canSee()) {
                         target = 0;
                         break;
                     }
-                    LosEffects los = LosEffects.calculateLos(game, en.getId(), layer);
+                    LosEffects los = LosEffects.calculateLOS(game, en, layer);
                     if (los.canSee()) {
                         // TODO : need to add mods
                         ToHitData current = new ToHitData(4, "base");
@@ -13503,7 +13503,7 @@ public class Server implements Runnable {
                             public Targetable target = aaa.getTarget(game);
 
                             public boolean accept(Entity entity) {
-                                LosEffects los = LosEffects.calculateLos(game, entity.getId(), target);
+                                LosEffects los = LosEffects.calculateLOS(game, entity, target);
                                 return ((player == entity.getOwnerId()) && !(los.isBlocked())
                                         && entity.isActive());
                             }
@@ -14151,8 +14151,7 @@ public class Server implements Runnable {
                     }
                 }
 
-                LosEffects los = LosEffects.calculateLos(game,
-                        detector.getId(), detected);
+                LosEffects los = LosEffects.calculateLOS(game, detector, detected);
                 if (los.canSee() || dist <= 1) {
                     detected.setHidden(false);
                     entityUpdate(detected.getId());
@@ -29262,7 +29261,7 @@ public class Server implements Runnable {
             EntityTargetPair etp = new EntityTargetPair(spotter, entity);
             LosEffects los = losCache.get(etp);
             if (los == null) {
-                los = LosEffects.calculateLos(game, spotter.getId(), entity);
+                los = LosEffects.calculateLOS(game, spotter, entity);
                 losCache.put(etp, los);
             }
             if (Compute.canSee(game, spotter, entity, useSensors, los,
@@ -29316,7 +29315,7 @@ public class Server implements Runnable {
             EntityTargetPair etp = new EntityTargetPair(spotter, entity);
             LosEffects los = losCache.get(etp);
             if (los == null) {
-                los = LosEffects.calculateLos(game, spotter.getId(), entity);
+                los = LosEffects.calculateLOS(game, spotter, entity);
                 losCache.put(etp, los);
             }
             if (Compute.inSensorRange(game, los, spotter, entity, allECMInfo)) {
@@ -29449,7 +29448,7 @@ public class Server implements Runnable {
                 EntityTargetPair etp = new EntityTargetPair(spotter, e);
                 LosEffects los = losCache.get(etp);
                 if (los == null) {
-                    los = LosEffects.calculateLos(game, spotter.getId(), e);
+                    los = LosEffects.calculateLOS(game, spotter, e);
                     losCache.put(etp, los);
                 }
                 // Otherwise, if they can see the entity in question

--- a/megamek/src/megamek/server/commands/ShowValidTargetsCommand.java
+++ b/megamek/src/megamek/server/commands/ShowValidTargetsCommand.java
@@ -33,7 +33,7 @@ public class ShowValidTargetsCommand extends ServerCommand {
 
                 for (int i = 0; i < entList.size(); i++) {
                     target = entList.get(i);
-                    thd = LosEffects.calculateLos(server.getGame(), id, target)
+                    thd = LosEffects.calculateLOS(server.getGame(), ent, target)
                             .losModifiers(server.getGame());
                     if (thd.getValue() != TargetRoll.IMPOSSIBLE) {
                         thd.setSideTable(target.sideTable(ent.getPosition()));

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -1642,7 +1642,7 @@ public class FireControlTest {
         final LosEffects spyLosEffects = Mockito.spy(new LosEffects());
         Mockito.doReturn(spyLosEffects)
                .when(testFireControl)
-               .getLosEffects(Mockito.any(IGame.class), Mockito.anyInt(), Mockito.any(Targetable.class),
+               .getLosEffects(Mockito.any(IGame.class), Mockito.any(Entity.class), Mockito.any(Targetable.class),
                               Mockito.any(Coords.class), Mockito.any(Coords.class), Mockito.anyBoolean());
         Mockito.doReturn(new ToHitData()).when(spyLosEffects).losModifiers(Mockito.eq(mockGame));
 


### PR DESCRIPTION
This fixes the following exception and prevents a bunch of potential entity NPEs. It was found in the logs for #3005 

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at megamek.common.LosEffects.calculateLos(LosEffects.java:366)
	at megamek.common.LosEffects.calculateLos(LosEffects.java:353)
	at megamek.common.Compute.getSensorRangeByBracket(Compute.java:4881)
	at megamek.client.ui.swing.boardview.BoardView1.getHexTooltip(BoardView1.java:5757)
	at megamek.client.ui.swing.boardview.BoardView1$2.mouseMoved(BoardView1.java:630)
	at java.desktop/java.awt.AWTEventMulticaster.mouseMoved(AWTEventMulticaster.java:337)
	at java.desktop/java.awt.Component.processMouseMotionEvent(Component.java:6680)
	at java.desktop/javax.swing.JComponent.processMouseMotionEvent(JComponent.java:3360)
```

The first commit is the refactor that cleans up the code and swaps the methods to using Entity instead of the Id. The second commit is fixes the NPEs and prevents null returns.