### PR TITLE
PlayerSettingsDialog update

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
@@ -72,10 +72,10 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
     
     private MMToggleButton forcedWithdrawalCheck = new TipMMToggleButton(Messages.getString("BotConfigDialog.forcedWithdrawalCheck"));
     private JLabel withdrawEdgeLabel = new JLabel(Messages.getString("BotConfigDialog.retreatEdgeLabel"));
-    private JComboBox<CardinalEdge> withdrawEdgeCombo = new TipCombo<>(CardinalEdge.values());
+    private JComboBox<CardinalEdge> withdrawEdgeCombo = new TipCombo<>("EdgeToWithdraw", CardinalEdge.values());
     private MMToggleButton autoFleeCheck = new TipMMToggleButton(Messages.getString("BotConfigDialog.autoFleeCheck"));
     private JLabel fleeEdgeLabel = new JLabel(Messages.getString("BotConfigDialog.homeEdgeLabel"));
-    private JComboBox<CardinalEdge> fleeEdgeCombo = new TipCombo<>(CardinalEdge.values()); 
+    private JComboBox<CardinalEdge> fleeEdgeCombo = new TipCombo<>("EdgeToFlee", CardinalEdge.values());
     
     private TipSlider aggressionSlidebar = new TipSlider(SwingConstants.HORIZONTAL, 0, 10, 5);
     private TipSlider fallShameSlidebar = new TipSlider(SwingConstants.HORIZONTAL, 0, 10, 5);
@@ -189,7 +189,7 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
         result.add(panContent);
         
         var namePanel = new JPanel();
-        nameField.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.namefield.tooltip")));
+        nameField.setToolTipText(Messages.getString("BotConfigDialog.namefield.tooltip"));
         // When the dialog configures an existing player, the name must not be changed
         nameField.setText((fixedBotPlayerName == null) ? getFreePrincessName() : fixedBotPlayerName);
         nameField.setEnabled(fixedBotPlayerName == null);
@@ -199,8 +199,8 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
         namePanel.add(nameField);
         
         var verbosityPanel = new JPanel();
-        verbosityCombo = new TipCombo<String>(LogLevel.getLogLevelNames());
-        verbosityCombo.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.verbosityToolTip")));
+        verbosityCombo = new TipCombo<String>("Verbosity", LogLevel.getLogLevelNames());
+        verbosityCombo.setToolTipText(Messages.getString("BotConfigDialog.verbosityToolTip"));
         verbosityCombo.setSelectedIndex(0);
         verbosityLabel.setLabelFor(verbosityCombo);
         verbosityLabel.setDisplayedMnemonic(KeyEvent.VK_V);
@@ -295,11 +295,11 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
         
         savePreset.addActionListener(this);
         savePreset.setMnemonic(KeyEvent.VK_S);
-        savePreset.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.saveTip")));
+        savePreset.setToolTipText(Messages.getString("BotConfigDialog.saveTip"));
         buttonPanel.add(savePreset);
         saveNewPreset.addActionListener(this);
         saveNewPreset.setMnemonic(KeyEvent.VK_A);
-        saveNewPreset.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.saveNewTip")));
+        saveNewPreset.setToolTipText(Messages.getString("BotConfigDialog.saveNewTip"));
         buttonPanel.add(saveNewPreset);
 
         return result;
@@ -335,7 +335,7 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
         buttonPanel.add(Box.createHorizontalGlue());
         buttonPanel.add(removeButtonPanel);
 
-        targetsList.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.targetsListTip")));
+        targetsList.setToolTipText(Messages.getString("BotConfigDialog.targetsListTip"));
         targetsList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         targetsList.getSelectionModel().addListSelectionListener(this);
         targetsList.setLayoutOrientation(JList.VERTICAL);
@@ -357,21 +357,21 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
         panContent.setLayout(new BoxLayout(panContent, BoxLayout.PAGE_AXIS));
         result.add(panContent);
 
-        autoFleeCheck.setToolTipText(formatTooltip(formatTooltip(Messages.getString("BotConfigDialog.autoFleeTooltip"))));
+        autoFleeCheck.setToolTipText(Messages.getString("BotConfigDialog.autoFleeTooltip"));
         autoFleeCheck.addActionListener(this);
         autoFleeCheck.setMnemonic(KeyEvent.VK_F);
         
         fleeEdgeCombo.removeItem(CardinalEdge.NONE);
-        fleeEdgeCombo.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.homeEdgeTooltip")));
+        fleeEdgeCombo.setToolTipText(Messages.getString("BotConfigDialog.homeEdgeTooltip"));
         fleeEdgeCombo.setSelectedIndex(0);
         fleeEdgeCombo.addActionListener(this);
         
-        forcedWithdrawalCheck.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.forcedWithdrawalTooltip")));
+        forcedWithdrawalCheck.setToolTipText(Messages.getString("BotConfigDialog.forcedWithdrawalTooltip"));
         forcedWithdrawalCheck.addActionListener(this);
         forcedWithdrawalCheck.setMnemonic(KeyEvent.VK_W);
 
         withdrawEdgeCombo.removeItem(CardinalEdge.NONE);
-        withdrawEdgeCombo.setToolTipText(formatTooltip(Messages.getString("BotConfigDialog.retreatEdgeTooltip")));
+        withdrawEdgeCombo.setToolTipText(Messages.getString("BotConfigDialog.retreatEdgeTooltip"));
         withdrawEdgeCombo.setSelectedIndex(0);
 
         var firstLine = new JPanel(new FlowLayout(FlowLayout.LEFT));
@@ -455,8 +455,8 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
             String maxMsgProperty, String toolTip, String title) {
         var result = new TipPanel();
         result.setLayout(new BoxLayout(result, BoxLayout.PAGE_AXIS));
-        result.setToolTipText(formatTooltip(toolTip));
-        thisSlider.setToolTipText(formatTooltip(toolTip));
+        result.setToolTipText(toolTip);
+        thisSlider.setToolTipText(toolTip);
         thisSlider.setPaintLabels(false);
         thisSlider.setSnapToTicks(true);
         thisSlider.addChangeListener(this);
@@ -649,12 +649,6 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
     
     public void setBotName(String value) {
         nameField.setText(value);
-    }
-    
-    /** Completes the tooltip for this dialog, setting its width and adding HTML tags. */
-    private String formatTooltip(String text) {
-        String result = "<P WIDTH=" + UIUtil.scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
-        return UIUtil.scaleStringForGUI(result);
     }
     
     @Override

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
@@ -35,6 +35,7 @@ import megamek.client.Client;
 import megamek.client.bot.princess.*;
 import megamek.client.ui.Messages;
 import megamek.client.ui.baseComponents.AbstractButtonDialog;
+import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.dialogs.helpDialogs.PrincessHelpDialog;
 import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.swing.*;
@@ -61,7 +62,7 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
 
     private JLabel nameLabel = new JLabel(Messages.getString("BotConfigDialog.nameLabel"));
     private TipTextField nameField = new TipTextField("", 16);
-    private JComboBox<String> verbosityCombo;
+    private MMComboBox<String> verbosityCombo;
     private JLabel verbosityLabel = new JLabel(Messages.getString("BotConfigDialog.verbosityLabel"), SwingConstants.RIGHT);
     
     private JButton addTargetButton = new TipButton(Messages.getString("BotConfigDialog.addHexTarget"));
@@ -72,10 +73,10 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
     
     private MMToggleButton forcedWithdrawalCheck = new TipMMToggleButton(Messages.getString("BotConfigDialog.forcedWithdrawalCheck"));
     private JLabel withdrawEdgeLabel = new JLabel(Messages.getString("BotConfigDialog.retreatEdgeLabel"));
-    private JComboBox<CardinalEdge> withdrawEdgeCombo = new TipCombo<>("EdgeToWithdraw", CardinalEdge.values());
+    private MMComboBox<CardinalEdge> withdrawEdgeCombo = new TipCombo<>("EdgeToWithdraw", CardinalEdge.values());
     private MMToggleButton autoFleeCheck = new TipMMToggleButton(Messages.getString("BotConfigDialog.autoFleeCheck"));
     private JLabel fleeEdgeLabel = new JLabel(Messages.getString("BotConfigDialog.homeEdgeLabel"));
-    private JComboBox<CardinalEdge> fleeEdgeCombo = new TipCombo<>("EdgeToFlee", CardinalEdge.values());
+    private MMComboBox<CardinalEdge> fleeEdgeCombo = new TipCombo<>("EdgeToFlee", CardinalEdge.values());
     
     private TipSlider aggressionSlidebar = new TipSlider(SwingConstants.HORIZONTAL, 0, 10, 5);
     private TipSlider fallShameSlidebar = new TipSlider(SwingConstants.HORIZONTAL, 0, 10, 5);
@@ -199,7 +200,7 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
         namePanel.add(nameField);
         
         var verbosityPanel = new JPanel();
-        verbosityCombo = new TipCombo<String>("Verbosity", LogLevel.getLogLevelNames());
+        verbosityCombo = new TipCombo<>("Verbosity", LogLevel.getLogLevelNames());
         verbosityCombo.setToolTipText(Messages.getString("BotConfigDialog.verbosityToolTip"));
         verbosityCombo.setSelectedIndex(0);
         verbosityLabel.setLabelFor(verbosityCombo);
@@ -623,19 +624,19 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
     
     private void savePrincessProperties() {
         BehaviorSettings tempBehavior = new BehaviorSettings();
-        tempBehavior.setVerbosity(LogLevel.getLogLevel((String) verbosityCombo.getSelectedItem()));
+        tempBehavior.setVerbosity(LogLevel.getLogLevel(verbosityCombo.getSelectedItem()));
         tempBehavior.setFallShameIndex(fallShameSlidebar.getValue());
         tempBehavior.setForcedWithdrawal(forcedWithdrawalCheck.isSelected());
         tempBehavior.setAutoFlee(autoFleeCheck.isSelected());
-        tempBehavior.setDestinationEdge((CardinalEdge) fleeEdgeCombo.getSelectedItem());
-        tempBehavior.setRetreatEdge((CardinalEdge) withdrawEdgeCombo.getSelectedItem());
+        tempBehavior.setDestinationEdge(fleeEdgeCombo.getSelectedItem());
+        tempBehavior.setRetreatEdge(withdrawEdgeCombo.getSelectedItem());
         tempBehavior.setHyperAggressionIndex(aggressionSlidebar.getValue());
         tempBehavior.setSelfPreservationIndex(selfPreservationSlidebar.getValue());
         tempBehavior.setHerdMentalityIndex(herdingSlidebar.getValue());
         tempBehavior.setBraveryIndex(braverySlidebar.getValue());
         for (int i = 0; i < targetsListModel.getSize(); i++) {
             if (targetsListModel.get(i) instanceof Coords) {
-                tempBehavior.addStrategicTarget(((Coords)targetsListModel.get(i)).toString());
+                tempBehavior.addStrategicTarget(targetsListModel.get(i).toString());
             } else {
                 tempBehavior.addPriorityUnit(Integer.toString((int)targetsListModel.get(i)));
             }

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigTargetHexDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigTargetHexDialog.java
@@ -88,7 +88,7 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
         
         var coordsFieldPanel = new UIUtil.FixedYPanel();
         coordsFieldPanel.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-        coordsField.setToolTipText(UIUtil.formatSideTooltip(Messages.getString("BotConfigDialog.hexCoordsTip")));
+        coordsField.setToolTipText(Messages.getString("BotConfigDialog.hexCoordsTip"));
         coordsLabel.setLabelFor(coordsField);
         coordsLabel.setDisplayedMnemonic(KeyEvent.VK_X);
         coordsFieldPanel.add(coordsLabel);

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigTargetUnitDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigTargetUnitDialog.java
@@ -67,7 +67,7 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
         result.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
         
         JPanel unitIDPanel = new UIUtil.FixedYPanel();
-        unitIDField.setToolTipText(UIUtil.formatSideTooltip(Messages.getString("BotConfigDialog.unitIdTip")));
+        unitIDField.setToolTipText(Messages.getString("BotConfigDialog.unitIdTip"));
         unitIDLabel.setLabelFor(unitIDField);
         unitIDLabel.setDisplayedMnemonic(KeyEvent.VK_I);
         unitIDPanel.add(unitIDLabel);

--- a/megamek/src/megamek/client/ui/panels/SkillGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/panels/SkillGenerationOptionsPanel.java
@@ -28,6 +28,8 @@ import megamek.client.ui.swing.MMToggleButton;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
 
+import static megamek.client.ui.swing.util.UIUtil.*;
+
 import javax.swing.*;
 import java.awt.*;
 import java.util.Objects;
@@ -36,9 +38,9 @@ public class SkillGenerationOptionsPanel extends AbstractPanel {
     //region Variable Declarations
     private final ClientGUI clientGUI;
     private Client client;
-    private MMComboBox<SkillGeneratorMethod> comboMethod;
-    private MMComboBox<SkillGeneratorType> comboType;
-    private MMComboBox<SkillLevel> comboSkillLevel;
+    private TipCombo<SkillGeneratorMethod> comboMethod;
+    private TipCombo<SkillGeneratorType> comboType;
+    private TipCombo<SkillLevel> comboSkillLevel;
     private MMToggleButton tglForceClose;
     //endregion Variable Declarations
 
@@ -69,7 +71,7 @@ public class SkillGenerationOptionsPanel extends AbstractPanel {
         return comboMethod;
     }
 
-    public void setComboMethod(final MMComboBox<SkillGeneratorMethod> comboMethod) {
+    public void setComboMethod(final TipCombo<SkillGeneratorMethod> comboMethod) {
         this.comboMethod = comboMethod;
     }
 
@@ -77,7 +79,7 @@ public class SkillGenerationOptionsPanel extends AbstractPanel {
         return comboType;
     }
 
-    public void setComboType(final MMComboBox<SkillGeneratorType> comboType) {
+    public void setComboType(final TipCombo<SkillGeneratorType> comboType) {
         this.comboType = comboType;
     }
 
@@ -85,7 +87,7 @@ public class SkillGenerationOptionsPanel extends AbstractPanel {
         return comboSkillLevel;
     }
 
-    public void setComboSkillLevel(final MMComboBox<SkillLevel> comboSkillLevel) {
+    public void setComboSkillLevel(final TipCombo<SkillLevel> comboSkillLevel) {
         this.comboSkillLevel = comboSkillLevel;
     }
 
@@ -102,72 +104,66 @@ public class SkillGenerationOptionsPanel extends AbstractPanel {
     @Override
     protected void initialize() {
         // Create Panel Components
-        final JLabel lblMethod = new JLabel(resources.getString("lblMethod.text"));
+        final JLabel lblMethod = new TipLabel(resources.getString("lblMethod.text"));
         lblMethod.setToolTipText(resources.getString("lblMethod.toolTipText"));
         lblMethod.setName("lblMethod");
 
-        setComboMethod(new MMComboBox<>("comboMethod", SkillGeneratorMethod.values()));
+        setComboMethod(new TipCombo<>("comboMethod", SkillGeneratorMethod.values()));
         getComboMethod().setToolTipText(resources.getString("lblMethod.toolTipText"));
-        getComboMethod().setName("comboMethod");
         getComboMethod().setSelectedItem(getClient().getSkillGenerator().getMethod());
         getComboMethod().setRenderer(new DefaultListCellRenderer() {
             @Override
             public Component getListCellRendererComponent(final JList<?> list, final Object value,
                                                           final int index, final boolean isSelected,
                                                           final boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof SkillGeneratorMethod) {
-                    list.setToolTipText(((SkillGeneratorMethod) value).getToolTipText());
+                    list.setToolTipText(formatSideTooltip(((SkillGeneratorMethod) value).getToolTipText()));
                 }
-                return this;
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             }
         });
 
-        final JLabel lblType = new JLabel(resources.getString("lblType.text"));
+        final JLabel lblType = new TipLabel(resources.getString("lblType.text"));
         lblType.setToolTipText(resources.getString("lblType.toolTipText"));
         lblType.setName("lblType");
 
-        setComboType(new MMComboBox<>("comboType", SkillGeneratorType.values()));
+        setComboType(new TipCombo<>("comboType", SkillGeneratorType.values()));
         getComboType().setToolTipText(resources.getString("lblType.toolTipText"));
-        getComboType().setName("comboType");
         getComboType().setSelectedItem(getClient().getSkillGenerator().getType());
         getComboType().setRenderer(new DefaultListCellRenderer() {
             @Override
             public Component getListCellRendererComponent(final JList<?> list, final Object value,
                                                           final int index, final boolean isSelected,
                                                           final boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof SkillGeneratorType) {
-                    list.setToolTipText(((SkillGeneratorType) value).getToolTipText());
+                    list.setToolTipText(formatSideTooltip(((SkillGeneratorType) value).getToolTipText()));
                 }
-                return this;
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             }
         });
 
-        final JLabel lblSkillLevel = new JLabel(resources.getString("lblSkillLevel.text"));
+        final JLabel lblSkillLevel = new TipLabel(resources.getString("lblSkillLevel.text"));
         lblSkillLevel.setToolTipText(resources.getString("lblSkillLevel.toolTipText"));
         lblSkillLevel.setName("lblSkillLevel");
 
         final DefaultComboBoxModel<SkillLevel> skillLevelModel = new DefaultComboBoxModel<>();
         skillLevelModel.addAll(SkillLevel.getGeneratableValues());
-        setComboSkillLevel(new MMComboBox<>("comboSkillLevel", skillLevelModel));
+        setComboSkillLevel(new TipCombo<>("comboSkillLevel", skillLevelModel));
         getComboSkillLevel().setToolTipText(resources.getString("lblSkillLevel.toolTipText"));
-        getComboSkillLevel().setName("comboSkillLevel");
         getComboSkillLevel().setSelectedItem(getClient().getSkillGenerator().getLevel());
         getComboSkillLevel().setRenderer(new DefaultListCellRenderer() {
             @Override
             public Component getListCellRendererComponent(final JList<?> list, final Object value,
                                                           final int index, final boolean isSelected,
                                                           final boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof SkillLevel) {
-                    list.setToolTipText(((SkillLevel) value).getToolTipText());
+                    list.setToolTipText(formatSideTooltip(((SkillLevel) value).getToolTipText()));
                 }
-                return this;
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             }
         });
 
-        setTglForceClose(new MMToggleButton(resources.getString("tglForceClose.text")));
+        setTglForceClose(new TipMMToggleButton(resources.getString("tglForceClose.text")));
         getTglForceClose().setToolTipText(resources.getString("tglForceClose.toolTipText"));
         getTglForceClose().setName("tglForceClose");
         getTglForceClose().setSelected(getClient().getSkillGenerator().isForceClose());

--- a/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
@@ -110,9 +110,9 @@ public class PlanetaryConditionsDialog extends ClientDialog {
     private static final String PCD = "PlanetaryConditionsDialog.";
     private JLabel labLight = new JLabel(Messages.getString(PCD + "labLight"), SwingConstants.RIGHT); 
     private JComboBox<String> comLight = new JComboBox<String>();
-    private JLabel labWeather = new TipLabel(Messages.getString(PCD + "labWeather"), SwingConstants.RIGHT, this); 
+    private JLabel labWeather = new TipLabel(Messages.getString(PCD + "labWeather"), SwingConstants.RIGHT);
     private JComboBox<String> comWeather = new JComboBox<String>();
-    private JLabel labWind = new TipLabel(Messages.getString(PCD + "labWind"), SwingConstants.RIGHT, this); 
+    private JLabel labWind = new TipLabel(Messages.getString(PCD + "labWind"), SwingConstants.RIGHT);
     private JComboBox<String> comWind = new JComboBox<String>();
     private JLabel labMinWind = new JLabel(Messages.getString(PCD + "labMinWind"), SwingConstants.RIGHT); 
     private JComboBox<String> comWindFrom = new JComboBox<String>();
@@ -120,20 +120,20 @@ public class PlanetaryConditionsDialog extends ClientDialog {
     private JComboBox<String> comWindDirection = new JComboBox<>();
     private JLabel labWindDirection = new JLabel(Messages.getString(PCD + "labWindDirection"), SwingConstants.RIGHT);
     private JComboBox<String> comWindTo = new JComboBox<String>();
-    private JLabel labAtmosphere = new TipLabel(Messages.getString(PCD + "labAtmosphere"), SwingConstants.RIGHT, this); 
+    private JLabel labAtmosphere = new TipLabel(Messages.getString(PCD + "labAtmosphere"), SwingConstants.RIGHT);
     private JComboBox<String> comFog = new JComboBox<String>();
-    private JLabel labFog = new TipLabel(Messages.getString(PCD + "labFog"), SwingConstants.RIGHT, this); 
+    private JLabel labFog = new TipLabel(Messages.getString(PCD + "labFog"), SwingConstants.RIGHT);
     private JComboBox<String> comAtmosphere = new JComboBox<String>();
-    private JLabel labBlowingSands = new TipLabel(Messages.getString(PCD + "BlowingSands"), SwingConstants.RIGHT, this);
+    private JLabel labBlowingSands = new TipLabel(Messages.getString(PCD + "BlowingSands"), SwingConstants.RIGHT);
     private JCheckBox chkBlowingSands = new JCheckBox();
     private JLabel labShiftWindDir = new JLabel(Messages.getString(PCD + "shiftWindDir"), SwingConstants.RIGHT);
     private JCheckBox chkShiftWindDir = new JCheckBox();
     private JLabel labShiftWindStr = new JLabel(Messages.getString(PCD + "shiftWindStr"), SwingConstants.RIGHT);
     private JCheckBox chkShiftWindStr = new JCheckBox();
     private JTextField fldTemp = new JTextField(4);
-    private JLabel labTemp = new TipLabel(Messages.getString(PCD + "labTemp"), SwingConstants.RIGHT, this); 
+    private JLabel labTemp = new TipLabel(Messages.getString(PCD + "labTemp"), SwingConstants.RIGHT);
     private JTextField fldGrav = new JTextField(4);
-    private JLabel labGrav = new TipLabel(Messages.getString(PCD + "labGrav"), SwingConstants.RIGHT, this);
+    private JLabel labGrav = new TipLabel(Messages.getString(PCD + "labGrav"), SwingConstants.RIGHT);
     private JLabel labEMI = new JLabel(Messages.getString(PCD + "EMI"), SwingConstants.RIGHT);
     private JCheckBox chkEMI = new JCheckBox();
     private JLabel labTerrainAffected = new JLabel(Messages.getString(PCD + "TerrainAffected"), SwingConstants.RIGHT);
@@ -441,7 +441,7 @@ public class PlanetaryConditionsDialog extends ClientDialog {
             label.setToolTipText(null);
         } else {
             label.setForeground(GUIPreferences.getInstance().getWarningColor());
-            label.setToolTipText(formatTooltip(text.toString()));
+            label.setToolTipText(text.toString());
         }
     }
     
@@ -630,12 +630,5 @@ public class PlanetaryConditionsDialog extends ClientDialog {
         @Override
         public void focusGained(FocusEvent e) { }
     };
-
-    
-    /** Applies formatting and HTML tags to the plain tooltip string. */
-    private String formatTooltip(String text) {
-        String result = "<P WIDTH=" + scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
-        return scaleStringForGUI(result);
-    }
 
 }

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1496,8 +1496,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         }
         
         PlayerSettingsDialog psd = new PlayerSettingsDialog(clientgui, c);
-        DialogResult result = psd.showDialog();
-        if (result.isConfirmed()) {
+        if (psd.showDialog().isConfirmed()) {
             IPlayer player = c.getLocalPlayer();
             player.setConstantInitBonus(psd.getInit());
             player.setNbrMFConventional(psd.getCnvMines());

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1496,9 +1496,8 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         }
         
         PlayerSettingsDialog psd = new PlayerSettingsDialog(clientgui, c);
-        boolean okay = psd.showDialog();
-        
-        if (okay) {
+        DialogResult result = psd.showDialog();
+        if (result.isConfirmed()) {
             IPlayer player = c.getLocalPlayer();
             player.setConstantInitBonus(psd.getInit());
             player.setNbrMFConventional(psd.getCnvMines());

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -113,8 +113,6 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
     private final Client client;
     private final ClientGUI clientgui;
     
-    private static final int TOOLTIP_WIDTH = 300;
-
     // Initiative Section
     private final JLabel labInit = new TipLabel(Messages.getString("PlayerSettingsDialog.initMod"), SwingConstants.RIGHT);
     private final TipTextField fldInit = new TipTextField(3);
@@ -150,9 +148,6 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         setupValues();
         
         JPanel mainPanel = new JPanel();
-        ContentScrollPane scrMain = new ContentScrollPane(mainPanel);
-        add(scrMain, BorderLayout.CENTER);
-
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
         mainPanel.add(headerSection());
         if (client instanceof BotClient) {
@@ -168,6 +163,12 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
             mainPanel.add(emailSection());
         }
         mainPanel.add(Box.createVerticalGlue());
+
+        var scrMain = new JScrollPane(mainPanel);
+        scrMain.getVerticalScrollBar().setUnitIncrement(16);
+        scrMain.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
+        scrMain.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        scrMain.setBorder(null);
         return scrMain;
     }
     
@@ -363,27 +364,4 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         }
     }
 
-    /** 
-     * A specialized JScrollPane that reports 80% of the parent frame's
-     * height as its maximum preferred viewport height. This makes the dialog
-     * scale to about 80% of MM's window height when needed but not more. 
-     */
-    private class ContentScrollPane extends JScrollPane {
-        private static final long serialVersionUID = -4976675600736422725L;
-        
-        public ContentScrollPane(Component view) {
-            super(view);
-            getVerticalScrollBar().setUnitIncrement(16);
-            setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
-            setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-            setBorder(null);
-        }
-
-        @Override
-        public Dimension getPreferredSize() {
-            var prefSize = super.getPreferredSize();
-            var maxHeight = clientgui.getFrame().getHeight() / 10 * 8;
-            return new Dimension(prefSize.width, Math.min(maxHeight, prefSize.height));
-        }
-    }
 }

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -24,14 +24,12 @@ import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
 import megamek.client.ui.Messages;
+import megamek.client.ui.baseComponents.AbstractButtonDialog;
 import megamek.client.ui.dialogs.BotConfigDialog;
 import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.panels.SkillGenerationOptionsPanel;
-import megamek.client.ui.swing.CancelAction;
-import megamek.client.ui.swing.ClientDialog;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
-import megamek.client.ui.swing.dialog.DialogButton;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.IPlayer;
 import megamek.common.IStartingPositions;
@@ -52,29 +50,22 @@ import static megamek.client.ui.swing.util.UIUtil.*;
  * minefields, and maybe other things in the future like force abilities.
  * 
  * @author Jay Lawson
+ * @author Simon (Juliez)
  */
-public class PlayerSettingsDialog extends ClientDialog {
+public class PlayerSettingsDialog extends AbstractButtonDialog {
 
-    private static final long serialVersionUID = -4597870528499580517L;
-    
     public PlayerSettingsDialog(ClientGUI cg, Client cl) {
-        super(cg.frame, Messages.getString("PlayerSettingsDialog.title"), true, true);
+        super(cg.frame, "PlayerSettingsDialog", "PlayerSettingsDialog.title");
         client = cl;
         clientgui = cg;
         currentPlayerStartPos = cl.getLocalPlayer().getStartingPos();
         if (currentPlayerStartPos > 10) {
             currentPlayerStartPos -= 10;
         }
-        setupDialog();
+        initialize();
+        UIUtil.adjustDialog(this);
     }
     
-    /** Sets the dialog visible and returns true if the user pressed the Okay button. */
-    public boolean showDialog() {
-        userResponse = false;
-        setVisible(true);
-        return userResponse;
-    }
-
     /** Returns the chosen initiative modifier. */
     public int getInit() {
         return parseField(fldInit);
@@ -123,46 +114,45 @@ public class PlayerSettingsDialog extends ClientDialog {
     private final ClientGUI clientgui;
     
     private static final int TOOLTIP_WIDTH = 300;
-    private static final String PSD = "PlayerSettingsDialog.";
-    
+
     // Initiative Section
-    private JLabel labInit = new TipLabel(Messages.getString(PSD + "initMod"), SwingConstants.RIGHT, this);
-    private TipTextField fldInit = new TipTextField(3);
+    private final JLabel labInit = new TipLabel(Messages.getString("PlayerSettingsDialog.initMod"), SwingConstants.RIGHT);
+    private final TipTextField fldInit = new TipTextField(3);
 
     // Mines Section
-    private JLabel labConventional = new JLabel(getString(PSD + "labConventional"), SwingConstants.RIGHT); 
-    private JLabel labVibrabomb = new JLabel(getString(PSD + "labVibrabomb"), SwingConstants.RIGHT); 
-    private JLabel labActive = new JLabel(getString(PSD + "labActive"), SwingConstants.RIGHT); 
-    private JLabel labInferno = new JLabel(getString(PSD + "labInferno"), SwingConstants.RIGHT); 
-    private JTextField fldConventional = new JTextField(3);
-    private JTextField fldVibrabomb = new JTextField(3);
-    private JTextField fldActive = new JTextField(3);
-    private JTextField fldInferno = new JTextField(3);
+    private final JLabel labConventional = new JLabel(getString("PlayerSettingsDialog.labConventional"), SwingConstants.RIGHT);
+    private final JLabel labVibrabomb = new JLabel(getString("PlayerSettingsDialog.labVibrabomb"), SwingConstants.RIGHT);
+    private final JLabel labActive = new JLabel(getString("PlayerSettingsDialog.labActive"), SwingConstants.RIGHT);
+    private final JLabel labInferno = new JLabel(getString("PlayerSettingsDialog.labInferno"), SwingConstants.RIGHT);
+    private final JTextField fldConventional = new JTextField(3);
+    private final JTextField fldVibrabomb = new JTextField(3);
+    private final JTextField fldActive = new JTextField(3);
+    private final JTextField fldInferno = new JTextField(3);
 
     // Skills Section
     private SkillGenerationOptionsPanel skillGenerationOptionsPanel;
 
     // Email section
-    private JLabel labEmail = new JLabel(getString(PSD + "labEmail"), SwingConstants.RIGHT);
-    private JTextField fldEmail = new JTextField(20);
+    private final JLabel labEmail = new JLabel(getString("PlayerSettingsDialog.labEmail"), SwingConstants.RIGHT);
+    private final JTextField fldEmail = new JTextField(20);
 
-    private JPanel panStartButtons = new JPanel();
-    private TipButton[] butStartPos = new TipButton[11];
-    private JButton butBotSettings = new JButton(Messages.getString(PSD + "botSettings"));
-    private DialogButton butOkay = new DialogButton(Messages.getString("Okay"));
+    // Deployment Section
+    private final JPanel panStartButtons = new JPanel();
+    private final TipButton[] butStartPos = new TipButton[11];
+
+    // Bot Settings Section
+    private final JButton butBotSettings = new JButton(Messages.getString("PlayerSettingsDialog.botSettings"));
     
     private int currentPlayerStartPos;
-    
-    private boolean userResponse;
-    
-    private void setupDialog() {
+
+    @Override
+    protected Container createCenterPane() {
         setupValues();
         
         JPanel mainPanel = new JPanel();
         ContentScrollPane scrMain = new ContentScrollPane(mainPanel);
         add(scrMain, BorderLayout.CENTER);
-        add(buttonPanel(), BorderLayout.PAGE_END);
-        
+
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
         mainPanel.add(headerSection());
         if (client instanceof BotClient) {
@@ -178,6 +168,7 @@ public class PlayerSettingsDialog extends ClientDialog {
             mainPanel.add(emailSection());
         }
         mainPanel.add(Box.createVerticalGlue());
+        return scrMain;
     }
     
     private JPanel headerSection() {
@@ -192,7 +183,7 @@ public class PlayerSettingsDialog extends ClientDialog {
     }
 
     private JPanel botSection() {
-        JPanel result = new OptionPanel(PSD + "header.botPlayer");
+        JPanel result = new OptionPanel("PlayerSettingsDialog.header.botPlayer");
         Content panContent = new Content(new FlowLayout());
         result.add(panContent);
         panContent.add(butBotSettings);
@@ -201,7 +192,7 @@ public class PlayerSettingsDialog extends ClientDialog {
     }
     
     private JPanel startSection() {
-        JPanel result = new OptionPanel(PSD + "header.startPos");
+        JPanel result = new OptionPanel("PlayerSettingsDialog.header.startPos");
         Content panContent = new Content(new GridLayout(1, 1));
         result.add(panContent);
         setupStartGrid();
@@ -210,18 +201,18 @@ public class PlayerSettingsDialog extends ClientDialog {
     }
     
     private JPanel initiativeSection() {
-        JPanel result = new OptionPanel(PSD + "header.initMod");
+        JPanel result = new OptionPanel("PlayerSettingsDialog.header.initMod");
         Content panContent = new Content(new GridLayout(1, 2, 10, 5));
         result.add(panContent);
         panContent.add(labInit);
         panContent.add(fldInit);
-        labInit.setToolTipText(formatTooltip(Messages.getString(PSD + "initModTT")));
-        fldInit.setToolTipText(formatTooltip(Messages.getString(PSD + "initModTT")));
+        labInit.setToolTipText(Messages.getString("PlayerSettingsDialog.initModTT"));
+        fldInit.setToolTipText(Messages.getString("PlayerSettingsDialog.initModTT"));
         return result;
     }
 
     private JPanel mineSection() {
-        JPanel result = new OptionPanel(PSD + "header.minefields");
+        JPanel result = new OptionPanel("PlayerSettingsDialog.header.minefields");
         Content panContent = new Content(new GridLayout(4, 2, 10, 5));
         result.add(panContent);
         panContent.add(labConventional);
@@ -236,7 +227,7 @@ public class PlayerSettingsDialog extends ClientDialog {
     }
 
     private JPanel skillsSection() {
-        final JPanel skillsPanel = new OptionPanel(PSD + "header.skills");
+        final JPanel skillsPanel = new OptionPanel("PlayerSettingsDialog.header.skills");
         skillsPanel.setName("skillsPanel");
 
         skillGenerationOptionsPanel = new SkillGenerationOptionsPanel(clientgui.getFrame(), clientgui, client);
@@ -248,19 +239,11 @@ public class PlayerSettingsDialog extends ClientDialog {
     }
 
     private JPanel emailSection() {
-        JPanel result = new OptionPanel(PSD + "header.email");
+        JPanel result = new OptionPanel("PlayerSettingsDialog.header.email");
         Content panContent = new Content(new GridLayout(1, 2, 10, 5));
         result.add(panContent);
         panContent.add(labEmail);
         panContent.add(fldEmail);
-        return result;
-    }
-
-    private JPanel buttonPanel() {
-        JPanel result = new JPanel(new FlowLayout());
-        butOkay.addActionListener(listener);
-        result.add(butOkay);
-        result.add(new DialogButton(new CancelAction(this)));
         return result;
     }
 
@@ -310,7 +293,7 @@ public class PlayerSettingsDialog extends ClientDialog {
             butText[i].append("<HTML><P ALIGN=CENTER>");
             if (!isValidStartPos(client.getGame(), client.getLocalPlayer(), i)) {
                 butText[i].append(guiScaledFontHTML(uiYellow()));
-                butTT[i].append(Messages.getString(PSD + "invalidStartPosTT"));
+                butTT[i].append(Messages.getString("PlayerSettingsDialog.invalidStartPosTT"));
             } else {
                 butText[i].append(guiScaledFontHTML());
             }
@@ -327,7 +310,7 @@ public class PlayerSettingsDialog extends ClientDialog {
                     if (butTT[index].length() > 0) {
                         butTT[index].append("<BR><BR>");
                     }
-                    butTT[index].append(Messages.getString(PSD + "deployingHere"));
+                    butTT[index].append(Messages.getString("PlayerSettingsDialog.deployingHere"));
                     hasPlayer[index] = true;
                 }
                 butTT[index].append("<BR>").append(player.getName());
@@ -340,7 +323,7 @@ public class PlayerSettingsDialog extends ClientDialog {
         for (int i = 0; i < 11; i++) {
             butStartPos[i].setText(butText[i].toString());
             if (butTT[i].length() > 0) {
-                butStartPos[i].setToolTipText(formatTooltip(butTT[i].toString()));
+                butStartPos[i].setToolTipText(butTT[i].toString());
             }
         }
     }
@@ -348,12 +331,6 @@ public class PlayerSettingsDialog extends ClientDialog {
     ActionListener listener = new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent e) {
-            // OKAY
-            if (e.getSource().equals(butOkay)) {
-                userResponse = true;
-                setVisible(false);
-            } 
-
             // Deployment buttons
             for (int i = 0; i < 11; i++) {
                 if (butStartPos[i].equals(e.getSource())) {
@@ -384,15 +361,6 @@ public class PlayerSettingsDialog extends ClientDialog {
         } catch (NumberFormatException ex) {
             return 0;
         }
-    }
-
-    /** 
-     * Completes the tooltip for this dialog, setting its width and adding
-     * HTML tags.
-     */
-    private String formatTooltip(String text) {
-        String result = "<P WIDTH=" + scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
-        return scaleStringForGUI(result);
     }
 
     /** 

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -33,6 +33,7 @@ import javax.swing.*;
 import javax.swing.border.*;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.MMToggleButton;
@@ -501,19 +502,20 @@ public final class UIUtil {
      * Used in the player settings and planetary settings dialogs.
      */
     public static class TipLabel extends JLabel {
-        private static final long serialVersionUID = -338233022633675883L;
-        
-        private JDialog parentDialog;
 
-        public TipLabel(String text, int align, JDialog parent) {
+        public TipLabel(String text) {
+            super(text);
+        }
+
+        public TipLabel(String text, int align) {
             super(text, align);
-            parentDialog = parent;
         }
 
         @Override
         public Point getToolTipLocation(MouseEvent event) {
-            Point p = SwingUtilities.convertPoint(this, 0, 0, parentDialog);
-            return new Point(parentDialog.getWidth() - p.x, 0);
+            Window win = SwingUtilities.getWindowAncestor(this);
+            Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
+            return new Point(win.getWidth() - origin.x, 0);
         }
         
         @Override
@@ -522,6 +524,11 @@ public final class UIUtil {
             tip.setBackground(alternateTableBGColor());
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
+        }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
         }
     }
     
@@ -550,21 +557,30 @@ public final class UIUtil {
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
         }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
+        }
     }
     
     /** 
-     * A JComboBox with a specialized tooltip display. Displays the tooltip to the right side
+     * An MMComboBox with a specialized tooltip display. Displays the tooltip to the right side
      * of the parent dialog, not following the mouse. 
-     * Used in the player settings and planetary settings dialogs.
+     * Used in the player settings dialog.
      */
-    public static class TipCombo<E> extends JComboBox<E> {
+    public static class TipCombo<E> extends MMComboBox<E> {
         
-        public TipCombo() {
-            super();
+        public TipCombo(String name) {
+            super(name);
         }
         
-        public TipCombo(E[] items) {
-            super(items);
+        public TipCombo(String name, E[] items) {
+            super(name, items);
+        }
+
+        public TipCombo(String name, final ComboBoxModel<E> model) {
+            super(name, model);
         }
 
         @Override
@@ -580,6 +596,11 @@ public final class UIUtil {
             tip.setBackground(alternateTableBGColor());
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
+        }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
         }
     }
     
@@ -611,6 +632,11 @@ public final class UIUtil {
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
         }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
+        }
     }
     
     /** 
@@ -620,8 +646,7 @@ public final class UIUtil {
      * Used in the player settings and planetary settings dialogs.
      */
     public static class TipTextField extends JTextField {
-        private static final long serialVersionUID = -2226586551388519966L;
-        
+
         String hintText;
         
         public TipTextField(int n) {
@@ -692,6 +717,11 @@ public final class UIUtil {
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
         }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
+        }
     }
     
     /** 
@@ -722,6 +752,11 @@ public final class UIUtil {
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
         }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
+        }
     }
     
     /** 
@@ -749,6 +784,11 @@ public final class UIUtil {
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
         }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
+        }
     }
     
     /** 
@@ -775,6 +815,11 @@ public final class UIUtil {
             tip.setBorder(BorderFactory.createLineBorder(uiGray(), 4));
             return tip;
         }
+
+        @Override
+        public void setToolTipText(String text) {
+            super.setToolTipText(formatSideTooltip(text));
+        }
     }
     
     /** 
@@ -782,8 +827,8 @@ public final class UIUtil {
      * its width and adding HTML tags. 
      */
     public static String formatSideTooltip(String text) {
-        String result = "<P WIDTH=" + UIUtil.scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
-        return UIUtil.scaleStringForGUI(result);
+        String result = "<P WIDTH=" + scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
+        return scaleStringForGUI(result);
     }
     
     /**
@@ -854,10 +899,8 @@ public final class UIUtil {
     public static Font getScaledFont() {
         return new Font("Dialog", Font.PLAIN, scaleForGUI(FONT_SCALE1));
     }
-    
-    
-    
-    // PRIVATE 
+
+    // PRIVATE
     
     private final static Color LIGHTUI_GREEN = new Color(20, 140, 20);
     private final static Color DARKUI_GREEN = new Color(40, 180, 40);

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -565,7 +565,8 @@ public final class UIUtil {
     }
     
     /** 
-     * An MMComboBox with a specialized tooltip display. Displays the tooltip to the right side
+     * A MMComboBox with a specialized tooltip display. Displays the tooltip to the right side
+
      * of the parent dialog, not following the mouse. 
      * Used in the player settings dialog.
      */


### PR DESCRIPTION
- Updates the PlayerSettingsDlg to extend AbstractButtonDlg, so it also closes on ESC and so on.
- Makes some updates to the various TipXYZ classes for dialogs in UIUtils so tooltip texts are formatted automatically. This required some adaptations in other dialogs. Also based the TipCombo on MMComboBox.
- Updates the SkillGenerationOptionsPanel to use the TipXYZ classes. As far as I can see it is not used by MHQ currently. (I couldnt find a way to influence where the combobox list tooltips are placed so when the method combo is open the tooltips of the choices still appear at the mouse cursor. Cant have everything)
