### PR TITLE
Adjusted FWL availability for Moltke MBT per current MUL data.

### DIFF
--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -11268,7 +11268,7 @@
 		</model>
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
-		<availability>FWL:2</availability>
+		<availability>FWL:2,DA:3</availability>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
@@ -11277,7 +11277,7 @@
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
-			<availability>FWL:4</availability>
+			<availability>FWL:2,DA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -10427,7 +10427,7 @@
 		</model>
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
-		<availability>DTA:3,CC:3,MOC:3,PR:3,DoO:4,PG:3,DO:4,TP:4,DA:4,RCM:3,MERC:3,RFS:3</availability>
+		<availability>CC:3,MOC:3,PR:3,DoO:4,DO:4,MERC:3,DTA:3,PG:3,FWL:3,TP:4,DA:4,RCM:3,RFS:3</availability>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
@@ -10436,7 +10436,7 @@
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
-			<availability>FWL:2,DA:4</availability>
+			<availability>DA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -10877,7 +10877,7 @@
 		</model>
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
-		<availability>CC:4,MOC:4,OP:4,PR:4,DoO:4,DO:4,MERC:4,DTA:4,RF:4,PG:4,TP:4,DA:6,RCM:4,RFS:4</availability>
+		<availability>CC:4,MOC:4,OP:4,PR:4,DoO:4,DO:4,MERC:4,DTA:4,RF:4,PG:4,FWL:4,TP:4,DA:6,RCM:4,RFS:4</availability>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
@@ -10886,7 +10886,7 @@
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
-			<availability>FWL:2,DA:4</availability>
+			<availability>DA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -11233,7 +11233,7 @@
 		</model>
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
-		<availability>DTA:4,CC:5,MOC:5,OP:4,RF:4,DA:7,RCM:4,MERC:4</availability>
+		<availability>DTA:4,CC:5,MOC:5,OP:4,RF:4,FWL:4,DA:7,RCM:4,MERC:4</availability>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
@@ -11242,7 +11242,7 @@
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
-			<availability>FWL:2,DA:4</availability>
+			<availability>DA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3135.xml
+++ b/megamek/data/forcegenerator/3135.xml
@@ -11873,7 +11873,7 @@
 		</model>
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
-		<availability>DTA:4,CC:5,MOC:5,OP:4,RF:4,DA:7,RCM:4,MERC:4</availability>
+		<availability>DTA:4,CC:5,MOC:5,OP:4,RF:4,FWL:4,DA:7,RCM:4,MERC:4</availability>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
@@ -11882,7 +11882,7 @@
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
-			<availability>FWL:2,DA:4</availability>
+			<availability>DA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -11752,7 +11752,7 @@
 		</model>
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
-		<availability>CC:5,MOC:5,RF:4,DA:7,MERC:4</availability>
+		<availability>CC:5,MOC:5,RF:4,FWL:5,DA:7,MERC:4</availability>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
@@ -11761,7 +11761,7 @@
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
-			<availability>FWL:2,DA:4</availability>
+			<availability>DA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3150.xml
+++ b/megamek/data/forcegenerator/3150.xml
@@ -11770,7 +11770,7 @@
 		</model>
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
-		<availability>CC:5,MOC:5,RF:4,DA:7,MERC:4</availability>
+		<availability>CC:5,MOC:5,RF:4,FWL:5,DA:7,MERC:4</availability>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
@@ -11779,7 +11779,7 @@
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
-			<availability>FWL:2,DA:4</availability>
+			<availability>DA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>


### PR DESCRIPTION
1. Adds FWL availability to Moltke MBT M1 and M2.
2. Removes FWL availability post-Jihad for the M3, which is only available to the Duchy of Andurien per MUL.

See http://masterunitlist.info/Unit/Details/2205/moltke-mbt-m1 and TRO 3085, p. 42.

Fixes #3140