### PR TITLE
Moves undo back to backspace

### DIFF
--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -162,9 +162,9 @@
     </KeyBind>
 
     <KeyBind>
-         <command>undo</command> <!-- Ctrl-Z -->
-        <keyCode>90</keyCode>
-        <modifier>128</modifier>
+         <command>undo</command> <!-- Backspace -->
+        <keyCode>8</keyCode>
+        <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 


### PR DESCRIPTION
Backspace is a much more intuitive button for it, in my opinion, and is also consistent with how it worked in 0.48.0.

This is subjective, note, so feel free to close this if you feel it's a bad idea.