### PR TITLE
Update Anubis ABS-3MC.mtf

### DIFF
--- a/megamek/data/mechfiles/mechs/XTRs/Periphery/Anubis ABS-3MC.mtf
+++ b/megamek/data/mechfiles/mechs/XTRs/Periphery/Anubis ABS-3MC.mtf
@@ -91,6 +91,7 @@ Endo Steel
 Endo Steel
 Stealth
 Stealth
+-Empty-
 
 Center Torso:
 Fusion Engine


### PR DESCRIPTION
Anubis ABS-3MC: Right torso only has 11 crits. Appears to be missing '-Empty-' in slot 12.