### PR TITLE
don't prevent attempts to hack ourselves using our own code

### DIFF
--- a/megamek/resources/megamek/serialkiller.xml
+++ b/megamek/resources/megamek/serialkiller.xml
@@ -45,6 +45,9 @@
         <regexp>\[\[Lmegamek.*</regexp>
         <regexp>\[Lmegamek.*</regexp>
         <regexp>megamek.*</regexp>
+        <regexp>\[\[Lmekhq.*</regexp>
+        <regexp>\[Lmekhq.*</regexp>
+        <regexp>mekhq.*</regexp>
         <regexp>\[Z$</regexp>
     </regexps>
   </whitelist>

--- a/megamek/resources/megamek/serialkiller.xml
+++ b/megamek/resources/megamek/serialkiller.xml
@@ -48,6 +48,9 @@
         <regexp>\[\[Lmekhq.*</regexp>
         <regexp>\[Lmekhq.*</regexp>
         <regexp>mekhq.*</regexp>
+	<regexp>\[\[Lmegameklab.*</regexp>
+        <regexp>\[Lmegameklab.*</regexp>
+        <regexp>megameklab.*</regexp>
         <regexp>\[Z$</regexp>
     </regexps>
   </whitelist>


### PR DESCRIPTION
When we pass a MekHQ data structure through megamek to serialize/deserialize it, don't block the deserialization.

Fixes #2934