### PR TITLE
Fix Quad Location Keys

### DIFF
--- a/megamek/data/mechfiles/mechs/3067/Blue Flame BLF-21.mtf
+++ b/megamek/data/mechfiles/mechs/3067/Blue Flame BLF-21.mtf
@@ -38,7 +38,7 @@ Weapons:6
 1 ISImprovedC3CPU, Center Torso
 1 ISStreakSRM2, Head
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -52,7 +52,7 @@ Endo-Steel
 -Empty-
 -Empty-
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -122,7 +122,7 @@ Life Support
 -Empty-
 -Empty-
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -136,7 +136,7 @@ Endo-Steel
 -Empty-
 -Empty-
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator

--- a/megamek/data/mechfiles/mechs/3145/Republic/Celerity CLR-04-R.mtf
+++ b/megamek/data/mechfiles/mechs/3145/Republic/Celerity CLR-04-R.mtf
@@ -36,7 +36,7 @@ Weapons:2
 1 ISDroneOperatingSystem, Right Torso
 1 ISTSEMPOS, Right Torso
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -44,7 +44,7 @@ Foot Actuator
 Endo-Steel
 Endo-Steel
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -102,7 +102,7 @@ Sensors
 Endo-Steel
 Endo-Steel
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -110,7 +110,7 @@ Foot Actuator
 Endo-Steel
 Endo-Steel
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator

--- a/megamek/data/mechfiles/mechs/3145/Republic/Celerity CLR-05-X.mtf
+++ b/megamek/data/mechfiles/mechs/3145/Republic/Celerity CLR-05-X.mtf
@@ -37,7 +37,7 @@ Weapons:3
 1 Spikes, Left Torso
 1 ISDroneOperatingSystem, Right Torso
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -45,7 +45,7 @@ Foot Actuator
 IS Impact-Resistant
 IS Impact-Resistant
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -103,7 +103,7 @@ Sensors
 -Empty-
 -Empty-
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -111,7 +111,7 @@ Foot Actuator
 IS Impact-Resistant
 IS Impact-Resistant
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator

--- a/megamek/data/mechfiles/mechs/Operation Klondike/Daedalus GTX2 (Militarized).mtf
+++ b/megamek/data/mechfiles/mechs/Operation Klondike/Daedalus GTX2 (Militarized).mtf
@@ -44,7 +44,7 @@ Weapons:12
 1 CLRocketLauncher20Prototype, Right Torso
 1 CLRocketLauncher20Prototype, Right Torso
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -52,7 +52,7 @@ Foot Actuator
 ISMachine Gun
 ISMachine Gun
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -110,7 +110,7 @@ Heat Sink
 Sensors
 Life Support
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -118,7 +118,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator

--- a/megamek/data/mechfiles/mechs/Operation Klondike/Daedalus GTX2A Stevedore.mtf
+++ b/megamek/data/mechfiles/mechs/Operation Klondike/Daedalus GTX2A Stevedore.mtf
@@ -49,7 +49,7 @@ Weapons:17
 1 Cargo (1 ton), Right Torso
 1 Cargo (1 ton), Right Torso
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -57,7 +57,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -115,7 +115,7 @@ Heat Sink
 Sensors
 Life Support
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -123,7 +123,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator

--- a/megamek/data/mechfiles/mechs/Operation Klondike/Daedalus GTX2B Navvy.mtf
+++ b/megamek/data/mechfiles/mechs/Operation Klondike/Daedalus GTX2B Navvy.mtf
@@ -41,7 +41,7 @@ Weapons:9
 1 Backhoe, Left Torso
 1 Rock Cutter, Right Torso
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -49,7 +49,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -107,7 +107,7 @@ Heat Sink
 Sensors
 Life Support
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -115,7 +115,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator

--- a/megamek/data/mechfiles/mechs/Operation Klondike/Harvester Ant KIC-3M-B AgroMech (LRM).mtf
+++ b/megamek/data/mechfiles/mechs/Operation Klondike/Harvester Ant KIC-3M-B AgroMech (LRM).mtf
@@ -34,7 +34,7 @@ Weapons:2
 1 ISLRM5, Left Torso, Ammo:24
 1 ISLRM5, Right Torso
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -42,7 +42,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -100,7 +100,7 @@ Cockpit
 Sensors
 Life Support
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -108,7 +108,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator

--- a/megamek/data/mechfiles/mechs/TR Vehicle Annex/Harvester Ant KIC-3M-B AgroMech MOD.mtf
+++ b/megamek/data/mechfiles/mechs/TR Vehicle Annex/Harvester Ant KIC-3M-B AgroMech MOD.mtf
@@ -34,7 +34,7 @@ Weapons:2
 1 ISLRM5, Left Torso, Ammo:24
 1 ISLRM5, Right Torso
 
-Left Arm:
+Front Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -42,7 +42,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Arm:
+Front Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -100,7 +100,7 @@ Cockpit
 Sensors
 Life Support
 
-Left Leg:
+Rear Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
@@ -108,7 +108,7 @@ Foot Actuator
 -Empty-
 -Empty-
 
-Right Leg:
+Rear Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator


### PR DESCRIPTION
Appears that some quad mech files have quad-specific crit-table location keys and others have biped keys.

It would be nice for other mtf consumers if keys were consistent. 

AFAIK there's no _need_ for quad mech files with biped keys to have biped keys instead of quad keys, but someone may want to chime in on that. 