### PR TITLE
Fix concurrent modification issue preventing multi-bot replacement

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -30691,11 +30691,13 @@ public class Server implements Runnable {
      * Sends out player info to all connections
      */
     private void transmitPlayerConnect(IPlayer player) {
-        for (var connection: connections) {
-            var playerId = player.getId();
-            connection.send(
-                createPlayerConnectPacket(player, playerId != connection.getId())
-            );
+        synchronized (connections) {
+            for (var connection: connections) {
+                var playerId = player.getId();
+                connection.send(
+                    createPlayerConnectPacket(player, playerId != connection.getId())
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #3175 - when sending bot connection commands real fast, the "connections" field changes rapidly. Make the "notify all players of new player connection" operation synchronous - slows it down a little bit, but should not be a performance issue as a player connection is a "rare" event.