### PR TITLE
Array bounds protecting Entity::getCritical

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4626,8 +4626,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * Returns a critical hit slot
      */
-    public CriticalSlot getCritical(int loc, int slot) {
-        return crits[loc][slot];
+    public @Nullable CriticalSlot getCritical(int loc, int slot) {
+        return ((loc < crits.length) && (slot < crits[loc].length)) ? crits[loc][slot] : null;
     }
 
     /**


### PR DESCRIPTION
This prevents it from breaking when checking locations that may or may not exist, like the Center Leg of a Tripod 'Mech.