### PR TITLE
nerf mausers

### DIFF
--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -73,6 +73,8 @@ public class Infantry extends Entity {
             | FIRE_ENGINEERS | MINE_ENGINEERS | SENSOR_ENGINEERS
             | TRENCH_ENGINEERS;
 
+    public static final double PRIMARY_WEAPON_DAMAGE_CAP = 0.6;
+    
     /**
      * squad size and number
      */
@@ -2275,11 +2277,26 @@ public class Infantry extends Entity {
             return 0;
         }
 
-        double damage = primaryW.getInfantryDamage() * (squadsize - secondn);
+        // per 09/2021 errata, primary infantry weapon damage caps out at .6
+        double adjustedDamage = primaryW.getInfantryDamage() > PRIMARY_WEAPON_DAMAGE_CAP ? 
+                PRIMARY_WEAPON_DAMAGE_CAP : primaryW.getInfantryDamage();
+        double damage = adjustedDamage * (squadsize - secondn);
         if(null != secondW) {
             damage += secondW.getInfantryDamage() * secondn;
         }
         return damage/squadsize;
+    }
+    
+    public boolean primaryWeaponDamageCapped() {
+        return getPrimaryWeaponDamage() > PRIMARY_WEAPON_DAMAGE_CAP;
+    }
+    
+    public double getPrimaryWeaponDamage() {
+        if (null == primaryW) {
+            return 0;
+        }
+        
+        return primaryW.getInfantryDamage();
     }
 
     public boolean isSquad() {

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -2278,8 +2278,7 @@ public class Infantry extends Entity {
         }
 
         // per 09/2021 errata, primary infantry weapon damage caps out at .6
-        double adjustedDamage = primaryW.getInfantryDamage() > PRIMARY_WEAPON_DAMAGE_CAP ? 
-                PRIMARY_WEAPON_DAMAGE_CAP : primaryW.getInfantryDamage();
+        double adjustedDamage = Math.min(PRIMARY_WEAPON_DAMAGE_CAP, primaryW.getInfantryDamage());
         double damage = adjustedDamage * (squadsize - secondn);
         if(null != secondW) {
             damage += secondW.getInfantryDamage() * secondn;

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
@@ -74,13 +74,13 @@ public abstract class InfantryWeapon extends Weapon {
 
     @Override
     public double getShortAV() {
-        return infantryDamage;
+        return getInfantryDamage();
     }
 
     @Override
     public double getMedAV() {
         if (infantryRange * 3 > AIRBORNE_WEAPON_RANGES[RANGE_SHORT]) {
-            return infantryDamage;
+            return getInfantryDamage();
         } else {
             return 0.0;
         }
@@ -89,7 +89,7 @@ public abstract class InfantryWeapon extends Weapon {
     @Override
     public double getLongAV() {
         if (infantryRange * 3 > AIRBORNE_WEAPON_RANGES[RANGE_MED]) {
-            return infantryDamage;
+            return getInfantryDamage();
         } else {
             return 0.0;
         }
@@ -98,7 +98,7 @@ public abstract class InfantryWeapon extends Weapon {
     @Override
     public double getExtAV() {
         if (infantryRange * 3 > AIRBORNE_WEAPON_RANGES[RANGE_LONG]) {
-            return infantryDamage;
+            return getInfantryDamage();
         } else {
             return 0.0;
         }
@@ -240,7 +240,7 @@ public abstract class InfantryWeapon extends Weapon {
     public int getSupportVeeSlots(Entity entity) {
         return 1;
     }
-
+    
     /*
      * (non-Javadoc)
      *
@@ -260,5 +260,4 @@ public abstract class InfantryWeapon extends Weapon {
         }
         return new InfantryWeaponHandler(toHit, waa, game, server);
     }
-
 }

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
@@ -116,7 +116,11 @@ public class InfantryWeaponHandler extends WeaponHandler {
             damage += 0.14;
         }
         int damageDealt = (int) Math.round(damage * troopersHit);
-        if (target.isConventionalInfantry() && wtype.hasFlag(WeaponType.F_INF_BURST)) {
+        
+        // conventional infantry weapons with high damage get treated as if they have the infantry burst mod
+        if (target.isConventionalInfantry() && 
+                wtype.hasFlag(WeaponType.F_INF_BURST) || 
+                (ae.isConventionalInfantry() && ((Infantry) ae).primaryWeaponDamageCapped())) {
             damageDealt += Compute.d6();
         }
         if ((target instanceof Infantry) && ((Infantry)target).isMechanized()) {

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
@@ -119,8 +119,8 @@ public class InfantryWeaponHandler extends WeaponHandler {
         
         // conventional infantry weapons with high damage get treated as if they have the infantry burst mod
         if (target.isConventionalInfantry() && 
-                wtype.hasFlag(WeaponType.F_INF_BURST) || 
-                (ae.isConventionalInfantry() && ((Infantry) ae).primaryWeaponDamageCapped())) {
+                (wtype.hasFlag(WeaponType.F_INF_BURST) || 
+                (ae.isConventionalInfantry() && ((Infantry) ae).primaryWeaponDamageCapped()))) {
             damageDealt += Compute.d6();
         }
         if ((target instanceof Infantry) && ((Infantry)target).isMechanized()) {


### PR DESCRIPTION
Per recent errata, infantry weapons have been nerfed to do a maximum of .6 damage per trooper when used as primary weapons. They do, however, get the "infantry burst fire" modifier.