### PR TITLE
Princess Config correction

### DIFF
--- a/megamek/src/megamek/client/bot/princess/UnitBehavior.java
+++ b/megamek/src/megamek/client/bot/princess/UnitBehavior.java
@@ -37,7 +37,7 @@ public class UnitBehavior {
             }
             
             return BehaviorType.ForcedWithdrawal;
-        } else if (botSettings.getDestinationEdge() != CardinalEdge.NONE) {
+        } else if (botSettings.shouldAutoFlee() && botSettings.getDestinationEdge() != CardinalEdge.NONE) {
             if(owner.getClusterTracker().getDestinationCoords(entity, owner.getHomeEdge(entity), true).isEmpty()) {
                 return BehaviorType.NoPathToDestination;
             }


### PR DESCRIPTION
With the new bot config dialog the edge to flee to is not necessarily set to NONE when autoflee is off. This makes Princess always run to the home edge. Correcting this by introducing a check in UnitBehavior which looks to me as it should have been there anyway.