### PR TITLE
CommonSettings cleanup & base on AbstractDialog

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -269,8 +269,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements
     @Override
     protected Container createCenterPane() {
         JTabbedPane panTabs = new JTabbedPane();
-        setLayout(new BorderLayout());
-        getContentPane().add(panTabs, BorderLayout.CENTER);
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
@@ -293,7 +291,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements
         panTabs.add("Button Order", getButtonOrderPanel());
         panTabs.add("Advanced", advancedSettingsPane);
 
-        pack();
         return panTabs;
     }
 

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1,99 +1,86 @@
 /*
- * MegaMek - Copyright (C) 2003, 2004, 2005 Ben Mazur (bmazur@sev.org)
+ * MegaMek
+ * Copyright (C) 2003, 2004, 2005 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This file is part of MegaMek.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package megamek.client.ui.swing;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.event.*;
-import java.io.File;
-import java.io.FilenameFilter;
-import java.util.*;
+import megamek.client.ui.Messages;
+import megamek.client.ui.baseComponents.AbstractButtonDialog;
+import megamek.client.ui.swing.StatusBarPhaseDisplay.PhaseCommand;
+import megamek.client.ui.swing.util.KeyCommandBind;
+import megamek.client.ui.swing.widget.SkinXMLHandler;
+import megamek.common.Configuration;
+import megamek.common.Entity;
+import megamek.common.IGame;
+import megamek.common.KeyBindParser;
+import megamek.common.preference.IClientPreferences;
+import megamek.common.preference.PreferenceManager;
+
 import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.*;
+import java.awt.*;
+import java.awt.event.*;
+import java.io.File;
+import java.util.List;
+import java.util.*;
 
-import megamek.client.ui.Messages;
-import megamek.client.ui.swing.StatusBarPhaseDisplay.PhaseCommand;
-import megamek.client.ui.swing.util.KeyCommandBind;
-import megamek.client.ui.swing.widget.SkinXMLHandler;
-import megamek.common.*;
-import megamek.common.preference.IClientPreferences;
-import megamek.common.preference.PreferenceManager;
-
-public class CommonSettingsDialog extends ClientDialog implements
-        ActionListener, ItemListener, FocusListener, ListSelectionListener,
+/** The Client Settings Dialog offering GUI options concerning tooltips, map display, keybinds etc. */
+public class CommonSettingsDialog extends AbstractButtonDialog implements
+        ItemListener, FocusListener, ListSelectionListener,
         ChangeListener {
 
     /**
      * A class for storing information about an GUIPreferences advanced option.
-     *
      * @author arlith
-     *
      */
-    private class AdvancedOptionData implements Comparable<AdvancedOptionData> {
+    private static class AdvancedOptionData implements Comparable<AdvancedOptionData> {
 
         public String option;
-
         public AdvancedOptionData(String option) {
             this.option = option;
         }
 
-        /**
-         * Returns true if this option has tooltip text.
-         *
-         * @return
-         */
+        /** Returns true if this option has tooltip text. */
         public boolean hasTooltipText() {
             return Messages.keyExists("AdvancedOptions." + option + ".tooltip");
         }
 
-        /**
-         * Returns the tooltip text for this option.
-         *
-         * @return
-         */
+        /** Returns the tooltip text for this option. */
         public String getTooltipText() {
             return Messages.getString("AdvancedOptions." + option + ".tooltip");
         }
 
-        /**
-         * Returns a human-readable name for this advanced option.
-         *
-         */
+        /** Returns a human-readable name for this advanced option. */
         public String toString() {
-            if (Messages.keyExists("AdvancedOptions." + option + ".name")) {
-                return Messages.getString("AdvancedOptions." + option + ".name");
-            } else {
-                return option;
-            }
+            String key = "AdvancedOptions." + option + ".name";
+            return Messages.keyExists(key) ? Messages.getString(key) : option;
         }
 
         @Override
         public int compareTo(AdvancedOptionData other) {
-            return this.toString().compareTo(other.toString());
+            return toString().compareTo(other.toString());
         }
     }
 
-    private class PhaseCommandListMouseAdapter extends MouseInputAdapter {
+    private static class PhaseCommandListMouseAdapter extends MouseInputAdapter {
         private boolean mouseDragging = false;
         private int dragSourceIndex;
 
@@ -133,67 +120,61 @@ public class CommonSettingsDialog extends ClientDialog implements
             srcModel.remove(srcIndex);
             srcModel.add(trgIndex, dragElement);
         }
-
     }
-    
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1535370193846895473L;
 
-    private JCheckBox autoEndFiring;
-    private JCheckBox autoDeclareSearchlight;
-    private JCheckBox nagForMASC;
-    private JCheckBox nagForPSR;
-    private JCheckBox nagForWiGELanding;
-    private JCheckBox nagForNoAction;
-    private JCheckBox animateMove;
-    private JCheckBox showWrecks;
-    private JCheckBox soundMute;
-    private JCheckBox showWpsinTT;
-    private JCheckBox showArmorMiniVisTT;
-    private JCheckBox showPilotPortraitTT;
-    private JCheckBox chkAntiAliasing;
+    private final JCheckBox autoEndFiring = new JCheckBox(Messages.getString("CommonSettingsDialog.autoEndFiring"));
+    private final JCheckBox autoDeclareSearchlight = new JCheckBox(Messages.getString("CommonSettingsDialog.autoDeclareSearchlight"));
+    private final JCheckBox nagForMASC = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForMASC"));
+    private final JCheckBox nagForPSR = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForPSR"));
+    private final JCheckBox nagForWiGELanding = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForWiGELanding"));
+    private final JCheckBox nagForNoAction = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForNoAction"));
+    private final JCheckBox animateMove = new JCheckBox(Messages.getString("CommonSettingsDialog.animateMove"));
+    private final JCheckBox showWrecks = new JCheckBox(Messages.getString("CommonSettingsDialog.showWrecks"));
+    private final JCheckBox soundMute = new JCheckBox(Messages.getString("CommonSettingsDialog.soundMute"));
+    private final JCheckBox showWpsinTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showWpsinTT"));
+    private final JCheckBox showArmorMiniVisTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showArmorMiniVisTT"));
+    private final JCheckBox showPilotPortraitTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showPilotPortraitTT"));
+    private final JCheckBox chkAntiAliasing = new JCheckBox(Messages.getString("CommonSettingsDialog.antiAliasing"));
     private JComboBox<String> defaultWeaponSortOrder;
     private JTextField tooltipDelay;
     private JTextField tooltipDismissDelay;
     private JTextField tooltipDistSupression;
     private JComboBox<String> unitStartChar;
     private JTextField maxPathfinderTime;
-    private JCheckBox getFocus;
+    private final JCheckBox getFocus = new JCheckBox(Messages.getString("CommonSettingsDialog.getFocus"));
     private JSlider guiScale;
 
-    private JCheckBox keepGameLog;
+    private final JCheckBox keepGameLog = new JCheckBox(Messages.getString("CommonSettingsDialog.keepGameLog"));
     private JTextField gameLogFilename;
     // private JTextField gameLogMaxSize;
-    private JCheckBox stampFilenames;
+    private final JCheckBox stampFilenames = new JCheckBox(Messages.getString("CommonSettingsDialog.stampFilenames"));
     private JTextField stampFormat;
-    private JCheckBox defaultAutoejectDisabled;
-    private JCheckBox useAverageSkills;
-    private JCheckBox generateNames;
-    private JCheckBox showUnitId;
+    private final JCheckBox defaultAutoejectDisabled = new JCheckBox(Messages.getString("CommonSettingsDialog.defaultAutoejectDisabled"));
+    private final JCheckBox useAverageSkills = new JCheckBox(Messages.getString("CommonSettingsDialog.useAverageSkills"));
+    private final JCheckBox generateNames = new JCheckBox(Messages.getString("CommonSettingsDialog.generateNames"));
+    private final JCheckBox showUnitId = new JCheckBox(Messages.getString("CommonSettingsDialog.showUnitId"));
     private JComboBox<String> displayLocale;
-    private JCheckBox showIPAddressesInChat;
+    private final JCheckBox showIPAddressesInChat = new JCheckBox(Messages.getString("CommonSettingsDialog.showIPAddressesInChat"));
 
-    private JCheckBox showDamageLevel;
-    private JCheckBox showDamageDecal;
-    private JCheckBox showMapsheets;
-    private JCheckBox aOHexShadows;
-    private JCheckBox floatingIso;
-    private JCheckBox mmSymbol;
-    private JCheckBox entityOwnerColor;
-    private JCheckBox teamColoring;
-    private JCheckBox useSoftCenter;
-    private JCheckBox levelhighlight;
-    private JCheckBox shadowMap;
-    private JCheckBox hexInclines;
-    private JCheckBox mouseWheelZoom;
-    private JCheckBox mouseWheelZoomFlip;
+    private final JCheckBox showDamageLevel = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageLevel"));
+    private final JCheckBox showDamageDecal = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageDecal"));
+    private final JCheckBox showMapsheets = new JCheckBox(Messages.getString("CommonSettingsDialog.showMapsheets"));
+    private final JCheckBox aOHexShadows = new JCheckBox(Messages.getString("CommonSettingsDialog.AOHexSHadows"));
+    private final JCheckBox floatingIso = new JCheckBox(Messages.getString("CommonSettingsDialog.floatingIso"));
+    private final JCheckBox mmSymbol = new JCheckBox(Messages.getString("CommonSettingsDialog.mmSymbol"));
+    private final JCheckBox entityOwnerColor = new JCheckBox(Messages.getString("CommonSettingsDialog.entityOwnerColor"));
+    private final JCheckBox teamColoring = new JCheckBox(Messages.getString("CommonSettingsDialog.teamColoring"));
+    private final JCheckBox useSoftCenter = new JCheckBox(Messages.getString("CommonSettingsDialog.useSoftCenter"));
+    private final JCheckBox levelhighlight = new JCheckBox(Messages.getString("CommonSettingsDialog.levelHighlight"));
+    private final JCheckBox shadowMap = new JCheckBox(Messages.getString("CommonSettingsDialog.useShadowMap"));
+    private final JCheckBox hexInclines = new JCheckBox(Messages.getString("CommonSettingsDialog.useInclines"));
+    private final JCheckBox mouseWheelZoom = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoom"));
+    private final JCheckBox mouseWheelZoomFlip = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoomFlip"));
 
     // Tactical Overlay Options
-    private JCheckBox fovInsideEnabled;
+    private final JCheckBox fovInsideEnabled = new JCheckBox(Messages.getString("TacticalOverlaySettingsDialog.FovInsideEnabled"));
     private JSlider fovHighlightAlpha;
-    private JCheckBox fovOutsideEnabled;
+    private final JCheckBox fovOutsideEnabled = new JCheckBox(Messages.getString("TacticalOverlaySettingsDialog.FovOutsideEnabled"));
     private JSlider fovDarkenAlpha;
     private JSlider numStripesSlider;
     private JCheckBox fovGrayscaleEnabled;
@@ -210,11 +191,10 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JLabel stampFormatLabel;
     private JLabel gameLogFilenameLabel;
 
-    private JCheckBox gameSummaryBV;
-    private JCheckBox gameSummaryMM;
+    private final JCheckBox gameSummaryBV = new JCheckBox(Messages.getString("CommonSettingsDialog.gameSummaryBV.name"));
+    private final JCheckBox gameSummaryMM = new JCheckBox(Messages.getString("CommonSettingsDialog.gameSummaryMM.name"));
 
     private JComboBox<String> skinFiles;
-
     private JComboBox<UITheme> uiThemes;
 
     // Avanced Settings
@@ -228,38 +208,26 @@ public class CommonSettingsDialog extends ClientDialog implements
     private DefaultListModel<StatusBarPhaseDisplay.PhaseCommand> firingPhaseCommands;
     private DefaultListModel<StatusBarPhaseDisplay.PhaseCommand> physicalPhaseCommands;
     private DefaultListModel<StatusBarPhaseDisplay.PhaseCommand> targetingPhaseCommands;
-    private StatusBarPhaseDisplay.CommandComparator cmdComp = new StatusBarPhaseDisplay.CommandComparator(); 
-    private PhaseCommandListMouseAdapter cmdMouseAdaptor = new PhaseCommandListMouseAdapter();
+    private final StatusBarPhaseDisplay.CommandComparator cmdComp = new StatusBarPhaseDisplay.CommandComparator();
+    private final PhaseCommandListMouseAdapter cmdMouseAdaptor = new PhaseCommandListMouseAdapter();
     
     private JComboBox<String> tileSetChoice;
-    private List<File> tileSets;
+    private List<String> tileSets;
     
-    private MMToggleButton choiceToggle = new MMToggleButton("Enable tabbing through this dialog page");
+    private final MMToggleButton choiceToggle = new MMToggleButton("Enable tabbing through this dialog page");
 
-    /**
-     * A Map that maps command strings to a JTextField for updating the modifier
-     * for the command.
-     */
+    /** Maps command strings to a JTextField for updating the modifier for the command. */
     private Map<String, JTextField> cmdModifierMap;
 
-    /**
-     * A Map that maps command strings to a JTextField for updating the key
-     * for the command.
-     */
+    /** Maps command strings to a JTextField for updating the key for the command. */
     private Map<String, JTextField> cmdKeyMap;
     
-    /**
-     * A Map that maps command strings to a Integer for updating the key
-     * for the command.
-     */
+    /** Maps command strings to a Integer for updating the key for the command. */
     private Map<String, Integer> cmdKeyCodeMap; 
 
     private ClientGUI clientgui = null;
 
-    private static final String CANCEL = "CANCEL"; //$NON-NLS-1$
-    private static final String UPDATE = "UPDATE"; //$NON-NLS-1$
-
-    private static final String[] LOCALE_CHOICES = { "en", "de", "ru" }; //$NON-NLS-1$
+    private static final String[] LOCALE_CHOICES = { "en", "de", "ru" };
     
     private static final Dimension LABEL_SPACER = new Dimension(5,0);
     private static final Dimension DEPENDENT_INSET = new Dimension(25,0);
@@ -278,6 +246,7 @@ public class CommonSettingsDialog extends ClientDialog implements
     private boolean savedUnitLabelBorder;
     private boolean savedShowDamageDecal;
     private boolean savedShowDamageLabel;
+    private boolean savedAntiAlias;
     private String savedFovHighlightRingsRadii;
     private String savedFovHighlightRingsColors;
     private int savedFovHighlightAlpha;
@@ -285,114 +254,72 @@ public class CommonSettingsDialog extends ClientDialog implements
     private int savedNumStripesSlider;
     HashMap<String, String> savedAdvancedOpt = new HashMap<>();
 
-    /**
-     * Standard constructor. There is no default constructor for this class.
-     *
-     * @param owner - the <code>Frame</code> that owns this dialog.
-     */
+    /** Constructs the Client Settings Dialog with a clientgui (used within the client, i.e. in lobby and game). */
     public CommonSettingsDialog(JFrame owner, ClientGUI cg) {
         this(owner);
         clientgui = cg;
     }
     
-    /**
-     * Standard constructor. There is no default constructor for this class.
-     *
-     * @param owner - the <code>Frame</code> that owns this dialog.
-     */
+    /** Constructs the Client Settings Dialog without a clientgui (used in the main menu and board editor). */
     public CommonSettingsDialog(JFrame owner) {
-        super(owner, Messages.getString("CommonSettingsDialog.title"), true);
+        super(owner, true, "ClientSettings", "CommonSettingsDialog.title");
+        initialize();
+    }
 
+    @Override
+    protected Container createCenterPane() {
         JTabbedPane panTabs = new JTabbedPane();
         setLayout(new BorderLayout());
         getContentPane().add(panTabs, BorderLayout.CENTER);
-        getContentPane().add(getButtonsPanel(), BorderLayout.PAGE_END);
-        // Close this dialog when the window manager says to.
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
-                cancel();
+                cancelAction();
             }
         });
 
-        // Add the tabs
-        JPanel settingsPanel = getSettingsPanel();
         JScrollPane settingsPane = new JScrollPane(getSettingsPanel());
         settingsPane.getVerticalScrollBar().setUnitIncrement(16);
-        panTabs.add("Main", settingsPane);
-        
         JScrollPane graphicsPane = new JScrollPane(getGraphicsPanel());
         graphicsPane.getVerticalScrollBar().setUnitIncrement(16);
-        panTabs.add("Graphics", graphicsPane);
-
         JScrollPane keyBindPane = new JScrollPane(getKeyBindPanel());
         keyBindPane.getVerticalScrollBar().setUnitIncrement(16);
-        panTabs.add("Key Binds", keyBindPane);
-
-        panTabs.add("Button Order", getButtonOrderPanel());
-        
         JScrollPane advancedSettingsPane = new JScrollPane(getAdvancedSettingsPanel());
         advancedSettingsPane.getVerticalScrollBar().setUnitIncrement(16);
+
+        panTabs.add("Main", settingsPane);
+        panTabs.add("Graphics", graphicsPane);
+        panTabs.add("Key Binds", keyBindPane);
+        panTabs.add("Button Order", getButtonOrderPanel());
         panTabs.add("Advanced", advancedSettingsPane);
 
         pack();
-        setLocationAndSize(getPreferredSize().width, settingsPanel.getPreferredSize().height);
-    }
-
-    private JPanel getButtonsPanel() {
-        // Add the dialog controls.
-        JPanel buttons = new JPanel();
-        buttons.setLayout(new GridLayout(1, 0, 20, 5));
-        JButton update = new JButton(Messages.getString("CommonSettingsDialog.Update")); //$NON-NLS-1$
-        update.setActionCommand(UPDATE);
-        update.setMnemonic(KeyEvent.VK_U);
-        update.addActionListener(this);
-        buttons.add(update);
-        JButton cancel = new JButton(Messages.getString("Cancel")); //$NON-NLS-1$
-        cancel.setActionCommand(CANCEL);
-        cancel.setMnemonic(KeyEvent.VK_C);
-        cancel.addActionListener(this);
-        buttons.add(cancel);
-
-        return buttons;
+        return panTabs;
     }
 
     private JPanel getSettingsPanel() {
 
-        ArrayList<ArrayList<Component>> comps = new ArrayList<ArrayList<Component>>();
+        List<List<Component>> comps = new ArrayList<>();
         ArrayList<Component> row;
 
-        // displayLocale settings
-        JLabel displayLocaleLabel = new JLabel(Messages.getString("CommonSettingsDialog.locale")); //$NON-NLS-1$
-        displayLocale = new JComboBox<String>();
-        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.English")); //$NON-NLS-1$
-        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Deutsch")); //$NON-NLS-1$
-        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Russian")); //$NON-NLS-1$
+        JLabel displayLocaleLabel = new JLabel(Messages.getString("CommonSettingsDialog.locale"));
+        displayLocale = new JComboBox<>();
+        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.English")); 
+        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Deutsch")); 
+        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Russian")); 
         displayLocale.setMaximumSize(new Dimension(150,40));
         row = new ArrayList<>();
         row.add(displayLocaleLabel);
         row.add(displayLocale);
         comps.add(row);
         
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
+        addLineSpacer(comps);
 
-        JSeparator Sep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(Sep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
-        // --------------   
         guiScale = new JSlider();
         guiScale.setMajorTickSpacing(3);
         guiScale.setMinimum(7);
         guiScale.setMaximum(24);
-        Hashtable<Integer, JComponent> table = new Hashtable<Integer, JComponent>();
+        Hashtable<Integer, JComponent> table = new Hashtable<>();
         table.put(7, new JLabel("70%"));
         table.put(10, new JLabel("100%"));
         table.put(16, new JLabel("160%"));
@@ -408,66 +335,17 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(guiScale);
         comps.add(row);
 
-        showDamageLevel = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageLevel")); //$NON-NLS-1$
-        showDamageLevel.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(showDamageLevel);
-        comps.add(row);
-        
-        showDamageDecal = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageDecal")); //$NON-NLS-1$
-        showDamageDecal.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(showDamageDecal);
-        comps.add(row);
-        
-        showUnitId = new JCheckBox(Messages.getString("CommonSettingsDialog.showUnitId")); //$NON-NLS-1$
-        showUnitId.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(showUnitId);
-        comps.add(row);
+        comps.add(checkboxEntry(showDamageLevel, null));
+        comps.add(checkboxEntry(showDamageDecal, null));
+        comps.add(checkboxEntry(showUnitId, null));
+        comps.add(checkboxEntry(entityOwnerColor, null));
+        comps.add(checkboxEntry(teamColoring, null));
+        comps.add(checkboxEntry(useSoftCenter, Messages.getString("CommonSettingsDialog.useSoftCenterTip")));
+        addLineSpacer(comps);
 
-        entityOwnerColor = new JCheckBox(Messages.getString("CommonSettingsDialog.entityOwnerColor")); //$NON-NLS-1$
-        entityOwnerColor.setToolTipText(Messages.getString("CommonSettingsDialog.entityOwnerColorTip"));
-        entityOwnerColor.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(entityOwnerColor);
-        comps.add(row);
-        
-        teamColoring = new JCheckBox(Messages.getString("CommonSettingsDialog.teamColoring"));
-        teamColoring.setToolTipText(Messages.getString("CommonSettingsDialog.teamColoringTip"));
-        teamColoring.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(teamColoring);
-        comps.add(row);
-        
-        useSoftCenter = new JCheckBox(Messages.getString("CommonSettingsDialog.useSoftCenter")); //$NON-NLS-1$
-        useSoftCenter.setToolTipText(Messages.getString("CommonSettingsDialog.useSoftCenterTip"));
-        useSoftCenter.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(useSoftCenter);
-        comps.add(row);
-        
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
-
-        Sep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(Sep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
-        // --------------        
-
-        // Tooltip Stuff
-        //
-        // Popup Delay and Dismiss Delay
         tooltipDelay = new JTextField(4);
         tooltipDelay.setMaximumSize(new Dimension(150,40));
-        JLabel tooltipDelayLabel = new JLabel(Messages.getString("CommonSettingsDialog.tooltipDelay")); //$NON-NLS-1$
+        JLabel tooltipDelayLabel = new JLabel(Messages.getString("CommonSettingsDialog.tooltipDelay")); 
         row = new ArrayList<>();
         row.add(tooltipDelayLabel);
         row.add(tooltipDelay);
@@ -476,7 +354,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         tooltipDismissDelay = new JTextField(4);
         tooltipDismissDelay.setMaximumSize(new Dimension(150,40));
         tooltipDismissDelay.setToolTipText(Messages.getString("CommonSettingsDialog.tooltipDismissDelayTooltip"));
-        JLabel tooltipDismissDelayLabel = new JLabel(Messages.getString("CommonSettingsDialog.tooltipDismissDelay")); //$NON-NLS-1$
+        JLabel tooltipDismissDelayLabel = new JLabel(Messages.getString("CommonSettingsDialog.tooltipDismissDelay")); 
         tooltipDismissDelayLabel.setToolTipText(Messages.getString("CommonSettingsDialog.tooltipDismissDelayTooltip"));
         row = new ArrayList<>();
         row.add(tooltipDismissDelayLabel);
@@ -486,48 +364,18 @@ public class CommonSettingsDialog extends ClientDialog implements
         tooltipDistSupression = new JTextField(4);
         tooltipDistSupression.setMaximumSize(new Dimension(150,40));
         tooltipDistSupression.setToolTipText(Messages.getString("CommonSettingsDialog.tooltipDistSuppressionTooltip"));
-        JLabel tooltipDistSupressionLabel = new JLabel(Messages.getString("CommonSettingsDialog.tooltipDistSuppression")); //$NON-NLS-1$
+        JLabel tooltipDistSupressionLabel = new JLabel(Messages.getString("CommonSettingsDialog.tooltipDistSuppression")); 
         tooltipDistSupressionLabel.setToolTipText(Messages.getString("CommonSettingsDialog.tooltipDistSuppressionTooltip"));
         row = new ArrayList<>();
         row.add(tooltipDistSupressionLabel);
         row.add(tooltipDistSupression);
         comps.add(row);
 
-        showWpsinTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showWpsinTT")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(showWpsinTT);
-        comps.add(row);
-
-        // copied from showWpsinTT, kept comment as it looks like a relevant compiler/editor flag?
-        showArmorMiniVisTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showArmorMiniVisTT")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(showArmorMiniVisTT);
-        comps.add(row);
-        
-        showPilotPortraitTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showPilotPortraitTT")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(showPilotPortraitTT);
-        comps.add(row);
-
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
-
-        Sep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(Sep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
-        // --------------        
-        
-        soundMute = new JCheckBox(Messages.getString("CommonSettingsDialog.soundMute")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(soundMute);
-        comps.add(row);
+        comps.add(checkboxEntry(showWpsinTT, null));
+        comps.add(checkboxEntry(showArmorMiniVisTT, null));
+        comps.add(checkboxEntry(showPilotPortraitTT, null));
+        addLineSpacer(comps);
+        comps.add(checkboxEntry(soundMute, null));
         
         JLabel maxPathfinderTimeLabel = new JLabel(Messages.getString("CommonSettingsDialog.pathFiderTimeLimit"));
         maxPathfinderTime = new JTextField(5);
@@ -537,68 +385,19 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(maxPathfinderTime);
         comps.add(row);
 
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
+        addLineSpacer(comps);
+        comps.add(checkboxEntry(nagForMASC, null));
+        comps.add(checkboxEntry(nagForPSR, null));
+        comps.add(checkboxEntry(nagForWiGELanding, null));
+        comps.add(checkboxEntry(nagForNoAction, null));
+        comps.add(checkboxEntry(getFocus, null));
+        comps.add(checkboxEntry(mouseWheelZoom, null));
+        comps.add(checkboxEntry(mouseWheelZoomFlip, null));
+        comps.add(checkboxEntry(autoEndFiring, null));
+        comps.add(checkboxEntry(autoDeclareSearchlight, null));
 
-        Sep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(Sep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
-        // --------------
-        
-        nagForMASC = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForMASC")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(nagForMASC);
-        comps.add(row);
-
-        nagForPSR = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForPSR")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(nagForPSR);
-        comps.add(row);
-
-        nagForWiGELanding = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForWiGELanding")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(nagForWiGELanding);
-        comps.add(row);
-
-        nagForNoAction = new JCheckBox(Messages.getString("CommonSettingsDialog.nagForNoAction")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(nagForNoAction);
-        comps.add(row);
-        
-        getFocus = new JCheckBox(Messages.getString("CommonSettingsDialog.getFocus")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(getFocus);
-        comps.add(row);
-        mouseWheelZoom = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoom")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(mouseWheelZoom);
-        comps.add(row);
-
-        mouseWheelZoomFlip = new JCheckBox(Messages.getString("CommonSettingsDialog.mouseWheelZoomFlip")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(mouseWheelZoomFlip);
-        comps.add(row);
-
-        autoEndFiring = new JCheckBox(Messages.getString("CommonSettingsDialog.autoEndFiring")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(autoEndFiring);
-        comps.add(row);
-
-        autoDeclareSearchlight = new JCheckBox(Messages.getString("CommonSettingsDialog.autoDeclareSearchlight")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(autoDeclareSearchlight);
-        comps.add(row);
-        
-        JLabel defaultSortOrderLabel = new JLabel(Messages.getString("CommonSettingsDialog.defaultWeaponSortOrder")); //$NON-NLS-1$
-        String toolTip = Messages
-                .getString("CommonSettingsDialog.defaultWeaponSortOrderTooltip");
+        JLabel defaultSortOrderLabel = new JLabel(Messages.getString("CommonSettingsDialog.defaultWeaponSortOrder"));
+        String toolTip = Messages.getString("CommonSettingsDialog.defaultWeaponSortOrderTooltip");
         defaultSortOrderLabel.setToolTipText(toolTip);
         defaultWeaponSortOrder = new JComboBox<>();
         defaultWeaponSortOrder.setToolTipText(toolTip);
@@ -615,77 +414,29 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(defaultWeaponSortOrder);
         comps.add(row);
 
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
+        addLineSpacer(comps);
 
-        Sep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(Sep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
-        // --------------        
-
-        JLabel unitStartCharLabel = new JLabel(Messages.getString("CommonSettingsDialog.protoMechUnitCodes")); //$NON-NLS-1$
-        unitStartChar = new JComboBox<String>();
+        JLabel unitStartCharLabel = new JLabel(Messages.getString("CommonSettingsDialog.protoMechUnitCodes")); 
+        unitStartChar = new JComboBox<>();
         // Add option for "A, B, C, D..."
-        unitStartChar.addItem("\u0041, \u0042, \u0043, \u0044..."); //$NON-NLS-1$
+        unitStartChar.addItem("\u0041, \u0042, \u0043, \u0044..."); 
         // Add option for "ALPHA, BETA, GAMMA, DELTA..."
-        unitStartChar.addItem("\u0391, \u0392, \u0393, \u0394..."); //$NON-NLS-1$
+        unitStartChar.addItem("\u0391, \u0392, \u0393, \u0394..."); 
         // Add option for "alpha, beta, gamma, delta..."
-        unitStartChar.addItem("\u03B1, \u03B2, \u03B3, \u03B4..."); //$NON-NLS-1$
+        unitStartChar.addItem("\u03B1, \u03B2, \u03B3, \u03B4..."); 
         unitStartChar.setMaximumSize(new Dimension(150,40));
         row = new ArrayList<>();
         row.add(unitStartCharLabel);
         row.add(unitStartChar);
         comps.add(row);
 
-        // player-specific settings
-        defaultAutoejectDisabled = new JCheckBox(Messages.getString("CommonSettingsDialog.defaultAutoejectDisabled")); //$NON-NLS-1$
-        defaultAutoejectDisabled.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(defaultAutoejectDisabled);
-        comps.add(row);
+        comps.add(checkboxEntry(defaultAutoejectDisabled, null));
+        comps.add(checkboxEntry(useAverageSkills, null));
+        comps.add(checkboxEntry(generateNames, null));
+        addLineSpacer(comps);
+        comps.add(checkboxEntry(keepGameLog, null));
 
-        useAverageSkills = new JCheckBox(Messages.getString("CommonSettingsDialog.useAverageSkills")); //$NON-NLS-1$
-        useAverageSkills.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(useAverageSkills);
-        comps.add(row);
-
-        generateNames = new JCheckBox(Messages.getString("CommonSettingsDialog.generateNames")); //$NON-NLS-1$
-        generateNames.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(generateNames);
-        comps.add(row);
-        
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
-
-        Sep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(Sep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
-        // --------------  
-
-        // client-side gameLog settings
-        keepGameLog = new JCheckBox(Messages.getString("CommonSettingsDialog.keepGameLog")); //$NON-NLS-1$
-        keepGameLog.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(keepGameLog);
-        comps.add(row);
-
-        gameLogFilenameLabel = new JLabel(Messages.getString("CommonSettingsDialog.logFileName")); //$NON-NLS-1$
+        gameLogFilenameLabel = new JLabel(Messages.getString("CommonSettingsDialog.logFileName")); 
         gameLogFilename = new JTextField(15);
         gameLogFilename.setMaximumSize(new Dimension(250,40));
         row = new ArrayList<>();
@@ -693,18 +444,11 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(gameLogFilenameLabel);
         row.add(gameLogFilename);
         comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
 
-        stampFilenames = new JCheckBox(Messages.getString("CommonSettingsDialog.stampFilenames")); //$NON-NLS-1$
-        stampFilenames.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(stampFilenames);
-        comps.add(row);
+        addSpacer(comps, 5);
+        comps.add(checkboxEntry(stampFilenames, null));
 
-        stampFormatLabel = new JLabel(Messages.getString("CommonSettingsDialog.stampFormat")); //$NON-NLS-1$
+        stampFormatLabel = new JLabel(Messages.getString("CommonSettingsDialog.stampFormat")); 
         stampFormat = new JTextField(15);
         stampFormat.setMaximumSize(new Dimension(15*13,40));
         row = new ArrayList<>();
@@ -713,28 +457,38 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(stampFormat);
         comps.add(row);
 
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
+        addLineSpacer(comps);
+        comps.add(checkboxEntry(showIPAddressesInChat, Messages.getString("CommonSettingsDialog.showIPAddressesInChat.tooltip")));
+        return createSettingsPanel(comps);
+    }
+
+    private List<Component> checkboxEntry(JCheckBox checkbox, String toolTip) {
+        checkbox.setToolTipText(toolTip);
+        checkbox.addItemListener(this);
+        List<Component> row = new ArrayList<>();
+        row.add(checkbox);
+        return row;
+    }
+
+    private void addLineSpacer(List<List<Component>> comps) {
+        List<Component> row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(0, 10)));
         comps.add(row);
 
-        Sep = new JSeparator(SwingConstants.HORIZONTAL);
+        JSeparator Sep = new JSeparator(SwingConstants.HORIZONTAL);
         row = new ArrayList<>();
         row.add(Sep);
         comps.add(row);
-        
+
         row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(0, 5)));
         comps.add(row);
-        // -------------- 
+    }
 
-        showIPAddressesInChat = new JCheckBox(Messages.getString("CommonSettingsDialog.showIPAddressesInChat"));
-        showIPAddressesInChat.setToolTipText(Messages.getString("CommonSettingsDialog.showIPAddressesInChat.tooltip"));
-        row = new ArrayList<>();
-        row.add(showIPAddressesInChat);
+    private void addSpacer(List<List<Component>> comps, int height) {
+        List<Component> row = new ArrayList<>();
+        row.add(Box.createVerticalStrut(height));
         comps.add(row);
-
-        return createSettingsPanel(comps);
     }
 
     /**
@@ -819,24 +573,11 @@ public class CommonSettingsDialog extends ClientDialog implements
             teamColoring.setSelected(gs.getTeamColoring());
 
             File dir = Configuration.hexesDir();
-            tileSets = new ArrayList<>(Arrays.asList(dir.listFiles(new FilenameFilter() {
-                public boolean accept(File direc, String name) {
-                    return name.endsWith(".tileset");
-                }
-            })));
-            dir = new File(Configuration.userdataDir(),
-                    Configuration.hexesDir().toString());
-            File[] userDataTilesets = dir.listFiles(new FilenameFilter() {
-                public boolean accept(File direc, String name) {
-                    return name.endsWith(".tileset");
-                }
-            });
-            if (userDataTilesets != null) {
-                tileSets.addAll(Arrays.asList(userDataTilesets));
-            }
+            tileSets = new ArrayList<>(Arrays.asList(dir.list((direc, name) -> name.endsWith(".tileset"))));
+            tileSets.addAll(userDataFiles(Configuration.hexesDir(), ".tileset"));
             tileSetChoice.removeAllItems();
-            for (int i = 0; (tileSets != null) && i < tileSets.size(); i++) {
-                String name = tileSets.get(i).getName();
+            for (int i = 0; i < tileSets.size(); i++) {
+                String name = tileSets.get(i);
                 tileSetChoice.addItem(name.substring(0, name.length() - 8));
                 if (name.equals(cs.getMapTileset())) {
                     tileSetChoice.setSelectedIndex(i);
@@ -848,21 +589,8 @@ public class CommonSettingsDialog extends ClientDialog implements
 
             skinFiles.removeAllItems();
             List<String> xmlFiles = new ArrayList<>(Arrays
-                    .asList(Configuration.skinsDir().list(new FilenameFilter() {
-                        public boolean accept(File directory, String fileName) {
-                            return fileName.endsWith(".xml");
-                        }
-                    })));
-            String[] files = new File(Configuration.userdataDir(), Configuration.skinsDir().toString())
-                    .list(new FilenameFilter() {
-                        public boolean accept(File directory, String fileName) {
-                            return fileName.endsWith(".xml");
-                        }
-                    });
-            if (files != null) {
-                xmlFiles.addAll(Arrays.asList(files));
-
-            }
+                    .asList(Configuration.skinsDir().list((directory, fileName) -> fileName.endsWith(".xml"))));
+            xmlFiles.addAll(userDataFiles(Configuration.skinsDir(), ".xml"));
             Collections.sort(xmlFiles);
             for (String file : xmlFiles) {
                 if (SkinXMLHandler.validSkinSpecFile(file)) {
@@ -871,7 +599,7 @@ public class CommonSettingsDialog extends ClientDialog implements
             }
             // Select the default file first
             skinFiles.setSelectedItem(SkinXMLHandler.defaultSkinXML);
-            // If this select fials, the default skin will be selected
+            // If this select fails, the default skin will be selected
             skinFiles.setSelectedItem(GUIPreferences.getInstance().getSkinFile());
 
             uiThemes.removeAllItems();
@@ -925,6 +653,7 @@ public class CommonSettingsDialog extends ClientDialog implements
             savedFovHighlightAlpha = gs.getFovHighlightAlpha();
             savedFovDarkenAlpha = gs.getFovDarkenAlpha();
             savedNumStripesSlider = gs.getFovStripes();
+            savedAntiAlias = gs.getAntiAliasing();
             savedAdvancedOpt.clear();
             
             advancedKeys.clearSelection();
@@ -937,11 +666,11 @@ public class CommonSettingsDialog extends ClientDialog implements
             
         }   
         super.setVisible(visible);
-    }       
-            
-    /** Cancel any updates made in this dialog and close it.  */     
-    void cancel() {
-        // Restore values that are immediately updated by player clicks
+    }
+
+    /** Cancels any updates made in this dialog and closes it.  */
+    @Override
+    protected void cancelAction() {
         GUIPreferences guip = GUIPreferences.getInstance();
         guip.setFovHighlight(savedFovHighlight);
         guip.setFovDarken(savedFovDarken);
@@ -961,6 +690,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         guip.setFovHighlightAlpha(savedFovHighlightAlpha);
         guip.setFovDarkenAlpha(savedFovDarkenAlpha);
         guip.setFovStripes(savedNumStripesSlider);
+        guip.setAntiAliasing(savedAntiAlias);
          
         for (String option: savedAdvancedOpt.keySet()) {
             GUIPreferences.getInstance().setValue(option, savedAdvancedOpt.get(option));
@@ -969,10 +699,9 @@ public class CommonSettingsDialog extends ClientDialog implements
         setVisible(false);
     }
 
-    /**
-     * Update the settings from this dialog's values, then closes it.
-     */
-    private void update() {
+    /** Update the settings from this dialog's values, then close it. */
+    @Override
+    protected void okAction() {
         GUIPreferences gs = GUIPreferences.getInstance();
         IClientPreferences cs = PreferenceManager.getClientPreferences();
 
@@ -997,8 +726,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setTooltipDismissDelay(Integer.parseInt(tooltipDismissDelay.getText()));
         gs.setTooltipDistSuppression(Integer.parseInt(tooltipDistSupression.getText()));
         gs.setValue(GUIPreferences.GUI_SCALE, (float)(guiScale.getValue()) / 10);
-        cs.setUnitStartChar(((String) unitStartChar.getSelectedItem())
-                .charAt(0));
+        cs.setUnitStartChar(((String) unitStartChar.getSelectedItem()).charAt(0));
         
         gs.setMouseWheelZoom(mouseWheelZoom.isSelected());
         gs.setMouseWheelZoomFlip(mouseWheelZoomFlip.isSelected());
@@ -1022,8 +750,7 @@ public class CommonSettingsDialog extends ClientDialog implements
             clientgui.bv.updateEntityLabels();
         }
 
-        cs.setLocale(CommonSettingsDialog.LOCALE_CHOICES[displayLocale
-                .getSelectedIndex()]);
+        cs.setLocale(CommonSettingsDialog.LOCALE_CHOICES[displayLocale.getSelectedIndex()]);
 
         gs.setShowMapsheets(showMapsheets.isSelected());
         gs.setAOHexShadows(aOHexShadows.isSelected());
@@ -1033,15 +760,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setShadowMap(shadowMap.isSelected());
         gs.setHexInclines(hexInclines.isSelected());
         gs.setValue("SOFTCENTER", useSoftCenter.isSelected());
-
-        if ((gs.getAntiAliasing() != chkAntiAliasing.isSelected()) &&
-                ((clientgui != null) && (clientgui.bv != null))) {            
-            clientgui.bv.clearHexImageCache();
-            clientgui.bv.repaint();
-        }
-
-        gs.setAntiAliasing(chkAntiAliasing.isSelected());
-
         gs.setGameSummaryBoardView(gameSummaryBV.isSelected());
         gs.setGameSummaryMiniMap(gameSummaryMM.isSelected());
 
@@ -1057,19 +775,16 @@ public class CommonSettingsDialog extends ClientDialog implements
             boolean success = SkinXMLHandler.initSkinXMLHandler(newSkinFile);
             if (!success) {
                 SkinXMLHandler.initSkinXMLHandler(oldSkinFile);
-                String title = Messages
-                        .getString("CommonSettingsDialog.skinFileFail.title");
-                String msg = Messages
-                        .getString("CommonSettingsDialog.skinFileFail.msg");
-                JOptionPane.showMessageDialog(owner, msg, title,
-                        JOptionPane.ERROR_MESSAGE);
+                String title = Messages.getString("CommonSettingsDialog.skinFileFail.title");
+                String msg = Messages.getString("CommonSettingsDialog.skinFileFail.msg");
+                JOptionPane.showMessageDialog(getFrame(), msg, title, JOptionPane.ERROR_MESSAGE);
             } else {
                 gs.setSkinFile(newSkinFile);
             }            
         }
 
         if (tileSetChoice.getSelectedIndex() >= 0) {
-            String tileSetFileName = tileSets.get(tileSetChoice.getSelectedIndex()).getName();
+            String tileSetFileName = tileSets.get(tileSetChoice.getSelectedIndex());
             if (!cs.getMapTileset().equals(tileSetFileName) &&
                     (clientgui != null) && (clientgui.bv != null))  {
                 clientgui.bv.clearShadowMap();
@@ -1181,24 +896,6 @@ public class CommonSettingsDialog extends ClientDialog implements
         setVisible(false);
     }
 
-    /**
-     * Handle the player pressing the action buttons. <p/> Implements the
-     * <code>ActionListener</code> interface.
-     *
-     * @param event - the <code>ActionEvent</code> that initiated this call.
-     */
-    public void actionPerformed(ActionEvent event) {
-        String command = event.getActionCommand();
-        if (command.equals(UPDATE)) {
-            update();
-        } else if (command.equals(CANCEL)) {
-            cancel();
-        }
-        if (event.getSource() == choiceToggle) {
-            updateKeybindsFocusTraversal();
-        }
-    }
-
     /** Handle some setting changes that directly update e.g. the board. */
     public void itemStateChanged(ItemEvent event) {
         Object source = event.getItemSelectable();
@@ -1248,6 +945,8 @@ public class CommonSettingsDialog extends ClientDialog implements
             guip.setShowDamageDecal(showDamageDecal.isSelected());
         } else if (source.equals(showDamageLevel)) {
             guip.setShowDamageLevel(showDamageLevel.isSelected());
+        } else if (source.equals(chkAntiAliasing)) {
+            guip.setAntiAliasing(chkAntiAliasing.isSelected());
         }
     }
 
@@ -1269,132 +968,55 @@ public class CommonSettingsDialog extends ClientDialog implements
         guip.setValue(option, advancedValue.getText());
     }
 
-    /** 
-     * The Graphics Tab
-     */
+    /** The Graphics Tab */
     private JPanel getGraphicsPanel() {
 
-        ArrayList<ArrayList<Component>> comps = new ArrayList<ArrayList<Component>>();
+        List<List<Component>> comps = new ArrayList<>();
         ArrayList<Component> row;
-        
-        // Anti-Aliasing
-        chkAntiAliasing = new JCheckBox(Messages.getString(
-                "CommonSettingsDialog.antiAliasing")); //$NON-NLS-1$
-        chkAntiAliasing.setToolTipText(Messages.getString(
-                "CommonSettingsDialog.antiAliasingToolTip"));
-        row = new ArrayList<>();
-        row.add(chkAntiAliasing);
-        comps.add(row);
-        
-        // Animate Moves
-        animateMove = new JCheckBox(Messages.getString("CommonSettingsDialog.animateMove")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(animateMove);
-        comps.add(row);
 
-        // Show Wrecks
-        showWrecks = new JCheckBox(Messages.getString("CommonSettingsDialog.showWrecks")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(showWrecks);
-        comps.add(row);     
-        
-        // Show Mapsheet borders
-        showMapsheets = new JCheckBox(Messages.getString("CommonSettingsDialog.showMapsheets")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        row.add(showMapsheets);
-        comps.add(row);
+        comps.add(checkboxEntry(chkAntiAliasing, Messages.getString("CommonSettingsDialog.antiAliasingToolTip")));
+        comps.add(checkboxEntry(animateMove, null));
+        comps.add(checkboxEntry(showWrecks, null));
+        comps.add(checkboxEntry(showMapsheets, null));
+        comps.add(checkboxEntry(aOHexShadows, null));
+        comps.add(checkboxEntry(shadowMap, null));
+        comps.add(checkboxEntry(hexInclines, null));
+        comps.add(checkboxEntry(levelhighlight, null));
+        comps.add(checkboxEntry(floatingIso, null));
+        comps.add(checkboxEntry(mmSymbol, null));
+        comps.add(checkboxEntry(gameSummaryBV,
+                Messages.getString("CommonSettingsDialog.gameSummaryBV.tooltip", Configuration.gameSummaryImagesBVDir())));
+        comps.add(checkboxEntry(gameSummaryMM,
+                Messages.getString("CommonSettingsDialog.gameSummaryMM.tooltip", Configuration.gameSummaryImagesMMDir())));
 
-        // Hill Base AO Shadows
-        aOHexShadows = new JCheckBox(Messages.getString("CommonSettingsDialog.AOHexSHadows")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        aOHexShadows.addItemListener(this);
-        row.add(aOHexShadows);
-        comps.add(row);
-        
-        // Shadow Map = Terrain and Building shadows
-        shadowMap = new JCheckBox(Messages.getString("CommonSettingsDialog.useShadowMap")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        shadowMap.addItemListener(this);
-        row.add(shadowMap);
-        comps.add(row);
-        
-        // Use Incline graphics (hex border highlights/shadows)
-        hexInclines = new JCheckBox(Messages.getString("CommonSettingsDialog.useInclines")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        hexInclines.addItemListener(this);
-        row.add(hexInclines);
-        comps.add(row);
-        
-        // Level Highlight = borders around level changes
-        levelhighlight = new JCheckBox(Messages.getString("CommonSettingsDialog.levelHighlight")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        levelhighlight.addItemListener(this);
-        row.add(levelhighlight);
-        comps.add(row);
-        
-        // Floating Isometric = do not draw hex sides
-        floatingIso = new JCheckBox(Messages.getString("CommonSettingsDialog.floatingIso")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        floatingIso.addItemListener(this);
-        row.add(floatingIso);
-        comps.add(row);
-
-        // Type of symbol used on the minimap 
-        mmSymbol = new JCheckBox(Messages.getString("CommonSettingsDialog.mmSymbol")); //$NON-NLS-1$
-        row = new ArrayList<>();
-        mmSymbol.addItemListener(this);
-        row.add(mmSymbol);
-        comps.add(row);
-
-        // Game Summary - BoardView
-        gameSummaryBV = new JCheckBox(Messages.getString("CommonSettingsDialog.gameSummaryBV.name")); //$NON-NLS-1$
-        gameSummaryBV.setToolTipText(Messages.getString("CommonSettingsDialog.gameSummaryBV.tooltip", //$NON-NLS-1$
-                new Object[] { Configuration.gameSummaryImagesBVDir() }));
-        row = new ArrayList<>();
-        gameSummaryBV.addItemListener(this);
-        row.add(gameSummaryBV);
-        comps.add(row);
-
-        // Game Summary - Mini-map
-        gameSummaryMM = new JCheckBox(Messages.getString("CommonSettingsDialog.gameSummaryMM.name")); //$NON-NLS-1$
-        gameSummaryMM.setToolTipText(Messages.getString("CommonSettingsDialog.gameSummaryMM.tooltip", //$NON-NLS-1$
-                new Object[] { Configuration.gameSummaryImagesMMDir() }));
-        row = new ArrayList<>();
-        gameSummaryMM.addItemListener(this);
-        row.add(gameSummaryMM);
-        comps.add(row);
+        addLineSpacer(comps);
+        addSpacer(comps, 3);
 
         // UI Theme
-        uiThemes = new JComboBox<UITheme>();
-        uiThemes.setMaximumSize(new Dimension(400,uiThemes.getMaximumSize().height));
-        JLabel uiThemesLabel = new JLabel(Messages.getString("CommonSettingsDialog.uiTheme")); //$NON-NLS-1$
+        uiThemes = new JComboBox<>();
+        uiThemes.setMaximumSize(new Dimension(400, uiThemes.getMaximumSize().height));
+        JLabel uiThemesLabel = new JLabel(Messages.getString("CommonSettingsDialog.uiTheme")); 
         row = new ArrayList<>();
         row.add(uiThemesLabel);
         row.add(uiThemes);
-        comps.add(row);   
-        
-        // Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
         comps.add(row);
 
+        addSpacer(comps, 5);
+
         // Skin
-        skinFiles = new JComboBox<String>();
+        skinFiles = new JComboBox<>();
         skinFiles.setMaximumSize(new Dimension(400,skinFiles.getMaximumSize().height));
-        JLabel skinFileLabel = new JLabel(Messages.getString("CommonSettingsDialog.skinFile")); //$NON-NLS-1$
+        JLabel skinFileLabel = new JLabel(Messages.getString("CommonSettingsDialog.skinFile")); 
         row = new ArrayList<>();
         row.add(skinFileLabel);
         row.add(skinFiles);
-        comps.add(row);   
-        
-        // Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
         comps.add(row);
 
+        addSpacer(comps, 5);
+
         // Tileset
-        JLabel tileSetChoiceLabel = new JLabel(Messages.getString("CommonSettingsDialog.tileset")); //$NON-NLS-1$
-        tileSetChoice = new JComboBox<String>(); //$NON-NLS-1$
+        JLabel tileSetChoiceLabel = new JLabel(Messages.getString("CommonSettingsDialog.tileset")); 
+        tileSetChoice = new JComboBox<>(); 
         tileSetChoice.setMaximumSize(new Dimension(400,tileSetChoice.getMaximumSize().height));
         row = new ArrayList<>();
         row.add(tileSetChoiceLabel);
@@ -1402,28 +1024,10 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(tileSetChoice);
         comps.add(row);
         
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
-
-        JSeparator highlightSep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(highlightSep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
+        addLineSpacer(comps);
         
         // Highlighting Radius inside FoV
-        //
-        // Highlight inside Check box
-        fovInsideEnabled = new JCheckBox(Messages.getString("TacticalOverlaySettingsDialog.FovInsideEnabled")); //$NON-NLS-1$
-        fovInsideEnabled.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(fovInsideEnabled);
-        comps.add(row);
+        comps.add(checkboxEntry(fovInsideEnabled, null));
 
         // Add some vertical spacing
         row = new ArrayList<>();
@@ -1440,37 +1044,28 @@ public class CommonSettingsDialog extends ClientDialog implements
         fovHighlightAlpha.addChangeListener(this);
         fovHighlightAlpha.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.AlphaTooltip"));
         // Label
-        highlightAlphaLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovHighlightAlpha")); //$NON-NLS-1$
+        highlightAlphaLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovHighlightAlpha")); 
         row = new ArrayList<>();
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(highlightAlphaLabel);
         comps.add(row);
-        
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(1));
-        comps.add(row);
+
+        addSpacer(comps, 1);
         
         row = new ArrayList<>();
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(fovHighlightAlpha);
         comps.add(row);
-        
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(3));
-        comps.add(row);
+
+        addSpacer(comps, 3);
 
         row = new ArrayList<>();
-        fovHighlightRingsRadiiLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovHighlightRingsRadii")); //$NON-NLS-1$
+        fovHighlightRingsRadiiLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovHighlightRingsRadii")); 
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(fovHighlightRingsRadiiLabel);
         comps.add(row);
-        
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(2));
-        comps.add(row);
+
+        addSpacer(comps, 2);
         
         row = new ArrayList<>();
         fovHighlightRingsRadii= new JTextField((2+1)*7);
@@ -1480,22 +1075,16 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(fovHighlightRingsRadii);
         comps.add(row);
 
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(2));
-        comps.add(row);
-        
+        addSpacer(comps, 2);
+
         row= new ArrayList<>();
-        fovHighlightRingsColorsLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovHighlightRingsColors")); //$NON-NLS-1$
+        fovHighlightRingsColorsLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovHighlightRingsColors")); 
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(fovHighlightRingsColorsLabel);
         comps.add(row);
                 
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(2));
-        comps.add(row);
-        
+        addSpacer(comps, 2);
+
         row = new ArrayList<>();
         fovHighlightRingsColors= new JTextField(50);//      ((3+1)*3+1)*7);
         fovHighlightRingsColors.addFocusListener(this);
@@ -1505,33 +1094,12 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(Box.createHorizontalGlue());
         comps.add(row);
 
-        // Horizontal Line and Spacer
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 10)));
-        comps.add(row);
+        addLineSpacer(comps);
 
-        JSeparator OutSideSep = new JSeparator(SwingConstants.HORIZONTAL);
-        row = new ArrayList<>();
-        row.add(OutSideSep);
-        comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(new Dimension(0, 5)));
-        comps.add(row);
-        
         // Outside FoV Darkening
-        //
-        // Activation Checkbox
-        fovOutsideEnabled = new JCheckBox(Messages.getString("TacticalOverlaySettingsDialog.FovOutsideEnabled")); //$NON-NLS-1$
-        fovOutsideEnabled.addItemListener(this);
-        row = new ArrayList<>();
-        row.add(fovOutsideEnabled);
-        comps.add(row);
-        
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(1));
-        comps.add(row);
+        comps.add(checkboxEntry(fovOutsideEnabled, null));
+
+        addSpacer(comps, 1);
 
         fovDarkenAlpha = new JSlider(0, 255);
         fovDarkenAlpha.setMajorTickSpacing(25);
@@ -1541,7 +1109,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         fovDarkenAlpha.setMaximumSize(new Dimension(400, 100));
         fovDarkenAlpha.addChangeListener(this);
         fovDarkenAlpha.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.AlphaTooltip"));
-        darkenAlphaLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovDarkenAlpha")); //$NON-NLS-1$
+        darkenAlphaLabel = new JLabel(Messages.getString("TacticalOverlaySettingsDialog.FovDarkenAlpha")); 
         darkenAlphaLabel.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.AlphaTooltip"));
         row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(4,0)));
@@ -1549,20 +1117,14 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(darkenAlphaLabel);
         comps.add(row);
         
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(2));
-        comps.add(row);
+        addSpacer(comps, 2);
         
         row = new ArrayList<>();
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(fovDarkenAlpha);
         comps.add(row);
-        
-        // Add some vertical spacing
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(4));
-        comps.add(row);
+
+        addSpacer(comps, 4);
         
         numStripesSlider = new JSlider(0, 50);
         numStripesSlider.setMajorTickSpacing(10);
@@ -1573,31 +1135,27 @@ public class CommonSettingsDialog extends ClientDialog implements
         numStripesSlider.addChangeListener(this);
         numStripesSlider.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.FovStripesTooltip"));
         numStripesLabel = new JLabel(
-                Messages.getString("TacticalOverlaySettingsDialog.FovStripes")); //$NON-NLS-1$
+                Messages.getString("TacticalOverlaySettingsDialog.FovStripes")); 
         numStripesLabel.setToolTipText(Messages.getString("TacticalOverlaySettingsDialog.FovStripesTooltip"));
         row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(4,0)));
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(numStripesLabel);
         comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(1));
-        comps.add(row);
+
+        addSpacer(comps, 1);
         
         row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(4,0)));
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(numStripesSlider);
         comps.add(row);
-        
-        row = new ArrayList<>();
-        row.add(Box.createVerticalStrut(3));
-        comps.add(row);
+
+        addSpacer(comps, 3);
         
         row = new ArrayList<>();
         fovGrayscaleEnabled = new JCheckBox(
-                Messages.getString("TacticalOverlaySettingsDialog.FovGrayscale")); //$NON-NLS-1$
+                Messages.getString("TacticalOverlaySettingsDialog.FovGrayscale")); 
         fovGrayscaleEnabled.addItemListener(this);
         row.add(Box.createRigidArea(new Dimension(4,0)));
         row.add(Box.createRigidArea(DEPENDENT_INSET));
@@ -1607,16 +1165,9 @@ public class CommonSettingsDialog extends ClientDialog implements
         return createSettingsPanel(comps);
     }
     
-    /**
-     * Creates a panel with a box for all of the commands that can be bound to
-     * keys.
-     *
-     * @return
-     */
+    /** Creates a panel with a box for all of the commands that can be bound to keys. */
     private JPanel getKeyBindPanel() {
-        // The first column is for labels, the second column for modifiers, the third
-        // column for keys
-        
+        // The first column is for labels, the second column for modifiers, the third column for keys
         JPanel outer = new JPanel();
         outer.setLayout(new BoxLayout(outer, BoxLayout.PAGE_AXIS));
         
@@ -1625,8 +1176,11 @@ public class CommonSettingsDialog extends ClientDialog implements
         tabChoice.setBorder(new EmptyBorder(15, 15, 15, 15));
         var buttonPanel = new JPanel();
         var labelPanel = new JPanel();
-        choiceToggle.addActionListener(this);
-        var choiceLabel = new JLabel("<HTML><CENTER>This will enable stepping through the entry fields on this page using the TAB key.<BR> It will prevent TAB from being used as a keybind and <BR> remove any existing TAB keybinds.");
+        choiceToggle.addActionListener(e -> updateKeybindsFocusTraversal());
+        var choiceLabel = new JLabel(
+                "<HTML><CENTER>This will enable stepping through the entry fields on this page using the TAB key." +
+                        "<BR> It will prevent TAB from being used as a keybind and " +
+                        "<BR> remove any existing TAB keybinds.");
         buttonPanel.add(choiceToggle);
         labelPanel.add(choiceLabel);
         tabChoice.add(buttonPanel);
@@ -1665,9 +1219,9 @@ public class CommonSettingsDialog extends ClientDialog implements
 
         // Create maps to retrieve the text fields for saving
         int numBinds = KeyCommandBind.values().length;
-        cmdModifierMap = new HashMap<String, JTextField>((int)(numBinds*1.26));
-        cmdKeyMap = new HashMap<String, JTextField>((int)(numBinds*1.26));
-        cmdKeyCodeMap = new HashMap<String, Integer>((int)(numBinds*1.26));
+        cmdModifierMap = new HashMap<>((int) (numBinds * 1.26));
+        cmdKeyMap = new HashMap<>((int) (numBinds * 1.26));
+        cmdKeyCodeMap = new HashMap<>((int) (numBinds * 1.26));
 
         // For each keyCommandBind, create a label and two text fields
         for (KeyCommandBind kcb : KeyCommandBind.values()) {
@@ -1748,8 +1302,6 @@ public class CommonSettingsDialog extends ClientDialog implements
 
             });
             keyBinds.add(key, gbc);
-            gbc.gridx++;
-
             gbc.gridx = 0;
             gbc.gridy++;
             
@@ -1844,12 +1396,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         return modifiers;
     }
     
-    /**
-     * Creates a panel with a list boxes that allow the button order to be 
-     * changed.
-     *
-     * @return
-     */
+    /** Creates a panel with a list boxes that allow the button order to be changed. */
     private JPanel getButtonOrderPanel(){
         JPanel buttonOrderPanel = new JPanel();
         buttonOrderPanel.setLayout(new BoxLayout(buttonOrderPanel, BoxLayout.Y_AXIS));
@@ -1857,27 +1404,27 @@ public class CommonSettingsDialog extends ClientDialog implements
         buttonOrderPanel.add(phasePane);
         
         // MovementPhaseDisplay        
-        movePhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        movePhaseCommands = new DefaultListModel<>();
         phasePane.add("Movement", getButtonOrderPane(movePhaseCommands,
                 MovementDisplay.MoveCommand.values()));
         
         // DeploymentPhaseDisplay
-        deployPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        deployPhaseCommands = new DefaultListModel<>();
         phasePane.add("Deployment", getButtonOrderPane(deployPhaseCommands,
                 DeploymentDisplay.DeployCommand.values()));
         
         // FiringPhaseDisplay
-        firingPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        firingPhaseCommands = new DefaultListModel<>();
         phasePane.add("Firing", getButtonOrderPane(firingPhaseCommands,
                 FiringDisplay.FiringCommand.values()));
         
         // PhysicalPhaseDisplay
-        physicalPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        physicalPhaseCommands = new DefaultListModel<>();
         phasePane.add("Physical", getButtonOrderPane(physicalPhaseCommands,
                 PhysicalDisplay.PhysicalCommand.values()));          
         
         // TargetingPhaseDisplay
-        targetingPhaseCommands = new DefaultListModel<StatusBarPhaseDisplay.PhaseCommand>();
+        targetingPhaseCommands = new DefaultListModel<>();
         phasePane.add("Targeting", getButtonOrderPane(targetingPhaseCommands,
                 TargetingPhaseDisplay.TargetingCommand.values()));
         
@@ -1902,11 +1449,11 @@ public class CommonSettingsDialog extends ClientDialog implements
         return scrollPane;
     }
 
-    private JPanel createSettingsPanel(ArrayList<ArrayList<Component>> comps) {
+    private JPanel createSettingsPanel(List<List<Component>> comps) {
         JPanel panel = new JPanel();
         panel.setLayout(new BorderLayout());
         Box innerpanel = new Box(BoxLayout.PAGE_AXIS);
-        for (ArrayList<Component> cs : comps) {
+        for (List<Component> cs : comps) {
             Box subPanel = new Box(BoxLayout.LINE_AXIS);
             for (Component c : cs) {
                 if (c instanceof JLabel) {
@@ -1932,7 +1479,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         String[] s = GUIPreferences.getInstance().getAdvancedProperties();
         AdvancedOptionData[] opts = new AdvancedOptionData[s.length];
         for (int i = 0; i < s.length; i++) {
-            s[i] = s[i].substring(s[i].indexOf("Advanced") + 8, s[i].length());
+            s[i] = s[i].substring(s[i].indexOf("Advanced") + 8);
             opts[i] = new AdvancedOptionData(s[i]);
         }
         Arrays.sort(opts);
@@ -1945,11 +1492,7 @@ public class CommonSettingsDialog extends ClientDialog implements
                 int index = advancedKeys.locationToIndex(e.getPoint());
                 if (index > -1) {
                     AdvancedOptionData dat = advancedKeys.getModel().getElementAt(index);
-                    if (dat.hasTooltipText()) {
-                        advancedKeys.setToolTipText(dat.getTooltipText());
-                    } else {
-                        advancedKeys.setToolTipText(null);
-                    }
+                    advancedKeys.setToolTipText(dat.hasTooltipText() ? dat.getTooltipText() : null);
                 }
             }
         });
@@ -1979,11 +1522,25 @@ public class CommonSettingsDialog extends ClientDialog implements
     public void stateChanged(ChangeEvent evt) {
         GUIPreferences guip = GUIPreferences.getInstance();
         if (evt.getSource().equals(fovHighlightAlpha)) {
-            guip.setFovHighlightAlpha(Math.max(0, Math.min(255, (int) fovHighlightAlpha.getValue())));
+            guip.setFovHighlightAlpha(Math.max(0, Math.min(255, fovHighlightAlpha.getValue())));
         } else if (evt.getSource().equals(fovDarkenAlpha)) {
-            guip.setFovDarkenAlpha(Math.max(0, Math.min(255, (int) fovDarkenAlpha.getValue())));
+            guip.setFovDarkenAlpha(Math.max(0, Math.min(255, fovDarkenAlpha.getValue())));
         } else if (evt.getSource().equals(numStripesSlider)) {
             guip.setFovStripes(numStripesSlider.getValue());
         }
+    }
+
+    /**
+     *  Returns the files in the directory given as relativePath (e.g. Configuration.hexesDir())
+     *  under the userData directory ending with fileEnding (such as ".xml")
+     */
+    public static List<String> userDataFiles(File relativePath, String fileEnding) {
+        List<String> result = new ArrayList<>();
+        File dir = new File(Configuration.userdataDir(), relativePath.toString());
+        String[] userDataFiles = dir.list((direc, name) -> name.endsWith(fileEnding));
+        if (userDataFiles != null) {
+            result.addAll(Arrays.asList(userDataFiles));
+        }
+        return result;
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1022,6 +1022,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             case GUIPreferences.FOV_HIGHLIGHT_RINGS_COLORS_HSB:
             case GUIPreferences.FOV_HIGHLIGHT_RINGS_RADII:
             case GUIPreferences.SHADOWMAP:
+            case GUIPreferences.ANTIALIASING:
                 clearHexImageCache();
                 repaint();
                 break;


### PR DESCRIPTION
Sorry for the huge diff. 
Cleans up the CommonSettingsDialog (aka Client Settings), removing the NON-NLS and a lot of code repetition for UI creation. Also bases the dialog on the AbstractDialog system so it now, finally, closes on an ESC keypress and remembers it size.
No changes to the settings themselves.
