### PR TITLE
prevent concurrent mod error; minefield check error

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -30606,22 +30606,24 @@ public class Server implements Runnable {
      * Sends out player info updates for a player to all connections
      */
     void transmitPlayerUpdate(IPlayer player) {
-        for (var connection: connections) {
-            var playerId = player.getId();
-            var destPlayer = player;
-
-            if (playerId != connection.getId()) {
-                // Sending the player's data to another player's
-                // connection, need to redact any private data
-                destPlayer = player.copy();
-                destPlayer.redactPrivateData();
+        synchronized (connections) {
+            for (var connection: connections) {
+                var playerId = player.getId();
+                var destPlayer = player;
+    
+                if (playerId != connection.getId()) {
+                    // Sending the player's data to another player's
+                    // connection, need to redact any private data
+                    destPlayer = player.copy();
+                    destPlayer.redactPrivateData();
+                }
+                connection.send(
+                    new Packet(
+                        Packet.COMMAND_PLAYER_UPDATE,
+                        new Object[] { playerId, destPlayer }
+                    )
+                );
             }
-            connection.send(
-                new Packet(
-                    Packet.COMMAND_PLAYER_UPDATE,
-                    new Object[] { playerId, destPlayer }
-                )
-            );
         }
     }
 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -30607,7 +30607,7 @@ public class Server implements Runnable {
      */
     void transmitPlayerUpdate(IPlayer player) {
         synchronized (connections) {
-            for (var connection: connections) {
+            for (var connection : connections) {
                 var playerId = player.getId();
                 var destPlayer = player;
     

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -480,6 +480,12 @@ public class ServerHelper {
             return false;
         }
         
+        // can't detect minefields if the coordinates are invalid
+        if (coords == null) {
+            return false;
+        }
+        
+        // can't detect minefields if we have no probe
         int probeRange = entity.getBAPRange();
         if (probeRange <= 0) {
             return false;
@@ -487,7 +493,7 @@ public class ServerHelper {
         
         boolean minefieldDetected = false;
         
-        for (int distance = 1; distance <= probeRange; distance++) {      
+        for (int distance = 1; distance <= probeRange; distance++) {
             for (Coords potentialMineCoords : coords.allAtDistance(distance)) {
                 if (!game.getBoard().contains(potentialMineCoords)) {
                     continue;

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -485,6 +485,11 @@ public class ServerHelper {
             return false;
         }
         
+        // can't detect minefields if there aren't any to detect
+        if (!game.getMinedCoords().hasMoreElements()) {
+            return false;
+        }
+        
         // can't detect minefields if we have no probe
         int probeRange = entity.getBAPRange();
         if (probeRange <= 0) {


### PR DESCRIPTION
transmitPlayerUpdate is now synchronized on the connections list to prevent the list from being modified while looping through it. 

Also fixed a situation where an off-board entity was trying to detect minefields, and prevent the minefield detection loop from running if there aren't any minefields on the board in the first place to improve performance a little.

Fixes #3245