### PR TITLE
fix always-retreat bot behavior

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1158,8 +1158,8 @@ public class Princess extends BotClient {
      * @return Whether or not the entity is falling back.
      */
     boolean isFallingBack(final Entity entity) {
-        return (getBehaviorSettings().shouldGoHome()) ||
-                (getBehaviorSettings().isForcedWithdrawal() && entity.isCrippled(true));
+        return (getBehaviorSettings().shouldAutoFlee() ||
+                (getBehaviorSettings().isForcedWithdrawal() && entity.isCrippled(true)));
     }
 
     /**
@@ -2143,9 +2143,9 @@ public class Princess extends BotClient {
      * launchable units in some kind of bay.
      */
     private void launchFighters(MovePath path) {
-        // if my objective is to cross the board, even though it's tempting, I won't be leaving the infantry
+        // if my objective is to cross the board, even though it's tempting, I won't be leaving the aerospace
         // behind. They're not that good at screening against high speed pursuit anyway.
-        if (getBehaviorSettings().shouldGoHome()) {
+        if (getBehaviorSettings().shouldAutoFlee()) {
             return;
         }
         


### PR DESCRIPTION
The semantics behind one of the behavior settings got changed, so Princess is getting updated to account for it.