### PR TITLE
Implement TacOps active probe rules for hidden units

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1956,6 +1956,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 return;
             }
             butDone.setText("<html><b>" + Messages.getString("MovementDisplay.Move") + "</b></html>");
+            butDone.setEnabled(clientgui.getClient().isMyTurn());
             updateProneButtons();
             updateRACButton();
             updateSearchlightButton();

--- a/megamek/src/megamek/common/Coords.java
+++ b/megamek/src/megamek/common/Coords.java
@@ -464,6 +464,20 @@ public class Coords implements Serializable {
     }
     
     /**
+     * Returns a list of all coordinates at the given distance dist 
+     * and anything less than dist as well.
+     */
+    public ArrayList<Coords> allAtDistanceOrLess(int dist) {
+        ArrayList<Coords> retval = new ArrayList<>();
+        
+        for (int radius = 0; radius < dist; radius++) {
+            retval.addAll(allAtDistance(radius));
+        }
+        
+        return retval;
+    }
+    
+    /**
      * Returns a list of all coordinates at the given distance dist, 
      * regardless of whether they're on the board or not. Returns an 
      * empty Set for dist < 0 and the calling Coords itself for dist == 0.

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -550,7 +550,7 @@ public class ServerHelper {
             return false;
         }
        
-        int probeRange = 100;//detector.getBAPRange();
+        int probeRange = detector.getBAPRange();
         
         // if no probe, save ourselves a few loops
         if (probeRange <= 0) {

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -18,7 +18,11 @@
  */
 package megamek.server;
 
+import java.time.Clock;
 import java.util.*;
+import java.util.stream.Collectors;
+
+import megamek.MegaMek;
 import megamek.common.*;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.other.TSEMPWeapon;
@@ -546,7 +550,7 @@ public class ServerHelper {
             return false;
         }
        
-        int probeRange = detector.getBAPRange();
+        int probeRange = 100;//detector.getBAPRange();
         
         // if no probe, save ourselves a few loops
         if (probeRange <= 0) {
@@ -555,7 +559,7 @@ public class ServerHelper {
                 
         // Get all hidden units in probe range
         List<Entity> hiddenUnits = new ArrayList<>();
-        for (Coords coords : detectorCoords.allAtDistance(probeRange)) {
+        for (Coords coords : detectorCoords.allAtDistanceOrLess(probeRange)) {
             for (Entity entity : game.getEntitiesVector(coords, true)) {
                 if (entity.isHidden() && entity.isEnemyOf(detector)) {
                     hiddenUnits.add(entity);


### PR DESCRIPTION
Previously, active probes could only find hidden units at the end of a move; now they can do so in the middle of the move if the "tacops active probes" rule is turned on. Doing so interrupts the unit's movement.