### PR TITLE
remove unnecessary logging in CommonMenuBar

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -471,9 +471,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
     public synchronized void setEnabled(String command, boolean enabled) {
         if (itemMap.containsKey(command)) {
             itemMap.get(command).setEnabled(enabled);
-        } else {
-            MegaMek.getLogger().error("ActionCommand " + command + " not recognized.");
-            return;
         }
     }
 


### PR DESCRIPTION
This method is called pretty much everywhere (MovementPhaseDisplay, FiringPhaseDisplay etc), every time the user takes an action that would change the state of one or more buttons. This tends to flood the log file with unnecessary messages, as the "CommonMenuBar" doesn't have a lot of the buttons that the phase-specific bars have.. It seems to me like we can just skip this for performance reasons as it doesn't really do anything.