### PR TITLE
Preventing three Compute::getTargetTotalNP NPEs

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2873,42 +2873,34 @@ public class Compute {
         int targetId = target.getTargetId();
         Coords position = target.getPosition();
 
-        //First, handle buildings versus entities, since they are handled differently.
-        if(targetType == Targetable.TYPE_BUILDING) {
-            //Buildings are a simple sum of their current CF and armor values.
+        // First, handle buildings versus entities, since they are handled differently.
+        if (targetType == Targetable.TYPE_BUILDING) {
+            // Buildings are a simple sum of their current CF and armor values.
             Building parentBuilding = game.getBoard().getBuildingAt(position); //the building the targeted hex belongs to. We have to get this and then get values for the specific hex internally to it.
             int targetCF = parentBuilding.getCurrentCF(position);
             int targetArmor = parentBuilding.getArmor(position);
             return targetCF + targetArmor;
         } else if (targetType == Targetable.TYPE_ENTITY) {
-            //I don't *think* we have to handle infantry differently here- I think these methods should return the total number of men remaining as internal structure.
+            //I don't *think* we have to handle infantry differently here - I think these methods should return the total number of men remaining as internal structure.
             Entity targetEntity = game.getEntity(targetId);
 
-            if (targetEntity instanceof GunEmplacement) { //If this is a gun emplacement, handle it as the building hex it is in.
-                Building parentBuilding = game.getBoard().getBuildingAt(position);
-                int targetCF = parentBuilding.getCurrentCF(position);
-                int targetArmor = parentBuilding.getArmor(position);
-                return targetCF + targetArmor;
+            if (targetEntity == null) {
+                return 0;
+            } else if (targetEntity instanceof GunEmplacement) {
+                // If this is a gun emplacement, handle it as the building hex it is in.
+                final Building parentBuilding = game.getBoard().getBuildingAt(position);
+                return (parentBuilding == null) ? 0
+                        : parentBuilding.getCurrentCF(position) + parentBuilding.getArmor(position);
+            } else {
+                return targetEntity.getTotalArmor() + targetEntity.getTotalInternal();
             }
-            int targetArmor = targetEntity.getTotalArmor();
-            int targetStructure = targetEntity.getTotalInternal();
-            return targetArmor + targetStructure;
         } else if (targetType == Targetable.TYPE_HEX_CLEAR) {
             // clearing a hex - the "HP" is the terrain factor of destroyable terrain on this hex
             IHex mhex = game.getBoard().getHex(position);
-            int terrainTypes[] = mhex.getTerrainTypes();
             int totalTF = 0;
-            
-            for (int i = 0; i < terrainTypes.length; i++) {
-                int tf = 0;
-                int terType = terrainTypes[i];
-                if (mhex.containsTerrain(terType)) {
-                    tf = mhex.getTerrain(terType).getTerrainFactor();
-                }
-                
-                totalTF += tf;
+            for (final int terrainType : mhex.getTerrainTypes()) {
+                totalTF += mhex.containsTerrain(terrainType) ? mhex.getTerrain(terrainType).getTerrainFactor() : 0;
             }
-            
             return totalTF;
         } else { //something else, e.g. terrain. We probably don't need to handle it for now.
             return 0;

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2865,7 +2865,7 @@ public class Compute {
     }
 
     /**
-     * Calculates the current theoretical damage absorbable(armor+structure, etc) by the given target.
+     * Calculates the current theoretical damage absorbable (armor+structure, etc) by the given target.
      * Used as a measure of the potential durability of the target under fire.
      */
     public static int getTargetTotalHP(IGame game, Targetable target) {
@@ -2876,10 +2876,10 @@ public class Compute {
         // First, handle buildings versus entities, since they are handled differently.
         if (targetType == Targetable.TYPE_BUILDING) {
             // Buildings are a simple sum of their current CF and armor values.
-            Building parentBuilding = game.getBoard().getBuildingAt(position); //the building the targeted hex belongs to. We have to get this and then get values for the specific hex internally to it.
-            int targetCF = parentBuilding.getCurrentCF(position);
-            int targetArmor = parentBuilding.getArmor(position);
-            return targetCF + targetArmor;
+            // the building the targeted hex belongs to. We have to get this and then get values for the specific hex internally to it.
+            final Building parentBuilding = game.getBoard().getBuildingAt(position);
+            return (parentBuilding == null) ? 0
+                    : parentBuilding.getCurrentCF(position) + parentBuilding.getArmor(position);
         } else if (targetType == Targetable.TYPE_ENTITY) {
             //I don't *think* we have to handle infantry differently here - I think these methods should return the total number of men remaining as internal structure.
             Entity targetEntity = game.getEntity(targetId);
@@ -2902,7 +2902,7 @@ public class Compute {
                 totalTF += mhex.containsTerrain(terrainType) ? mhex.getTerrain(terrainType).getTerrainFactor() : 0;
             }
             return totalTF;
-        } else { //something else, e.g. terrain. We probably don't need to handle it for now.
+        } else { // something else, e.g. terrain. We probably don't need to handle it for now.
             return 0;
         }
     }


### PR DESCRIPTION
This was found in the megameklog.txt in #3005, and this fixes it and two other potential null issues.

```
java.lang.NullPointerException
	at megamek.common.Compute.getTargetTotalHP(Compute.java:2880)
	at megamek.client.bot.princess.FireControl.calcDamageAllocationUtility(FireControl.java:1402)
	at megamek.client.bot.princess.FireControl.calculateUtility(FireControl.java:1290)
	at megamek.client.bot.princess.FireControl.getFullFiringPlan(FireControl.java:1881)
	at megamek.client.bot.princess.FireControl.getBestFiringPlan(FireControl.java:2075)
	at megamek.client.bot.princess.FireControl.determineBestFiringPlan(FireControl.java:2210)
	at megamek.client.bot.princess.FireControl.getBestFiringPlan(FireControl.java:2439)
	at megamek.client.bot.princess.Princess.calculateFiringTurn(Princess.java:672)
	at megamek.client.bot.BotClient.calculateMyTurnWorker(BotClient.java:560)
	at megamek.client.bot.BotClient.calculateMyTurn(BotClient.java:517)
	at megamek.client.bot.BotClient$CalculateBotTurn.run(BotClient.java:110)
	at java.base/java.lang.Thread.run(Thread.java:829)
```