### PR TITLE
protection vs npes when retrieving force camo

### DIFF
--- a/megamek/src/megamek/client/generator/skillGenerators/AbstractSkillGenerator.java
+++ b/megamek/src/megamek/client/generator/skillGenerators/AbstractSkillGenerator.java
@@ -52,6 +52,10 @@ public abstract class AbstractSkillGenerator implements Serializable {
     }
 
     public SkillLevel getLevel() {
+        if (level == null) {
+            level = SkillLevel.REGULAR;
+        }
+        
         return level;
     }
 

--- a/megamek/src/megamek/common/force/Force.java
+++ b/megamek/src/megamek/common/force/Force.java
@@ -117,6 +117,10 @@ public final class Force implements Serializable {
     }
 
     public Camouflage getCamouflageOrElse(final IGame game, final Camouflage camouflage) {
+        if (getCamouflage() == null) {
+            setCamouflage(new Camouflage());
+        }
+        
         return getCamouflage().hasDefaultCategory()
                 ? ((getParentId() == NO_FORCE) ? camouflage : getParent(game).getCamouflageOrElse(game, camouflage))
                 : getCamouflage();


### PR DESCRIPTION
Fixes another NPE when retrieving camo, this time for forces, addressing a behavior that prevents loading a game. 