### PR TITLE
Logging: Reducing Throwable::printStackTrace Uses

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -270,11 +270,11 @@ public class Client implements IClientCommandHandler {
             try {
                 log.close();
             } catch (IOException e) {
-                System.err.print("Exception closing logfile: "); //$NON-NLS-1$
-                e.printStackTrace();
+                MegaMek.getLogger().error("Exception closing logfile", e);
             }
         }
-        System.out.println("client: died"); //$NON-NLS-1$
+        MegaMek.getLogger().info("Client: Died");
+
         System.out.flush();
     }
 
@@ -287,7 +287,7 @@ public class Client implements IClientCommandHandler {
             if (connected) {
                 die();
             }
-            if (!host.equals("localhost")) { //$NON-NLS-1$
+            if (!host.equals("localhost")) {
                 game.processGameEvent(new GamePlayerDisconnectedEvent(this, getLocalPlayer()));
             }
         }
@@ -944,13 +944,12 @@ public class Client implements IClientCommandHandler {
 
             send(new Packet(Packet.COMMAND_LOAD_GAME, new Object[] { newGame }));
         } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println("Can't find local savegame " + f); //$NON-NLS-1$
+            MegaMek.getLogger().error("Can't find local save game " + f, e);
         }
     }
 
     public void sendExplodeBuilding(DemolitionCharge charge) {
-        Object data[] = new Object[1];
+        Object[] data = new Object[1];
         data[0] = charge;
         send(new Packet(Packet.COMMAND_BLDG_EXPLODE, data));
     }
@@ -999,12 +998,12 @@ public class Client implements IClientCommandHandler {
         game.setEntitiesVector(newEntities);
         if (newOutOfGame != null) {
             game.setOutOfGameEntitiesVector(newOutOfGame);
-            for(Entity e: newOutOfGame) {
+            for (Entity e: newOutOfGame) {
                 cacheImgTag(e);
             }
         }
         //cache the image data for the entities
-        for(Entity e: newEntities) {
+        for (Entity e: newEntities) {
             cacheImgTag(e);
         }
     }
@@ -1317,7 +1316,7 @@ public class Client implements IClientCommandHandler {
             fw.flush();
             fw.close();
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 
@@ -1615,8 +1614,7 @@ public class Client implements IClientCommandHandler {
                 fout.flush();
                 fout.close();
             } catch (Exception e) {
-                System.err.println("Unable to save file: " + sFinalFile);
-                e.printStackTrace();
+                MegaMek.getLogger().error("Unable to save file: " + sFinalFile, e);
             }
             break;
         case Packet.COMMAND_LOAD_SAVEGAME:
@@ -1625,7 +1623,7 @@ public class Client implements IClientCommandHandler {
                 File f = new File("savegames", loadFile);
                 sendLoadGame(f);
             } catch (Exception e) {
-                System.err.println("Unable to find the file: " + loadFile);
+                MegaMek.getLogger().error("Unable to find the file: " + loadFile, e);
             }
             break;
         case Packet.COMMAND_SENDING_SPECIAL_HEX_DISPLAY:
@@ -1662,12 +1660,12 @@ public class Client implements IClientCommandHandler {
                 cfrEvt.setTargetId((int) c.getObject(2));
                 break;
             case Packet.COMMAND_CFR_TELEGUIDED_TARGET:
-                cfrEvt.setTeleguidedMissileTargets((List<Integer>)c.getObject(1));
-                cfrEvt.setTmToHitValues((List<Integer>)c.getObject(2));
+                cfrEvt.setTeleguidedMissileTargets((List<Integer>) c.getObject(1));
+                cfrEvt.setTmToHitValues((List<Integer>) c.getObject(2));
                 break;
             case Packet.COMMAND_CFR_TAG_TARGET:
-                cfrEvt.setTAGTargets((List<Integer>)c.getObject(1));
-                cfrEvt.setTAGTargetTypes((List<Integer>)c.getObject(2));
+                cfrEvt.setTAGTargets((List<Integer>) c.getObject(1));
+                cfrEvt.setTAGTargetTypes((List<Integer>) c.getObject(2));
                 break;
             }
             game.processGameEvent(cfrEvt);
@@ -1693,19 +1691,18 @@ public class Client implements IClientCommandHandler {
                 e.setNewRoundNovaNetworkString(networkID);
             }
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
-
     }
 
     public void sendDominoCFRResponse(MovePath mp) {
-        Object data[] = { Packet.COMMAND_CFR_DOMINO_EFFECT, mp };
+        Object[] data = { Packet.COMMAND_CFR_DOMINO_EFFECT, mp };
         Packet packet = new Packet(Packet.COMMAND_CLIENT_FEEDBACK_REQUEST, data);
         send(packet);
     }
 
     public void sendAMSAssignCFRResponse(Integer waaIndex) {
-        Object data[] = { Packet.COMMAND_CFR_AMS_ASSIGN, waaIndex };
+        Object[] data = { Packet.COMMAND_CFR_AMS_ASSIGN, waaIndex };
         Packet packet = new Packet(Packet.COMMAND_CLIENT_FEEDBACK_REQUEST, data);
         send(packet);
     }

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -452,14 +452,14 @@ public abstract class BotClient extends Client {
                     break;
                 case VICTORY:
                     runEndGame();
-                    sendChat(Messages.getString("BotClient.Bye")); //$NON-NLS-1$
+                    sendChat(Messages.getString("BotClient.Bye"));
                     die();
                     break;
                 default:
                     break;
             }
         } catch (Throwable t) {
-            t.printStackTrace();
+            MegaMek.getLogger().error(t);
         }
     }
 
@@ -493,9 +493,9 @@ public abstract class BotClient extends Client {
         try {
             // Save the entities to the file.
             EntityListFile.saveTo(unitFile, living);
-        } catch (IOException excep) {
-            excep.printStackTrace(System.err);
-            doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"), excep.getMessage()); //$NON-NLS-1$
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
+            doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"), e.getMessage());
         }
     }
 
@@ -1170,8 +1170,7 @@ public abstract class BotClient extends Client {
             return null;
         }// CYA exception
         catch (Exception ex) {
-            System.err.println("Error while reading ./mmconf/botmessages.txt.");
-            ex.printStackTrace();
+            MegaMek.getLogger().error("Exception reading bot messages", ex);
             return null;
         }
         return message;

--- a/megamek/src/megamek/client/bot/ChatProcessor.java
+++ b/megamek/src/megamek/client/bot/ChatProcessor.java
@@ -17,6 +17,7 @@ package megamek.client.bot;
 import java.util.Enumeration;
 import java.util.StringTokenizer;
 
+import megamek.MegaMek;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.CardinalEdge;
@@ -186,7 +187,7 @@ public class ChatProcessor {
                 }
             }
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
     }
 

--- a/megamek/src/megamek/client/bot/GALance.java
+++ b/megamek/src/megamek/client/bot/GALance.java
@@ -17,6 +17,7 @@ package megamek.client.bot;
 import java.util.ArrayList;
 import java.util.Iterator;
 
+import megamek.MegaMek;
 import megamek.client.bot.ga.Chromosome;
 import megamek.client.bot.ga.GA;
 import megamek.common.Compute;
@@ -182,7 +183,7 @@ public class GALance extends GA {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
         double max = 0;
         // bonuses for endangering or dooming opponent mechs

--- a/megamek/src/megamek/client/bot/TestBot.java
+++ b/megamek/src/megamek/client/bot/TestBot.java
@@ -605,7 +605,7 @@ public class TestBot extends BotClient {
         // top balanced
         filterMoves(move_array, self.pass, new MoveOption.WeightedComparator(1, 1), 100);
         // top damage
-        filterMoves(move_array, self.pass, new MoveOption.WeightedComparator(.5, 1), 100);
+        filterMoves(move_array, self.pass, new MoveOption.WeightedComparator(0.5, 1), 100);
     }
 
     /**

--- a/megamek/src/megamek/client/bot/TestBot.java
+++ b/megamek/src/megamek/client/bot/TestBot.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.Vector;
 
+import megamek.MegaMek;
 import megamek.client.bot.MoveOption.DamageInfo;
 import megamek.common.AmmoType;
 import megamek.common.Compute;
@@ -186,15 +187,12 @@ public class TestBot extends BotClient {
                     }
                     try {
                         Thread.sleep(5000);
-                    } catch (InterruptedException e1) {
-                        System.out
-                                .println("Interrupted waiting for Bot to move.");
-                        e1.printStackTrace();
+                    } catch (InterruptedException e) {
+                        MegaMek.getLogger().error("Interrupted waiting for Bot to move", e);
                     } // Technically we should be using wait() but its not
                     // waking up reliably.
                     if (running > 0) {
-                        sendChat("Calculating the move for " + running
-                                 + " units. ");
+                        sendChat("Calculating the move for " + running + " units. ");
                     } else {
                         sendChat("Finalizing move.");
                     }
@@ -596,8 +594,8 @@ public class TestBot extends BotClient {
                                 option.threat += Integer.MAX_VALUE;
                             }
                         }
-                    } catch (Exception e1) {
-                        e1.printStackTrace();
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                         option.threat += Integer.MAX_VALUE;
                     }
                 }
@@ -605,11 +603,9 @@ public class TestBot extends BotClient {
             self.current.setState();
         } // -- end while of first pass
         // top balanced
-        filterMoves(move_array, self.pass, new MoveOption.WeightedComparator(1,
-                                                                             1), 100);
+        filterMoves(move_array, self.pass, new MoveOption.WeightedComparator(1, 1), 100);
         // top damage
-        filterMoves(move_array, self.pass, new MoveOption.WeightedComparator(
-                .5, 1), 100);
+        filterMoves(move_array, self.pass, new MoveOption.WeightedComparator(.5, 1), 100);
     }
 
     /**

--- a/megamek/src/megamek/client/generator/RandomUnitGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomUnitGenerator.java
@@ -37,6 +37,7 @@ import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import megamek.MegaMek;
 import megamek.common.Configuration;
 import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
@@ -348,34 +349,35 @@ public class RandomUnitGenerator implements Serializable {
                 }
                 continue;
             }
-            if( ratFileNameLC.endsWith(".zip") ) { //$NON-NLS-1$
-                try(ZipFile zipFile = new ZipFile(ratFile)) {
+
+            if (ratFileNameLC.endsWith(".zip")) {
+                try (ZipFile zipFile = new ZipFile(ratFile)) {
                     Enumeration<? extends ZipEntry> entries = zipFile.entries();
-                    while(entries.hasMoreElements()) {
+                    while (entries.hasMoreElements()) {
                         ZipEntry entry = entries.nextElement();
                         String entryName = entry.getName();
-                        if(!entry.isDirectory() && entryName.toLowerCase(Locale.ROOT).endsWith(".txt")) //$NON-NLS-1$
+                        if (!entry.isDirectory() && entryName.toLowerCase(Locale.ROOT).endsWith(".txt"))
                         {
                             RatTreeNode subNode = getNodeByPath(node, entryName);
-                            try(InputStream zis = zipFile.getInputStream(entry))
+                            try (InputStream zis = zipFile.getInputStream(entry))
                             {
-                                readRat(zis, subNode, ratFile.getName() + ":" + entryName, msc); //$NON-NLS-1$
+                                readRat(zis, subNode, ratFile.getName() + ":" + entryName, msc);
                             }
                         }
                     }
-                } catch(IOException e) {
-                    System.err.println(String.format("Unable to load %s", ratFile.getName())); //$NON-NLS-1$
+                } catch (IOException e) {
+                    MegaMek.getLogger().error("Unable to load " + ratFile.getName());
                 }
             }
-            if (!ratFileNameLC.endsWith(".txt")) { //$NON-NLS-1$
+
+            if (!ratFileNameLC.endsWith(".txt")) {
                 continue;
             }
-            try(InputStream ratInputStream = new FileInputStream(ratFile)) {
+
+            try (InputStream ratInputStream = new FileInputStream(ratFile)) {
                 readRat(ratInputStream, node, ratFile.getName(), msc);
-            } catch(IOException e) {
-                System.err.println(String.format("Unable to load %s", ratFile.getName())); //$NON-NLS-1$
-                System.err.println(e.getMessage());
-                e.printStackTrace();
+            } catch (IOException e) {
+                MegaMek.getLogger().error("Unable to load " + ratFile.getName(), e);
             }
         }
     }
@@ -461,7 +463,7 @@ public class RandomUnitGenerator implements Serializable {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
         return units;
     }

--- a/megamek/src/megamek/client/generator/RandomUnitGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomUnitGenerator.java
@@ -343,8 +343,8 @@ public class RandomUnitGenerator implements Serializable {
                 // recursion is fun
                 loadRatsFromDirectory(ratFile, msc, newNode);
 
-                // Prune empty nodes (this removes the "Unofficial" place holder)
-                if (newNode.children.size() == 0) {
+                // Prune empty nodes (this removes the "Unofficial" placeholder)
+                if (newNode.children.isEmpty()) {
                     node.children.remove(newNode);
                 }
                 continue;
@@ -356,11 +356,9 @@ public class RandomUnitGenerator implements Serializable {
                     while (entries.hasMoreElements()) {
                         ZipEntry entry = entries.nextElement();
                         String entryName = entry.getName();
-                        if (!entry.isDirectory() && entryName.toLowerCase(Locale.ROOT).endsWith(".txt"))
-                        {
+                        if (!entry.isDirectory() && entryName.toLowerCase(Locale.ROOT).endsWith(".txt")) {
                             RatTreeNode subNode = getNodeByPath(node, entryName);
-                            try (InputStream zis = zipFile.getInputStream(entry))
-                            {
+                            try (InputStream zis = zipFile.getInputStream(entry)) {
                                 readRat(zis, subNode, ratFile.getName() + ":" + entryName, msc);
                             }
                         }
@@ -406,10 +404,10 @@ public class RandomUnitGenerator implements Serializable {
             int retryCount = 0;
             
             // give the RATs a few seconds to load
-            while(!initialized && retryCount < 5) {
+            while (!initialized && retryCount < 5) {
                 try {
                     Thread.sleep(1000);
-                } catch(Exception e) {
+                } catch (Exception ignored) {
                     
                 }
                 
@@ -527,6 +525,7 @@ public class RandomUnitGenerator implements Serializable {
         if (null == rug) {
             rug = new RandomUnitGenerator();
         }
+
         if (!rug.initialized && !rug.initializing) {
             rug.initializing = true;
             interrupted = false;

--- a/megamek/src/megamek/client/generator/RandomUnitGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomUnitGenerator.java
@@ -531,15 +531,11 @@ public class RandomUnitGenerator implements Serializable {
             rug.initializing = true;
             interrupted = false;
             dispose = false;
-            rug.loader = new Thread(new Runnable() {
-                public void run() {
-                    long start = System.currentTimeMillis();
-                    rug.populateUnits();
-                    long end = System.currentTimeMillis();
-                    System.out.println("Loaded Rats in: " + (end - start)
-                            + "ms.");
-                    System.out.flush();
-                }
+            rug.loader = new Thread(() -> {
+                long start = System.currentTimeMillis();
+                rug.populateUnits();
+                long end = System.currentTimeMillis();
+                MegaMek.getLogger().info(String.format("Loaded RATs in: %sms", (end - start)));
             }, "Random Unit Generator unit populator");
             rug.loader.setPriority(Thread.NORM_PRIORITY - 1);
             rug.loader.start();

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1148,9 +1149,9 @@ public class RATGenerator {
 
         file = new File(dir + "/factions.xml");
         try {
-            pw = new PrintWriter(file, "UTF-8");
-        } catch (Exception e1) {
-            e1.printStackTrace();
+            pw = new PrintWriter(file, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
             return;
         }
         pw.println("<?xml version='1.0' encoding='UTF-8'?>");
@@ -1172,7 +1173,7 @@ public class RATGenerator {
             int nextEra = (i < ERAS.size() - 1)? ERAS.get(i + 1) : era;
             try {
                 file = new File(dir + "/" + era + ".xml");
-                pw = new PrintWriter(file, "UTF-8");
+                pw = new PrintWriter(file, StandardCharsets.UTF_8);
                 pw.println("<?xml version='1.0' encoding='UTF-8'?>");
                 pw.println("<!-- Era " + era + "-->");
                 pw.println("<ratgen>");
@@ -1262,7 +1263,7 @@ public class RATGenerator {
                 pw.println("</ratgen>");
                 pw.close();
             } catch (Exception e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
         }
     }

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
@@ -31,6 +31,7 @@ import javax.swing.*;
 import javax.swing.border.*;
 import javax.swing.event.*;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.bot.princess.*;
 import megamek.client.ui.Messages;
@@ -618,7 +619,7 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
                 princessBehavior = ((Princess)bc).getBehaviorSettings().getCopy();
                 updateDialogFields();
             } catch (PrincessException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/ChatterBox2.java
+++ b/megamek/src/megamek/client/ui/swing/ChatterBox2.java
@@ -15,6 +15,7 @@
 
 package megamek.client.ui.swing;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.ui.IDisplayable;
 import megamek.client.ui.swing.boardview.BoardView;
@@ -34,10 +35,8 @@ import megamek.common.util.fileUtils.MegaMekFile;
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
-import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Vector;
 
@@ -546,7 +545,7 @@ public class ChatterBox2 implements KeyListener, IDisplayable {
         while (words.hasMoreElements()) {
             String nextWord = words.nextElement();
             if (fm.stringWidth(nextLine + " " + nextWord) < lineWidth) {
-                nextLine = (nextLine.equals("")) ? nextWord : nextLine + " "
+                nextLine = (nextLine.isEmpty()) ? nextWord : nextLine + " "
                         + nextWord;
             } else {
                 messages.addElement(nextLine);
@@ -716,18 +715,10 @@ public class ChatterBox2 implements KeyListener, IDisplayable {
                     content.isDataFlavorSupported(DataFlavor.stringFlavor);
             if (hasTransferableText) {
                 try {
-                    addChatMessage((String)content.getTransferData(
-                            DataFlavor.stringFlavor));
-                  }
-                  catch (UnsupportedFlavorException ex){
-                    //highly unlikely since we are using a standard DataFlavor
-                    System.out.println(ex);
-                    ex.printStackTrace();
-                  }
-                  catch (IOException ex) {
-                      System.out.println(ex);
-                      ex.printStackTrace();
-                  }
+                    addChatMessage((String) content.getTransferData(DataFlavor.stringFlavor));
+                } catch (Exception  ex) {
+                    MegaMek.getLogger().error(ex);
+                }
             }            
             return;
         }
@@ -809,7 +800,7 @@ public class ChatterBox2 implements KeyListener, IDisplayable {
                 slideDown();
                 break;
             case KeyEvent.VK_BACK_SPACE:
-                if ((message == null) || message.equals("")) {
+                if ((message == null) || message.isEmpty()) {
                     return;
                 }
 

--- a/megamek/src/megamek/client/ui/swing/ChatterBox2.java
+++ b/megamek/src/megamek/client/ui/swing/ChatterBox2.java
@@ -545,8 +545,7 @@ public class ChatterBox2 implements KeyListener, IDisplayable {
         while (words.hasMoreElements()) {
             String nextWord = words.nextElement();
             if (fm.stringWidth(nextLine + " " + nextWord) < lineWidth) {
-                nextLine = (nextLine.isEmpty()) ? nextWord : nextLine + " "
-                        + nextWord;
+                nextLine = nextLine.isEmpty() ? nextWord : nextLine + " " + nextWord;
             } else {
                 messages.addElement(nextLine);
                 nextLine = nextWord;

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -917,8 +917,8 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         frame.setVisible(false);
         try {
             frame.dispose();
-        } catch (Throwable error) {
-            error.printStackTrace();
+        } catch (Throwable t) {
+            MegaMek.getLogger().error(t);
         }
         client.die();
 
@@ -1483,13 +1483,13 @@ public class ClientGUI extends JPanel implements BoardViewListener,
                         }
                     }
                 }
-                if (loadedUnits.size() > 0){
+                if (loadedUnits.size() > 0) {
                     client.sendAddEntity(loadedUnits);
                     addedUnits = true;
                 }
-            } catch (IOException excep) {
-                excep.printStackTrace(System.err);
-                doAlertDialog(Messages.getString("ClientGUI.errorLoadingFile"), excep.getMessage()); //$NON-NLS-1$
+            } catch (IOException e) {
+                MegaMek.getLogger().error(e);
+                doAlertDialog(Messages.getString("ClientGUI.errorLoadingFile"), e.getMessage());
             }
         }
 
@@ -1518,7 +1518,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             // the name
             String path = fc.getSelectedFile().getParentFile().getPath();
             path = path.replace(" ", "|");
-            client.sendChat("/localsave " + file + " " + path); //$NON-NLS-1$
+            client.sendChat("/localsave " + file + " " + path);
             return true;
         }
         return false;
@@ -1586,9 +1586,9 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             try {
                 // Save the player's entities to the file.
                 EntityListFile.saveTo(unitFile, unitList);
-            } catch (IOException excep) {
-                excep.printStackTrace(System.err);
-                doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"), excep.getMessage()); //$NON-NLS-1$
+            } catch (IOException e) {
+                MegaMek.getLogger().error(e);
+                doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"), e.getMessage());
             }
         }
     }
@@ -1628,9 +1628,9 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             try {
                 // Save the player's entities to the file.
                 EntityListFile.saveTo(unitFile, getClient());
-            } catch (IOException excep) {
-                excep.printStackTrace(System.err);
-                doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"), excep.getMessage()); //$NON-NLS-1$
+            } catch (Exception e) {
+                MegaMek.getLogger().error(e);
+                doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"), e.getMessage());
             }
         }
     }
@@ -2168,7 +2168,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         try {
             ImageIO.write(bv.getEntireBoardImage(ignoreUnits, false), "png", curfileBoardImage);
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
         waitD.setVisible(false);
         frame.setCursor(Cursor.getDefaultCursor());

--- a/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
@@ -31,6 +31,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 
+import megamek.MegaMek;
 import megamek.MegaMekConstants;
 import megamek.client.ui.Messages;
 import megamek.common.Configuration;
@@ -65,8 +66,8 @@ public class CommonAboutDialog extends JDialog {
             try {
                 tracker.waitForID(0);
                 imgTitleImage = image;
-            } catch (InterruptedException exp) {
-                exp.printStackTrace();
+            } catch (Exception e) {
+                MegaMek.getLogger().error(e);
             }
         } // End load-imgTitleImage
 

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -35,6 +35,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.border.TitledBorder;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.ui.GBC;
 import megamek.client.ui.Messages;
@@ -913,15 +914,14 @@ public class EquipChoicePanel extends JPanel {
                 }
                     
                 // Add the newly mounted weapon
-                try{
-                    Mounted newWeap =  entity.addEquipment(apType, 
-                            m_APmounted.getLocation());
+                try {
+                    Mounted newWeap =  entity.addEquipment(apType, m_APmounted.getLocation());
                     m_APmounted.setLinked(newWeap);
                     newWeap.setLinked(m_APmounted);
                     newWeap.setAPMMounted(true);
-                } catch (LocationFullException ex){
+                } catch (LocationFullException ex) {
                     // This shouldn't happen for BA...
-                    ex.printStackTrace();
+                    MegaMek.getLogger().error(ex);
                 }
 
             }
@@ -974,7 +974,7 @@ public class EquipChoicePanel extends JPanel {
                 if (m != null){
                     curType = m.getType();
                 }
-                m_choice = new JComboBox<String>();
+                m_choice = new JComboBox<>();
                 m_choice.addItem("None");
                 m_choice.setSelectedIndex(0);
                 Iterator<MiscType> it = m_Manipulators.iterator();
@@ -1013,29 +1013,28 @@ public class EquipChoicePanel extends JPanel {
                     return;
                 }
                 MiscType manipType = null;
-                if (n > 0 && n <= m_Manipulators.size()){
+                if (n > 0 && n <= m_Manipulators.size()) {
                     // Need to account for the "None" selection
-                    manipType = m_Manipulators.get(n-1);
+                    manipType = m_Manipulators.get(n - 1);
                 }
 
-                if (m_Manipmounted != null){
+                if (m_Manipmounted != null) {
                     entity.getEquipment().remove(m_Manipmounted);
                     entity.getMisc().remove(m_Manipmounted);
                 }            
                 
                 // Was no manipulator selected?
-                if (n == 0){
+                if (n == 0) {
                     return;
                 }
                     
                 // Add the newly mounted maniplator
-                try{
-                    m_Manipmounted = entity.addEquipment(manipType, 
-                            m_Manipmounted.getLocation());
+                try {
+                    m_Manipmounted = entity.addEquipment(manipType, m_Manipmounted.getLocation());
                     m_Manipmounted.setBaMountLoc(baMountLoc);
-                } catch (LocationFullException ex){
+                } catch (LocationFullException ex) {
                     // This shouldn't happen for BA...
-                    ex.printStackTrace();
+                    MegaMek.getLogger().error(ex);
                 }
 
             }

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
@@ -1228,7 +1228,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
             } catch (InterruptedException ex) {
                 //Ignore
             } catch (ExecutionException e) {
-                e.getCause().printStackTrace();
+                MegaMek.getLogger().error(e);
             } finally {
                 btnGenerate.setEnabled(true);
             }

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -324,7 +324,7 @@ public class MapMenu extends JPopupMenu {
                                 .selectEntity(selectedEntity.getId());
                     }
                 } catch (Exception ex) {
-                    ex.printStackTrace();
+                    MegaMek.getLogger().error(ex);
                 }
             }
         });
@@ -338,16 +338,13 @@ public class MapMenu extends JPopupMenu {
                 + en.getDisplayName());
 
         item.setActionCommand(Integer.toString(en.getId()));
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    selectedEntity = game.getEntity(Integer.parseInt(e
-                            .getActionCommand()));
-                    GUIPreferences.getInstance().showUnitDisplay();
-                    gui.mechD.displayEntity(selectedEntity);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                selectedEntity = game.getEntity(Integer.parseInt(e.getActionCommand()));
+                GUIPreferences.getInstance().showUnitDisplay();
+                gui.mechD.displayEntity(selectedEntity);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -472,17 +469,13 @@ public class MapMenu extends JPopupMenu {
         }
 
         if (entityInHex) {
-            JMenuItem item = new JMenuItem(
-                    Messages.getString("MovementDisplay.MoveEnvelope")); //$NON-NLS-1$
-            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_ENVELOPE
-                                          .getCmd());
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    try {
-                        ((MovementDisplay) currentPanel).actionPerformed(e);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                    }
+            JMenuItem item = new JMenuItem(Messages.getString("MovementDisplay.MoveEnvelope"));
+            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_ENVELOPE.getCmd());
+            item.addActionListener(e -> {
+                try {
+                    ((MovementDisplay) currentPanel).actionPerformed(e);
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             });
             menu.add(item);
@@ -491,13 +484,11 @@ public class MapMenu extends JPopupMenu {
             item = new JMenuItem(Messages.getString("MovementDisplay.butWalk"));
 
             item.setActionCommand(MovementDisplay.MoveCommand.MOVE_WALK.getCmd());
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    try {
-                        ((MovementDisplay) currentPanel).actionPerformed(e);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                    }
+            item.addActionListener(e -> {
+                try {
+                    ((MovementDisplay) currentPanel).actionPerformed(e);
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             });
             menu.add(item);
@@ -505,87 +496,69 @@ public class MapMenu extends JPopupMenu {
             item = new JMenuItem(Messages.getString("MovementDisplay.butBackup"));
 
             item.setActionCommand(MovementDisplay.MoveCommand.MOVE_BACK_UP.getCmd());
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    try {
-                        ((MovementDisplay) currentPanel).actionPerformed(e);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                    }
+            item.addActionListener(e -> {
+                try {
+                    ((MovementDisplay) currentPanel).actionPerformed(e);
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             });
 
             menu.add(item);
 
             if (myEntity.getJumpMP() > 0) {
-                item = new JMenuItem(
-                        Messages.getString("CommonMenuBar.moveJump"));
+                item = new JMenuItem(Messages.getString("CommonMenuBar.moveJump"));
 
-                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_JUMP
-                                              .getCmd());
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        try {
-                            ((MovementDisplay) currentPanel).actionPerformed(e);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
+                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_JUMP.getCmd());
+                item.addActionListener(e -> {
+                    try {
+                        ((MovementDisplay) currentPanel).actionPerformed(e);
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                     }
                 });
                 menu.add(item);
             }
 
             if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_EVADE)) {
-                item = new JMenuItem(
-                        Messages.getString("MovementDisplay.butEvade"));
+                item = new JMenuItem(Messages.getString("MovementDisplay.butEvade"));
 
-                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_EVADE
-                                              .getCmd());
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        try {
-                            ((MovementDisplay) currentPanel).actionPerformed(e);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
+                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_EVADE.getCmd());
+                item.addActionListener(e -> {
+                    try {
+                        ((MovementDisplay) currentPanel).actionPerformed(e);
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                     }
                 });
                 menu.add(item);
             }
 
             if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_VEHICLE_ADVANCED_MANEUVERS)) {
-                item = new JMenuItem(
-                        Messages.getString("MovementDisplay.butEvade"));
+                item = new JMenuItem(Messages.getString("MovementDisplay.butEvade"));
 
-                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_BOOTLEGGER
-                                              .getCmd());
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        try {
-                            ((MovementDisplay) currentPanel).actionPerformed(e);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
+                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_BOOTLEGGER.getCmd());
+                item.addActionListener(e -> {
+                    try {
+                        ((MovementDisplay) currentPanel).actionPerformed(e);
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                     }
                 });
                 menu.add(item);
             }
 
             if (game.getPlanetaryConditions().isRecklessConditions()
-                && !game.getBoard().inSpace()
-                && !game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_NO_NIGHT_MOVE_PEN)) {
-                item = new JMenuItem(
-                        Messages.getString("MovementDisplay.butReckless"));
+                    && !game.getBoard().inSpace()
+                    && !game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_NO_NIGHT_MOVE_PEN)) {
+                item = new JMenuItem(Messages.getString("MovementDisplay.butReckless"));
 
-                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_RECKLESS
-                                              .getCmd());
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        try {
-                            ((MovementDisplay) currentPanel).actionPerformed(e);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
+                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_RECKLESS.getCmd());
+                item.addActionListener(e -> {
+                    try {
+                        ((MovementDisplay) currentPanel).actionPerformed(e);
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                     }
                 });
                 menu.add(item);
@@ -593,125 +566,97 @@ public class MapMenu extends JPopupMenu {
 
         } else {
 
-            JMenuItem item = new JMenuItem(
-                    Messages.getString("MovementDisplay.butWalk"));
+            JMenuItem item = new JMenuItem(Messages.getString("MovementDisplay.butWalk"));
 
-            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_WALK
-                                          .getCmd());
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    try {
-                        plotCourse(e);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                    }
+            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_WALK.getCmd());
+            item.addActionListener(e -> {
+                try {
+                    plotCourse(e);
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             });
 
             menu.add(item);
 
-            item = new JMenuItem(
-                    Messages.getString("MovementDisplay.butBackup"));
+            item = new JMenuItem(Messages.getString("MovementDisplay.butBackup"));
 
-            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_BACK_UP
-                                          .getCmd());
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    try {
-                        plotCourse(e);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                    }
+            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_BACK_UP.getCmd());
+            item.addActionListener(e -> {
+                try {
+                    plotCourse(e);
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             });
 
             menu.add(item);
 
             if (myEntity.getJumpMP() > 0) {
-                item = new JMenuItem(
-                        Messages.getString("CommonMenuBar.moveJump"));
+                item = new JMenuItem(Messages.getString("CommonMenuBar.moveJump"));
 
-                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_JUMP
-                                              .getCmd());
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        try {
-                            plotCourse(e);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
+                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_JUMP.getCmd());
+                item.addActionListener(e -> {
+                    try {
+                        plotCourse(e);
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                     }
                 });
                 menu.add(item);
             }
 
-            item = new JMenuItem(
-                    Messages.getString("MovementDisplay.moveLongestRun")); //$NON-NLS-1$
+            item = new JMenuItem(Messages.getString("MovementDisplay.moveLongestRun"));
 
-            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_LONGEST_RUN
-                                          .getCmd());
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    try {
-                        plotCourse(e);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                    }
+            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_LONGEST_RUN.getCmd());
+            item.addActionListener(e -> {
+                try {
+                    plotCourse(e);
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             });
 
             menu.add(item);
 
-            item = new JMenuItem(
-                    Messages.getString("MovementDisplay.moveLongestWalk")); //$NON-NLS-1$
+            item = new JMenuItem(Messages.getString("MovementDisplay.moveLongestWalk"));
 
-            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_LONGEST_WALK
-                                          .getCmd());
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    try {
-                        plotCourse(e);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                    }
+            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_LONGEST_WALK.getCmd());
+            item.addActionListener(e -> {
+                try {
+                    plotCourse(e);
+                } catch (Exception ex) {
+                    MegaMek.getLogger().error(ex);
                 }
             });
 
             menu.add(item);
 
             if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_EVADE)) {
-                item = new JMenuItem(
-                        Messages.getString("MovementDisplay.butEvade"));
+                item = new JMenuItem(Messages.getString("MovementDisplay.butEvade"));
 
-                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_EVADE
-                                              .getCmd());
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        try {
-                            plotCourse(e);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
+                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_EVADE.getCmd());
+                item.addActionListener(e -> {
+                    try {
+                        plotCourse(e);
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                     }
                 });
                 menu.add(item);
             }
 
             if (game.getPlanetaryConditions().isRecklessConditions()
-                && !game.getBoard().inSpace()
-                && !game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_NO_NIGHT_MOVE_PEN)) {
-                item = new JMenuItem(
-                        Messages.getString("MovementDisplay.butReckless"));
+                    && !game.getBoard().inSpace()
+                    && !game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_NO_NIGHT_MOVE_PEN)) {
+                item = new JMenuItem(Messages.getString("MovementDisplay.butReckless"));
 
-                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_RECKLESS
-                                              .getCmd());
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        try {
-                            plotCourse(e);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
+                item.setActionCommand(MovementDisplay.MoveCommand.MOVE_RECKLESS.getCmd());
+                item.addActionListener(e -> {
+                    try {
+                        plotCourse(e);
+                    } catch (Exception ex) {
+                        MegaMek.getLogger().error(ex);
                     }
                 });
                 menu.add(item);
@@ -724,50 +669,40 @@ public class MapMenu extends JPopupMenu {
     private JMenu createTurnMenu() {
         JMenu menu = new JMenu(Messages.getString("MovementDisplay.butTurn"));
 
-        JMenuItem item = new JMenuItem(
-                Messages.getString("MovementDisplay.butTurnRight"));
+        JMenuItem item = new JMenuItem(Messages.getString("MovementDisplay.butTurnRight"));
 
-        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_TURN_RIGHT
-                                      .getCmd());
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_TURN_RIGHT.getCmd());
+        item.addActionListener(e -> {
+            try {
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
         menu.add(item);
 
         item = new JMenuItem(Messages.getString("MovementDisplay.butTurnLeft"));
 
-        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_TURN_LEFT
-                                      .getCmd());
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_TURN_LEFT.getCmd());
+        item.addActionListener(e -> {
+            try {
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
         menu.add(item);
 
         item = new JMenuItem("About Face");
 
-        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_TURN_RIGHT
-                                      .getCmd());
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_TURN_RIGHT.getCmd());
+        item.addActionListener(e -> {
+            try {
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
         menu.add(item);
@@ -797,13 +732,11 @@ public class MapMenu extends JPopupMenu {
 
     private JMenuItem createSkipJMenuItem() {
         JMenuItem item = new JMenuItem("Skip");
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((FiringDisplay) currentPanel).nextWeapon();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((FiringDisplay) currentPanel).nextWeapon();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -812,43 +745,40 @@ public class MapMenu extends JPopupMenu {
 
     private JMenuItem createAlphaStrikeJMenuItem() {
         JMenuItem item = new JMenuItem("Alpha Strike");
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    FiringDisplay panel = (FiringDisplay) currentPanel;
-                    // Get all weapons
-                    ArrayList<Mounted> weapons = myEntity.getWeaponList();
-                    // We will need to map a Mounted to it's weapon number
-                    HashMap<Mounted, Integer> weapToId = 
-                            new HashMap<Mounted, Integer>();
-                    for (Mounted weapon : weapons) {
-                        weapToId.put(weapon, myEntity.getEquipmentNum(weapon));
-                    }
-                    // Sort weapons from high damage to low
-                    Collections.sort(weapons, new WeaponComparatorDamage(false));
-                    
-                    Targetable target = panel.getTarget();
-                    for (Mounted weapon : weapons) {
-                        // If the weapon has been used at all this turn, ignore
-                        if (weapon.usedInPhase() != GamePhase.UNKNOWN) {
-                            continue;
-                        }
-                        int weaponNum = weapToId.get(weapon);
-                        // Used to determine if attack is valid
-                        WeaponAttackAction waa = new WeaponAttackAction(
-                                myEntity.getId(), target.getTargetType(),
-                                target.getTargetId(), weaponNum);
-                        // Only fire weapons that have a chance to hit
-                        int toHitVal = waa.toHit(game).getValue(); 
-                        if ((toHitVal != TargetRoll.IMPOSSIBLE)
-                                && (toHitVal <= 12)) {
-                            gui.mechD.wPan.selectWeapon(weaponNum);
-                            panel.fire();
-                        }
-                    }
-                } catch (Exception ex) {
-                    ex.printStackTrace();
+        item.addActionListener(e -> {
+            try {
+                FiringDisplay panel = (FiringDisplay) currentPanel;
+                // Get all weapons
+                ArrayList<Mounted> weapons = myEntity.getWeaponList();
+                // We will need to map a Mounted to it's weapon number
+                HashMap<Mounted, Integer> weapToId = new HashMap<>();
+                for (Mounted weapon : weapons) {
+                    weapToId.put(weapon, myEntity.getEquipmentNum(weapon));
                 }
+                // Sort weapons from high damage to low
+                weapons.sort(new WeaponComparatorDamage(false));
+
+                Targetable target = panel.getTarget();
+                for (Mounted weapon : weapons) {
+                    // If the weapon has been used at all this turn, ignore
+                    if (weapon.usedInPhase() != GamePhase.UNKNOWN) {
+                        continue;
+                    }
+                    int weaponNum = weapToId.get(weapon);
+                    // Used to determine if attack is valid
+                    WeaponAttackAction waa = new WeaponAttackAction(
+                            myEntity.getId(), target.getTargetType(),
+                            target.getTargetId(), weaponNum);
+                    // Only fire weapons that have a chance to hit
+                    int toHitVal = waa.toHit(game).getValue();
+                    if ((toHitVal != TargetRoll.IMPOSSIBLE)
+                            && (toHitVal <= 12)) {
+                        gui.mechD.wPan.selectWeapon(weaponNum);
+                        panel.fire();
+                    }
+                }
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -859,16 +789,14 @@ public class MapMenu extends JPopupMenu {
         JMenuItem item = new JMenuItem("Flip Arms");
 
         item.setActionCommand(Integer.toString(myEntity.getId()));
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    FiringDisplay display = (FiringDisplay) currentPanel;
+        item.addActionListener(e -> {
+            try {
+                FiringDisplay display = (FiringDisplay) currentPanel;
 
-                    int id = Integer.parseInt(e.getActionCommand());
-                    display.updateFlipArms(!game.getEntity(id).getArmsFlipped());
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+                int id = Integer.parseInt(e.getActionCommand());
+                display.updateFlipArms(!game.getEntity(id).getArmsFlipped());
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -878,13 +806,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createFireJMenuItem() {
         JMenuItem item = new JMenuItem("Fire");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((FiringDisplay) currentPanel).fire();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((FiringDisplay) currentPanel).fire();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1051,24 +977,19 @@ public class MapMenu extends JPopupMenu {
     }
 
     private JMenuItem createStandJMenuItem(boolean carefulStand) {
-        JMenuItem item = new JMenuItem(
-                Messages.getString("MovementDisplay.butUp"));
+        JMenuItem item = new JMenuItem(Messages.getString("MovementDisplay.butUp"));
 
         if (carefulStand) {
             item.setText("Careful Stand");
-            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_CAREFUL_STAND
-                                          .getCmd());
+            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_CAREFUL_STAND.getCmd());
         } else {
-            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_GET_UP
-                                          .getCmd());
+            item.setActionCommand(MovementDisplay.MoveCommand.MOVE_GET_UP.getCmd());
         }
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1076,18 +997,14 @@ public class MapMenu extends JPopupMenu {
     }
 
     private JMenuItem createHullDownJMenuItem() {
-        JMenuItem item = new JMenuItem(
-                Messages.getString("MovementDisplay.butHullDown"));
+        JMenuItem item = new JMenuItem(Messages.getString("MovementDisplay.butHullDown"));
 
-        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_HULL_DOWN
-                                      .getCmd());
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_HULL_DOWN.getCmd());
+        item.addActionListener(e -> {
+            try {
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1095,18 +1012,14 @@ public class MapMenu extends JPopupMenu {
     }
 
     private JMenuItem createProneJMenuItem() {
-        JMenuItem item = new JMenuItem(
-                Messages.getString("MovementDisplay.butDown"));
+        JMenuItem item = new JMenuItem(Messages.getString("MovementDisplay.butDown"));
 
-        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_GO_PRONE
-                                      .getCmd());
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((MovementDisplay) currentPanel).actionPerformed(e);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.setActionCommand(MovementDisplay.MoveCommand.MOVE_GO_PRONE.getCmd());
+        item.addActionListener(e -> {
+            try {
+                ((MovementDisplay) currentPanel).actionPerformed(e);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1116,7 +1029,7 @@ public class MapMenu extends JPopupMenu {
     private JMenu createConvertMenu() {
         JMenu menu = new JMenu(Messages.getString("MovementDisplay.moveModeConvert"));
         
-        if (myEntity instanceof Mech && ((Mech)myEntity).hasTracks()) {
+        if (myEntity instanceof Mech && ((Mech) myEntity).hasTracks()) {
             menu.add(createConvertMenuItem("MovementDisplay.moveModeLeg",
                     MovementDisplay.MoveCommand.MOVE_MODE_LEG, false));
             menu.add(createConvertMenuItem("MovementDisplay.moveModeTrack",
@@ -1134,15 +1047,15 @@ public class MapMenu extends JPopupMenu {
                     MovementDisplay.MoveCommand.MOVE_MODE_LEG,
                     currentMode == LandAirMech.CONV_MODE_MECH);
             item.setEnabled(currentMode == LandAirMech.CONV_MODE_MECH
-                    || ((LandAirMech)myEntity).canConvertTo(currentMode,
+                    || ((LandAirMech) myEntity).canConvertTo(currentMode,
                             LandAirMech.CONV_MODE_MECH));
             menu.add(item);
-            if (((LandAirMech)myEntity).getLAMType() == LandAirMech.LAM_STANDARD) {
+            if (((LandAirMech) myEntity).getLAMType() == LandAirMech.LAM_STANDARD) {
                 item = createConvertMenuItem("MovementDisplay.moveModeAirmech",
                         MovementDisplay.MoveCommand.MOVE_MODE_VEE,
                         currentMode == LandAirMech.CONV_MODE_AIRMECH);
                 item.setEnabled(currentMode == LandAirMech.CONV_MODE_AIRMECH
-                        || ((LandAirMech)myEntity).canConvertTo(currentMode,
+                        || ((LandAirMech) myEntity).canConvertTo(currentMode,
                                 LandAirMech.CONV_MODE_AIRMECH));
                 menu.add(item);
             }
@@ -1150,7 +1063,7 @@ public class MapMenu extends JPopupMenu {
                     MovementDisplay.MoveCommand.MOVE_MODE_AIR,
                     currentMode == LandAirMech.CONV_MODE_FIGHTER);
             item.setEnabled(currentMode == LandAirMech.CONV_MODE_FIGHTER
-                    || ((LandAirMech)myEntity).canConvertTo(currentMode,
+                    || ((LandAirMech) myEntity).canConvertTo(currentMode,
                             LandAirMech.CONV_MODE_FIGHTER));
             menu.add(item);
         }
@@ -1169,7 +1082,7 @@ public class MapMenu extends JPopupMenu {
             try {
                 ((MovementDisplay) currentPanel).actionPerformed(e);
             } catch (Exception ex) {
-                ex.printStackTrace();
+                MegaMek.getLogger().error(ex);
             }
         });
         return item;
@@ -1374,7 +1287,7 @@ public class MapMenu extends JPopupMenu {
         }
 
         for (Mounted wpn : myEntity.getWeaponList()) {
-            if (((WeaponType) wpn.getType()).hasFlag(weaponFlag)) {
+            if (wpn.getType().hasFlag(weaponFlag)) {
                 return true;
             }
         }
@@ -1424,16 +1337,14 @@ public class MapMenu extends JPopupMenu {
         }
 
         item.setActionCommand(Integer.toString(direction));
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    int twistDir = Integer.parseInt(e.getActionCommand());
-                    if (currentPanel instanceof FiringDisplay) {
-                        ((FiringDisplay) currentPanel).torsoTwist(twistDir);
-                    }
-                } catch (Exception ex) {
-                    ex.printStackTrace();
+        item.addActionListener(e -> {
+            try {
+                int twistDir = Integer.parseInt(e.getActionCommand());
+                if (currentPanel instanceof FiringDisplay) {
+                    ((FiringDisplay) currentPanel).torsoTwist(twistDir);
                 }
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1444,27 +1355,22 @@ public class MapMenu extends JPopupMenu {
         JMenuItem item = new JMenuItem("Twist");
 
         item.setActionCommand(twistCoords.getX() + "|" + twistCoords.getY());
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    StringTokenizer result = new StringTokenizer(e
-                                                                         .getActionCommand(), "|");
-                    Coords coord = new Coords(Integer.parseInt(result
-                                                                       .nextToken()), Integer.parseInt(result.nextToken()));
-                    if (currentPanel instanceof FiringDisplay) {
-                        ((FiringDisplay) currentPanel).torsoTwist(coord);
-                    }
-                } catch (Exception ex) {
-                    ex.printStackTrace();
+        item.addActionListener(e -> {
+            try {
+                StringTokenizer result = new StringTokenizer(e.getActionCommand(), "|");
+                Coords coord = new Coords(Integer.parseInt(result.nextToken()), Integer.parseInt(result.nextToken()));
+                if (currentPanel instanceof FiringDisplay) {
+                    ((FiringDisplay) currentPanel).torsoTwist(coord);
                 }
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
         return item;
     }
 
-    private JMenuItem createRotateTurretJMenuItem(final Mech mech,
-                                                  final Mounted turret) {
+    private JMenuItem createRotateTurretJMenuItem(final Mech mech, final Mounted turret) {
         String turretString;
         if (turret.getType().hasFlag(MiscType.F_SHOULDER_TURRET)) {
             turretString = "Rotate Shoulder Turret ("
@@ -1475,12 +1381,9 @@ public class MapMenu extends JPopupMenu {
             turretString = "Rotate Quad Turret";
         }
         JMenuItem item = new JMenuItem(turretString);
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ae) {
-                TurretFacingDialog tfe = new TurretFacingDialog(gui.frame,
-                                                                mech, turret, gui);
-                tfe.setVisible(true);
-            }
+        item.addActionListener(ae -> {
+            TurretFacingDialog tfe = new TurretFacingDialog(gui.frame, mech, turret, gui);
+            tfe.setVisible(true);
         });
         return item;
     }
@@ -1489,12 +1392,9 @@ public class MapMenu extends JPopupMenu {
         String turretString;
         turretString = "Rotate Front Turret";
         JMenuItem item = new JMenuItem(turretString);
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ae) {
-                TurretFacingDialog tfe = new TurretFacingDialog(gui.frame,
-                                                                tank, gui);
-                tfe.setVisible(true);
-            }
+        item.addActionListener(ae -> {
+            TurretFacingDialog tfe = new TurretFacingDialog(gui.frame, tank, gui);
+            tfe.setVisible(true);
         });
         return item;
     }
@@ -1606,18 +1506,15 @@ public class MapMenu extends JPopupMenu {
         }
 
         item.setActionCommand(Integer.toString(position));
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    int modePosition = Integer.parseInt(e.getActionCommand());
-                    int weaponNum = gui.mechD.wPan.getSelectedWeaponNum();
-                    Mounted equip = myEntity.getEquipment(weaponNum);
-                    equip.setMode(modePosition);
-                    client.sendModeChange(myEntity.getId(), weaponNum,
-                                          modePosition);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                int modePosition = Integer.parseInt(e.getActionCommand());
+                int weaponNum = gui.mechD.wPan.getSelectedWeaponNum();
+                Mounted equip = myEntity.getEquipment(weaponNum);
+                equip.setMode(modePosition);
+                client.sendModeChange(myEntity.getId(), weaponNum, modePosition);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
         return item;
@@ -1627,13 +1524,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createPunchJMenuItem() {
         JMenuItem item = new JMenuItem("Punch");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).punch();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).punch();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1643,13 +1538,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createKickJMenuItem() {
         JMenuItem item = new JMenuItem("Kick");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).kick();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).kick();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1659,13 +1552,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createPushJMenuItem() {
         JMenuItem item = new JMenuItem("Push");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).push();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).push();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1675,13 +1566,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createVibroClawMenuItem() {
         JMenuItem item = new JMenuItem("Vibro Claw Attack");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).vibroclawatt();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).vibroclawatt();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1691,13 +1580,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createJumpJetAttackJMenuItem() {
         JMenuItem item = new JMenuItem("Jump Jet Attack");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).jumpjetatt();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).jumpjetatt();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1707,13 +1594,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createThrashJMenuItem() {
         JMenuItem item = new JMenuItem("Thrash");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).thrash();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).thrash();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1723,13 +1608,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createGrappleJMenuItem() {
         JMenuItem item = new JMenuItem("Grapple");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).doGrapple();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).doGrapple();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1739,13 +1622,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createTripJMenuItem() {
         JMenuItem item = new JMenuItem("Trip");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).trip();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).trip();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1755,13 +1636,11 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createDodgeJMenuItem() {
         JMenuItem item = new JMenuItem("Dodge");
 
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    ((PhysicalDisplay) currentPanel).dodge();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                ((PhysicalDisplay) currentPanel).dodge();
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1784,15 +1663,13 @@ public class MapMenu extends JPopupMenu {
         JMenuItem item = new JMenuItem(clubName);
 
         item.setActionCommand(Integer.toString(clubNumber));
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    Mounted club = myEntity.getClubs().get(
-                            Integer.parseInt(e.getActionCommand()));
-                    ((PhysicalDisplay) currentPanel).club(club);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+        item.addActionListener(e -> {
+            try {
+                Mounted club = myEntity.getClubs().get(
+                        Integer.parseInt(e.getActionCommand()));
+                ((PhysicalDisplay) currentPanel).club(club);
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -1810,5 +1687,4 @@ public class MapMenu extends JPopupMenu {
     public boolean getHasMenu() {
         return hasMenu;
     }
-
 }

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -37,7 +37,6 @@ import megamek.common.weapons.other.ISFireExtinguisher;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.math.BigInteger;
@@ -58,7 +57,7 @@ public class MapMenu extends JPopupMenu {
     Entity selectedEntity;
     Entity myEntity;
     Targetable myTarget = null;
-    private boolean hasMenu = false;
+    private boolean hasMenu;
 
     public MapMenu(Coords coords, Client client, Component panel, ClientGUI gui) {
         this.coords = coords;
@@ -248,17 +247,14 @@ public class MapMenu extends JPopupMenu {
         }
 
         item.setActionCommand(targetCode);
-        item.addActionListener(new ActionListener() {
-
-            public void actionPerformed(ActionEvent e) {
-                myTarget = decodeTargetInfo(e.getActionCommand());
-                if (currentPanel instanceof FiringDisplay) {
-                    ((FiringDisplay) currentPanel).target(myTarget);
-                } else if (currentPanel instanceof PhysicalDisplay) {
-                    ((PhysicalDisplay) currentPanel).target(myTarget);
-                } else if (currentPanel instanceof TargetingPhaseDisplay) {
-                    ((TargetingPhaseDisplay) currentPanel).target(myTarget);
-                }
+        item.addActionListener(e -> {
+            myTarget = decodeTargetInfo(e.getActionCommand());
+            if (currentPanel instanceof FiringDisplay) {
+                ((FiringDisplay) currentPanel).target(myTarget);
+            } else if (currentPanel instanceof PhysicalDisplay) {
+                ((PhysicalDisplay) currentPanel).target(myTarget);
+            } else if (currentPanel instanceof TargetingPhaseDisplay) {
+                ((TargetingPhaseDisplay) currentPanel).target(myTarget);
             }
         });
 
@@ -273,12 +269,7 @@ public class MapMenu extends JPopupMenu {
             return null;
         }
         item.setActionCommand(MovementDisplay.MoveCommand.MOVE_CHARGE.getCmd());
-        item.addActionListener(new ActionListener() {
-
-            public void actionPerformed(ActionEvent e) {
-                plotCourse(e);
-            }
-        });
+        item.addActionListener(this::plotCourse);
 
         return item;
     }
@@ -291,12 +282,7 @@ public class MapMenu extends JPopupMenu {
             return null;
         }
         item.setActionCommand(MovementDisplay.MoveCommand.MOVE_DFA.getCmd());
-        item.addActionListener(new ActionListener() {
-
-            public void actionPerformed(ActionEvent e) {
-                plotCourse(e);
-            }
-        });
+        item.addActionListener(this::plotCourse);
 
         return item;
     }
@@ -307,25 +293,18 @@ public class MapMenu extends JPopupMenu {
                 + en.getDisplayName());
 
         item.setActionCommand(Integer.toString(en.getId()));
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    Entity entity = game.getEntity(Integer.parseInt(e
-                            .getActionCommand()));
-                    selectedEntity = entity;
-                    if (currentPanel instanceof MovementDisplay) {
-                        ((MovementDisplay) currentPanel)
-                                .selectEntity(selectedEntity.getId());
-                    } else if (currentPanel instanceof FiringDisplay) {
-                        ((FiringDisplay) currentPanel)
-                                .selectEntity(selectedEntity.getId());
-                    } else if (currentPanel instanceof PhysicalDisplay) {
-                        ((PhysicalDisplay) currentPanel)
-                                .selectEntity(selectedEntity.getId());
-                    }
-                } catch (Exception ex) {
-                    MegaMek.getLogger().error(ex);
+        item.addActionListener(e -> {
+            try {
+                selectedEntity = game.getEntity(Integer.parseInt(e.getActionCommand()));
+                if (currentPanel instanceof MovementDisplay) {
+                    ((MovementDisplay) currentPanel).selectEntity(selectedEntity.getId());
+                } else if (currentPanel instanceof FiringDisplay) {
+                    ((FiringDisplay) currentPanel).selectEntity(selectedEntity.getId());
+                } else if (currentPanel instanceof PhysicalDisplay) {
+                    ((PhysicalDisplay) currentPanel).selectEntity(selectedEntity.getId());
                 }
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
         });
 
@@ -333,8 +312,7 @@ public class MapMenu extends JPopupMenu {
     }
 
     private JMenuItem viewJMenuItem(Entity en) {
-        JMenuItem item = new JMenuItem(
-                Messages.getString("ClientGUI.viewMenuItem")
+        JMenuItem item = new JMenuItem(Messages.getString("ClientGUI.viewMenuItem")
                 + en.getDisplayName());
 
         item.setActionCommand(Integer.toString(en.getId()));
@@ -360,11 +338,7 @@ public class MapMenu extends JPopupMenu {
                 if (charge.playerId == client.getLocalPlayer().getId()
                         && coords.equals(charge.pos)) {
                     JMenuItem item = new JMenuItem(charge.damage + " Damage");
-                    item.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e) {
-                            client.sendExplodeBuilding(charge);
-                        }
-                    });
+                    item.addActionListener(e -> client.sendExplodeBuilding(charge));
                     menu.add(item);
                 }
             }
@@ -404,26 +378,20 @@ public class MapMenu extends JPopupMenu {
             finalNote = note;
         }
         JMenuItem item = new JMenuItem(Messages.getString("NoteDialog.action")); //$NON-NLS-1$
-        item.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                NoteDialog nd = new NoteDialog(gui.frame, finalNote);
-                gui.getBoardView().setShouldIgnoreKeys(true);
-                nd.setVisible(true);
-                gui.getBoardView().setShouldIgnoreKeys(false);
-                if (nd.isAccepted()) {
-                    client.sendSpecialHexDisplayAppend(coords, finalNote);
-                }
+        item.addActionListener(e -> {
+            NoteDialog nd = new NoteDialog(gui.frame, finalNote);
+            gui.getBoardView().setShouldIgnoreKeys(true);
+            nd.setVisible(true);
+            gui.getBoardView().setShouldIgnoreKeys(false);
+            if (nd.isAccepted()) {
+                client.sendSpecialHexDisplayAppend(coords, finalNote);
             }
         });
         menu.add(item);
 
         if (note != null) {
             item = new JMenuItem(Messages.getString("NoteDialog.delete")); //$NON-NLS-1$
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    client.sendSpecialHexDisplayDelete(coords, finalNote);
-                }
-            });
+            item.addActionListener(e -> client.sendSpecialHexDisplayDelete(coords, finalNote));
         }
         menu.add(item);
 
@@ -434,8 +402,7 @@ public class MapMenu extends JPopupMenu {
         JMenu menu = new JMenu("Select");
         // add select options
         if (canSelectEntities()) {
-            for (Entity entity : client.getGame().getEntitiesVector(coords,
-                    canTargetEntities())) {
+            for (Entity entity : client.getGame().getEntitiesVector(coords, canTargetEntities())) {
                 if (client.getMyTurn().isValidEntity(entity, client.getGame())) {
                     menu.add(selectJMenuItem(entity));
                 }
@@ -1071,7 +1038,7 @@ public class MapMenu extends JPopupMenu {
     }
     
     private JMenuItem createConvertMenuItem(String resourceKey, MovementDisplay.MoveCommand cmd,
-            boolean isCurrent) {
+                                            boolean isCurrent) {
         String text = Messages.getString(resourceKey);
         if (isCurrent) {
             text = "No Conversion";
@@ -1106,7 +1073,7 @@ public class MapMenu extends JPopupMenu {
         final boolean isFiringDisplay = (currentPanel instanceof FiringDisplay);
         final boolean isTargetingDisplay = (currentPanel instanceof TargetingPhaseDisplay);
         final boolean canStartFires = client.getGame().getOptions()
-                .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_START_FIRE); //$NON-NLS-1$
+                .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_START_FIRE);
         
         IPlayer localPlayer = client.getLocalPlayer();
         
@@ -1114,8 +1081,7 @@ public class MapMenu extends JPopupMenu {
         for (Entity entity : client.getGame().getEntitiesVector(coords)) {
             // Only add the unit if it's actually visible
             //  With double blind on, the game may have unseen units
-            if (!entity.isSensorReturn(localPlayer)
-                    && entity.hasSeenEntity(localPlayer)
+            if (!entity.isSensorReturn(localPlayer) && entity.hasSeenEntity(localPlayer)
                     && !entity.isHidden()) {
                 menu.add(TargetMenuItem(entity));
             }
@@ -1194,6 +1160,7 @@ public class MapMenu extends JPopupMenu {
                         || hasAmmoType(AmmoType.T_BA_TUBE)) {
                     menu.add(TargetMenuItem(new HexTarget(coords, Targetable.TYPE_HEX_ARTILLERY)));
                 }
+
                 if (canStartFires && hasFireExtinguisher()
                     && h.containsTerrain(Terrains.FIRE)) {
                     menu.add(TargetMenuItem(new HexTarget(coords, Targetable.TYPE_HEX_EXTINGUISH)));

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -128,8 +128,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         try {
             UIManager.setLookAndFeel(GUIPreferences.getInstance().getUITheme());
         } catch (Exception e) {
-            System.err.println("Error setting look and feel!");
-            e.printStackTrace();
+            MegaMek.getLogger().error("Error setting look and feel!", e);
         }
 
         ToolTipManager.sharedInstance().setInitialDelay(

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -20,6 +20,7 @@
  */
 package megamek.client.ui.swing;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
@@ -192,7 +193,7 @@ public final class MiniMap extends JPanel implements IPreferenceChangeListener {
             tempMM.drawMap(true);
             return ImageUtil.createAcceleratedImage(tempMM.mapImage);
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return ImageUtil.failStandardImage();
         }
     }
@@ -380,7 +381,7 @@ public final class MiniMap extends JPanel implements IPreferenceChangeListener {
             }
         } catch (Exception e) {
             // Fall back to the default colors
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 
@@ -448,7 +449,7 @@ public final class MiniMap extends JPanel implements IPreferenceChangeListener {
                     SwingUtilities.invokeLater(drawMapable);
                 }
             } catch (Throwable t) {
-                t.printStackTrace();
+                MegaMek.getLogger().error(t);
             }
         }
     };
@@ -1343,8 +1344,8 @@ public final class MiniMap extends JPanel implements IPreferenceChangeListener {
 						+ e.getOldPhase() + ".png");
                 try {
                     ImageIO.write(getMinimapImage(game, bv, GAME_SUMMARY_ZOOM), "png", imgFile);
-                } catch (IOException e1) {
-                    e1.printStackTrace();
+                } catch (IOException ex) {
+                    MegaMek.getLogger().error(ex);
                 }
 
             }

--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -14,6 +14,7 @@
  */
 package megamek.client.ui.swing;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
@@ -561,10 +562,8 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                         }
                         entities.add(e);
                     } catch (EntityLoadingException ex) {
-                        System.out.println("Unable to load mech: " + //$NON-NLS-1$ 
-                                ms.getSourceFile() + ": " + ms.getEntryName() + //$NON-NLS-1$
-                                ": " + ex.getMessage()); //$NON-NLS-1$ 
-                        ex.printStackTrace();
+                        MegaMek.getLogger().error(String.format("Unable to load entity %s: %s",
+                                ms.getSourceFile(), ms.getEntryName()), ex);
                         return;
                     }
                 }
@@ -828,9 +827,8 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
         createRatTreeNodes(root, ratTree);
         m_treeRAT.setModel(new DefaultTreeModel(root));
         
-        String selectedRATPath = 
-                GUIPreferences.getInstance().getRATSelectedRAT();
-        if (!selectedRATPath.equals("")) {
+        String selectedRATPath = GUIPreferences.getInstance().getRATSelectedRAT();
+        if (!selectedRATPath.isEmpty()) {
             String[] nodes = selectedRATPath.replace('[', ' ')
                     .replace(']', ' ').split(",");
             TreePath path = findPathByName(nodes);

--- a/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
@@ -48,6 +48,7 @@ import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.filechooser.FileFilter;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.UIUtil;
@@ -380,10 +381,10 @@ public class RandomMapDialog extends JDialog implements ActionListener {
         // Cache the selected boards, so we can restore them
         ArrayList<String> selectedBoards = mapSettings.getBoardsSelectedVector();
         // Load the file.  If there is an error, log it and return.
-        try(InputStream is = new FileInputStream(selectedFile)) {
+        try (InputStream is = new FileInputStream(selectedFile)) {
             mapSettings = MapSettings.getInstance(is);
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return;
         }
         mapSettings.setBoardsSelectedVector(selectedBoards);
@@ -412,10 +413,10 @@ public class RandomMapDialog extends JDialog implements ActionListener {
         }
 
         // Load the changed settings into the existing map settings object.
-        try(OutputStream os = new FileOutputStream(selectedFile)) {
+        try (OutputStream os = new FileOutputStream(selectedFile)) {
             mapSettings.save(os);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
         return true;
     }

--- a/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
@@ -13,6 +13,7 @@
  */
 package megamek.client.ui.swing;
 
+import megamek.MegaMek;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.VerifyInRange;
 import megamek.client.ui.swing.util.VerifyIsInteger;
@@ -1052,7 +1053,7 @@ public class RandomMapPanelAdvanced extends JPanel {
         String result = field.verifyTextS();
         if (result != null) {
             result = field.getName() + ": " + result;
-            new RuntimeException(result).printStackTrace();
+            MegaMek.getLogger().error(new RuntimeException(result));
             field.requestFocus();
             showDataValidationError(result);
         }
@@ -1068,7 +1069,7 @@ public class RandomMapPanelAdvanced extends JPanel {
 
         final String INVALID = "Minimum cannot exceed maximum.";
         if (min.getAsInt() > max.getAsInt()) {
-            new RuntimeException(INVALID).printStackTrace();
+            MegaMek.getLogger().error(new RuntimeException(INVALID));
             min.setOldToolTip(min.getToolTipText());
             max.setOldToolTip(max.getToolTipText());
             min.setBackground(VerifiableTextField.getInvalidColor());

--- a/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
@@ -49,6 +49,7 @@ import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.filechooser.FileFilter;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.VerifyInRange;
@@ -399,10 +400,10 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
         }
 
         // Load the file.  If there is an error, log it and return.
-        try(InputStream is = new FileInputStream(selectedFile)) {
+        try (InputStream is = new FileInputStream(selectedFile)) {
             mapSettings = MapSettings.getInstance(is);
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return;
         }
 
@@ -412,7 +413,6 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
     }
 
     private boolean doSave() {
-
         // Apply the changes.
         if (!doApply()) {
             return false;
@@ -428,10 +428,10 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
         }
 
         // Load the changed settings into the existing map settings object.
-        try(InputStream is = new FileInputStream(selectedFile)) {
+        try (InputStream is = new FileInputStream(selectedFile)) {
             mapSettings = MapSettings.getInstance(is);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
         return true;
     }

--- a/megamek/src/megamek/client/ui/swing/Ruler.java
+++ b/megamek/src/megamek/client/ui/swing/Ruler.java
@@ -14,6 +14,7 @@
 
 package megamek.client.ui.swing;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
@@ -86,13 +87,13 @@ public class Ruler extends JDialog implements BoardViewListener {
             //getContentPane().add(panel1);
             pack();
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
     }
 
     private void jbInit() {
         buttonPanel = new JPanel();
-        butFlip.setText(Messages.getString("Ruler.flip")); //$NON-NLS-1$
+        butFlip.setText(Messages.getString("Ruler.flip"));
         butFlip.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 butFlip_actionPerformed();

--- a/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
@@ -286,33 +286,28 @@ class FovHighlightingAndDarkening {
         ringsRadii= new ArrayList<>();
         ringsColors= new ArrayList<>();
 
-        for(String rrRaw: dRingsRadiiRaw){
+        for (String rrRaw: dRingsRadiiRaw) {
             try {
-                int rr= Integer.parseInt(rrRaw.trim());
-                ringsRadii.add( Math.min(rr, max_dist) );
+                int rr = Integer.parseInt(rrRaw.trim());
+                ringsRadii.add(Math.min(rr, max_dist));
             } catch (NumberFormatException e) {
-                System.err.printf("%s parameter unparsable '%s'"
-                        ,GUIPreferences.FOV_HIGHLIGHT_RINGS_RADII, rrRaw );
-                e.printStackTrace();
-                System.err.flush();
+                MegaMek.getLogger().error(String.format("%s parameter unparsable '%s'",
+                        GUIPreferences.FOV_HIGHLIGHT_RINGS_RADII, rrRaw), e);
                 break;
             }
         }
 
-        for(String rcr: dRingsColorsRaw ){
+        for (String rcr : dRingsColorsRaw) {
             try {
-                String[] hsbr= rcr.trim().split("\\s+");
-                float h=Float.parseFloat( hsbr[0] );
-                float s=Float.parseFloat( hsbr[1] );
-                float b=Float.parseFloat( hsbr[2] );
+                String[] hsbr = rcr.trim().split("\\s+");
+                float h = Float.parseFloat( hsbr[0] );
+                float s = Float.parseFloat( hsbr[1] );
+                float b = Float.parseFloat( hsbr[2] );
                 Color tc= new Color( Color.HSBtoRGB(h, s, b) );
-                ringsColors.add(new Color(tc.getRed(), tc.getGreen(), tc
-                        .getBlue(), highlight_alpha));
+                ringsColors.add(new Color(tc.getRed(), tc.getGreen(), tc.getBlue(), highlight_alpha));
             } catch (NumberFormatException e) {
-                System.err.printf("%s parameter unparsable '%s'"
-                        ,GUIPreferences.FOV_HIGHLIGHT_RINGS_COLORS_HSB, rcr );
-                e.printStackTrace();
-                System.err.flush();
+                MegaMek.getLogger().error(String.format("%s paremater unparsable '%s'",
+                        GUIPreferences.FOV_HIGHLIGHT_RINGS_COLORS_HSB, rcr), e);
                 break;
             }
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import megamek.MegaMek;
 import megamek.client.ui.IDisplayable;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
@@ -267,7 +268,7 @@ public class KeyBindingsOverlay implements IDisplayable, IPreferenceChangeListen
                 int blu = Integer.parseInt(s.substring(5,7), 16);
                 textColor = new Color(red, grn, blu);
             } catch (NumberFormatException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
             s = s.substring(7);
         }

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2541,7 +2541,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         List<Entity> newEntities = new ArrayList<>();
         if (hasTransferableText) {
             try {
-                String result = (String)contents.getTransferData(DataFlavor.stringFlavor);
+                String result = (String) contents.getTransferData(DataFlavor.stringFlavor);
                 StringTokenizer lines = new StringTokenizer(result, "\n");
                 while (lines.hasMoreTokens()) {
                     String line = lines.nextToken();
@@ -2564,10 +2564,10 @@ public class ChatLounge extends AbstractPhaseDisplay implements
                         newEntities.add(newEntity);
                     }
                 }
+            } catch (Exception ex) {
+                MegaMek.getLogger().error(ex);
             }
-            catch (Exception ex) {
-                ex.printStackTrace();
-            }
+
             if (!newEntities.isEmpty()) {
                 client().sendAddEntity(newEntities);
             }
@@ -2682,16 +2682,16 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             String[] command = action.getActionCommand().split(":");
 
             switch (command[0]) {
-            case MapListPopup.MLP_BOARD:
-                boolean rotate = (command.length > 3) && Boolean.valueOf(command[3]);
-                String rotateRequest = rotate ? Board.BOARD_REQUEST_ROTATION : "";
-                
-                changeMapDnD(rotateRequest + command[2], mapButtons.get(Integer.parseInt(command[1])));
-                break;
+                case MapListPopup.MLP_BOARD:
+                    boolean rotate = (command.length > 3) && Boolean.parseBoolean(command[3]);
+                    String rotateRequest = rotate ? Board.BOARD_REQUEST_ROTATION : "";
 
-            case MapListPopup.MLP_SURPRISE:
-                changeMapDnD(command[2], mapButtons.get(Integer.parseInt(command[1])));
-                break;
+                    changeMapDnD(rotateRequest + command[2], mapButtons.get(Integer.parseInt(command[1])));
+                    break;
+
+                case MapListPopup.MLP_SURPRISE:
+                    changeMapDnD(command[2], mapButtons.get(Integer.parseInt(command[1])));
+                    break;
             }
         }
 
@@ -3279,14 +3279,14 @@ public class ChatLounge extends AbstractPhaseDisplay implements
 
     class ImageLoader extends SwingWorker<Void, Image> {
 
-        private BlockingQueue<String> boards = new LinkedBlockingQueue<String>();
+        private BlockingQueue<String> boards = new LinkedBlockingQueue<>();
 
         private synchronized void add(String name) {
             if (!boards.contains(name)) {
                 try {
                     boards.put(name);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    MegaMek.getLogger().error(e);
                 }
             }
         }

--- a/megamek/src/megamek/client/ui/swing/lobby/MapPreviewButton.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MapPreviewButton.java
@@ -263,9 +263,8 @@ public class MapPreviewButton extends JButton {
                     } else {
                         return false;
                     }
-                } catch (Exception exp) {
-                    MegaMek.getLogger().error("A problem has occurred with map drag-and-drop.");
-                    exp.printStackTrace();
+                } catch (Exception e) {
+                    MegaMek.getLogger().error("A problem has occurred with map drag-and-drop.", e);
                 }
             }
             return false;

--- a/megamek/src/megamek/client/ui/swing/lobby/MekForceTreeTransferHandler.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekForceTreeTransferHandler.java
@@ -31,6 +31,7 @@ import javax.swing.JTree;
 import javax.swing.TransferHandler;
 import javax.swing.tree.TreePath;
 
+import megamek.MegaMek;
 import megamek.common.Entity;
 import megamek.common.force.Force;
 
@@ -111,7 +112,7 @@ public class MekForceTreeTransferHandler extends TransferHandler {
             }
             
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return false;
         }
         return true;
@@ -177,7 +178,7 @@ public class MekForceTreeTransferHandler extends TransferHandler {
             
             
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return false;
         }
         return false;

--- a/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
+++ b/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
@@ -14,6 +14,7 @@
  */
 package megamek.client.ui.swing.skinEditor;
 
+import megamek.MegaMek;
 import megamek.client.TimerSingleton;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
@@ -128,7 +129,7 @@ public class SkinEditorMainGUI extends JPanel implements WindowListener, BoardVi
             testEntity = new MechFileParser(ms.getSourceFile(),
                     ms.getEntryName()).getEntity();
         } catch (EntityLoadingException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 
@@ -212,9 +213,9 @@ public class SkinEditorMainGUI extends JPanel implements WindowListener, BoardVi
             bvc = bv.getComponent();
             bvc.setName("BoardView");
         } catch (IOException e) {
-            e.printStackTrace();
-            doAlertDialog(Messages.getString("ClientGUI.FatalError.title"), //$NON-NLS-1$
-                    Messages.getString("ClientGUI.FatalError.message") + e); //$NON-NLS-1$
+            MegaMek.getLogger().error(e);
+            doAlertDialog(Messages.getString("ClientGUI.FatalError.title"),
+                    Messages.getString("ClientGUI.FatalError.message") + e);
             die();
         }
         switchPanel(GamePhase.MOVEMENT);
@@ -252,9 +253,9 @@ public class SkinEditorMainGUI extends JPanel implements WindowListener, BoardVi
             bvc = bv.getComponent();
             bvc.setName("BoardView");
         } catch (Exception e) {
-            e.printStackTrace();
-            doAlertDialog(Messages.getString("ClientGUI.FatalError.title"), //$NON-NLS-1$
-                    Messages.getString("ClientGUI.FatalError.message") + e); //$NON-NLS-1$
+            MegaMek.getLogger().error(e);
+            doAlertDialog(Messages.getString("ClientGUI.FatalError.title"),
+                    Messages.getString("ClientGUI.FatalError.message") + e);
             die();
         }
 
@@ -348,8 +349,8 @@ public class SkinEditorMainGUI extends JPanel implements WindowListener, BoardVi
         frame.setVisible(false);
         try {
             frame.dispose();
-        } catch (Throwable error) {
-            error.printStackTrace();
+        } catch (Throwable t) {
+            MegaMek.getLogger().error(t);
         }
 
         TimerSingleton.getInstance().killTimer();

--- a/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
@@ -542,7 +542,7 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         try {
             tracker.waitForID(1);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/util/BASE64ImageView.java
+++ b/megamek/src/megamek/client/ui/swing/util/BASE64ImageView.java
@@ -91,7 +91,7 @@ public class BASE64ImageView extends ImageView {
             try {
                 this.url = new URL("file:/" + this.getElement().toString());
             } catch (MalformedURLException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
 
             return this.url;

--- a/megamek/src/megamek/client/ui/swing/util/ImageAtlasMap.java
+++ b/megamek/src/megamek/client/ui/swing/util/ImageAtlasMap.java
@@ -21,13 +21,16 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.thoughtworks.xstream.XStream;
 
+import megamek.MegaMek;
 import megamek.common.Configuration;
+import megamek.common.annotations.Nullable;
 
 /**
  * Class to encapsulate a map that maps old image paths to the subsequent location in an image atlas.  This allows us
@@ -106,10 +109,10 @@ public class ImageAtlasMap {
     public boolean writeToFile() {
         XStream xstream = new XStream();
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(Configuration.imageFileAtlasMapFile()),
-                Charset.forName("UTF-8"));) {
+                StandardCharsets.UTF_8)) {
             xstream.toXML(imgFileToAtlasMap, writer);
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return false;
         }
         return true;
@@ -120,7 +123,7 @@ public class ImageAtlasMap {
      * @return
      */
     @SuppressWarnings("unchecked")
-    public static ImageAtlasMap readFromFile() {
+    public static @Nullable ImageAtlasMap readFromFile() {
         if (!Configuration.imageFileAtlasMapFile().exists()) {
             return null;
         }
@@ -129,13 +132,11 @@ public class ImageAtlasMap {
         try (InputStream is = new FileInputStream(Configuration.imageFileAtlasMapFile())) {
             XStream xstream = new XStream();
             map = new ImageAtlasMap((Map<String, String>) xstream.fromXML(is));
-        } catch (FileNotFoundException e) {
+        } catch (Exception e) {
             map = null;
-            e.printStackTrace();
-        } catch (IOException e) {
-            map = null;
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
+
         return map;
     }
 

--- a/megamek/src/megamek/client/ui/swing/widget/MegamekBorder.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MegamekBorder.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import javax.swing.ImageIcon;
 import javax.swing.border.EtchedBorder;
 
+import megamek.MegaMek;
 import megamek.common.Configuration;
 import megamek.common.util.fileUtils.MegaMekFile;
 
@@ -259,10 +260,8 @@ public class MegamekBorder extends EtchedBorder {
             } else {
                 insets = new Insets(5, 5, 5, 5);
             }
-        } catch (Exception e){
-            System.out.println("Error: loading icons for " +
-                    "a MegamekBorder!");
-            e.printStackTrace();
+        } catch (Exception e) {
+            MegaMek.getLogger().error("Failed Loading icons for a MegaMek Border", e);
             iconsLoaded = false;
         }      
     }
@@ -270,14 +269,13 @@ public class MegamekBorder extends EtchedBorder {
     /**
      * Paints the border using the loaded corner icons and edge icons.
      */
-    public void paintBorder(Component c, Graphics g, int x, int y, int width, 
-            int height) {
+    public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
         // Do nothing if we don't want to draw a border
         if (noBorder) {
             return;
         }
         
-        // If the icons didn't loaded, treat this as a regualar border
+        // If the icons didn't load, treat this as a regular border
         if (!iconsLoaded) {
             super.paintBorder(c, g, x, y, width, height);
             return;
@@ -286,7 +284,7 @@ public class MegamekBorder extends EtchedBorder {
         g.translate(x, y);
         
         // Draw Top Left Corner Icon
-        if (tlCorner.getImageLoadStatus() == MediaTracker.COMPLETE){
+        if (tlCorner.getImageLoadStatus() == MediaTracker.COMPLETE) {
             paintCorner(c, g, 0, 0, tlCorner);
         }
         

--- a/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
@@ -14,7 +14,6 @@
 * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
 * details.
 */
-
 package megamek.client.ui.swing.widget;
 
 import java.awt.Color;
@@ -45,10 +44,9 @@ import org.w3c.dom.NodeList;
 
 /**
  * This class reads in an XML file that specifies different aspects of the
- * visual skin for Megamek.
+ * visual skin for MegaMek.
  *
  * @author arlith
- *
  */
 public class SkinXMLHandler {
 
@@ -59,7 +57,7 @@ public class SkinXMLHandler {
         StringBuffer sb = new StringBuffer();
         sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         sb.append("<!--\n");
-        sb.append("  This is the default skin for Megamek\n");
+        sb.append("  This is the default skin for MegaMek\n");
         sb.append("\n");
         sb.append("  New skins can be created by specifying UI_Element tags\n");
         sb.append("\n");
@@ -67,7 +65,7 @@ public class SkinXMLHandler {
         sb.append("    components\n");
         sb.append("\n");
         sb.append("  The defaultButton UI_Element specifies the default border and background\n");
-        sb.append("   images to use for Megamek buttons.  The first image is the base default\n");
+        sb.append("   images to use for MegaMek buttons.  The first image is the base default\n");
         sb.append("   image and the second image is the pressed image\n");
         sb.append("\n");
         sb.append("  NOTE: All locations should be in data/images/widgets\n");
@@ -552,7 +550,7 @@ public class SkinXMLHandler {
         File filePath = new MegaMekFile(Configuration.skinsDir(), filename).getFile();
 
         try (Writer output = new BufferedWriter(new OutputStreamWriter(
-                new FileOutputStream(filePath)))){
+                new FileOutputStream(filePath)))) {
             output.write(SKIN_HEADER);
             for (String component : skinSpecs.keySet()) {
                 writeSkinComponent(component, output);
@@ -561,7 +559,7 @@ public class SkinXMLHandler {
                 writeUnitDisplaySkinSpec(output);
             }
             output.write(SKIN_FOOTER);
-        } catch (IOException e) {
+        } catch (Exception e) {
             MegaMek.getLogger().error(e);
         }
     }

--- a/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 
+import megamek.MegaMek;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.widget.SkinSpecification.UIComponents;
 import megamek.common.Configuration;
@@ -333,8 +334,7 @@ public class SkinXMLHandler {
                 return false;
             }
         } catch (Exception e) {
-            System.out.println(e.getMessage());
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return false;
         }
         // Skin spec didn't specify UnitDisplay skin, use default
@@ -549,11 +549,10 @@ public class SkinXMLHandler {
      * @param filename
      */
     public static void writeSkinToFile(String filename) {
-        File filePath = new MegaMekFile(Configuration.skinsDir(),
-                filename).getFile();
+        File filePath = new MegaMekFile(Configuration.skinsDir(), filename).getFile();
 
         try (Writer output = new BufferedWriter(new OutputStreamWriter(
-                new FileOutputStream(filePath)));){
+                new FileOutputStream(filePath)))){
             output.write(SKIN_HEADER);
             for (String component : skinSpecs.keySet()) {
                 writeSkinComponent(component, output);
@@ -562,10 +561,8 @@ public class SkinXMLHandler {
                 writeUnitDisplaySkinSpec(output);
             }
             output.write(SKIN_FOOTER);
-            output.close();
         } catch (IOException e) {
-            System.out.println(e.getMessage());
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -343,15 +343,14 @@ public class Board implements Serializable, IBoard {
                             while (iter.hasMoreElements()) {
                                 bldgByCoords.put(iter.nextElement(), bldg);
                             }
-                        } catch (IllegalArgumentException excep) {
+                        } catch (IllegalArgumentException e) {
                             // Log the error and remove the
                             // building from the board.
                             if (errBuff == null) {
-                                MegaMek.getLogger().error("Unable to create building.");
-                                excep.printStackTrace();
+                                MegaMek.getLogger().error("Unable to create building.", e);
                             } else {
-                                errBuff.append("Unable to create building at " + coords + "!\n");
-                                errBuff.append(excep.getMessage() + "\n");
+                                errBuff.append("Unable to create building at ").append(coords)
+                                        .append("!\n").append(e.getMessage()).append("\n");
                             }
                             curHex.removeTerrain(Terrains.BUILDING);
                         }
@@ -373,15 +372,14 @@ public class Board implements Serializable, IBoard {
                             while (iter.hasMoreElements()) {
                                 bldgByCoords.put(iter.nextElement(), bldg);
                             }
-                        } catch (IllegalArgumentException excep) {
+                        } catch (IllegalArgumentException e) {
                             // Log the error and remove the
                             // fuel tank from the board.
                             if (errBuff == null) {
-                                MegaMek.getLogger().error("Unable to create fuel tank.");
-                                excep.printStackTrace();
+                                MegaMek.getLogger().error("Unable to create fuel tank.", e);
                             } else {
-                                errBuff.append("Unable to create fuel tank at " + coords.toString() + "!\n");
-                                errBuff.append(excep.getMessage() + "\n");
+                                errBuff.append("Unable to create fuel tank at ").append(coords)
+                                        .append("!\n").append(e.getMessage()).append("\n");
                             }
                             curHex.removeTerrain(Terrains.FUEL_TANK);
                         }
@@ -403,15 +401,14 @@ public class Board implements Serializable, IBoard {
                             while (iter.hasMoreElements()) {
                                 bldgByCoords.put(iter.nextElement(), bldg);
                             }
-                        } catch (IllegalArgumentException excep) {
+                        } catch (IllegalArgumentException e) {
                             // Log the error and remove the
                             // bridge from the board.
                             if (errBuff == null) {
-                                MegaMek.getLogger().error("Unable to create bridge.");
-                                excep.printStackTrace();
+                                MegaMek.getLogger().error("Unable to create bridge.", e);
                             } else {
-                                errBuff.append("Unable to create bridge at " + coords.toString() + "!\n");
-                                errBuff.append(excep.getMessage() + "\n");
+                                errBuff.append("Unable to create bridge at ").append(coords)
+                                        .append("!\n").append(e.getMessage()).append("\n");
                             }
                             curHex.removeTerrain(Terrains.BRIDGE);
                         }

--- a/megamek/src/megamek/common/EjectedCrew.java
+++ b/megamek/src/megamek/common/EjectedCrew.java
@@ -9,6 +9,7 @@ package megamek.common;
 import java.util.HashMap;
 import java.util.Map;
 
+import megamek.MegaMek;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
@@ -70,7 +71,7 @@ public class EjectedCrew extends Infantry {
                         Infantry.LOC_INFANTRY);
                 setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE));
             } catch (Exception ex) {
-                ex.printStackTrace();
+                MegaMek.getLogger().error(ex);
             }
         }
     }
@@ -137,7 +138,7 @@ public class EjectedCrew extends Infantry {
                         Infantry.LOC_INFANTRY);
                 setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE));
             } catch (Exception ex) {
-                ex.printStackTrace();
+                MegaMek.getLogger().error(ex);
             }
         }
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -14855,7 +14855,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
             // Make sure this is a weapon.
             if (!(m.getType() instanceof WeaponType) && !(m.getType().hasFlag(MiscType.F_CLUB))) {
-
                 MegaMek.getLogger().error(String.format("%s failed for %s %s - %s is not a weapon",
                         q.toLog(), getChassis(), getModel(), m.getName()));
                 continue;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10690,7 +10690,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     this.addEquipment(et, LOC_NONE);
                 } catch (LocationFullException e) {
                     // can't happen
-                    e.printStackTrace();
+                    MegaMek.getLogger().error(e);
                 }
             }
         }
@@ -10713,7 +10713,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     this.addEquipment(et, LOC_NONE);
                 } catch (LocationFullException e) {
                     // can't happen
-                    e.printStackTrace();
+                    MegaMek.getLogger().error(e);
                 }
             }
         }
@@ -10736,7 +10736,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     this.addEquipment(et, LOC_NONE);
                 } catch (LocationFullException e) {
                     // can't happen
-                    e.printStackTrace();
+                    MegaMek.getLogger().error(e);
                 }
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -14815,7 +14815,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public void loadDefaultQuirks() {
-
         // Get a list of quirks for this entity.
         List<QuirkEntry> quirks = QuirksHandler.getQuirks(this);
 
@@ -14824,87 +14823,67 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             return;
         }
 
-        // System.out.println("Loading quirks for " + getChassis() + " " +
-        // getModel());
-
         // Load all the unit's quirks.
         for (QuirkEntry q : quirks) {
-
-            // System.out.print("  " + q.toLog() + "... ");
 
             // If the quirk doesn't have a location, then it is a unit quirk,
             // not a weapon quirk.
             if (StringUtil.isNullOrEmpty(q.getLocation())) {
-
                 // Activate the unit quirk.
                 if (getQuirks().getOption(q.getQuirk()) == null) {
-                    System.out.println(q.toLog() + " failed for "
-                                       + getChassis() + " " + getModel()
-                                       + " - Invalid quirk!");
+                    MegaMek.getLogger().error(String.format("%s failed for %s %s - Invalid Quirk Name",
+                            q.toLog(), getChassis(), getModel()));
                     continue;
                 }
                 getQuirks().getOption(q.getQuirk()).setValue(true);
-                // System.out.println("Loaded.");
                 continue;
             }
 
             // Get the weapon in the indicated location and slot.
-            // System.out.print("Getting CriticalSlot... ");
-            CriticalSlot cs = getCritical(getLocationFromAbbr(q.getLocation()),
-                                          q.getSlot());
+            CriticalSlot cs = getCritical(getLocationFromAbbr(q.getLocation()), q.getSlot());
             if (cs == null) {
-                System.out.println(q.toLog() + " failed for " + getChassis()
-                                   + " " + getModel() + " - Critical slot ("
-                                   + q.getLocation() + "-" + q.getSlot()
-                                   + ") did not load!");
+                MegaMek.getLogger().error(String.format("%s failed for %s %s - Critical Slot (%s-%s) did not load",
+                        q.toLog(), getChassis(), getModel(), q.getLocation(), q.getSlot()));
                 continue;
             }
             Mounted m = cs.getMount();
             if (m == null) {
-                System.out.println(q.toLog() + " failed for " + getChassis()
-                                   + " " + getModel() + " - Critical slot ("
-                                   + q.getLocation() + "-" + q.getSlot() + ") is empty!");
+                MegaMek.getLogger().error(String.format("%s failed for %s %s - Critical Slot (%s-%s) is empty",
+                        q.toLog(), getChassis(), getModel(), q.getLocation(), q.getSlot()));
                 continue;
             }
 
             // Make sure this is a weapon.
-            // System.out.print("Getting WeaponType... ");
-            if (!(m.getType() instanceof WeaponType)
-                    && !(m.getType().hasFlag(MiscType.F_CLUB))) {
-                System.out.println(q.toLog() + " failed for " + getChassis()
-                                   + " " + getModel() + " - " + m.getName()
-                                   + " is not a weapon!");
+            if (!(m.getType() instanceof WeaponType) && !(m.getType().hasFlag(MiscType.F_CLUB))) {
+
+                MegaMek.getLogger().error(String.format("%s failed for %s %s - %s is not a weapon",
+                        q.toLog(), getChassis(), getModel(), m.getName()));
                 continue;
             }
 
             // Make sure it is the weapon we expect.
-            // System.out.print("Matching weapon... ");
             boolean matchFound = false;
             Enumeration<String> typeNames = m.getType().getNames();
             while (typeNames.hasMoreElements()) {
                 String typeName = typeNames.nextElement();
-                // System.out.print(typeName + "... ");
                 if (typeName.equals(q.getWeaponName())) {
                     matchFound = true;
                     break;
                 }
             }
             if (!matchFound) {
-                System.out.println(q.toLog() + " failed for " + getChassis()
-                                   + " " + getModel() + " - " + m.getType().getName()
-                                   + " != " + q.getWeaponName());
+                MegaMek.getLogger().error(String.format("%s failed for %s %s - %s != %s",
+                        q.toLog(), getChassis(), getModel(), m.getType().getName(), q.getWeaponName()));
                 continue;
             }
 
             // Activate the weapon quirk.
-            // System.out.print("Activating quirk... ");
             if (m.getQuirks().getOption(q.getQuirk()) == null) {
-                System.out.println(q.toLog() + " failed for " + getChassis()
-                                   + " " + getModel() + " - Invalid quirk!");
+                MegaMek.getLogger().error(String.format("%s failed for %s %s - Invalid Quirk",
+                        q.toLog(), getChassis(), getModel()));
                 continue;
             }
             m.getQuirks().getOption(q.getQuirk()).setValue(true);
-            // System.out.println("Loaded.");
         }
     }
 

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Vector;
 import java.util.stream.Collectors;
 
+import megamek.MegaMek;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.GameOptions;
 import megamek.common.weapons.autocannons.HVACWeapon;
@@ -1334,7 +1335,7 @@ public class EquipmentType implements ITechnology {
             w.flush();
             w.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 
@@ -1434,7 +1435,7 @@ public class EquipmentType implements ITechnology {
             w.flush();
             w.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import megamek.MegaMek;
 import megamek.common.MovePath.MoveStepType;
 
 /**
@@ -219,8 +220,7 @@ public interface IAero {
                         newmount.setNWeapons(groups.get(key));
                         getWeaponGroups().put(key, ((Entity) this).getEquipmentNum(newmount));
                     } catch (LocationFullException ex) {
-                        System.out.println("Unable to compile weapon groups"); //$NON-NLS-1$
-                        ex.printStackTrace();
+                        MegaMek.getLogger().error("Unable to compile weapon groups", ex);
                         return;
                     }
                 } else if (name != "0") {

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1955,9 +1955,9 @@ public class Infantry extends Entity {
     		try {
     			addEquipment(armorKit, LOC_INFANTRY);
     		} catch (LocationFullException ex) {
-    			ex.printStackTrace();
+    			MegaMek.getLogger().error(ex);
     		}
-    		damageDivisor = ((MiscType)armorKit).getDamageDivisor();
+    		damageDivisor = ((MiscType) armorKit).getDamageDivisor();
     		encumbering = (armorKit.getSubType() & MiscType.S_ENCUMBERING) != 0;
     		spaceSuit = (armorKit.getSubType() & MiscType.S_SPACE_SUIT) != 0;
     		dest = (armorKit.getSubType() & MiscType.S_DEST) != 0;
@@ -2036,7 +2036,7 @@ public class Infantry extends Entity {
                 EquipmentType shovels = EquipmentType.get(EquipmentTypeLookup.VIBRO_SHOVEL);
                 addEquipment(shovels, Infantry.LOC_INFANTRY);
             } catch (LocationFullException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
         } else if ((spec & TRENCH_ENGINEERS) == 0
                 && (infSpecs & TRENCH_ENGINEERS) > 0) {
@@ -2058,7 +2058,7 @@ public class Infantry extends Entity {
                 EquipmentType shovels = EquipmentType.get(EquipmentTypeLookup.DEMOLITION_CHARGE);
                 addEquipment(shovels, Infantry.LOC_INFANTRY);
             } catch (LocationFullException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
         } else if ((spec & DEMO_ENGINEERS) == 0
                 && (infSpecs & DEMO_ENGINEERS) > 0) {

--- a/megamek/src/megamek/common/KeyBindParser.java
+++ b/megamek/src/megamek/common/KeyBindParser.java
@@ -25,6 +25,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import javax.xml.parsers.DocumentBuilder;
 
+import megamek.MegaMek;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.MegaMekController;
 import megamek.common.preference.IPreferenceChangeListener;
@@ -42,7 +43,6 @@ import org.w3c.dom.NodeList;
  * the XML file.
  *
  * @author arlith
- *
  */
 public class KeyBindParser {
 
@@ -75,15 +75,15 @@ public class KeyBindParser {
         // Build the XML document.
         try {
             DocumentBuilder builder = MegaMekXmlUtil.newSafeDocumentBuilder();
+            MegaMek.getLogger().info("Parsing " + file.getName());
             System.out.println("Parsing " + file.getName());
             Document doc = builder.parse(file);
-            System.out.println("Parsing finished.");
+            MegaMek.getLogger().info("Finished Parsing " + file.getName());
 
             // Get the list of units.
             NodeList listOfUnits = doc.getElementsByTagName(KEY_BIND);
             int totalBinds = listOfUnits.getLength();
-            System.out.println("Total number of key binds parsed: "
-                    + totalBinds);
+            MegaMek.getLogger().info("Total number of key binds parsed: " + totalBinds);
 
             for (int bindCount = 0; bindCount < totalBinds; bindCount++) {
 
@@ -91,52 +91,42 @@ public class KeyBindParser {
                 Element bindingList = (Element) listOfUnits.item(bindCount);
 
                 // Get the key code
-                Element elem = (Element) bindingList
-                        .getElementsByTagName(KEY_CODE).item(0);
+                Element elem = (Element) bindingList.getElementsByTagName(KEY_CODE).item(0);
                 if (elem == null) {
-                    System.err.println("Missing " + KEY_CODE + " element #"
-                            + bindCount);
+                    MegaMek.getLogger().error(String.format("Missing %s element #%s", KEY_CODE, bindCount));
                     continue;
                 }
                 int keyCode = Integer.parseInt(elem.getTextContent());
 
                 // Get the modifier.
-                elem = (Element) bindingList
-                        .getElementsByTagName(KEY_MODIFIER).item(0);
+                elem = (Element) bindingList.getElementsByTagName(KEY_MODIFIER).item(0);
                 if (elem == null) {
-                    System.err.println("Missing " + KEY_MODIFIER + " element #"
-                            + bindCount);
+                    MegaMek.getLogger().error(String.format("Missing %s element #%s", KEY_MODIFIER, bindCount));
                     continue;
                 }
                 int modifiers = Integer.parseInt(elem.getTextContent());
 
 
                 // Get the command
-                elem = (Element) bindingList
-                        .getElementsByTagName(COMMAND).item(0);
+                elem = (Element) bindingList.getElementsByTagName(COMMAND).item(0);
                 if (elem == null) {
-                    System.err.println("Missing " + COMMAND + " element #"
-                            + bindCount);
+                    MegaMek.getLogger().error(String.format("Missing %s element #%s", COMMAND, bindCount));
                     continue;
                 }
                 String command = elem.getTextContent();
 
                 // Get the isRepeatable
-                elem = (Element) bindingList
-                        .getElementsByTagName(IS_REPEATABLE).item(0);
+                elem = (Element) bindingList.getElementsByTagName(IS_REPEATABLE).item(0);
                 if (elem == null) {
-                    System.err.println("Missing " + IS_REPEATABLE + " element #"
-                            + bindCount);
+                    MegaMek.getLogger().error(String.format("Missing %s element #%s", IS_REPEATABLE, bindCount));
                     continue;
                 }
-                boolean isRepeatable =
-                        Boolean.parseBoolean(elem.getTextContent());
+                boolean isRepeatable = Boolean.parseBoolean(elem.getTextContent());
 
                 KeyCommandBind keyBind = KeyCommandBind.getBindByCmd(command);
 
-                if (keyBind == null){
-                    System.err.println("Unknown command: " + command +
-                            ", element #" + bindCount);
+                if (keyBind == null) {
+                    MegaMek.getLogger().error(String.format("Unknown command: %s, element #%s", command, bindCount));
                 } else {
                     keyBind.key = keyCode;
                     keyBind.modifiers = modifiers;
@@ -145,8 +135,7 @@ public class KeyBindParser {
                 }
             }
         } catch (Exception e) {
-            System.err.println("Error parsing key bindings!");
-            e.printStackTrace(System.err);
+            MegaMek.getLogger().error("Error parsing key bindings", e);
             controller.removeAllKeyCommandBinds();
             registerDefaultKeyBinds(controller);
         }
@@ -230,7 +219,7 @@ public class KeyBindParser {
 
     private synchronized static void fireKeyBindsChangeEvent() {
         final PreferenceChangeEvent pe = new PreferenceChangeEvent(KeyBindParser.class, KEYBINDS_CHANGED, null, null);
-        listeners.stream().forEach(l -> l.preferenceChange(pe));
+        listeners.forEach(l -> l.preferenceChange(pe));
     }
 
 }

--- a/megamek/src/megamek/common/MMRandom.java
+++ b/megamek/src/megamek/common/MMRandom.java
@@ -1,24 +1,19 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
  * 
- *  This program is free software; you can redistribute it and/or modify it 
- *  under the terms of the GNU General Public License as published by the Free 
- *  Software Foundation; either version 2 of the License, or (at your option) 
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  * 
- *  This program is distributed in the hope that it will be useful, but 
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
-
-/*
- * MMRandom.java
- *
- * Created on April 27, 2003, 11:29 PM
- */
-
 package megamek.common;
+
+import megamek.MegaMek;
 
 import java.util.Random;
 
@@ -26,7 +21,7 @@ import java.util.Random;
  * Used by Compute to generate random numbers, usually dice rolls. The base
  * class is abstract, having a number of concrete subclasses that it will give
  * using the generate() method.
- * 
+ * Created on April 27, 2003, 11:29 PM
  * @author Ben
  */
 public abstract class MMRandom {
@@ -42,7 +37,7 @@ public abstract class MMRandom {
      * errors.
      */
     static MMRandom generate(int type) {
-        System.err.println("MMRandom: generating RNG type #" + type);
+        MegaMek.getLogger().info("MMRandom: generating RNG type #" + type);
         try {
             switch (type) {
                 case R_CRYPTO:
@@ -54,10 +49,7 @@ public abstract class MMRandom {
                     return new MMRandom.SunRandom();
             }
         } catch (Exception ex) {
-            System.err.println("MMRandom: could not create desired RNG #"
-                    + type);
-            System.err.println("MMRandom: using SunRandom (#0) instead");
-
+            MegaMek.getLogger().error("Could not create desired RNG #" + type + "using SunRandom (#0) instead.", ex);
             return new MMRandom.SunRandom();
         }
     }

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -2427,12 +2427,12 @@ public class MULParser {
         }
 
         // Was no manipulator selected?
-        if (manipType == null){
+        if (manipType == null) {
             return;
         }
 
         // Add the newly mounted maniplator
-        try{
+        try {
             int baMountLoc = mountedManip.getBaMountLoc();
             mountedManip = entity.addEquipment(manipType, mountedManip.getLocation());
             mountedManip.setBaMountLoc(baMountLoc);
@@ -2448,10 +2448,9 @@ public class MULParser {
      * @param apmTag
      * @param entity
      */
-    private void parseBAAPM(Element apmTag, Entity entity){
-        if (!(entity instanceof BattleArmor)){
-            warning.append("Found a BA APM tag but Entity is not " +
-                    "BattleArmor!\n");
+    private void parseBAAPM(Element apmTag, Entity entity) {
+        if (!(entity instanceof BattleArmor)) {
+            warning.append("Found a BA APM tag but Entity is not " + "BattleArmor!\n");
             return;
         }
 

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -284,12 +284,12 @@ public class MULParser {
         pilots = new Vector<>();
     }
 
-    public MULParser(InputStream fin){
+    public MULParser(InputStream fin) {
         this();
         parse(fin);
     }
 
-    public void parse(InputStream fin){
+    public void parse(InputStream fin) {
         // Reset the warning message.
         warning = new StringBuffer();
 
@@ -311,9 +311,8 @@ public class MULParser {
 
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fin);
-        } catch (Exception ex) {
-            System.err.println(ex.getMessage());
-            ex.printStackTrace(System.err);
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
             warning.append("Error parsing MUL file!\n");
             return;
         }
@@ -581,7 +580,7 @@ public class MULParser {
                 key.append(" ").append(model);
                 ms = MechSummaryCache.getInstance().getMech(
                         key.toString());
-                // That didn't work. Try swaping model and chassis.
+                // That didn't work. Try swapping model and chassis.
                 if (ms == null) {
                     key = new StringBuffer(model);
                     key.append(" ").append(chassis);
@@ -601,14 +600,14 @@ public class MULParser {
                 try {
                     newEntity = new MechFileParser(ms.getSourceFile(),
                             ms.getEntryName()).getEntity();
-                } catch (EntityLoadingException excep) {
-                    excep.printStackTrace(System.err);
+                } catch (Exception e) {
+                    MegaMek.getLogger().error(e);
                     warning.append("Unable to load mech: ")
                             .append(ms.getSourceFile()).append(": ")
                             .append(ms.getEntryName()).append(": ")
-                            .append(excep.getMessage());
+                            .append(e.getMessage());
                 }
-            } // End found-MechSummary
+            }
         }
         return newEntity;
     }
@@ -1820,17 +1819,15 @@ public class MULParser {
      * @param turretLockTag
      * @param entity
      */
-    private void parseTurretLock(Element turretLockTag, Entity entity){
+    private void parseTurretLock(Element turretLockTag, Entity entity) {
         String value = turretLockTag.getAttribute(DIRECTION);
         try {
             int turDir = Integer.parseInt(value);
-            ((Tank) entity).setSecondaryFacing(turDir);
-            ((Tank) entity).lockTurret(((Tank)entity).getLocTurret());
+            entity.setSecondaryFacing(turDir);
+            ((Tank) entity).lockTurret(((Tank) entity).getLocTurret());
         } catch (Exception e) {
-            System.err.println(e);
-            e.printStackTrace();
-            warning.append("Invalid turret lock direction value in " +
-                    "movement tag.\n");
+            MegaMek.getLogger().error(e);
+            warning.append("Invalid turret lock direction value in " + "movement tag.\n");
         }
     }
 
@@ -1840,17 +1837,15 @@ public class MULParser {
      * @param turret2LockTag
      * @param entity
      */
-    private void parseTurret2Lock(Element turret2LockTag, Entity entity){
+    private void parseTurret2Lock(Element turret2LockTag, Entity entity) {
         String value = turret2LockTag.getAttribute(DIRECTION);
         try {
             int turDir = Integer.parseInt(value);
             ((Tank) entity).setDualTurretOffset(turDir);
-            ((Tank) entity).lockTurret(((Tank)entity).getLocTurret2());
+            ((Tank) entity).lockTurret(((Tank) entity).getLocTurret2());
         } catch (Exception e) {
-            System.err.println(e);
-            e.printStackTrace();
-            warning.append("Invalid turret2 lock direction value in " +
-                    "movement tag.\n");
+            MegaMek.getLogger().error(e);
+            warning.append("Invalid turret2 lock direction value in " + "movement tag.\n");
         }
     }
 
@@ -2439,12 +2434,11 @@ public class MULParser {
         // Add the newly mounted maniplator
         try{
             int baMountLoc = mountedManip.getBaMountLoc();
-            mountedManip = entity.addEquipment(manipType,
-                    mountedManip.getLocation());
+            mountedManip = entity.addEquipment(manipType, mountedManip.getLocation());
             mountedManip.setBaMountLoc(baMountLoc);
-        } catch (LocationFullException ex){
+        } catch (LocationFullException ex) {
             // This shouldn't happen for BA...
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
     }
 
@@ -2507,15 +2501,14 @@ public class MULParser {
         }
 
         // Add the newly mounted weapon
-        try{
-            Mounted newWeap =  entity.addEquipment(apType,
-                    apMount.getLocation());
+        try {
+            Mounted newWeap =  entity.addEquipment(apType, apMount.getLocation());
             apMount.setLinked(newWeap);
             newWeap.setLinked(apMount);
             newWeap.setAPMMounted(true);
-        } catch (LocationFullException ex){
+        } catch (LocationFullException ex) {
             // This shouldn't happen for BA...
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
 
     }

--- a/megamek/src/megamek/common/MapSettings.java
+++ b/megamek/src/megamek/common/MapSettings.java
@@ -1607,8 +1607,7 @@ public class MapSettings implements Serializable {
 
             marshaller.marshal(element, os);
         } catch (JAXBException ex) {
-            System.err.println("Error writing XML for map settings: " + ex.getMessage()); //$NON-NLS-1$
-            ex.printStackTrace();
+            MegaMek.getLogger().error("Error writing XML for map settings", ex);
         }
     }
 }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -2193,9 +2193,10 @@ public abstract class Mech extends Entity {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             if (side == ToHitData.SIDE_FRONT) {
                 // normal front hits
                 switch (roll) {
@@ -2452,9 +2453,10 @@ public abstract class Mech extends Entity {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             if (side == ToHitData.SIDE_FRONT) {
                 // front punch hits
                 switch (roll) {
@@ -2569,28 +2571,29 @@ public abstract class Mech extends Entity {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             if ((side == ToHitData.SIDE_FRONT) || (side == ToHitData.SIDE_REAR)) {
                 // front/rear kick hits
                 switch (roll) {
                     case 1:
                     case 2:
                     case 3:
-                        return new HitData(Mech.LOC_RLEG,
-                                (side == ToHitData.SIDE_REAR));
+                        return new HitData(Mech.LOC_RLEG, (side == ToHitData.SIDE_REAR));
                     case 4:
                     case 5:
                     case 6:
-                        return new HitData(Mech.LOC_LLEG,
-                                (side == ToHitData.SIDE_REAR));
+                        return new HitData(Mech.LOC_LLEG, (side == ToHitData.SIDE_REAR));
                 }
             }
+
             if (side == ToHitData.SIDE_LEFT) {
                 // left side kick hits
                 return new HitData(Mech.LOC_LLEG);
             }
+
             if (side == ToHitData.SIDE_RIGHT) {
                 // right side kick hits
                 return new HitData(Mech.LOC_RLEG);
@@ -2615,20 +2618,18 @@ public abstract class Mech extends Entity {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             // Swarm attack locations.
             switch (roll) {
                 case 2:
                     if (getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
-                                    OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
-                        HitData result = rollHitLocation(table, side,
-                                aimedLocation, aimingMode, cover);
-                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD,
-                                false, effects));
+                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
                         return result;
                     } // if
                     return new HitData(Mech.LOC_HEAD, false, effects);
@@ -2676,9 +2677,10 @@ public abstract class Mech extends Entity {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             // Hits from above.
             switch (roll) {
                 case 1:
@@ -2723,29 +2725,24 @@ public abstract class Mech extends Entity {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             // Hits from below.
             switch (roll) {
                 case 1:
-                    return new HitData(Mech.LOC_LLEG,
-                            (side == ToHitData.SIDE_REAR));
+                    return new HitData(Mech.LOC_LLEG, (side == ToHitData.SIDE_REAR));
                 case 2:
-                    return new HitData(Mech.LOC_LLEG,
-                            (side == ToHitData.SIDE_REAR));
+                    return new HitData(Mech.LOC_LLEG, (side == ToHitData.SIDE_REAR));
                 case 3:
-                    return new HitData(Mech.LOC_LT,
-                            (side == ToHitData.SIDE_REAR));
+                    return new HitData(Mech.LOC_LT, (side == ToHitData.SIDE_REAR));
                 case 4:
-                    return new HitData(Mech.LOC_RT,
-                            (side == ToHitData.SIDE_REAR));
+                    return new HitData(Mech.LOC_RT, (side == ToHitData.SIDE_REAR));
                 case 5:
-                    return new HitData(Mech.LOC_RLEG,
-                            (side == ToHitData.SIDE_REAR));
+                    return new HitData(Mech.LOC_RLEG, (side == ToHitData.SIDE_REAR));
                 case 6:
-                    return new HitData(Mech.LOC_RLEG,
-                            (side == ToHitData.SIDE_REAR));
+                    return new HitData(Mech.LOC_RLEG, (side == ToHitData.SIDE_REAR));
             }
         }
         return null;

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -32,6 +32,7 @@ import java.util.Vector;
 import java.util.function.Predicate;
 import java.util.zip.ZipFile;
 
+import megamek.MegaMek;
 import megamek.common.loaders.BLKAeroFile;
 import megamek.common.loaders.BLKBattleArmorFile;
 import megamek.common.loaders.BLKConvFighterFile;
@@ -67,28 +68,26 @@ import megamek.common.weapons.ppc.ISLightPPC;
 import megamek.common.weapons.ppc.ISPPC;
 import megamek.common.weapons.ppc.ISSnubNosePPC;
 
-/*
+/**
  * Switches between the various type-specific parsers depending on suffix
  */
-
 public class MechFileParser {
     private Entity m_entity = null;
     private static Vector<String> canonUnitNames = null;
-    public static final String FILENAME_OFFICIAL_UNITS = "OfficialUnitList.txt"; //$NON-NLS-1$
+    public static final String FILENAME_OFFICIAL_UNITS = "OfficialUnitList.txt";
 
     public MechFileParser(File f) throws EntityLoadingException {
         this(f, null);
     }
 
-    public MechFileParser(File f, String entryName)
-            throws EntityLoadingException {
+    public MechFileParser(File f, String entryName) throws EntityLoadingException {
         if (entryName == null) {
             // try normal file
-            try(InputStream is = new FileInputStream(f.getAbsolutePath())) {
+            try (InputStream is = new FileInputStream(f.getAbsolutePath())) {
                 parse(is, f.getName());
             } catch (Exception ex) {
                 System.out.println("Error parsing " + entryName + "!");
-                ex.printStackTrace();
+                MegaMek.getLogger().error(ex);
                 if (ex instanceof EntityLoadingException) {
                     throw new EntityLoadingException("While parsing file "
                             + f.getName() + ", " + ex.getMessage());
@@ -109,19 +108,18 @@ public class MechFileParser {
             } catch (NullPointerException npe) {
                 throw new NullPointerException();
             } catch (Exception ex) {
-                ex.printStackTrace();
+                MegaMek.getLogger().error(ex);
                 throw new EntityLoadingException("Exception from "
                         + ex.getClass() + ": " + ex.getMessage());
             }
         }
     }
 
-    public MechFileParser(InputStream is, String fileName)
-            throws EntityLoadingException {
+    public MechFileParser(InputStream is, String fileName) throws EntityLoadingException {
         try {
             parse(is, fileName);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             if (ex instanceof EntityLoadingException) {
                 throw new EntityLoadingException(ex.getMessage());
             }
@@ -134,8 +132,7 @@ public class MechFileParser {
         return m_entity;
     }
 
-    public void parse(InputStream is, String fileName)
-            throws EntityLoadingException {
+    public void parse(InputStream is, String fileName) throws EntityLoadingException {
         String lowerName = fileName.toLowerCase();
         IMechLoader loader;
 
@@ -214,14 +211,11 @@ public class MechFileParser {
      * Automatically add BattleArmorHandles to all OmniMechs.
      */
     public static void postLoadInit(Entity ent) throws EntityLoadingException {
-
         try {
             ent.loadDefaultQuirks();
             ent.loadDefaultCustomWeaponOrder();
         } catch (Exception e) {
-            System.out.println("Error in postLoadInit for "
-                    + ent.getDisplayName() + "!");
-            e.printStackTrace();
+            MegaMek.getLogger().error("Error in postLoadInit for " + ent.getDisplayName(), e);
         }
 
         // add any sensors to the entity's vector of sensors
@@ -964,8 +958,7 @@ public class MechFileParser {
         try {
             entity = new MechFileParser(f, entityName).getEntity();
         } catch (megamek.common.loaders.EntityLoadingException e) {
-            System.out.println("Exception: " + e.toString());
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
         return entity;
     }

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -74,7 +74,7 @@ import megamek.common.weapons.ppc.ISSnubNosePPC;
 public class MechFileParser {
     private Entity m_entity = null;
     private static Vector<String> canonUnitNames = null;
-    public static final String FILENAME_OFFICIAL_UNITS = "OfficialUnitList.txt";
+    public static final String FILENAME_OFFICIAL_UNITS = "OfficialUnitList.txt"; // TODO : Remove inline filename
 
     public MechFileParser(File f) throws EntityLoadingException {
         this(f, null);

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -320,7 +320,7 @@ public class MovePath implements Cloneable, Serializable {
             try {
                 step.compile(getGame(), getEntity(), prev, getCachedEntityState());
             } catch (final RuntimeException re) {
-                // // N.B. the pathfinding will try steps off the map.
+                // N.B. the pathfinding will try steps off the map.
                 // MegaMek.getLogger().error(re);
                 step.setMovementType(EntityMovementType.MOVE_ILLEGAL);
             }
@@ -331,12 +331,11 @@ public class MovePath implements Cloneable, Serializable {
         final Coords start = getEntity().getPosition();
         final Coords land = step.getPosition();
         if ((start == null) || (land == null)) {
-            // If we have null for either coordinate then we know the step
-            // isn't legal.
+            // If we have null for either coordinate then we know the step isn't legal.
             step.setMovementType(EntityMovementType.MOVE_ILLEGAL);
         } else {
             // if we're jumping without a mechanical jump booster (?)
-            // or we're acting like a spheroid dropship in the atmosphere
+            // or we're acting like a spheroid DropShip in the atmosphere
             if ((isJumping() && (getEntity().getJumpType() != Mech.JUMP_BOOSTER)) ||
                     (Compute.useSpheroidAtmosphere(game, getEntity()) && (step.getType() != MoveStepType.HOVER))) {
                 int distance = start.distance(land);
@@ -353,7 +352,7 @@ public class MovePath implements Cloneable, Serializable {
             step.setMovementType(EntityMovementType.MOVE_ILLEGAL);
         }
         
-        // If jumpships turn, they can't do anything else 
+        // If JumpShips turn, they can't do anything else
         if (game.getBoard().inSpace()
                 && (entity instanceof Jumpship)
                 && !(entity instanceof Warship)
@@ -369,8 +368,10 @@ public class MovePath implements Cloneable, Serializable {
             for (int i = 0; i < steps.size() - 1; i++) {
                 if (steps.get(i).getType() == MoveStepType.LAY_MINE) {
                     containsOtherLayMineStep = true;
+                    break;
                 }
             }
+
             if (containsOtherLayMineStep) {
                 step.setMovementType(EntityMovementType.MOVE_ILLEGAL);
             }

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -321,7 +321,7 @@ public class MovePath implements Cloneable, Serializable {
                 step.compile(getGame(), getEntity(), prev, getCachedEntityState());
             } catch (final RuntimeException re) {
                 // // N.B. the pathfinding will try steps off the map.
-                // re.printStackTrace();
+                // MegaMek.getLogger().error(re);
                 step.setMovementType(EntityMovementType.MOVE_ILLEGAL);
             }
         }

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -18,6 +18,7 @@ import java.io.PrintWriter;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import megamek.MegaMek;
 import megamek.common.preference.PreferenceManager;
 
 /**
@@ -706,8 +707,8 @@ public class Protomech extends Entity {
                 pw.print("\t");
                 pw.println(roll);
             }
-        } catch (Throwable thrown) {
-            thrown.printStackTrace();
+        } catch (Throwable t) {
+            MegaMek.getLogger().error(t);
         }
 
         switch (roll) {

--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -19,6 +19,7 @@ package megamek.common;
 import java.io.PrintWriter;
 import java.util.List;
 
+import megamek.MegaMek;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 
@@ -458,47 +459,48 @@ public class QuadMech extends Mech {
                         pw.print("\t");
                         pw.println(roll);
                     }
-                } catch (Throwable thrown) {
-                    thrown.printStackTrace();
+                } catch (Throwable t) {
+                    MegaMek.getLogger().error(t);
                 }
+
                 if (side == ToHitData.SIDE_FRONT) {
                     // normal front hits
                     switch (roll) {
-                    case 2:
-                        if ((getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
-                                && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
-                            getCrew().decreaseEdge();
-                            HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
-                            result.setUndoneLocation(tac(table, side, Mech.LOC_CT, cover, false));
-                            return result;
-                        } // if
-                        return tac(table, side, Mech.LOC_CT, cover, false);
-                    case 3:
-                        return new HitData(Mech.LOC_LLEG);
-                    case 4:
-                    case 5:
-                        return new HitData(Mech.LOC_LARM);
-                    case 6:
-                        return new HitData(Mech.LOC_LT);
-                    case 7:
-                        return new HitData(Mech.LOC_CT);
-                    case 8:
-                        return new HitData(Mech.LOC_RT);
-                    case 9:
-                    case 10:
-                        return new HitData(Mech.LOC_RARM);
-                    case 11:
-                        return new HitData(Mech.LOC_RLEG);
-                    case 12:
-                        if ((getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
-                            getCrew().decreaseEdge();
-                            HitData result = rollHitLocation(table, side, aimedLocation, cover, aimingMode);
-                            result.setUndoneLocation(new HitData(Mech.LOC_HEAD));
-                            return result;
-                        } // if
-                        return new HitData(Mech.LOC_HEAD);
+                        case 2:
+                            if ((getCrew().hasEdgeRemaining()
+                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                                    && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
+                                getCrew().decreaseEdge();
+                                HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                                result.setUndoneLocation(tac(table, side, Mech.LOC_CT, cover, false));
+                                return result;
+                            } // if
+                            return tac(table, side, Mech.LOC_CT, cover, false);
+                        case 3:
+                            return new HitData(Mech.LOC_LLEG);
+                        case 4:
+                        case 5:
+                            return new HitData(Mech.LOC_LARM);
+                        case 6:
+                            return new HitData(Mech.LOC_LT);
+                        case 7:
+                            return new HitData(Mech.LOC_CT);
+                        case 8:
+                            return new HitData(Mech.LOC_RT);
+                        case 9:
+                        case 10:
+                            return new HitData(Mech.LOC_RARM);
+                        case 11:
+                            return new HitData(Mech.LOC_RLEG);
+                        case 12:
+                            if ((getCrew().hasEdgeRemaining()
+                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
+                                getCrew().decreaseEdge();
+                                HitData result = rollHitLocation(table, side, aimedLocation, cover, aimingMode);
+                                result.setUndoneLocation(new HitData(Mech.LOC_HEAD));
+                                return result;
+                            } // if
+                            return new HitData(Mech.LOC_HEAD);
                     }
                 } else if (side == ToHitData.SIDE_REAR) {
                     switch (roll) {
@@ -629,94 +631,95 @@ public class QuadMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             if (side == ToHitData.SIDE_FRONT) {
                 switch (roll) {
-                case 1:
-                    return new HitData(Mech.LOC_LARM);
-                case 2:
-                    return new HitData(Mech.LOC_LT);
-                case 3:
-                    return new HitData(Mech.LOC_CT);
-                case 4:
-                    return new HitData(Mech.LOC_RT);
-                case 5:
-                    return new HitData(Mech.LOC_RARM);
-                case 6:
-                    if (getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
-                        getCrew().decreaseEdge();
-                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
-                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
-                        return result;
-                    } // if
-                    return new HitData(Mech.LOC_HEAD, true);
+                    case 1:
+                        return new HitData(Mech.LOC_LARM);
+                    case 2:
+                        return new HitData(Mech.LOC_LT);
+                    case 3:
+                        return new HitData(Mech.LOC_CT);
+                    case 4:
+                        return new HitData(Mech.LOC_RT);
+                    case 5:
+                        return new HitData(Mech.LOC_RARM);
+                    case 6:
+                        if (getCrew().hasEdgeRemaining()
+                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                            getCrew().decreaseEdge();
+                            HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                            result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
+                            return result;
+                        } // if
+                        return new HitData(Mech.LOC_HEAD, true);
                 }
             } else if (side == ToHitData.SIDE_REAR) {
                 switch (roll) {
-                case 1:
-                    return new HitData(Mech.LOC_LLEG, true);
-                case 2:
-                    return new HitData(Mech.LOC_LT, true);
-                case 3:
-                    return new HitData(Mech.LOC_CT, true);
-                case 4:
-                    return new HitData(Mech.LOC_RT, true);
-                case 5:
-                    return new HitData(Mech.LOC_RLEG, true);
-                case 6:
-                    if (getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
-                        getCrew().decreaseEdge();
-                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
-                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
-                        return result;
-                    } // if
-                    return new HitData(Mech.LOC_HEAD, true);
+                    case 1:
+                        return new HitData(Mech.LOC_LLEG, true);
+                    case 2:
+                        return new HitData(Mech.LOC_LT, true);
+                    case 3:
+                        return new HitData(Mech.LOC_CT, true);
+                    case 4:
+                        return new HitData(Mech.LOC_RT, true);
+                    case 5:
+                        return new HitData(Mech.LOC_RLEG, true);
+                    case 6:
+                        if (getCrew().hasEdgeRemaining()
+                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                            getCrew().decreaseEdge();
+                            HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                            result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
+                            return result;
+                        } // if
+                        return new HitData(Mech.LOC_HEAD, true);
                 }
             } else if (side == ToHitData.SIDE_LEFT) {
                 switch (roll) {
-                case 1:
-                case 2:
-                    return new HitData(Mech.LOC_LT);
-                case 3:
-                    return new HitData(Mech.LOC_CT);
-                case 4:
-                    return new HitData(Mech.LOC_LARM);
-                case 5:
-                    return new HitData(Mech.LOC_LLEG);
-                case 6:
-                    if (getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
-                        getCrew().decreaseEdge();
-                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
-                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
-                        return result;
-                    } // if
-                    return new HitData(Mech.LOC_HEAD);
+                    case 1:
+                    case 2:
+                        return new HitData(Mech.LOC_LT);
+                    case 3:
+                        return new HitData(Mech.LOC_CT);
+                    case 4:
+                        return new HitData(Mech.LOC_LARM);
+                    case 5:
+                        return new HitData(Mech.LOC_LLEG);
+                    case 6:
+                        if (getCrew().hasEdgeRemaining()
+                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                            getCrew().decreaseEdge();
+                            HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                            result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
+                            return result;
+                        } // if
+                        return new HitData(Mech.LOC_HEAD);
                 }
             } else if (side == ToHitData.SIDE_RIGHT) {
                 switch (roll) {
-                case 1:
-                case 2:
-                    return new HitData(Mech.LOC_RT);
-                case 3:
-                    return new HitData(Mech.LOC_CT);
-                case 4:
-                    return new HitData(Mech.LOC_RARM);
-                case 5:
-                    return new HitData(Mech.LOC_RLEG);
-                case 6:
-                    if (getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
-                        getCrew().decreaseEdge();
-                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
-                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
-                        return result;
-                    } // if
-                    return new HitData(Mech.LOC_HEAD);
+                    case 1:
+                    case 2:
+                        return new HitData(Mech.LOC_RT);
+                    case 3:
+                        return new HitData(Mech.LOC_CT);
+                    case 4:
+                        return new HitData(Mech.LOC_RARM);
+                    case 5:
+                        return new HitData(Mech.LOC_RLEG);
+                    case 6:
+                        if (getCrew().hasEdgeRemaining()
+                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                            getCrew().decreaseEdge();
+                            HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                            result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
+                            return result;
+                        } // if
+                        return new HitData(Mech.LOC_HEAD);
                 }
             }
         } else if (table == ToHitData.HIT_KICK) {
@@ -730,9 +733,10 @@ public class QuadMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             boolean left = (roll <= 3);
             if (side == ToHitData.SIDE_FRONT) {
                 if (left) {
@@ -772,47 +776,48 @@ public class QuadMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             // Swarm attack locations.
             switch (roll) {
-            case 2:
-                if (getCrew().hasEdgeRemaining()
-                        && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
-                    getCrew().decreaseEdge();
-                    HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
-                    result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
-                    return result;
-                } // if
-                return new HitData(Mech.LOC_HEAD, false, effects);
-            case 3:
-                return new HitData(Mech.LOC_RT, false, effects);
-            case 4:
-                return new HitData(Mech.LOC_CT, true, effects);
-            case 5:
-                return new HitData(Mech.LOC_RT, true, effects);
-            case 6:
-                return new HitData(Mech.LOC_RT, false, effects);
-            case 7:
-                return new HitData(Mech.LOC_CT, false, effects);
-            case 8:
-                return new HitData(Mech.LOC_LT, false, effects);
-            case 9:
-                return new HitData(Mech.LOC_LT, true, effects);
-            case 10:
-                return new HitData(Mech.LOC_CT, true, effects);
-            case 11:
-                return new HitData(Mech.LOC_LT, false, effects);
-            case 12:
-                if (getCrew().hasEdgeRemaining()
-                        && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
-                    getCrew().decreaseEdge();
-                    HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
-                    result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
-                    return result;
-                } // if
-                return new HitData(Mech.LOC_HEAD, false, effects);
+                case 2:
+                    if (getCrew().hasEdgeRemaining()
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        getCrew().decreaseEdge();
+                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
+                        return result;
+                    } // if
+                    return new HitData(Mech.LOC_HEAD, false, effects);
+                case 3:
+                    return new HitData(Mech.LOC_RT, false, effects);
+                case 4:
+                    return new HitData(Mech.LOC_CT, true, effects);
+                case 5:
+                    return new HitData(Mech.LOC_RT, true, effects);
+                case 6:
+                    return new HitData(Mech.LOC_RT, false, effects);
+                case 7:
+                    return new HitData(Mech.LOC_CT, false, effects);
+                case 8:
+                    return new HitData(Mech.LOC_LT, false, effects);
+                case 9:
+                    return new HitData(Mech.LOC_LT, true, effects);
+                case 10:
+                    return new HitData(Mech.LOC_CT, true, effects);
+                case 11:
+                    return new HitData(Mech.LOC_LT, false, effects);
+                case 12:
+                    if (getCrew().hasEdgeRemaining()
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        getCrew().decreaseEdge();
+                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
+                        return result;
+                    } // if
+                    return new HitData(Mech.LOC_HEAD, false, effects);
             }
         }
         return super.rollHitLocation(table, side, aimedLocation, aimingMode, cover);

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -1,30 +1,26 @@
-/**
- * MegaMek -
- *  Copyright (C) 2013
- *    Ben Mazur (bmazur@sev.org)
+/*
+ * MegaMek - Copyright (C) 2013 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.common;
 
 import java.io.PrintWriter;
 import java.util.List;
 
+import megamek.MegaMek;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 
 public class TripodMech extends Mech {
-    /**
-     *
-     */
     private static final long serialVersionUID = 4166375446709772785L;
 
     private static final String[] LOCATION_NAMES = {"Head", "Center Torso",
@@ -1024,9 +1020,10 @@ public class TripodMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             if (side == ToHitData.SIDE_FRONT) {
                 // normal front hits
                 switch (roll) {
@@ -1311,9 +1308,10 @@ public class TripodMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             if (side == ToHitData.SIDE_FRONT) {
                 // front punch hits
                 switch (roll) {
@@ -1428,9 +1426,10 @@ public class TripodMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             if ((side == ToHitData.SIDE_FRONT) || (side == ToHitData.SIDE_REAR)) {
                 // front/rear kick hits
                 switch (roll) {
@@ -1488,20 +1487,18 @@ public class TripodMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             // Swarm attack locations.
             switch (roll) {
                 case 2:
                     if (getCrew().hasEdgeRemaining()
-                        && getCrew().getOptions().booleanOption(
-                            "edge_when_headhit")) {
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
-                        HitData result = rollHitLocation(table, side,
-                                                         aimedLocation, aimingMode, cover);
-                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD,
-                                                             false, effects));
+                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
                         return result;
                     } // if
                     return new HitData(Mech.LOC_HEAD, false, effects);
@@ -1525,13 +1522,10 @@ public class TripodMech extends Mech {
                     return new HitData(Mech.LOC_CT, true, effects);
                 case 12:
                     if (getCrew().hasEdgeRemaining()
-                        && getCrew().getOptions().booleanOption(
-                            "edge_when_headhit")) {
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
-                        HitData result = rollHitLocation(table, side,
-                                                         aimedLocation, aimingMode, cover);
-                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD,
-                                                             false, effects));
+                        HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+                        result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
                         return result;
                     } // if
                     return new HitData(Mech.LOC_HEAD, false, effects);
@@ -1540,8 +1534,7 @@ public class TripodMech extends Mech {
         if (table == ToHitData.HIT_ABOVE) {
             roll = Compute.d6(1);
             try {
-                PrintWriter pw = PreferenceManager.getClientPreferences()
-                                                  .getMekHitLocLog();
+                PrintWriter pw = PreferenceManager.getClientPreferences().getMekHitLocLog();
                 if (pw != null) {
                     pw.print(table);
                     pw.print("\t");
@@ -1549,9 +1542,10 @@ public class TripodMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             // Hits from above.
             switch (roll) {
                 case 1:
@@ -1596,9 +1590,10 @@ public class TripodMech extends Mech {
                     pw.print("\t");
                     pw.println(roll);
                 }
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
             }
+
             // Hits from below.
             switch (roll) {
                 case 1:

--- a/megamek/src/megamek/common/WeaponOrderHandler.java
+++ b/megamek/src/megamek/common/WeaponOrderHandler.java
@@ -260,16 +260,13 @@ public class WeaponOrderHandler {
      * @return A {@code Map} for the custom weapon order for the given
      *         unit. If the unit is not in the list, a NULL value is returned.
      */
-    @Nullable
-    public static synchronized WeaponOrder getWeaponOrder(
-            String chassis, String model) {
+    public static synchronized @Nullable WeaponOrder getWeaponOrder(String chassis, String model) {
         if (!initialized.get() || (null == weaponOrderMap)) {
             try {
                 weaponOrderMap = loadWeaponOrderFile();
                 initialized.set(true);
             } catch (IOException e) {
-                System.out.println("Failed to load custom weapon order file!");
-                e.printStackTrace();
+                MegaMek.getLogger().error("Failed to load custom weapon order file", e);
                 return null;
             }
         }
@@ -313,8 +310,7 @@ public class WeaponOrderHandler {
                 weaponOrderMap = loadWeaponOrderFile();
                 initialized.set(true);
             } catch (IOException e) {
-                System.out.println("Failed to load custom weapon order file!");
-                e.printStackTrace();
+                MegaMek.getLogger().error("Failed to load custom weapon order file", e);
             }
         }
 

--- a/megamek/src/megamek/common/event/EventListener.java
+++ b/megamek/src/megamek/common/event/EventListener.java
@@ -10,6 +10,8 @@
 
 package megamek.common.event;
 
+import megamek.MegaMek;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -28,15 +30,11 @@ class EventListener {
     }
     
     public void trigger(MMEvent event) {
-        if(!event.isCancellable() || !event.isCancelled()) {
+        if (!event.isCancellable() || !event.isCancelled()) {
             try {
                 method.invoke(handler, event);
-            } catch(IllegalAccessException e) {
-                e.printStackTrace();
-            } catch(IllegalArgumentException e) {
-                e.printStackTrace();
-            } catch(InvocationTargetException e) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                MegaMek.getLogger().error(e);
             }
         }
     }

--- a/megamek/src/megamek/common/loaders/HmpFile.java
+++ b/megamek/src/megamek/common/loaders/HmpFile.java
@@ -1,51 +1,26 @@
 /*
  * MegaMek - Copyright (C) 2000,2001,2002,2003,2004 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
-
-/* OMIT_FOR_JHMPREAD_COMPILATION BLOCK_BEGIN */
 package megamek.common.loaders;
 
-/* BLOCK_END */
+import megamek.MegaMek;
+import megamek.common.*;
 
-import java.io.BufferedWriter;
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
+import java.io.*;
 import java.math.BigInteger;
 import java.util.Hashtable;
 import java.util.Objects;
 import java.util.Vector;
-
-import megamek.common.ArmlessMech;
-import megamek.common.BipedMech;
-import megamek.common.CriticalSlot;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EquipmentType;
-import megamek.common.LocationFullException;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.QuadMech;
-import megamek.common.TechConstants;
-import megamek.common.WeaponType;
-
-/* BLOCK_END */
 
 /**
  * Based on the hmpread.c program and the MtfFile object. Note that this class
@@ -56,14 +31,10 @@ import megamek.common.WeaponType;
  * @version $Revision$ Modified by Ryan McConnell (oscarmm) with lots of
  *          help from Ian Hamilton.
  */
-public class HmpFile
-/* OMIT_FOR_JHMPREAD_COMPILATION BLOCK_BEGIN */
-implements IMechLoader
-/* BLOCK_END */
-{
+public class HmpFile implements IMechLoader {
     private String name;
     private String model;
-    private String fluff = null;
+    private String fluff;
 
     private ChassisType chassisType;
 
@@ -395,7 +366,7 @@ implements IMechLoader
 
             dis.close();
         } catch (IOException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             /* OMIT_FOR_JHMPREAD_COMPILATION BLOCK_BEGIN */
             throw new EntityLoadingException("I/O Error reading file");
             /* BLOCK_END */
@@ -564,7 +535,7 @@ implements IMechLoader
 
             return mech;
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             throw new EntityLoadingException(e.getMessage());
         }
     }
@@ -662,12 +633,9 @@ implements IMechLoader
                             mech.addEquipment(EquipmentType.get("Improved Jump Jet"), location, false);
                         }
                     } catch (LocationFullException ex) {
-                        System.err.print("Location was full when adding jump jets to slot #");
-                        System.err.print(i);
-                        System.err.print(" of location ");
-                        System.err.println(location);
-                        ex.printStackTrace(System.err);
-                        System.err.println("... aborting entity loading.");
+                        MegaMek.getLogger().error(String.format(
+                                "Location was full when adding jump jets to slot #%s of location %s. Aborting entity loading",
+                                i, location), ex);
                         throw new EntityLoadingException(ex.getMessage());
                     }
                 } else if (criticalName != null) {
@@ -675,7 +643,7 @@ implements IMechLoader
                     try {
                         equipment = EquipmentType.get(criticalName);
                         if (equipment == null) {
-                            equipment = EquipmentType.get(mech.isClan()?"Clan "+criticalName:"IS "+criticalName);
+                            equipment = EquipmentType.get(mech.isClan() ? "Clan " + criticalName : "IS " + criticalName);
                         }
                         if (equipment != null) {
                             // for experimental or unofficial equipment, we need
@@ -755,14 +723,9 @@ implements IMechLoader
                             }
                         }
                     } catch (LocationFullException ex) {
-                        System.err.print("Location was full when adding ");
-                        System.err.print(equipment.getInternalName());
-                        System.err.print(" to slot #");
-                        System.err.print(i);
-                        System.err.print(" of location ");
-                        System.err.println(location);
-                        ex.printStackTrace(System.err);
-                        System.err.println("... aborting entity loading.");
+                        MegaMek.getLogger().error(String.format(
+                                "Full location when adding %s to slot #%s of location %s. Aborting entity loading",
+                                equipment.getInternalName(), i, location), ex);
                         throw new EntityLoadingException(ex.getMessage());
                     }
                 }
@@ -1979,21 +1942,21 @@ implements IMechLoader
                 }
                 return;
             }
-            HmpFile hmpFile = null;
+            HmpFile hmpFile;
             try(InputStream is = new FileInputStream(args[i])) {
                 hmpFile = new HmpFile(is);
             } catch (Exception e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
                 return;
             }
             filename = filename.substring(0, filename.lastIndexOf(".hmp"));
             filename += ".mtf";
             BufferedWriter out = null;
             try {
-                out = new BufferedWriter(new FileWriter(new File(filename)));
+                out = new BufferedWriter(new FileWriter(filename));
                 out.write(hmpFile.getMtf());
             } catch (Exception e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             } finally {
                 if (out != null) {
                     try {

--- a/megamek/src/megamek/common/loaders/HmvFile.java
+++ b/megamek/src/megamek/common/loaders/HmvFile.java
@@ -23,6 +23,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Objects;
 
+import megamek.MegaMek;
 import megamek.common.AmmoType;
 import megamek.common.Engine;
 import megamek.common.Entity;
@@ -390,7 +391,7 @@ public class HmvFile implements IMechLoader {
 
             dis.close();
         } catch (IOException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             throw new EntityLoadingException("I/O Error reading file");
         }
     }
@@ -570,23 +571,18 @@ public class HmvFile implements IMechLoader {
 
             return vehicle;
         } catch (Exception e) {
-            // System.out.println(structureType.toString());
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             throw new EntityLoadingException(e.getMessage());
         }
     }
 
     private void addEquipmentType(EquipmentType equipmentType, int weaponCount, HMVWeaponLocation weaponLocation) {
-        Hashtable<EquipmentType, Integer> equipmentAtLocation = equipment.get(weaponLocation);
-        if (equipmentAtLocation == null) {
-            equipmentAtLocation = new Hashtable<EquipmentType, Integer>();
-            equipment.put(weaponLocation, equipmentAtLocation);
-        }
+        Hashtable<EquipmentType, Integer> equipmentAtLocation = equipment.computeIfAbsent(weaponLocation, k -> new Hashtable<>());
         Integer prevCount = equipmentAtLocation.get(equipmentType);
         if (null != prevCount) {
-            weaponCount += prevCount.intValue();
+            weaponCount += prevCount;
         }
-        equipmentAtLocation.put(equipmentType, Integer.valueOf(weaponCount));
+        equipmentAtLocation.put(equipmentType, weaponCount);
     }
 
     private void addEquipment(Tank tank, HMVWeaponLocation weaponLocation, int location) throws Exception {

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -23,6 +23,7 @@ package megamek.common.loaders;
 import java.io.*;
 import java.util.*;
 
+import megamek.MegaMek;
 import megamek.common.*;
 
 /**
@@ -145,13 +146,13 @@ public class MtfFile implements IMechLoader {
 
             readCrits(r);
         } catch (IOException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             throw new EntityLoadingException("I/O Error reading file");
         } catch (StringIndexOutOfBoundsException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             throw new EntityLoadingException("StringIndexOutOfBoundsException reading file (format error)");
         } catch (NumberFormatException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             throw new EntityLoadingException("NumberFormatException reading file (format error)");
         }
     }
@@ -507,13 +508,13 @@ public class MtfFile implements IMechLoader {
             }
             return mech;
         } catch (NumberFormatException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             throw new EntityLoadingException("NumberFormatException parsing file");
         } catch (NullPointerException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             throw new EntityLoadingException("NullPointerException parsing file");
         } catch (StringIndexOutOfBoundsException ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
             throw new EntityLoadingException("StringIndexOutOfBoundsException parsing file");
         }
     }

--- a/megamek/src/megamek/common/net/AbstractConnection.java
+++ b/megamek/src/megamek/common/net/AbstractConnection.java
@@ -30,6 +30,7 @@ import java.util.Vector;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import megamek.MegaMek;
 import megamek.common.net.marshall.PacketMarshaller;
 import megamek.common.net.marshall.PacketMarshallerFactory;
 import megamek.common.util.CircularIntegerBuffer;
@@ -210,7 +211,7 @@ public abstract class AbstractConnection implements IConnection {
                 System.err.println(e.getMessage());
                 // We don't need a full stack trace... we're
                 // just closing the connection anyway.
-                // e.printStackTrace();
+                // MegaMek.getLogger().error(e);
             }
             socket = null;
         }
@@ -281,7 +282,7 @@ public abstract class AbstractConnection implements IConnection {
             sendNetworkPacket(packet.getData(), packet.isCompressed());
             debugLastFewCommandsSent.push(packet.getCommand());
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
     }
 
@@ -406,7 +407,7 @@ public abstract class AbstractConnection implements IConnection {
      * @return
      */
     protected String getConnectionTypeAbbrevation() {
-        return isServer() ? "s:" : "c:"; //$NON-NLS-1$ //$NON-NLS-2$
+        return isServer() ? "s:" : "c:";
     }
 
     /**
@@ -452,18 +453,14 @@ public abstract class AbstractConnection implements IConnection {
             while ((np = readNetworkPacket()) != null) {
                 processPacket(np);
             }
-        } catch (SocketException e) {
-            // Do nothing, happens when the socket closes
-            close();
-        } catch (EOFException e) {
+        } catch (SocketException | EOFException e) {
             // Do nothing, happens when the socket closes
             close();
         } catch (IOException e) {
-            System.out
-                    .println("IOException during AbstractConnection#update()");
+            MegaMek.getLogger().error(e);
             close();
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             reportReceiveException(e);
             close();
         }
@@ -627,7 +624,7 @@ public abstract class AbstractConnection implements IConnection {
                 data = bos.toByteArray();
                 bytesSent += data.length;
             } catch (Exception e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
         }
 

--- a/megamek/src/megamek/common/net/DataStreamConnection.java
+++ b/megamek/src/megamek/common/net/DataStreamConnection.java
@@ -14,6 +14,8 @@
 
 package megamek.common.net;
 
+import megamek.MegaMek;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -134,9 +136,8 @@ class DataStreamConnection extends AbstractConnection {
             // to, and it's not a big deal, since the connection is being broken
             // anyways
             close();
-        } catch (IOException ioe) {
-            // Log non-SocketException IOExceptions
-            ioe.printStackTrace();
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
             // close this connection, because it's broken
             close();
         }

--- a/megamek/src/megamek/common/net/marshall/PacketMarshaller.java
+++ b/megamek/src/megamek/common/net/marshall/PacketMarshaller.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import megamek.MegaMek;
 import megamek.common.net.Packet;
 
 /**
@@ -44,7 +45,7 @@ public abstract class PacketMarshaller {
             bo.flush();
             return bo.toByteArray();
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return null;
         }
     }
@@ -71,7 +72,7 @@ public abstract class PacketMarshaller {
         try {
             return unmarshall(new ByteArrayInputStream(data));
         } catch (Exception e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return null;
         }
 

--- a/megamek/src/megamek/common/options/GameOptions.java
+++ b/megamek/src/megamek/common/options/GameOptions.java
@@ -434,8 +434,7 @@ public class GameOptions extends AbstractOptions {
             
             marshaller.marshal(element, new File(file));
         } catch (JAXBException ex) {
-            System.err.println("Error writing XML for game options: " + ex.getMessage()); 
-            ex.printStackTrace();
+            MegaMek.getLogger().error("Error writing Game Options XML", ex);
         }
     }
 

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -19,6 +19,7 @@ import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.util.Locale;
 
+import megamek.MegaMek;
 import megamek.common.MovePath;
 import megamek.common.util.LocaleParser;
 
@@ -303,11 +304,10 @@ class ClientPreferences extends PreferenceStoreProxy implements
         String name = store.getString(MEK_HIT_LOC_LOG);
         if (name.length() != 0) {
             try {
-                mekHitLocLog = new PrintWriter(new BufferedWriter(
-                        new FileWriter(name)));
+                mekHitLocLog = new PrintWriter(new BufferedWriter(new FileWriter(name)));
                 mekHitLocLog.println("Table\tSide\tRoll");
-            } catch (Throwable thrown) {
-                thrown.printStackTrace();
+            } catch (Throwable t) {
+                MegaMek.getLogger().error(t);
                 mekHitLocLog = null;
             }
         }

--- a/megamek/src/megamek/common/preference/PreferenceManager.java
+++ b/megamek/src/megamek/common/preference/PreferenceManager.java
@@ -146,8 +146,7 @@ public class PreferenceManager {
             
             marshaller.marshal(element, file);
         } catch (JAXBException ex) {
-            System.err.println("Error writing XML for client settings: " + ex.getMessage()); //$NON-NLS-1$
-            ex.printStackTrace();
+            MegaMek.getLogger().error("Error writing XML for client settings", ex);
         }
     }
 

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -142,7 +142,6 @@ public class TROView {
                 return os.toString();
             } catch (TemplateException | IOException e) {
                 MegaMek.getLogger().error(e);
-                e.printStackTrace();
             }
         }
         return null;

--- a/megamek/src/megamek/common/util/BuildingBlock.java
+++ b/megamek/src/megamek/common/util/BuildingBlock.java
@@ -28,6 +28,8 @@ package megamek.common.util; // add to this package so BLKMechFile can read
 
 // it's files...
 
+import megamek.MegaMek;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -323,10 +325,9 @@ public class BuildingBlock {
                 }
                 data[dataRecord] = Integer.parseInt(rawString);
                 dataRecord++;
-            } catch (NumberFormatException oops) {
+            } catch (NumberFormatException e) {
                 data[0] = 0;
-                System.err.println("getDataAsInt(\"" + blockName + "\") failed.  NumberFormatException was caught."); //$NON-NLS-1$ //$NON-NLS-2$
-                oops.printStackTrace();
+                MegaMek.getLogger().error("getDataAsInt(\"" + blockName + "\") failed", e);
             }
         }
         return data; // hand back the goods...

--- a/megamek/src/megamek/common/util/ImageUtil.java
+++ b/megamek/src/megamek/common/util/ImageUtil.java
@@ -36,9 +36,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import megamek.MegaMek;
 import megamek.client.ui.swing.util.ImageAtlasMap;
 import megamek.client.ui.swing.util.ImprovedAveragingScaleFilter;
 import megamek.common.Coords;
+import megamek.common.annotations.Nullable;
 
 /**
  * Generic utility methods for image data
@@ -203,7 +205,7 @@ public final class ImageUtil {
         public Image loadImage(String fileName) {
             File fin = new File(fileName);
             if (!fin.exists()) {
-                System.out.println(String.format("Trying to load image for a non-existent file! Path: %s", fileName));
+                MegaMek.getLogger().error(String.format("Trying to load image for a non-existent file! Path: %s", fileName));
                 return null;
             }
             Image result = Toolkit.getDefaultToolkit().getImage(fileName);
@@ -231,19 +233,20 @@ public final class ImageUtil {
          * @param c
          * @return
          */
-        protected Coords parseCoords(String c) {
-            if(null == c || c.isEmpty()) {
+        protected @Nullable Coords parseCoords(String c) {
+            if (null == c || c.isEmpty()) {
                 return null;
             }
-            String[] elements = c.split(",", -1); //$NON-NLS-1$
-            if(elements.length != 2) {
+            String[] elements = c.split(",", -1);
+            if (elements.length != 2) {
                 return null;
             }
+
             try {
                 int x = Integer.parseInt(elements[0]);
                 int y = Integer.parseInt(elements[1]);
                 return new Coords(x, y);
-            } catch(NumberFormatException nfe) {
+            } catch (NumberFormatException nfe) {
                 return null;
             }
         }
@@ -257,17 +260,17 @@ public final class ImageUtil {
         public Image loadImage(String fileName) {
             int tileStart = fileName.indexOf('(');
             int tileEnd = fileName.indexOf(')');
-            if((tileStart == -1) || (tileEnd == -1) || (tileEnd < tileStart)) {
+            if ((tileStart == -1) || (tileEnd == -1) || (tileEnd < tileStart)) {
                 return null;
             }
             String coords = fileName.substring(tileStart + 1, tileEnd);
             int coordsSplitter = coords.indexOf('-');
-            if(coordsSplitter == -1) {
+            if (coordsSplitter == -1) {
                 return null;
             }
             Coords start = parseCoords(coords.substring(0, coordsSplitter));
             Coords size = parseCoords(coords.substring(coordsSplitter + 1));
-            if((null == start) || (null == size) || (0 == size.getX()) || (0 == size.getY())) {
+            if ((null == start) || (null == size) || (0 == size.getX()) || (0 == size.getY())) {
                 return null;
             }
             String baseName = fileName.substring(0, tileStart);
@@ -275,9 +278,9 @@ public final class ImageUtil {
             if (!baseFile.exists()) {
                 return null;
             }
-            System.out.println("Loading atlas: " + baseFile);
+            MegaMek.getLogger().info("Loading Atlas: " + baseFile);
             Image base = Toolkit.getDefaultToolkit().getImage(baseFile.getPath());
-            if(null == base) {
+            if (null == base) {
                 return null;
             }
             waitUntilLoaded(base);

--- a/megamek/src/megamek/server/FireProcessor.java
+++ b/megamek/src/megamek/server/FireProcessor.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Vector;
 
+import megamek.MegaMek;
 import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Coords;
@@ -228,7 +229,7 @@ public class FireProcessor extends DynamicTerrainProcessor {
         try {
             burnDamage = game.getOptions().intOption(OptionsConstants.ADVANCED_WOODS_BURN_DOWN_AMOUNT);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
         // Report that damage applied to terrain
         Report r = new Report(3383, Report.PUBLIC);
@@ -236,8 +237,7 @@ public class FireProcessor extends DynamicTerrainProcessor {
         r.add(burnDamage);
         burnReports.addElement(r);
 
-        Vector<Report> newReports =
-                server.tryClearHex(coords, burnDamage, Entity.NONE);
+        Vector<Report> newReports = server.tryClearHex(coords, burnDamage, Entity.NONE);
         for (Report nr : newReports) {
             nr.indent(2);
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -30135,7 +30135,7 @@ public class Server implements Runnable {
             // by the clients possible input.
             e.setNewRoundNovaNetworkString(networkID);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMek.getLogger().error(ex);
         }
 
     }
@@ -34021,7 +34021,7 @@ public class Server implements Runnable {
                     guerrilla.setPrimaryWeapon((InfantryWeapon) InfantryWeapon
                             .get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE));
                 } catch (Exception ex) {
-                    ex.printStackTrace();
+                    MegaMek.getLogger().error(ex);
                 }
                 guerrilla.setDeployed(true);
                 guerrilla.setDone(true);
@@ -35339,7 +35339,7 @@ public class Server implements Runnable {
         try {
             return InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return "";
         }
     }

--- a/megamek/src/megamek/test/HexSetTest.java
+++ b/megamek/src/megamek/test/HexSetTest.java
@@ -2,47 +2,38 @@
  * MegaMek - Copyright (C) 2000,2001,2002,2003,2004 Ben Mazur (bmazur@sev.org)
  * Copyright © 2013 Nicholas Walczak (walczak@cs.umn.edu)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
-
 package megamek.test;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StreamTokenizer;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Vector;
-
+import megamek.MegaMek;
 import megamek.client.ui.swing.tileset.TilesetManager;
 import megamek.common.Configuration;
 import megamek.common.Terrain;
 import megamek.common.util.StringUtil;
 
+import java.io.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Vector;
 
 /**
  * This class provides a utility to read in a HexTileSet and test to make
  * sure all images are accessible
  * 
  * @author arlith
- *
  */
 public class HexSetTest {
 
-    private static class StringCompCaseInsensitive implements
-            Comparator<String> {
+    private static class StringCompCaseInsensitive implements Comparator<String> {
         @Override
         public int compare(String arg0, String arg1) {
             return arg0.compareToIgnoreCase(arg1);
@@ -58,9 +49,8 @@ public class HexSetTest {
      * @param filename
      * @throws IOException
      */
-    private static void testFile(File dir, String filename, int incDepth)
-            throws IOException {
-        System.out.println("Checking file: " + filename);
+    private static void testFile(File dir, String filename, int incDepth) throws IOException {
+        MegaMek.getLogger().info("Checking file: " + filename);
 
         // make inpustream for board
         Reader r = new BufferedReader(new FileReader(new File(dir, filename)));
@@ -109,11 +99,10 @@ public class HexSetTest {
                 if (ort) {
                     orthos++;
                 }
-                Vector<String> filenames = StringUtil.splitString(imageName,
-                        ";"); //$NON-NLS-1$
+                Vector<String> filenames = StringUtil.splitString(imageName, ";");
                 for (String entryFile : filenames) {
                     String entryName;
-                    if ((theme == null) || theme.equals("")) {
+                    if ((theme == null) || theme.isEmpty()) {
                         entryName = terrain;
                     } else {
                         entryName = terrain + " " +  theme;
@@ -143,7 +132,7 @@ public class HexSetTest {
                 && imgFile.getCanonicalPath().endsWith(imgFile.getName());
         if (!exactmatch) {
             System.out.print("Error with " + entryName + ": ");
-            String dirFiles[] = imgFile.getParentFile().list();
+            String[] dirFiles = imgFile.getParentFile().list();
             if (dirFiles != null) {
                 Arrays.sort(dirFiles, new StringCompCaseInsensitive());
                 int result = Arrays.binarySearch(dirFiles, imgFile.getName(),
@@ -167,11 +156,7 @@ public class HexSetTest {
             File hexesDir = Configuration.hexesDir();
             
             String[] tilesetFiles = Configuration.hexesDir().list(
-                    new FilenameFilter() {
-                        public boolean accept(File directory, String fileName) {
-                            return fileName.endsWith(".tileset");
-                        }
-                    });
+                    (directory, fileName) -> fileName.endsWith(".tileset"));
             if (tilesetFiles != null) {
                 Arrays.sort(tilesetFiles);
                 for (String tileset : tilesetFiles) {
@@ -180,10 +165,8 @@ public class HexSetTest {
             }
             // Create the default hexset, so we can validate it as well
             testFile(hexesDir, TilesetManager.FILENAME_DEFAULT_HEX_SET, 0);
-
-        }catch (IOException e){
-            System.out.println("IOException!");
-            e.printStackTrace();
+        } catch (IOException e) {
+            MegaMek.getLogger().error(e);
         }
     }
 }

--- a/megamek/src/megamek/test/ImageToBoard.java
+++ b/megamek/src/megamek/test/ImageToBoard.java
@@ -14,6 +14,8 @@
  */
 package megamek.test;
 
+import megamek.MegaMek;
+
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.BufferedWriter;
@@ -85,7 +87,7 @@ public class ImageToBoard {
             boardOut = new BufferedWriter(new FileWriter(new File(outputDir,
                     "new.board")));
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
             return;
         } 
         loaded = true;
@@ -95,13 +97,12 @@ public class ImageToBoard {
         if (!loaded) {
             return;
         }
-        BufferedImage hexImg = new BufferedImage(hexWidth, hexHeight,
-                BufferedImage.TYPE_INT_ARGB);
+        BufferedImage hexImg = new BufferedImage(hexWidth, hexHeight, BufferedImage.TYPE_INT_ARGB);
         
         try {
             boardOut.write("size " + hexCols + " " + hexRows + "\n");
-        } catch (IOException e1) {
-            e1.printStackTrace();
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
             return;
         }
         
@@ -151,7 +152,7 @@ public class ImageToBoard {
                     boardOut.write("hex " + terrName + " 0 \"fluff:99"
                             + terrName + "\" \"\"\n");
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    MegaMek.getLogger().error(e);
                     return;
                 }
             }
@@ -160,7 +161,7 @@ public class ImageToBoard {
             boardOut.close();
             tilesetOut.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }        
     }
 }

--- a/megamek/src/megamek/test/MechSetTest.java
+++ b/megamek/src/megamek/test/MechSetTest.java
@@ -2,38 +2,31 @@
  * MegaMek - Copyright (C) 2000,2001,2002,2003,2004 Ben Mazur (bmazur@sev.org)
  * Copyright © 2013 Nicholas Walczak (walczak@cs.umn.edu)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
-
 package megamek.test;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StreamTokenizer;
-import java.util.Arrays;
-import java.util.Comparator;
-
+import megamek.MegaMek;
 import megamek.client.ui.swing.tileset.TilesetManager;
 import megamek.common.Configuration;
 
+import java.io.*;
+import java.util.Arrays;
+import java.util.Comparator;
 
 /**
  * This class provides a utility to read in the current MechSet and test to make
  * sure all images are accessible
  * 
  * @author arlith
- *
  */
 public class MechSetTest {
 
@@ -106,7 +99,7 @@ public class MechSetTest {
                 && imgFile.getCanonicalPath().endsWith(imgFile.getName());
         if (!exactmatch) {
             System.out.print("Error with " + entryName + ": ");
-            String dirFiles[] = imgFile.getParentFile().list();
+            String[] dirFiles = imgFile.getParentFile().list();
             if (dirFiles == null) {
                 System.out.println("File is not a directory! Entry Path: " + imageName);
                 return;
@@ -133,10 +126,8 @@ public class MechSetTest {
             
             testFile(mechDir, mechset);
             testFile(wreckDir, wreckset);
-            
-        }catch (IOException e){
-            System.out.println("IOException!");
-            e.printStackTrace();
+        } catch (IOException e) {
+            MegaMek.getLogger().error(e);
         }
     }
 }

--- a/megamek/src/megamek/test/PacketTool.java
+++ b/megamek/src/megamek/test/PacketTool.java
@@ -38,6 +38,7 @@ import java.util.TimerTask;
 
 import javax.swing.SwingUtilities;
 
+import megamek.MegaMek;
 import megamek.common.Board;
 import megamek.common.net.ConnectionFactory;
 import megamek.common.net.ConnectionListenerAdapter;
@@ -236,8 +237,8 @@ public class PacketTool extends Frame implements Runnable {
             board = new Board();
             panConnect.setEnabled(false);
             panXmit.setEnabled(true);
-        } catch (Throwable err) {
-            err.printStackTrace();
+        } catch (Throwable t) {
+            MegaMek.getLogger().error(t);
         }
     }
 
@@ -315,8 +316,8 @@ public class PacketTool extends Frame implements Runnable {
             panConnect.setEnabled(false);
             panXmit.setEnabled(true);
 
-        } catch (Throwable err) {
-            err.printStackTrace();
+        } catch (Throwable t) {
+            MegaMek.getLogger().error(t);
         }
     }
 
@@ -426,10 +427,10 @@ public class PacketTool extends Frame implements Runnable {
                      * * Save the board here.
                      */
                     Board recvBoard = (Board) packet.getObject(0);
-                    try(OutputStream os = new FileOutputStream("xmit.board")) { //$NON-NLS-1$
+                    try (OutputStream os = new FileOutputStream("xmit.board")) {
                         recvBoard.save(os);
-                    } catch (IOException ioErr) {
-                        ioErr.printStackTrace();
+                    } catch (IOException e) {
+                        MegaMek.getLogger().error(e);
                     }
                     break;
                 case Packet.COMMAND_SENDING_ENTITIES:
@@ -517,5 +518,4 @@ public class PacketTool extends Frame implements Runnable {
         }
 
     };
-
 }

--- a/megamek/src/megamek/test/QuirkRewriteTool.java
+++ b/megamek/src/megamek/test/QuirkRewriteTool.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import megamek.MegaMek;
 import megamek.common.EquipmentType;
 import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
@@ -55,8 +56,7 @@ public class QuirkRewriteTool implements MechSummaryCache.Listener {
         try {
             QuirksHandler.initQuirksList();
         } catch (IOException e) {
-            System.err.println("Error initializing quirks!");
-            e.printStackTrace();
+            MegaMek.getLogger().error("Error initializing quirks!", e);
             return;
         }
 
@@ -96,7 +96,7 @@ public class QuirkRewriteTool implements MechSummaryCache.Listener {
         try {
             QuirksHandler.saveCustomQuirksList();
         } catch (IOException e) {
-            e.printStackTrace();
+            MegaMek.getLogger().error(e);
         }
         System.out.println("\n");
 

--- a/megamek/src/megamek/test/QuirkTool.java
+++ b/megamek/src/megamek/test/QuirkTool.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import megamek.MegaMek;
 import megamek.common.Aero;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
@@ -35,6 +36,7 @@ import megamek.common.Protomech;
 import megamek.common.QuirksHandler;
 import megamek.common.Tank;
 import megamek.common.VTOL;
+import megamek.common.loaders.EntityLoadingException;
 
 /**
  * This program is a tool to help gather information about quirks.  It goes
@@ -66,8 +68,7 @@ public class QuirkTool implements MechSummaryCache.Listener {
         try {
             QuirksHandler.initQuirksList();
         } catch (IOException e) {
-            System.err.println("Error initializing quirks!");
-            e.printStackTrace();
+            MegaMek.getLogger().error("Error initializing quirks!", e);
             return;
         }
         
@@ -142,11 +143,9 @@ public class QuirkTool implements MechSummaryCache.Listener {
         Entity entity = null;
         try {
             entity = new MechFileParser(f, entityName).getEntity();
-        } catch (megamek.common.loaders.EntityLoadingException e) {
-            System.out.println("Exception: " + e.toString()); //$NON-NLS-1$
+        } catch (EntityLoadingException e) {
+            MegaMek.getLogger().error(e);
         }
         return entity;
     }
-
-    
 }

--- a/megamek/src/megamek/test/ScenarioLoaderTest.java
+++ b/megamek/src/megamek/test/ScenarioLoaderTest.java
@@ -41,9 +41,9 @@ public class ScenarioLoaderTest {
             
             @Override
             public void write(int b) throws IOException {
-                if(b == '\n') {
+                if (b == '\n') {
                     String s = line.toString();
-                    if(!s.startsWith("MMRandom: generating RNG")) { //$NON-NLS-1$
+                    if (!s.startsWith("MMRandom: generating RNG")) {
                         errCache.add(s);
                     }
                     line.setLength(0);
@@ -57,13 +57,15 @@ public class ScenarioLoaderTest {
 
         // Wait for MSC (we have to wait anyway, better to do it once if we want to measure)
         MechSummaryCache msc = MechSummaryCache.getInstance();
-        while(!msc.isInitialized()) {
+        while (!msc.isInitialized()) {
             try {
                 Thread.sleep(1000);
-            } catch(InterruptedException e) {}
+            } catch (InterruptedException e) {
+
+            }
         }
         
-        File baseDir = new File("data/scenarios"); //$NON-NLS-1$
+        File baseDir = new File("data/scenarios");
         checkScenarioFile(baseDir, errorAccumulator);
         System.setOut(originalOut);
         System.setErr(originalErr);
@@ -74,14 +76,14 @@ public class ScenarioLoaderTest {
     
     private void checkScenarioFile(File file, List<String> errorAccumulator) {
         int port = 7770;
-        if(null == file) {
+        if (null == file) {
             return;
         }
-        if(file.isFile() && file.getName().toLowerCase(Locale.ROOT).endsWith(".mms")) {
+        if (file.isFile() && file.getName().toLowerCase(Locale.ROOT).endsWith(".mms")) {
             ScenarioLoader loader = new ScenarioLoader(file);
             try {
                 Game game = loader.createGame();
-                Server server = new Server("test", port ++);
+                Server server = new Server("test", port++);
                 server.setGame(game);
                 loader.applyDamage(server);
                 server.die();
@@ -89,17 +91,17 @@ public class ScenarioLoaderTest {
                 MegaMek.getLogger().error(e);
             }
             
-            if(errCache.size() > 0) {
+            if (!errCache.isEmpty()) {
                 errorAccumulator.add("ERROR in " + file.getPath());
                 originalErr.println("ERROR in " + file.getPath());
-                for(String line : errCache) {
+                for (String line : errCache) {
                     errorAccumulator.add(line);
                     originalErr.println(line);
                 }
                 errCache.clear();
             }
-        } else if(file.isDirectory()) {
-            for(File subFile : file.listFiles()) {
+        } else if (file.isDirectory()) {
+            for (File subFile : file.listFiles()) {
                 checkScenarioFile(subFile, errorAccumulator);
             }
         }

--- a/megamek/src/megamek/test/ScenarioLoaderTest.java
+++ b/megamek/src/megamek/test/ScenarioLoaderTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import megamek.MegaMek;
 import megamek.common.Game;
 import megamek.common.MechSummaryCache;
 import megamek.server.ScenarioLoader;
@@ -76,21 +77,21 @@ public class ScenarioLoaderTest {
         if(null == file) {
             return;
         }
-        if(file.isFile() && file.getName().toLowerCase(Locale.ROOT).endsWith(".mms")) { //$NON-NLS-1$
+        if(file.isFile() && file.getName().toLowerCase(Locale.ROOT).endsWith(".mms")) {
             ScenarioLoader loader = new ScenarioLoader(file);
             try {
                 Game game = loader.createGame();
-                Server server = new Server("test", port ++); //$NON-NLS-1$
+                Server server = new Server("test", port ++);
                 server.setGame(game);
                 loader.applyDamage(server);
                 server.die();
-            } catch(Exception e) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                MegaMek.getLogger().error(e);
             }
             
             if(errCache.size() > 0) {
-                errorAccumulator.add("ERROR in " + file.getPath()); //$NON-NLS-1$
-                originalErr.println("ERROR in " + file.getPath()); //$NON-NLS-1$
+                errorAccumulator.add("ERROR in " + file.getPath());
+                originalErr.println("ERROR in " + file.getPath());
                 for(String line : errCache) {
                     errorAccumulator.add(line);
                     originalErr.println(line);

--- a/megamek/src/megamek/utils/TechLevelCompareTool.java
+++ b/megamek/src/megamek/utils/TechLevelCompareTool.java
@@ -1,5 +1,6 @@
 package megamek.utils;
 
+import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -21,14 +22,12 @@ import megamek.common.loaders.EntityLoadingException;
  * Note that some failures may be due to system or construction options rather than EquipmentType.
  * 
  * @author Neoancient
- *
  */
-
 public class TechLevelCompareTool {
     
-    static Set<EquipmentType> weaponSet = new TreeSet<>((e1, e2) -> e1.getName().compareTo(e2.getName()));
-    static Set<EquipmentType> ammoSet = new TreeSet<>((e1, e2) -> e1.getName().compareTo(e2.getName()));
-    static Set<EquipmentType> miscSet = new TreeSet<>((e1, e2) -> e1.getName().compareTo(e2.getName()));
+    static Set<EquipmentType> weaponSet = new TreeSet<>(Comparator.comparing(EquipmentType::getName));
+    static Set<EquipmentType> ammoSet = new TreeSet<>(Comparator.comparing(EquipmentType::getName));
+    static Set<EquipmentType> miscSet = new TreeSet<>(Comparator.comparing(EquipmentType::getName));
     
     public static void main(String[] args) {
         int bad = 0;
@@ -37,23 +36,23 @@ public class TechLevelCompareTool {
             try {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
         }
+
         for (MechSummary ms : msc.getAllMechs()) {
             Entity en = null;
             try {
                 en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
             } catch (EntityLoadingException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
+
             if (null != en) {
                  SimpleTechLevel fixed = SimpleTechLevel.convertCompoundToSimple(en.getTechLevel());
                  SimpleTechLevel calc = en.getStaticTechLevel();
                 if (fixed.compareTo(calc) < 0) {
-                    System.out.println(en.getShortName() + ": " + fixed.toString() + "/" + calc.toString());
+                    System.out.println(en.getShortName() + ": " + fixed + "/" + calc);
                     for (Mounted m : en.getEquipment()) {
                         if (fixed.compareTo(m.getType().getStaticTechLevel()) < 0) {
                             if (m.getType() instanceof WeaponType) {

--- a/megamek/unittests/megamek/common/EquipmentTypeLookupTest.java
+++ b/megamek/unittests/megamek/common/EquipmentTypeLookupTest.java
@@ -1,5 +1,6 @@
 package megamek.common;
 
+import megamek.MegaMek;
 import megamek.common.loaders.EntityLoadingException;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -47,7 +48,7 @@ public class EquipmentTypeLookupTest {
             try {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
         }
 
@@ -57,7 +58,7 @@ public class EquipmentTypeLookupTest {
                         ms.getEntryName()).getEntity();
                 failedEquipment.addAll(entity.failedEquipmentList);
             } catch (EntityLoadingException e) {
-                e.printStackTrace();
+                MegaMek.getLogger().error(e);
             }
         }
 


### PR DESCRIPTION
This PR reduces the number of throwable::printStackTrace uses because of how they tend to extend the debugging process in MekHQ, and swaps a few other logged calls that are often seen in the MekHQ log so they are properly in the MegaMek log.

To review:
Whitespace differences off, as I was hitting a lot of old files in need of formatting fixes.
MapMenu is the largest changed file, as it not just had the most calls of printStackTrace but I also removed the unnecessary ActionListener uses and fixed a bunch of other formatting issues in that file.