### PR TITLE
Ammo/Weapon techbase mismatch fixes + one instance of missing ammo

### DIFF
--- a/megamek/data/mechfiles/mechs/3145/NTNU RS/Deimos E.mtf
+++ b/megamek/data/mechfiles/mechs/3145/NTNU RS/Deimos E.mtf
@@ -84,7 +84,7 @@ CLDoubleHeatSink (omnipod)
 CLStreakSRM4 (omnipod)
 CLStreakSRM4 (omnipod)
 CLERMediumLaser
-IS Streak SRM 4 Ammo (omnipod)
+Clan Streak SRM 4 Ammo (omnipod)
 
 Right Torso:
 Fusion Engine

--- a/megamek/data/mechfiles/mechs/ER 2750/Victor VTR-9B (Shoji).mtf
+++ b/megamek/data/mechfiles/mechs/ER 2750/Victor VTR-9B (Shoji).mtf
@@ -67,7 +67,7 @@ Autocannon/10
 
 Left Torso:
 SRM 4
--Empty-
+IS Ammo SRM-4
 -Empty-
 -Empty-
 -Empty-

--- a/megamek/data/mechfiles/mechs/Golden Century/Emperor EMP-6A-EC.mtf
+++ b/megamek/data/mechfiles/mechs/Golden Century/Emperor EMP-6A-EC.mtf
@@ -76,8 +76,8 @@ ISDoubleHeatSink
 ISDoubleHeatSink
 ISMediumPulseLaser
 Clan LB 10-X AC Ammo
-IS LB 10-X AC Ammo
-IS LB 10-X Cluster Ammo
+Clan LB 10-X AC Ammo
+Clan LB 10-X Cluster Ammo
 Clan LB 10-X Cluster Ammo
 ISCASE
 

--- a/megamek/data/mechfiles/mechs/Recognition Guide ilClan/Vol 18/Jenner IIC 3.mtf
+++ b/megamek/data/mechfiles/mechs/Recognition Guide ilClan/Vol 18/Jenner IIC 3.mtf
@@ -83,8 +83,8 @@ Right Torso:
 Fusion Engine
 Fusion Engine
 Jump Jet
-ISNarc Pods
-ISNarc Pods
+CLNarc Pods
+CLNarc Pods
 Clan Endo Steel
 Clan Endo Steel
 Clan Endo Steel

--- a/megamek/data/mechfiles/mechs/Recognition Guide ilClan/Vol 7/Koshi (Mist Lynx) I.mtf
+++ b/megamek/data/mechfiles/mechs/Recognition Guide ilClan/Vol 7/Koshi (Mist Lynx) I.mtf
@@ -59,8 +59,8 @@ Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
 CLNarcBeacon (OMNIPOD)
-ISNarc Pods (OMNIPOD)
-ISNarc Pods (OMNIPOD)
+CLNarc Pods (OMNIPOD)
+CLNarc Pods (OMNIPOD)
 Clan Endo Steel
 Clan Ferro-Fibrous
 -Empty-

--- a/megamek/data/mechfiles/mechs/Recognition Guide ilClan/Vol 8/Dragonfly (Viper) R.mtf
+++ b/megamek/data/mechfiles/mechs/Recognition Guide ilClan/Vol 8/Dragonfly (Viper) R.mtf
@@ -43,8 +43,8 @@ Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
 CLNarcBeacon (OMNIPOD)
-ISNarc Pods (OMNIPOD)
-ISNarc Pods (OMNIPOD)
+CLNarc Pods (OMNIPOD)
+CLNarc Pods (OMNIPOD)
 Clan Ferro-Fibrous
 Clan Ferro-Fibrous
 -Empty-

--- a/megamek/data/mechfiles/mechs/Shattered Fortress/Templar III TLR2-J Arthur.mtf
+++ b/megamek/data/mechfiles/mechs/Shattered Fortress/Templar III TLR2-J Arthur.mtf
@@ -91,7 +91,7 @@ ISDoubleHeatSink (OMNIPOD)
 ISDoubleHeatSink (OMNIPOD)
 CLStreakSRM6 (OMNIPOD)
 CLStreakSRM6 (OMNIPOD)
-IS Streak SRM 6 Ammo (OMNIPOD)
+Clan Streak SRM 6 Ammo (OMNIPOD)
 ISCASEII
 IS Endo Steel
 IS Endo Steel

--- a/megamek/data/mechfiles/mechs/Turning Points/OTP WidowMaker Absorption/Highlander HGN-732 (Jorgensson).mtf
+++ b/megamek/data/mechfiles/mechs/Turning Points/OTP WidowMaker Absorption/Highlander HGN-732 (Jorgensson).mtf
@@ -72,8 +72,8 @@ LRM 20
 LRM 20
 LRM 20
 ISArtemisIV
-Clan Ammo LRM-20 (Clan) Artemis-capable
-Clan Ammo LRM-20 (Clan) Artemis-capable
+IS Ammo LRM-20 Artemis-capable
+IS Ammo LRM-20 Artemis-capable
 ISCASE
 IS Ferro-Fibrous
 IS Ferro-Fibrous

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Zephyros Infantry Support Vehicle.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Zephyros Infantry Support Vehicle.blk
@@ -57,7 +57,7 @@ Wheeled
 </armor>
 
 <Body Equipment>
-Clan Light Machine Gun Ammo - Proto
+Clan Light Machine Gun Ammo - Full
 CLECMSuite
 CLCASE
 </Body Equipment>

--- a/megamek/data/mechfiles/vehicles/3145/NTNU/Bolla Stealth Tank D.blk
+++ b/megamek/data/mechfiles/vehicles/3145/NTNU/Bolla Stealth Tank D.blk
@@ -73,8 +73,8 @@ IS Vehicular Stealth
 IS Vehicular Stealth
 ISC3SlaveUnit
 ISGuardianECMSuite
-CLSniperCannonAmmo:OMNI
-CLSniperCannonAmmo:OMNI
+ISSniperCannonAmmo:OMNI
+ISSniperCannonAmmo:OMNI
 CLMediumChemLaserAmmo:OMNI
 IS Machine Gun Ammo - Half
 </Body Equipment>


### PR DESCRIPTION
While there are advanced rules for weapon/ammo techbase mismatches, no units have been published with intentional mismatches to the best of my knowledge. 

**Bolla Stealth Tank (RotS) D**
Clan Sniper cannon ammo should be IS. (Chassis is IS and has IS cannon.)

**Deimos E**
IS SSRM4 ammo should probably be Clan. (Chassis is technically mixed tech but has Clan SSRM4.)

**Dragonfly R**
IS Narc ammo should probably be Clan. (Chassis is technically mixed tech but has Clan Narc.)

**Highlander HGN-732 (Jorgensson)**
CL LRM20 Artemis IV capable ammo should probably be IS. (Chassis technically mixed tech but has IS LRM and IS Artemis IV.)

**Jenner IIC 3**
IS Narc ammo should probably be Clan. (Chassis is clan and has clan launcher)

**Koshi I**
IS Narc ammo should probably be Clan. (Chassis is clan and has clan launcher)

**Templar III TLR2-J 'Arthur'**
IS SSRM6 ammo should probably be Clan. (Chassis technically mixed tech but has Clan launcher.)

**Victor VTR-9B (Shoji)**
Missing SRM4 ammo in left torso slot 2. (mtf had no SRM ammo, was a ton too light, and the normal 9B has SRM4 ammo in that slot.)

**Zephyros Infantry Support Vehicle (Standard)**
Mounts "- proto" light machine-gun ammo, should probably be "- full".