### PR TITLE
dead-fire missile errata

### DIFF
--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -915,9 +915,6 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
             }
 
             isHotLoaded = link.hotloaded;
-            if (((AmmoType) link.getType()).getMunitionType() == AmmoType.M_DEAD_FIRE) {
-                return true;
-            }
 
             // Check to see if the ammo has its mode set to hotloaded.
             // This is for vehicles that can change hotload status during
@@ -932,10 +929,6 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
 
         if (getType() instanceof AmmoType) {
             isHotLoaded = hotloaded;
-
-            if (((AmmoType) getType()).getMunitionType() == AmmoType.M_DEAD_FIRE) {
-                return true;
-            }
 
             // Check to see if the ammo has its mode set to hotloaded.
             // This is for vehicles that can change hotload status during

--- a/megamek/src/megamek/common/weapons/LRMDeadFireHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMDeadFireHandler.java
@@ -15,7 +15,6 @@ package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.AmmoType;
 import megamek.common.IGame;
 import megamek.common.Report;
 import megamek.common.ToHitData;

--- a/megamek/src/megamek/common/weapons/LRMDeadFireHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMDeadFireHandler.java
@@ -13,7 +13,11 @@
  */
 package megamek.common.weapons;
 
+import java.util.Vector;
+
+import megamek.common.AmmoType;
 import megamek.common.IGame;
+import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.server.Server;
@@ -39,17 +43,28 @@ public class LRMDeadFireHandler extends LRMHandler {
         super(t, w, g, s);
         sSalvoType = " dead fire missile(s) ";
     }
-
+    
     /*
      * (non-Javadoc)
-     * 
-     * @see megamek.common.weapons.WeaponHandler#calcnCluster()
+     *
+     * @see megamek.common.weapons.WeaponHandler#calcHits(java.util.Vector)
      */
     @Override
-    protected int calcnCluster() {
-        return 1;
+    protected int calcHits(Vector<Report> vPhaseReport) {
+        // Per IntOps p. 132, dead-fire missiles do 2 damage per missile, but still in 5 point clusters
+        // so we figure out how many missile hits get done first, then implement a hack similar to that in ATMHandler
+        int hits = super.calcHits(vPhaseReport);
+        // change to 5 damage clusters here, after AMS has been done
+        hits = nDamPerHit * hits;
+        nDamPerHit = 1;
+        return hits;
     }
 
+    @Override
+    protected int getClusterModifiers(boolean clusterRangePenalty) {
+        return super.getClusterModifiers(clusterRangePenalty) - 3;
+    }
+    
     /*
      * (non-Javadoc)
      * 

--- a/megamek/src/megamek/common/weapons/SRMDeadFireHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMDeadFireHandler.java
@@ -42,16 +42,11 @@ public class SRMDeadFireHandler extends SRMHandler {
         sSalvoType = " dead fire missile(s) ";
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see megamek.common.weapons.WeaponHandler#calcnCluster()
-     */
     @Override
-    protected int calcnCluster() {
-        return 1;
+    protected int getClusterModifiers(boolean clusterRangePenalty) {
+        return super.getClusterModifiers(clusterRangePenalty) - 3;
     }
-
+    
     /*
      * (non-Javadoc)
      * 


### PR DESCRIPTION
Updated dead-fire missiles per intops page 132. LRMs now deliver damage in 5 point clusters, and neither SRM nor LRM are now considered hot-loaded.