### PR TITLE
bulletproof mul loading in lobby with transported units

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2623,7 +2623,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Returns the primary facing, or -1 if n/a
      */
     public int getFacing() {
-        if (Entity.NONE != conveyance) {
+        if ((Entity.NONE != conveyance) && (game != null)) {
             Entity transporter = game.getEntity(conveyance);
             if (transporter == null) {
                 transporter = game.getOutOfGameEntity(conveyance);


### PR DESCRIPTION
When loading a MUL with elementals mounted on clan mechs into the lobby, it fails to load due to an NPE because the game doesn't exist yet.