### PR TITLE
naval vessels passing over bottom mud no longer take MP penalty

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -2999,6 +2999,13 @@ public class MoveStep implements Serializable {
             // if this is an amphibious unit crossing water, increment movement cost by 1
             if(isAmphibious && !destHex.containsTerrain(Terrains.ICE) && (destHex.terrainLevel(Terrains.WATER) > 0)) {
                 mp++;
+                
+                // this is kind of a hack, but only occurs when an amphibious unit passes over mud at the bottom
+                // of a body of water. We can't account for that in the hex's movement cost function
+                // because it doesn't have the ability to pretend the entity is at a particular elevation
+                if (destHex.containsTerrain(Terrains.MUD) && destHex.floor() < nDestEl) {
+                    mp--;
+                }
             }
             
             // non-hovers, non-navals and non-VTOLs check for water depth and

--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -438,7 +438,7 @@ public class Terrain implements ITerrain, Serializable {
                 }
                 return 0;
             case Terrains.MUD:
-                if ((moveMode == EntityMovementMode.HOVER) || (moveMode == EntityMovementMode.WIGE)) {
+                if ((moveMode == EntityMovementMode.HOVER) || (moveMode == EntityMovementMode.WIGE) || e.isNaval()) {
                     return 0;
                 }
                 if (e.hasAbility(OptionsConstants.PILOT_TM_SWAMP_BEAST)) {


### PR DESCRIPTION
fixes #2217

Took the easy way out since naval vessels never actually go over the mud. Don't give amphibious vehicles the penalty either if they're above the bottom of the lake.