### PR TITLE
Migrating to MavenCentral from JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ allprojects {
     targetCompatibility = 11
     
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' } // SerialKiller master branch
     }
 }


### PR DESCRIPTION
JCenter is shutting down in February.