### PR TITLE
Vibrabomb updates

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -108,6 +108,7 @@
 2160=<data> is hit by a vibrabomb attack.
 2161=<data> takes <data> damage to the minesweeper, <data> armor value remaining.
 2162=<data> damage transfers through the minesweeper!
+2163=<data> discovers a minefield in hex <data> using an active probe.
 2165=The swarming unit, <data>, drowns!
 2170=Inferno removed from <data> (<data>).
 2175=Inferno removed from <data> (<data>) and fire started in hex!

--- a/megamek/src/megamek/client/ui/swing/DeployMinefieldDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeployMinefieldDisplay.java
@@ -299,6 +299,7 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 return;
             }
             if (mf != null) {
+                mf.setWeaponDelivered(false);
                 clientgui.getClient().getGame().addMinefield(mf);
                 deployedMinefields.addElement(mf);
             }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4324,6 +4324,12 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 && (clientgui.getClient().getGame().getTurnIndex() != 0)) {
             return;
         }
+        
+        // if all our entities are actually done, don't start up the turn.
+        if (clientgui.getClient().getGame().getPlayerEntities(clientgui.getClient().getLocalPlayer(), false)
+                .stream().allMatch(entity -> entity.isDone())) {
+            return;
+        }
 
         if (clientgui.getClient().getGame().getPhase() != IGame.Phase.PHASE_MOVEMENT) {
             // ignore

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -710,6 +710,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     private boolean isCommander = false;
 
     protected boolean isCarefulStanding = false;
+    
+    private boolean turnWasInterrupted = false;
 
     /**
      * a vector of currently active sensors that might be able to check range
@@ -6528,6 +6530,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         setSelfDestructedThisTurn(false);
 
         setClimbMode(GUIPreferences.getInstance().getBoolean(GUIPreferences.ADVANCED_MOVE_DEFAULT_CLIMB_MODE));
+        
+        setTurnInterrupted(false);
     }
 
     /**
@@ -12331,6 +12335,18 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     public boolean isCarefulStand() {
         return false;
+    }
+    
+    public void setTurnInterrupted(boolean interrupted) {
+        turnWasInterrupted = interrupted;
+    }
+    
+    /**
+     * This should eventually be true for any situation where the entity's
+     * turn was interrupted, e.g. walking over a minefield
+     */
+    public boolean turnWasInterrupted() {
+        return turnWasInterrupted;
     }
 
     public Vector<Sensor> getSensors() {

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -72,7 +72,7 @@ public class Minefield implements Serializable, Cloneable {
     private boolean sea = false;
     private int depth = 0;
     private boolean detonated = false;
-    private boolean weaponDelivered = false;
+    private boolean weaponDelivered = true;
 
     private Minefield() {
         //Creates a minefield
@@ -222,6 +222,13 @@ public class Minefield implements Serializable, Cloneable {
      *                    a result of another minefield in the same hex explodin
      */
     public void checkReduction(int bonus, boolean direct) {
+        // per TacOps:AR page 176, non-conventional minefields automatically reduce
+        if (getType() != Minefield.TYPE_CONVENTIONAL &&
+                getType() != Minefield.TYPE_INFERNO) {
+            setDensity(getDensity() - 5);
+            return;
+        }
+        
         boolean isReduced = ((Compute.d6(2) + bonus) >= getTrigger()) || (direct && getType() != Minefield.TYPE_CONVENTIONAL && getType() != Minefield.TYPE_INFERNO);
         if(getType() == Minefield.TYPE_CONVENTIONAL && getDensity() < 10) {
             isReduced = false;

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -223,8 +223,8 @@ public class Minefield implements Serializable, Cloneable {
      */
     public void checkReduction(int bonus, boolean direct) {
         // per TacOps:AR page 176, non-conventional minefields automatically reduce
-        if (getType() != Minefield.TYPE_CONVENTIONAL &&
-                getType() != Minefield.TYPE_INFERNO) {
+        if ((getType() != Minefield.TYPE_CONVENTIONAL) &&
+                (getType() != Minefield.TYPE_INFERNO)) {
             setDensity(getDensity() - 5);
             return;
         }

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -41,6 +41,9 @@ public class Minefield implements Serializable, Cloneable {
     public static final int CLEAR_NUMBER_INF_ENG_ACCIDENT = 3;
     public static final int CLEAR_NUMBER_BA_SWEEPER = 6;
     public static final int CLEAR_NUMBER_BA_SWEEPER_ACCIDENT = 2;
+    
+    public static final int BAP_DETECT_TARGET_PREPLACED = 10;
+    public static final int BAP_DETECT_TARGET_WEAPON_DELIVERED = 7;
 
     public static final int TO_HIT_SIDE = ToHitData.SIDE_FRONT;
     public static final int TO_HIT_TABLE = ToHitData.HIT_KICK;
@@ -69,6 +72,7 @@ public class Minefield implements Serializable, Cloneable {
     private boolean sea = false;
     private int depth = 0;
     private boolean detonated = false;
+    private boolean weaponDelivered = false;
 
     private Minefield() {
         //Creates a minefield
@@ -118,6 +122,7 @@ public class Minefield implements Serializable, Cloneable {
         mf.type = type;
         mf.sea = sea;
         mf.depth = depth;
+        mf.weaponDelivered = weaponDelivered;
 
         return mf;
     }
@@ -131,7 +136,8 @@ public class Minefield implements Serializable, Cloneable {
             return false;
         }
         final Minefield other = (Minefield) obj;
-        return (playerId == other.playerId) && Objects.equals(coords, other.coords) && (type == other.type);
+        return (playerId == other.playerId) && Objects.equals(coords, other.coords) && 
+                (type == other.type) && (weaponDelivered == other.weaponDelivered);
     }
     
     @Override
@@ -201,6 +207,14 @@ public class Minefield implements Serializable, Cloneable {
         return detonated;
     }
     
+    public void setWeaponDelivered(boolean b) {
+        this.weaponDelivered = b;
+    }
+    
+    public boolean isWeaponDelivered() {
+        return weaponDelivered;
+    }
+    
     /**
      * check for a reduction in density
      * @param bonus - an <code>int</code> indicating the modifier to the target roll for reduction
@@ -217,4 +231,12 @@ public class Minefield implements Serializable, Cloneable {
         }    
     }
     
+    /**
+     * Gets the BAP detection target #
+     */
+    public int getBAPDetectionTarget() {
+        // per TacOps:AR 178, "pre-placed" minefields are detected on a 10+
+        // while weapon-delivered minefields are detected on a 7+
+        return isWeaponDelivered() ? BAP_DETECT_TARGET_WEAPON_DELIVERED : BAP_DETECT_TARGET_PREPLACED;
+    }
 }

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -219,7 +219,7 @@ public class Minefield implements Serializable, Cloneable {
      * check for a reduction in density
      * @param bonus - an <code>int</code> indicating the modifier to the target roll for reduction
      * @param direct - a <code>boolean</code> indicating whether this reduction was due to a direct explosion or
-     *                    a result of another minefield in the same hex explodin
+     *                 a result of another minefield in the same hex exploding
      */
     public void checkReduction(int bonus, boolean direct) {
         // per TacOps:AR page 176, non-conventional minefields automatically reduce

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -9353,14 +9353,12 @@ public class Server implements Runnable {
             entity.setDone(false);
             entity.setTurnInterrupted(true);
             
-            if (!game.isPhaseSimultaneous()) {
-                GameTurn newTurn = new GameTurn.SpecificEntityTurn(entity.getOwner().getId(), entity.getId());
-                // Need to set the new turn's multiTurn state
-                newTurn.setMultiTurn(true);
-                game.insertNextTurn(newTurn);
-                // brief everybody on the turn update
-                send(createTurnVectorPacket());
-            }
+            GameTurn newTurn = new GameTurn.SpecificEntityTurn(entity.getOwner().getId(), entity.getId());
+            // Need to set the new turn's multiTurn state
+            newTurn.setMultiTurn(true);
+            game.insertNextTurn(newTurn);
+            // brief everybody on the turn update
+            send(createTurnVectorPacket());
             
             // let everyone know about what just happened
             if (vPhaseReport.size() > 1) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -8122,10 +8122,11 @@ public class Server implements Runnable {
                 }
             }
             
-            // check for minefields. have to check both new hex and new
-            // elevation
+            // check for minefields. have to check both new hex and new elevation
             // VTOLs may land and submarines may rise or lower into a minefield
-            if (!lastPos.equals(curPos) || (lastElevation != curElevation)) {
+            // jumping units may end their movement with a turn but should still check at end of movement
+            if (!lastPos.equals(curPos) || (lastElevation != curElevation) || 
+                    ((stepMoveType == EntityMovementType.MOVE_JUMP) && !i.hasMoreElements())) {
                 boolean boom = false;
                 if (isOnGround) {
                     boom = checkVibrabombs(entity, curPos, false, lastPos, curPos, vPhaseReport);

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -505,9 +505,10 @@ public class ServerHelper {
                     if (roll >= minefield.getBAPDetectionTarget()) {
                         minefieldDetected = true;
                         
-                        Report r = new Report(2120);
+                        Report r = new Report(2163);
                         r.subject = entity.getId();
                         r.add(entity.getShortName(), true);
+                        r.add(potentialMineCoords.toFriendlyString());
                         vPhaseReport.add(r);
                         
                         server.revealMinefield(entity.getOwner(), minefield);

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -20,6 +20,7 @@ package megamek.server;
 
 import java.util.*;
 import megamek.common.*;
+import megamek.common.IGame.Phase;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.other.TSEMPWeapon;
 
@@ -451,6 +452,70 @@ public class ServerHelper {
         }
     }
 
-
-  
+    /**
+     * Loops through all active entities in the game and performs mine detection
+     */
+    public static void detectMinefields(IGame game, Vector<Report> vPhaseReport, Server server) {
+        boolean tacOpsBap = game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_BAP);
+        
+        // if the entity is on the board
+        // and it either a) hasn't moved or b) we're not using TacOps BAP rules
+        // if we are not using the TacOps BAP rules, that means we only check the entity's final hex
+        // if we are using TacOps BAP rules, all moved entities have made all their checks already
+        // so we just need to do the unmoved entities
+        for (Entity entity : game.getEntitiesVector()) {
+            if (!entity.isOffBoard() && entity.isDeployed() &&
+                    ((entity.delta_distance == 0) || !tacOpsBap)) {
+                detectMinefields(game, entity, entity.getPosition(), vPhaseReport, server);
+            }
+        }
+    }
+    
+    /**
+     * Checks for minefields within the entity's active probe range.
+     * @return True if any minefields have been detected.
+     */
+    public static boolean detectMinefields(IGame game, Entity entity, Coords coords, 
+            Vector<Report> vPhaseReport, Server server) {
+        if (!game.getOptions().booleanOption(OptionsConstants.ADVANCED_MINEFIELDS)) {
+            return false;
+        }
+        
+        int probeRange = entity.getBAPRange();
+        if (probeRange <= 0) {
+            return false;
+        }
+        
+        boolean minefieldDetected = false;
+        
+        for (int distance = 1; distance <= probeRange; distance++) {      
+            for (Coords potentialMineCoords : coords.allAtDistance(distance)) {
+                if (!game.getBoard().contains(potentialMineCoords)) {
+                    continue;
+                }
+                
+                for (Minefield minefield : game.getMinefields(potentialMineCoords)) {
+                    // no need to roll for already revealed minefields
+                    if (entity.getOwner().containsMinefield(minefield)) {
+                        continue;
+                    }
+                    
+                    int roll = Compute.d6(2);
+                    
+                    if (roll >= minefield.getBAPDetectionTarget()) {
+                        minefieldDetected = true;
+                        
+                        Report r = new Report(2120);
+                        r.subject = entity.getId();
+                        r.add(entity.getShortName(), true);
+                        vPhaseReport.add(r);
+                        
+                        server.revealMinefield(entity.getOwner(), minefield);
+                    }
+                }
+            }
+        }
+        
+        return minefieldDetected;
+    }  
 }


### PR DESCRIPTION
This pull request does a few things:

- properly reveals vibrabomb hexes that go off during a mech's movement
- allows active probes to reveal mines along the movement path when using "TacOps active probes" rules
- stops the unit's movement if it reveals a minefield during movement
- prevents soft-lock if a unit's movement is stopped when using simultaneous movement (the unit is able to keep moving but the server refuses to process subsequent commands because it's "done")

TODO:
- mark weapon-delivered minefields appropriately, different detection target numbers [done]
- check whether a jumping mech is properly triggering vibrabombs/minefields upon landing (was not happening when last step was a facing change) [done]
- prevent units from changing movement modes when movement is interrupted (must store "original" movement mode and prevent it from being changed) [going to a separate pull request]
- minefields isn't being activated when the activating unit also detects a different minefield [false alarm - there is an under the hood roll to trigger conventional minefields]

A follow-up will likely be to allow the detection of hidden units as per "TacOps active probes" rules (currently unimplemented)