### PR TITLE
stop bot walking into water with leg armor breaches

### DIFF
--- a/megamek/src/megamek/common/pathfinder/CachedEntityState.java
+++ b/megamek/src/megamek/common/pathfinder/CachedEntityState.java
@@ -155,8 +155,8 @@ public class CachedEntityState {
                         ((backingEntity.getArmor(TripodMech.LOC_RLEG) > 0) ? 0 : 1);
             } else if (backingEntity instanceof Mech) {
                 numBreachedLegs = 
-                        ((backingEntity.getArmor(TripodMech.LOC_LLEG) > 0) ? 0 : 1) +
-                        ((backingEntity.getArmor(TripodMech.LOC_RLEG) > 0) ? 0 : 1);
+                        ((backingEntity.getArmor(Mech.LOC_LLEG) > 0) ? 0 : 1) +
+                        ((backingEntity.getArmor(Mech.LOC_RLEG) > 0) ? 0 : 1);
             } else {
                 numBreachedLegs = 0;
             }

--- a/megamek/src/megamek/common/pathfinder/CachedEntityState.java
+++ b/megamek/src/megamek/common/pathfinder/CachedEntityState.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.MiscType;
+import megamek.common.QuadMech;
+import megamek.common.TripodMech;
 
 /**
  * A transient class used to lazy-load "calculated" information from an entity
@@ -26,6 +28,7 @@ public class CachedEntityState {
     private Map<BigInteger, Boolean> hasWorkingMisc;
     private Integer torsoJumpJets;
     private Integer jumpMPNoGravity;
+    private Integer numBreachedLegs;
     
     public CachedEntityState(Entity entity) {
         backingEntity = entity;
@@ -131,5 +134,34 @@ public class CachedEntityState {
         return hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS) || 
                 hasWorkingMisc(MiscType.F_AMPHIBIOUS) ||
                 hasWorkingMisc(MiscType.F_LIMITED_AMPHIBIOUS);
+    }
+    
+    /**
+     * Convenience property to determine how many armor-breached legs this entity has.
+     * By default, this is 0 unless the unit is a mech.
+     */
+    public int getNumBreachedLegs() {
+        if (numBreachedLegs == null) {
+            if (backingEntity instanceof QuadMech) {
+                numBreachedLegs = 
+                        ((backingEntity.getArmor(QuadMech.LOC_LLEG) > 0) ? 0 : 1) +
+                        ((backingEntity.getArmor(QuadMech.LOC_LARM) > 0) ? 0 : 1) +
+                        ((backingEntity.getArmor(QuadMech.LOC_RLEG) > 0) ? 0 : 1) +
+                        ((backingEntity.getArmor(QuadMech.LOC_RARM) > 0) ? 0 : 1);
+            } else if (backingEntity instanceof TripodMech) {
+                numBreachedLegs = 
+                        ((backingEntity.getArmor(TripodMech.LOC_LLEG) > 0) ? 0 : 1) +
+                        ((backingEntity.getArmor(TripodMech.LOC_CLEG) > 0) ? 0 : 1) +
+                        ((backingEntity.getArmor(TripodMech.LOC_RLEG) > 0) ? 0 : 1);
+            } else if (backingEntity instanceof Mech) {
+                numBreachedLegs = 
+                        ((backingEntity.getArmor(TripodMech.LOC_LLEG) > 0) ? 0 : 1) +
+                        ((backingEntity.getArmor(TripodMech.LOC_RLEG) > 0) ? 0 : 1);
+            } else {
+                numBreachedLegs = 0;
+            }
+        }
+        
+        return numBreachedLegs;
     }
 }

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -32,7 +32,6 @@ import megamek.common.EntityMovementMode;
 import megamek.common.IBoard;
 import megamek.common.IGame;
 import megamek.common.IHex;
-import megamek.common.Mech;
 import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.PlanetaryConditions;
@@ -242,7 +241,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         }
         
         // if we have a leg armor breach and are not jumping, let's not consider it
-        if (!child.isJumping() && waterCheck(child)) {
+        if (!child.isJumping() && underwaterLegBreachCheck(child)) {
             return;
         }
         
@@ -290,11 +289,15 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
     }
     
     /**
-     * Simplified logic for whether a mech going into the given hex will flood its legs.
+     * Simplified logic for whether a mech going into the given hex will flood 
+     * breached legs and effectively immobilize it.
      */
-    private boolean waterCheck(BulldozerMovePath path) {        
+    private boolean underwaterLegBreachCheck(BulldozerMovePath path) {        
         IHex hex = path.getGame().getBoard().getHex(path.getFinalCoords());
         
+        // investigate: do we want quad mechs with a single breached leg
+        // to risk this move? Currently not, but if we did, this is probably where
+        // this logic would go.
         return path.getCachedEntityState().getNumBreachedLegs() > 0 && 
                 hex != null &&
                 hex.terrainLevel(Terrains.WATER) > 0;

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -31,6 +31,8 @@ import megamek.common.Entity;
 import megamek.common.EntityMovementMode;
 import megamek.common.IBoard;
 import megamek.common.IGame;
+import megamek.common.IHex;
+import megamek.common.Mech;
 import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.PlanetaryConditions;
@@ -239,6 +241,11 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
             return;
         }
         
+        // if we have a leg armor breach and are not jumping, let's not consider it
+        if (!child.isJumping() && waterCheck(child)) {
+            return;
+        }
+        
         if ((!shortestPathsToCoords.containsKey(child.getFinalCoords()) ||
                 // shorter path to these coordinates
                 (movePathComparator.compare(shortestPathsToCoords.get(child.getFinalCoords()), child) > 0)) &&
@@ -280,6 +287,17 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         
         friendlyFireCheckResults.put(position, false);
         return false;
+    }
+    
+    /**
+     * Simplified logic for whether a mech going into the given hex will flood its legs.
+     */
+    private boolean waterCheck(BulldozerMovePath path) {        
+        IHex hex = path.getGame().getBoard().getHex(path.getFinalCoords());
+        
+        return path.getCachedEntityState().getNumBreachedLegs() > 0 && 
+                hex != null &&
+                hex.terrainLevel(Terrains.WATER) > 0;
     }
     
     /**


### PR DESCRIPTION
Pretty simple improvement to bot behavior which prevents it from stepping into water with breached leg armor. I could probably make it more accurate for tripods and quads, but it seems to me like stepping into water with a guaranteed fall over is generally a bad idea, so we'll avoid it entirely unless feedback indicates otherwise (the only situation I can think of where I'd even be willing to consider intentionally stepping into water with a breached leg is if I had a quad mech with only one breached leg).

Fixes #3031 