### PR TITLE
Issue 3015: Tonnage in the lobby table

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -18,41 +18,26 @@
  */
 package megamek.client.ui.swing.lobby;
 
-import static megamek.client.ui.Messages.getString;
-import static megamek.client.ui.swing.lobby.MekTableModel.DOT_SPACER;
-import static megamek.client.ui.swing.util.UIUtil.*;
-
-import java.awt.Color;
-import java.text.MessageFormat;
-import java.util.List;
-
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.PlayerColour;
-import megamek.common.Aero;
-import megamek.common.Board;
-import megamek.common.Crew;
-import megamek.common.Entity;
-import megamek.common.FighterSquadron;
-import megamek.common.GunEmplacement;
-import megamek.common.IAero;
-import megamek.common.IGame;
-import megamek.common.IPlayer;
-import megamek.common.IStartingPositions;
-import megamek.common.Infantry;
-import megamek.common.MapSettings;
-import megamek.common.Mech;
-import megamek.common.Protomech;
-import megamek.common.Tank;
-import megamek.common.UnitType;
-import megamek.common.VTOL;
+import megamek.common.*;
 import megamek.common.force.Force;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.CollectionUtil;
 import megamek.common.util.CrewSkillSummaryUtil;
+
+import java.awt.*;
+import java.text.MessageFormat;
+import java.text.NumberFormat;
+import java.util.List;
+
+import static megamek.client.ui.Messages.getString;
+import static megamek.client.ui.swing.lobby.MekTableModel.DOT_SPACER;
+import static megamek.client.ui.swing.util.UIUtil.*;
 
 class LobbyMekCellFormatter {
     
@@ -141,7 +126,9 @@ class LobbyMekCellFormatter {
         if (forceView) {
             result.append(DOT_SPACER);
         }
-        result.append(Math.round(entity.getWeight()) + Messages.getString("ChatLounge.Tons"));
+        NumberFormat formatter = NumberFormat.getNumberInstance(PreferenceManager.getClientPreferences().getLocale());
+        result.append(formatter.format(entity.getWeight()));
+        result.append(Messages.getString("ChatLounge.Tons"));
         result.append("</FONT>");
         
         // Invalid Design

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
@@ -39,6 +39,7 @@ import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.options.OptionsConstants;
+import megamek.common.preference.PreferenceManager;
 
 class PlayerTable extends JTable {
     private static final long serialVersionUID = 6252953920509362407L;
@@ -202,7 +203,8 @@ class PlayerTable extends JTable {
             result.append(UIUtil.DOT_SPACER);
             result.append(guiScaledFontHTML());
             result.append("BV: ");
-            result.append((player.getBV() != 0) ? NumberFormat.getIntegerInstance().format(player.getBV()) : "--");
+            NumberFormat formatter = NumberFormat.getIntegerInstance(PreferenceManager.getClientPreferences().getLocale());
+            result.append((player.getBV() != 0) ? formatter.format(player.getBV()) : "--");
             result.append("</FONT>");
 
             // Initiative Mod


### PR DESCRIPTION
- The lobby unit table now displays the tonnage unrounded, i.e. a Foot Platoon Rifle will accurately show 2.5 Tons instead of 3. The number is formatted by the locale of the preferences
- Changed the player BV display to also use the locale of the preferences instead of the PC's default locale to make the number display fit MM's language setting.
![image](https://user-images.githubusercontent.com/17069663/137586479-449f2631-9052-4e86-b851-e7b8bb463f52.png)
![image](https://user-images.githubusercontent.com/17069663/137586471-83a0c0ea-aa29-4b5e-8487-d13d9f57cb24.png)

Resolves #3015 