### PR TITLE
detachable pane always goes on top when detached

### DIFF
--- a/megamek/src/megamek/client/ui/swing/widget/DetachablePane.java
+++ b/megamek/src/megamek/client/ui/swing/widget/DetachablePane.java
@@ -188,6 +188,7 @@ public class DetachablePane extends JComponent {
                     super.setVisible(false);
 
                     this.window.add(this.root, BorderLayout.CENTER);
+                    this.window.setAlwaysOnTop(true);
                     this.window.pack();
                     this.window.setVisible(true);
 


### PR DESCRIPTION
Pretty straightforward: when the unit pane is detached, it doesn't "disappear" when clicking on the main game area. Will need to revisit this to make it so this can be specified by the caller at a later time, but it will do for now since the only thing that uses the detachable pane is the unit display.

Feel free to merge if approved and I'm not around.