### PR TITLE
defensive coding around facing changes

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import megamek.MegaMek;
+import megamek.client.bot.princess.FireControl;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.Building.BasementType;
@@ -955,6 +956,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         for (Mounted mounted : equipmentList) {
             mounted.restore();
         }
+        
+        // in some situations, an entity's facing winds up having an illegal value
+        // this will correct it as best as possible
+        facing = FireControl.correctFacing(getFacing());
+        
         // set game options, we derive some equipment's modes from this
         setGameOptions();
     }
@@ -2633,7 +2639,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Sets the primary facing.
      */
     public void setFacing(int facing) {
-        this.facing = facing;
+        this.facing = FireControl.correctFacing(facing);
         if (game != null) {
             game.processGameEvent(new GameEntityChangeEvent(this, this));
         }
@@ -2655,7 +2661,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Optionally does not fire a game change event (useful for bot evaluation)
      */
     public void setSecondaryFacing(int sec_facing, boolean fireEvent) {
-        this.sec_facing = sec_facing;
+        this.sec_facing = FireControl.correctFacing(sec_facing);
         if (fireEvent && (game != null)) {
             game.processGameEvent(new GameEntityChangeEvent(this, this));
         }


### PR DESCRIPTION
When working on #3065, it turns out that, in a previous turn, the civilian vehicle fish-tailed and wound up with a facing of -3. This causes the vehicle to fail to render and bot pathfinding efforts with that vehicle to fail.

Now, when setting an entity's facing a secondary facing, we call a method that guarantees a facing within range 0-5. Also, on loading a save game, we call the same method.

Fixes #3065 