### PR TITLE
Correct MUL Force Loading

### DIFF
--- a/megamek/src/megamek/common/force/Forces.java
+++ b/megamek/src/megamek/common/force/Forces.java
@@ -28,6 +28,7 @@ import megamek.common.icons.Camouflage;
 import java.io.Serializable;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -304,9 +305,9 @@ public final class Forces implements Serializable {
     public static List<Force> parseForceString(Entity entity) {
         final List<Force> forces = new ArrayList<>();
         final String a = entity.getForceString();
-        final String[] b = a.split("\\|\\|");
+        final String[] b = a.split(Pattern.quote("\\"));
         for (final String forceText : b) {
-            final String[] force = forceText.split("\\|");
+            final String[] force = forceText.split(Pattern.quote("|"));
             if ((force.length != 2) && (force.length != 4)) {
                 MegaMek.getLogger().error("Cannot parse " + forceText + " into a force! Ending parsing forces for " + entity.getShortName());
                 break;


### PR DESCRIPTION
Corrects loading force info saved with MULs.

@Windchild292 I currently have no way of creating a MUL with camo info. I assume it's stored as 
Force_Name|ID|CamoPart1|CamoPart2\Subforce|ID|CamoPart1|CamoPart2 
In that case it should now work as well. If you have such a MUL I'll test it.