### PR TITLE
attacks on hull down tanks now go to appropriate location

### DIFF
--- a/megamek/src/megamek/common/LargeSupportTank.java
+++ b/megamek/src/megamek/common/LargeSupportTank.java
@@ -14,6 +14,7 @@
 package megamek.common;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import megamek.MegaMek;
 import megamek.common.options.OptionsConstants;
@@ -49,6 +50,15 @@ public class LargeSupportTank extends SupportTank {
     // tanks have no critical slot limitations
     private static final int[] NUM_OF_SLOTS = { 25, 25, 25, 25, 25, 25, 25, 25 };
 
+    // maps ToHitData - SIDE_X constants to LOC_X constants here for hull down fixed side hit locations
+    protected static final Map<Integer, Integer> SIDE_LOC_MAPPING = 
+        Map.of(ToHitData.SIDE_FRONT, LOC_FRONT,
+                ToHitData.SIDE_FRONTLEFT, LOC_FRONTLEFT,
+                ToHitData.SIDE_FRONTRIGHT, LOC_FRONTRIGHT,
+                ToHitData.SIDE_REARLEFT, LOC_REARLEFT,
+                ToHitData.SIDE_REARRIGHT, LOC_REARRIGHT,
+                ToHitData.SIDE_REAR, LOC_REAR);
+    
     @Override
     public String[] getLocationAbbrs() {
         return LOCATION_ABBRS;

--- a/megamek/src/megamek/common/LargeSupportTank.java
+++ b/megamek/src/megamek/common/LargeSupportTank.java
@@ -14,7 +14,6 @@
 package megamek.common;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 import megamek.MegaMek;
 import megamek.common.options.OptionsConstants;
@@ -49,15 +48,6 @@ public class LargeSupportTank extends SupportTank {
 
     // tanks have no critical slot limitations
     private static final int[] NUM_OF_SLOTS = { 25, 25, 25, 25, 25, 25, 25, 25 };
-
-    // maps ToHitData - SIDE_X constants to LOC_X constants here for hull down fixed side hit locations
-    protected static final Map<Integer, Integer> SIDE_LOC_MAPPING = 
-        Map.of(ToHitData.SIDE_FRONT, LOC_FRONT,
-                ToHitData.SIDE_FRONTLEFT, LOC_FRONTLEFT,
-                ToHitData.SIDE_FRONTRIGHT, LOC_FRONTRIGHT,
-                ToHitData.SIDE_REARLEFT, LOC_REARLEFT,
-                ToHitData.SIDE_REARRIGHT, LOC_REARRIGHT,
-                ToHitData.SIDE_REAR, LOC_REAR);
     
     @Override
     public String[] getLocationAbbrs() {

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -98,6 +98,9 @@ public class Tank extends Entity {
 
     private static String[] LOCATION_NAMES_DUAL_TURRET = { "Body", "Front",
             "Right", "Left", "Rear", "Rear Turret", "Front Turret" };
+    
+    // maps ToHitData - SIDE_X constants to LOC_X constants here for hull down fixed side hit locations
+    private static final int[] SIDE_LOC_MAPPING = { 1, 4, 3, 2 };
 
     @Override
     public int getUnitType() {
@@ -941,8 +944,7 @@ public class Tank extends Entity {
                 if (!ignoreTurret) {
                     // on a hull down vee, all hits expect for those that come
                     // from the opposite direction to which it entered the hex
-                    // it
-                    // went Hull Down in go to turret if one exists.
+                    // it went Hull Down in go to turret if one exists.
                     if (!hasNoDualTurret()) {
                         int roll = Compute.d6() - 2;
                         if (roll <= 3) {
@@ -958,7 +960,7 @@ public class Tank extends Entity {
                 // the opposite direction to which it entered the hex it went
                 // Hull Down in hit side they come in from
                 else {
-                    nArmorLoc = side;
+                    nArmorLoc = SIDE_LOC_MAPPING[side];
                 }
                 // Hull Down tanks don't make hit location rolls
                 return new HitData(nArmorLoc);

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -100,7 +100,11 @@ public class Tank extends Entity {
             "Right", "Left", "Rear", "Rear Turret", "Front Turret" };
     
     // maps ToHitData - SIDE_X constants to LOC_X constants here for hull down fixed side hit locations
-    private static final int[] SIDE_LOC_MAPPING = { 1, 4, 3, 2 };
+    protected static final Map<Integer, Integer> SIDE_LOC_MAPPING = 
+        Map.of(ToHitData.SIDE_FRONT, LOC_FRONT,
+                ToHitData.SIDE_LEFT, LOC_LEFT,
+                ToHitData.SIDE_RIGHT, LOC_RIGHT,
+                ToHitData.SIDE_REAR, LOC_REAR);
 
     @Override
     public int getUnitType() {
@@ -960,7 +964,7 @@ public class Tank extends Entity {
                 // the opposite direction to which it entered the hex it went
                 // Hull Down in hit side they come in from
                 else {
-                    nArmorLoc = SIDE_LOC_MAPPING[side];
+                    nArmorLoc = SIDE_LOC_MAPPING.get(side);
                 }
                 // Hull Down tanks don't make hit location rolls
                 return new HitData(nArmorLoc);


### PR DESCRIPTION
What it says on the tin. ToHitData.SIDE_X didn't have the same numbers as Tank.LOC_X. Fixes #3048 