### PR TITLE
Update Atlas III AS7-D3.mtf

### DIFF
--- a/megamek/data/mechfiles/mechs/3145/Davion/Atlas III AS7-D3.mtf
+++ b/megamek/data/mechfiles/mechs/3145/Davion/Atlas III AS7-D3.mtf
@@ -72,7 +72,7 @@ ISStreakSRM6
 ISStreakSRM6
 ISMediumXPulseLaser
 ISMediumXPulseLaser
-Clan Streak SRM 6 Ammo
+IS Streak SRM 6 Ammo  
 Radical Heat Sink System
 Radical Heat Sink System
 Radical Heat Sink System

--- a/megamek/data/mechfiles/mechs/Golden Century/Omni-Corvis B.mtf
+++ b/megamek/data/mechfiles/mechs/Golden Century/Omni-Corvis B.mtf
@@ -82,8 +82,8 @@ Clan Endo Steel
 
 Right Torso:
 CLNarcBeacon (OMNIPOD)
-ISNarc Pods (OMNIPOD)
-ISNarc Pods (OMNIPOD)
+CLNarc Pods (OMNIPOD)
+CLNarc Pods (OMNIPOD)
 Clan Ferro-Fibrous
 Clan Ferro-Fibrous
 Clan Ferro-Fibrous


### PR DESCRIPTION
99.5% certain 'Clan Streak SRM6 Ammo' should be 'IS Streak SRM6 Ammo'.
The D3 has an IS Streak 6 (not a clan one) and the earlier D2 has IS Streak 6 ammo.