### PR TITLE
#3185 - don't crash server when equipment doesn't exist

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4832,8 +4832,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 if (ccs.isDestroyed() || ccs.isBreached() || ccs.isMissing()) {
                     if ((type == CriticalSlot.TYPE_SYSTEM) && (ccs.getIndex() == index)) {
                         hits++;
-                    } else if ((type == CriticalSlot.TYPE_EQUIPMENT) && (m.equals(ccs.getMount()) || m.equals(ccs
-                                                                                                                      .getMount2()))) {
+                    } else if ((type == CriticalSlot.TYPE_EQUIPMENT) && 
+                            ((m != null) && m.equals(ccs.getMount()) || m.equals(ccs.getMount2()))) {
                         hits++;
                     }
                 }


### PR DESCRIPTION
Fixes #3185. This appears to be an issue with processing a club attack action, as the club isn't actually a piece of equipment mounted on a mech in a critical slot.