### PR TITLE
Send dedicated server round reports by email

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'com.formdev:flatlaf:0.26'
     implementation 'com.github.ikkisoft:SerialKiller:master-SNAPSHOT'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.8'
+    implementation 'com.sun.mail:javax.mail:1.6.2'
 
     compile 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.2'

--- a/megamek/i18n/megamek/client/messages_en.properties
+++ b/megamek/i18n/megamek/client/messages_en.properties
@@ -2246,6 +2246,7 @@ PlayerSettingsDialog.header.startPos=Deployment Area
 PlayerSettingsDialog.header.initMod=Initiative Modifier
 PlayerSettingsDialog.header.minefields=Minefields
 PlayerSettingsDialog.header.skills=Method for Rolling Pilot Skills 
+PlayerSettingsDialog.header.email=Round Report Email
 PlayerSettingsDialog.botSettings=Bot Settings...
 PlayerSettingsDialog.labActive=Active:
 PlayerSettingsDialog.labConventional=Conventional:
@@ -2255,6 +2256,7 @@ PlayerSettingsDialog.butForceGP=Piloting = Gunnery + 1
 PlayerSettingsDialog.labMethod=Method:
 PlayerSettingsDialog.labPilot=Pilot Type:
 PlayerSettingsDialog.labXP=Experience:
+PlayerSettingsDialog.labEmail=Email address:
 PlayerSettingsDialog.title=Player Settings
 PlayerSettingsDialog.deployingHere=Other players deploying here:
 PlayerSettingsDialog.invalidStartPosTT=With Double Blind and Exclusive Deployment Zones options active, this deployment zone is invalid as it overlaps that of another player.

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -16,6 +16,9 @@
 
 # 0 through 999 -- System messages? (reserved at the moment)
 
+# Email subject lines
+990=MegaMek Deployment Report
+991=MegaMek Round #<data> Report
 
 # 1000's -- Initiative phase, Offboard phase, and other assorted stuff.
 1000=<B>Initiative Phase for Round #<data></B>

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1385,7 +1385,10 @@ public class Client implements IClientCommandHandler {
             break;
         case Packet.COMMAND_SERVER_GREETING:
             connected = true;
-            send(new Packet(Packet.COMMAND_CLIENT_NAME, name));
+            send(new Packet(
+                     Packet.COMMAND_CLIENT_NAME,
+                     new Object[] { name, isBot() }
+                 ));
             Object[] versionData = new Object[2];
             versionData[0] = MegaMek.VERSION;
             versionData[1] = MegaMek.getMegaMekSHA256();
@@ -1753,6 +1756,10 @@ public class Client implements IClientCommandHandler {
 
     public String getName() {
         return name;
+    }
+
+    public boolean isBot() {
+        return false;
     }
 
     public int getPort() {

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -224,6 +224,10 @@ public abstract class BotClient extends Client {
         });
     }
 
+    public boolean isBot() {
+        return true;
+    }
+
     BotConfiguration config = new BotConfiguration();
 
     protected BoardClusterTracker boardClusterTracker;

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1456,6 +1456,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             player.setNbrMFVibra(psd.getVibMines());
             player.setNbrMFActive(psd.getActMines());
             player.setNbrMFInferno(psd.getInfMines());
+            player.setEmail(psd.getEmail());
             var rsg = c.getRandomSkillsGenerator();
             rsg.setMethod(psd.getMethod());
             rsg.setType(psd.getPilot());

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -119,7 +119,12 @@ public class PlayerSettingsDialog extends ClientDialog {
     public boolean getForceGP() {
         return butForceGP.isSelected();
     }
-    
+
+    /** Returns the player's email address. */
+    public String getEmail() {
+        return fldEmail.getText().trim();
+    }
+
     // PRIVATE
 
     private final Client client;
@@ -150,7 +155,11 @@ public class PlayerSettingsDialog extends ClientDialog {
     private JComboBox<String> cmbPilot = new JComboBox<String>();
     private JComboBox<String> cmbXP = new JComboBox<String>();
     private MMToggleButton butForceGP = new MMToggleButton(getString(PSD + "butForceGP"));
-    
+
+    // Email section
+    private JLabel labEmail = new JLabel(getString(PSD + "labEmail"), SwingConstants.RIGHT);
+    private JTextField fldEmail = new JTextField(20);
+
     private JPanel panStartButtons = new JPanel();
     private TipButton[] butStartPos = new TipButton[11];
     private JButton butBotSettings = new JButton(Messages.getString(PSD + "botSettings"));
@@ -179,6 +188,9 @@ public class PlayerSettingsDialog extends ClientDialog {
             mainPanel.add(mineSection());
         }
         mainPanel.add(skillsSection());
+        if (!(client instanceof BotClient)) {
+            mainPanel.add(emailSection());
+        }
         mainPanel.add(Box.createVerticalGlue());
     }
     
@@ -251,7 +263,16 @@ public class PlayerSettingsDialog extends ClientDialog {
         panContent.add(butForceGP);
         return result;
     }
-    
+
+    private JPanel emailSection() {
+        JPanel result = new OptionPanel(PSD + "header.email");
+        Content panContent = new Content(new GridLayout(1, 2, 10, 5));
+        result.add(panContent);
+        panContent.add(labEmail);
+        panContent.add(fldEmail);
+        return result;
+    }
+
     private JPanel buttonPanel() {
         JPanel result = new JPanel(new FlowLayout());
         butOkay.addActionListener(listener);
@@ -282,8 +303,9 @@ public class PlayerSettingsDialog extends ClientDialog {
         cmbXP.setSelectedIndex(client.getRandomSkillsGenerator().getLevel());
         butForceGP.setSelected(client.getRandomSkillsGenerator().isClose());
         cmbMethod.addItemListener(e -> adjustSkillMethodTip());
+        fldEmail.setText(player.getEmail());
     }
-    
+
     private void setupStartGrid() {
         panStartButtons.setAlignmentX(Component.LEFT_ALIGNMENT);
         for (int i = 0; i < 11; i++) {

--- a/megamek/src/megamek/common/IPlayer.java
+++ b/megamek/src/megamek/common/IPlayer.java
@@ -82,6 +82,10 @@ public interface IPlayer extends ITurnOrdered {
 
     void setName(String name);
 
+    String getEmail();
+
+    void setEmail(String email);
+
     int getId();
 
     int getTeam();

--- a/megamek/src/megamek/common/IPlayer.java
+++ b/megamek/src/megamek/common/IPlayer.java
@@ -105,6 +105,12 @@ public interface IPlayer extends ITurnOrdered {
 
     void setGhost(boolean ghost);
 
+    /** Specifies if this player connected as a bot. */
+    boolean isBot();
+
+    /** Sets whether this player connected as a bot. */
+    void setBot(boolean bot);
+
     boolean isObserver();
 
     void setSeeAll(boolean see_all);

--- a/megamek/src/megamek/common/IPlayer.java
+++ b/megamek/src/megamek/common/IPlayer.java
@@ -32,6 +32,11 @@ public interface IPlayer extends ITurnOrdered {
     String[] teamNames = {"No Team", "Team 1", "Team 2", "Team 3", "Team 4", "Team 5"};
     int MAX_TEAMS = teamNames.length;
 
+    /**
+     * Constructs a shallow copy of this object.
+     */
+    IPlayer copy();
+
     Vector<Minefield> getMinefields();
 
     void addMinefield(Minefield mf);
@@ -206,4 +211,13 @@ public interface IPlayer extends ITurnOrdered {
      * @return string of playercolor
      */
     public String getColorForPlayer();
+
+    /**
+     * Un-sets any data that may be considered private.
+     *
+     * This method clears any data that should not be transmitted to
+     * other players from the server, such as email addresses.
+     */
+    public void redactPrivateData();
+
 }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -78,6 +78,52 @@ public final class Player extends TurnOrdered implements IPlayer {
      */
     private boolean allowingTeamChange = false;
 
+    public Player(int id, String name) {
+        this.name = name;
+        this.id = id;
+    }
+
+    @Override
+    public IPlayer copy() {
+        var copy = new Player(this.id, this.name);
+
+        copy.email = email;
+
+        copy.game = game;
+        copy.team = team;
+
+        copy.done = done;
+        copy.ghost = ghost;
+        copy.observer = observer;
+
+        copy.seeEntireBoard = seeEntireBoard;
+
+        copy.startingPos = startingPos;
+
+        copy.numMfConv = numMfConv;
+        copy.numMfCmd = numMfCmd;
+        copy.numMfVibra = numMfVibra;
+        copy.numMfActive = numMfActive;
+        copy.numMfInferno = numMfInferno;
+
+        copy.artyAutoHitHexes = new Vector<>(artyAutoHitHexes);
+
+        copy.initialEntityCount = initialEntityCount;
+        copy.initialBV = initialBV;
+
+        copy.constantInitBonus = constantInitBonus;
+        copy.streakCompensationBonus = streakCompensationBonus;
+
+        copy.camouflage = camouflage;
+        copy.colour = colour;
+
+        copy.visibleMinefields = new Vector<>(visibleMinefields);
+
+        copy.admitsDefeat = admitsDefeat;
+
+        return copy;
+    }
+
     @Override
     public Vector<Minefield> getMinefields() {
         return visibleMinefields;
@@ -178,11 +224,6 @@ public final class Player extends TurnOrdered implements IPlayer {
     @Override
     public void setCamouflage(Camouflage camouflage) {
         this.camouflage = camouflage;
-    }
-
-    public Player(int id, String name) {
-        this.name = name;
-        this.id = id;
     }
 
     @Override
@@ -598,4 +639,10 @@ public final class Player extends TurnOrdered implements IPlayer {
     public String getColorForPlayer(){
         return "<B><font color='" + getColour().getHexString(0x00F0F0F0) + "'>" + getName() + "</font></B>";
     }
+
+    @Override
+    public void redactPrivateData() {
+        this.email = null;
+    }
+
 }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -39,6 +39,7 @@ public final class Player extends TurnOrdered implements IPlayer {
 
     private boolean done = false; // done with phase
     private boolean ghost = false; // disconnected player
+    private boolean bot = false;
     private boolean observer = false;
 
     private boolean seeEntireBoard = false; // Player can observe double blind games
@@ -285,6 +286,16 @@ public final class Player extends TurnOrdered implements IPlayer {
     @Override
     public void setGhost(boolean ghost) {
         this.ghost = ghost;
+    }
+
+    @Override
+    public boolean isBot() {
+        return bot;
+    }
+
+    @Override
+    public void setBot(boolean bot) {
+        this.bot = bot;
     }
 
     @Override

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -27,11 +27,12 @@ import java.util.Vector;
  * Represents a player in the game.
  */
 public final class Player extends TurnOrdered implements IPlayer {
-    private static final long serialVersionUID = 6828849559007455760L;
+    private static final long serialVersionUID = 6828849559007455761L;
 
     private transient IGame game;
 
     private String name;
+    private String email;
     private int id;
 
     private int team = TEAM_NONE;
@@ -197,6 +198,16 @@ public final class Player extends TurnOrdered implements IPlayer {
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public void setEmail(String email) {
+        this.email = email;
     }
 
     @Override

--- a/megamek/src/megamek/common/util/EmailService.java
+++ b/megamek/src/megamek/common/util/EmailService.java
@@ -155,6 +155,7 @@ public class EmailService {
         Vector<IPlayer> emailable = new Vector<>();
         for (var player: game.getPlayersVector()) {
             if (!StringUtil.isNullOrEmpty(player.getEmail()) &&
+                !player.isBot() &&
                 !player.isObserver()) {
                 emailable.add(player);
             }

--- a/megamek/src/megamek/common/util/EmailService.java
+++ b/megamek/src/megamek/common/util/EmailService.java
@@ -1,0 +1,63 @@
+/*
+* MegaMek -
+* Copyright (C) 2021 - The MegaMek Team. All Rights Reserved.
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
+*/
+
+package megamek.common.util;
+
+import java.util.Properties;
+
+import javax.mail.Authenticator;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+
+public class EmailService {
+
+
+    private InternetAddress from;
+    private Properties mailProperties;
+    private Session session;
+
+
+    public EmailService(Properties mailProperties) throws Exception {
+        this.from = InternetAddress.parse(
+            mailProperties.getProperty("megamek.smtp.from", "")
+        )[0];
+        this.mailProperties = mailProperties;
+
+        Authenticator auth = null;
+        var login = mailProperties.getProperty("megamek.smtp.login", "").trim();
+        var password = mailProperties.getProperty("megamek.smtp.password", "").trim();
+        if (login.length() > 0 && password.length() > 0) {
+            auth = new Authenticator() {
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(login, password);
+                    }
+                };
+        }
+
+        this.session = Session.getInstance(mailProperties, auth);
+    }
+
+    public void send(final Message message) throws MessagingException {
+        Transport.send(message);
+    }
+
+}

--- a/megamek/src/megamek/common/util/EmailService.java
+++ b/megamek/src/megamek/common/util/EmailService.java
@@ -151,6 +151,17 @@ public class EmailService {
         mailWorker.start();
     }
 
+    public Vector<IPlayer> getEmailablePlayers(IGame game) {
+        Vector<IPlayer> emailable = new Vector<>();
+        for (var player: game.getPlayersVector()) {
+            if (!StringUtil.isNullOrEmpty(player.getEmail()) &&
+                !player.isObserver()) {
+                emailable.add(player);
+            }
+        }
+        return emailable;
+    }
+
     public Message newReportMessage(IGame game,
                                     Vector<Report> reports,
                                     IPlayer player) throws Exception {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -80,6 +80,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.BoardUtilities;
+import megamek.common.util.EmailService;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.util.SerializationHelper;
 import megamek.common.util.StringUtil;
@@ -150,6 +151,9 @@ public class Server implements Runnable {
     private ServerSocket serverSocket;
 
     private String motd;
+
+    private EmailService mailer;
+
 
     private static class ReceivedPacket {
         public int connId;
@@ -341,7 +345,12 @@ public class Server implements Runnable {
     private final Object serverLock = new Object();
 
     public Server(String password, int port) throws IOException {
-        this(password, port, false, "");
+        this(password, port, false, "", null);
+    }
+
+    public Server(String password, int port, boolean registerWithServerBrowser,
+                  String metaServerUrl) throws IOException {
+        this(password, port, registerWithServerBrowser, metaServerUrl, null);
     }
 
     /**
@@ -352,11 +361,14 @@ public class Server implements Runnable {
      *                                  used
      * @param registerWithServerBrowser a <code>boolean</code> indicating whether we should register
      *                                  with the master server browser on megamek.info
+     * @param mailer an email service instance to use for sending round reports.
      */
     public Server(String password, int port, boolean registerWithServerBrowser,
-                  String metaServerUrl) throws IOException {
+                  String metaServerUrl, EmailService mailer) throws IOException {
         this.metaServerUrl = metaServerUrl;
         this.password = password.length() > 0 ? password : null;
+        this.mailer = mailer;
+
         // initialize server socket
         serverSocket = new ServerSocket(port);
 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -620,6 +620,10 @@ public class Server implements Runnable {
             conn.close();
         }
 
+        if (mailer != null) {
+            mailer.shutdown();
+        }
+
         connections.removeAllElements();
         connectionIds.clear();
         if (serverBrowserUpdateTimer != null) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -695,6 +695,7 @@ public class Server implements Runnable {
                                + " to " + player.getConstantInitBonus() + ".");
             }
             gamePlayer.setConstantInitBonus(player.getConstantInitBonus());
+            gamePlayer.setEmail(player.getEmail());
         }
     }
 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -792,6 +792,7 @@ public class Server implements Runnable {
     private void receivePlayerName(Packet packet, int connId) {
         final IConnection conn = getPendingConnection(connId);
         String name = (String) packet.getObject(0);
+        boolean isBot = (boolean) packet.getObject(1);
         boolean returning = false;
 
         // this had better be from a pending connection
@@ -827,7 +828,7 @@ public class Server implements Runnable {
 
         // add and validate the player info
         if (!returning) {
-            addNewPlayer(connId, name);
+            addNewPlayer(connId, name, isBot);
         }
 
         // if it is not the lounge phase, this player becomes an observer
@@ -968,7 +969,7 @@ public class Server implements Runnable {
     /**
      * Adds a new player to the game
      */
-    private IPlayer addNewPlayer(int connId, String name) {
+    private IPlayer addNewPlayer(int connId, String name, boolean isBot) {
         int team = IPlayer.TEAM_UNASSIGNED;
         if (game.getPhase() == Phase.PHASE_LOUNGE) {
             team = IPlayer.TEAM_NONE;
@@ -980,6 +981,7 @@ public class Server implements Runnable {
             team++;
         }
         IPlayer newPlayer = new Player(connId, name);
+        newPlayer.setBot(isBot);
         PlayerColour colour = newPlayer.getColour();
         Enumeration<IPlayer> players = game.getPlayers();
         final PlayerColour[] colours = PlayerColour.values();
@@ -1382,7 +1384,7 @@ public class Server implements Runnable {
             }
             String name = idToNameMap.get(conn.getId());
             conn.setId(newId);
-            IPlayer newPlayer = addNewPlayer(newId, name);
+            IPlayer newPlayer = addNewPlayer(newId, name, false);
             newPlayer.setObserver(true);
             connectionIds.put(newId,  conn);
             send(newId, new Packet(Packet.COMMAND_LOCAL_PN, newId));

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -2488,7 +2488,23 @@ public class Server implements Runnable {
                         }
                     }
                 }
-            }
+                }
+                if (mailer != null) {
+                    for (var player: game.getPlayersVector()) {
+                        if (!StringUtil.isNullOrEmpty(player.getEmail())) {
+                            try {
+                                var message = mailer.newReportMessage(
+                                    player, game.getRoundCount(), vPhaseReport
+                                );
+                                mailer.send(message);
+                            } catch (Exception ex) {
+                                MegaMek.getLogger().error(
+                                    "Error sending email to: " + player.getEmail(), ex
+                                );
+                            }
+                        }
+                    }
+                }
                 send(createFullEntitiesPacket());
                 send(createReportPacket(null));
                 send(createEndOfGamePacket());
@@ -31131,6 +31147,22 @@ public class Server implements Runnable {
      * Send the round report to all connected clients.
      */
     private void sendReport(boolean tacticalGeniusReport) {
+        if (mailer != null) {
+            for (var player: game.getPlayersVector()) {
+                if (!StringUtil.isNullOrEmpty(player.getEmail())) {
+                    try {
+                        var reports = filterReportVector(vPhaseReport, player);
+                        var message = mailer.newReportMessage(
+                            player, game.getRoundCount(), reports
+                        );
+                        mailer.send(message);
+                    } catch (Exception e) {
+                        MegaMek.getLogger().error("Error sending email to: " + player.getEmail(), e);
+                    }
+                }
+            }
+        }
+
         if (connections == null) {
             return;
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1133,6 +1133,10 @@ public class Server implements Runnable {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
         MegaMek.getLogger().info(format.format(new Date()) + " END OF GAME");
 
+        if (mailer != null) {
+            mailer.reset();
+        }
+
         changePhase(IGame.Phase.PHASE_LOUNGE);
     }
 
@@ -2494,7 +2498,7 @@ public class Server implements Runnable {
                         if (!StringUtil.isNullOrEmpty(player.getEmail())) {
                             try {
                                 var message = mailer.newReportMessage(
-                                    player, game.getRoundCount(), vPhaseReport
+                                    game, vPhaseReport, player
                                 );
                                 mailer.send(message);
                             } catch (Exception ex) {
@@ -31153,7 +31157,7 @@ public class Server implements Runnable {
                     try {
                         var reports = filterReportVector(vPhaseReport, player);
                         var message = mailer.newReportMessage(
-                            player, game.getRoundCount(), reports
+                            game, reports, player
                         );
                         mailer.send(message);
                     } catch (Exception e) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -2499,18 +2499,14 @@ public class Server implements Runnable {
                 }
                 }
                 if (mailer != null) {
-                    for (var player: game.getPlayersVector()) {
-                        if (!StringUtil.isNullOrEmpty(player.getEmail())) {
-                            try {
-                                var message = mailer.newReportMessage(
-                                    game, vPhaseReport, player
-                                );
-                                mailer.send(message);
-                            } catch (Exception ex) {
-                                MegaMek.getLogger().error(
-                                    "Error sending email to: " + player.getEmail(), ex
-                                );
-                            }
+                    for (var player: mailer.getEmailablePlayers(game)) {
+                        try {
+                            var message = mailer.newReportMessage(
+                                game, vPhaseReport, player
+                            );
+                            mailer.send(message);
+                        } catch (Exception ex) {
+                            MegaMek.getLogger().error("Error sending email" + ex);
                         }
                     }
                 }
@@ -31188,17 +31184,15 @@ public class Server implements Runnable {
      */
     private void sendReport(boolean tacticalGeniusReport) {
         if (mailer != null) {
-            for (var player: game.getPlayersVector()) {
-                if (!StringUtil.isNullOrEmpty(player.getEmail())) {
-                    try {
-                        var reports = filterReportVector(vPhaseReport, player);
-                        var message = mailer.newReportMessage(
-                            game, reports, player
-                        );
-                        mailer.send(message);
-                    } catch (Exception e) {
-                        MegaMek.getLogger().error("Error sending email to: " + player.getEmail(), e);
-                    }
+            for (var player: mailer.getEmailablePlayers(game)) {
+                try {
+                    var reports = filterReportVector(vPhaseReport, player);
+                    var message = mailer.newReportMessage(
+                        game, reports, player
+                    );
+                    mailer.send(message);
+                } catch (Exception e) {
+                    MegaMek.getLogger().error("Error sending round report", e);
                 }
             }
         }

--- a/megamek/src/megamek/server/ServerLobbyHelper.java
+++ b/megamek/src/megamek/server/ServerLobbyHelper.java
@@ -353,7 +353,7 @@ class ServerLobbyHelper {
         
         server.send(server.createFullEntitiesPacket());
         for (IPlayer player: serverPlayers) {
-            server.send(server.createPlayerUpdatePacket(player.getId()));
+            server.transmitPlayerUpdate(player);
         }
     }
 


### PR DESCRIPTION
This adds the ability to send round reports via email from the dedicated server, so that players get a record of a game as it progresses, but also to notify players in long running games (e.g. very large games, double blind games, those with simultaneous phases, etc) when something has happened, so they know to re-connect and take their turn.

When starting a dedicated server, if `-mail path/to/email.properties` is specified, an email service is initialised when the server starts up. The given file contains standard JavaMail properties to configure the SMTP connection details. Then, for any players who have set an email address during game setup, a copy of every round report will be emailed to them when generated.

The emails sent are set up so that all email for the same turn are threaded together, to give the same effect as the GUI round report in email clients:

![mm-email-example](https://user-images.githubusercontent.com/3745088/128154040-d7c9b7ea-718c-4cac-ac1b-82042ce272fa.png)