### PR TITLE
bullert proofing several null pointer possibilities

### DIFF
--- a/megamek/src/megamek/common/BattleArmorHandles.java
+++ b/megamek/src/megamek/common/BattleArmorHandles.java
@@ -180,7 +180,11 @@ import megamek.common.annotations.Nullable;
         // Return a list of our carried troopers.
         Vector<Entity> units = new Vector<Entity>(1);
         if (troopers != Entity.NONE) {
-            units.addElement(game.getEntity(troopers));
+            Entity entity = game.getEntity(troopers);
+            
+            if (entity != null) {
+                units.addElement(entity);
+            }
         }
         return units;
     }

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -255,7 +255,11 @@ public class Bay implements Transporter, ITechnology {
         // Return a copy of our list of troops.
         Vector<Entity> loaded = new Vector<Entity>();
         for (int unit : troops) {
-            loaded.add(game.getEntity(unit));
+            Entity entity = game.getEntity(unit);
+            
+            if (entity != null) {
+                loaded.add(game.getEntity(unit));
+            }
         }
         return loaded;
     }

--- a/megamek/src/megamek/common/DockingCollar.java
+++ b/megamek/src/megamek/common/DockingCollar.java
@@ -175,7 +175,11 @@ public class DockingCollar implements Transporter {
         // Return a copy of our list of troops.
         Vector<Entity> loaded = new Vector<Entity>();
         for (int id : troops) {
-            loaded.add(game.getEntity(id));
+            Entity entity = game.getEntity(id);
+            
+            if (entity != null) {
+                loaded.add(game.getEntity(id));
+            }
         }
         return loaded;
     }

--- a/megamek/src/megamek/common/TankTrailerHitch.java
+++ b/megamek/src/megamek/common/TankTrailerHitch.java
@@ -154,7 +154,11 @@ public class TankTrailerHitch implements Transporter {
         // Return a list of our carried troopers.
         Vector<Entity> units = new Vector<Entity>(1);
         if (towed != Entity.NONE) {
-            units.addElement(game.getEntity(towed));
+            Entity entity = game.getEntity(towed);
+            
+            if (entity != null) {
+                units.addElement(entity);
+            }
         }
         return units;
     }

--- a/megamek/src/megamek/common/TroopSpace.java
+++ b/megamek/src/megamek/common/TroopSpace.java
@@ -143,7 +143,11 @@ public final class TroopSpace implements Transporter {
         Vector<Entity> loaded = new Vector<Entity>();
         for (Map.Entry<Integer, Double> entry : troops.entrySet()) {
             int key = entry.getKey();
-            loaded.add(game.getEntity(key));
+            Entity entity = game.getEntity(key);
+            
+            if (entity != null) {
+                loaded.add(entity);
+            }
         }
 
         return loaded;

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
@@ -253,6 +253,8 @@ public abstract class InfantryWeapon extends Weapon {
         Mounted m = game.getEntity(waa.getEntityId()).getEquipment(waa.getWeaponId());
         if (((null != m) && (m.curMode().equals(Weapon.MODE_FLAMER_HEAT)
                 || (waa.getEntity(game).isSupportVehicle()
+                    && m.getLinked() != null
+                    && m.getLinked().getType() != null
                     && (((AmmoType) m.getLinked().getType()).getMunitionType() == AmmoType.M_INFERNO))))) {
             return new InfantryHeatWeaponHandler(toHit, waa, game, server);
         }


### PR DESCRIPTION
Several changes that should hopefully address the issues found in #3052 - bullet proofing against situations where a transport's contents are no longer in the game for one reason or another, and when a support vehicle's weapon has no linked ammo bin.